### PR TITLE
Make `SignedWide` and `UInt::bits` visibility `pub(crate)`

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -47,7 +47,7 @@ pub type Wide = u64;
 
 /// SignedInner integer type: double the width of [`Limb`].
 #[cfg(target_pointer_width = "32")]
-pub type SignedWide = i64;
+pub(crate) type SignedWide = i64;
 
 //
 // 64-bit definitions
@@ -75,7 +75,7 @@ pub type Wide = u128;
 
 /// SignedInner integer type: double the width of [`Limb`].
 #[cfg(target_pointer_width = "64")]
-pub type SignedWide = i128;
+pub(crate) type SignedWide = i128;
 
 /// Highest bit in a [`Limb`].
 pub(crate) const HI_BIT: usize = BIT_SIZE - 1;

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -3,7 +3,7 @@ use crate::{Limb, UInt};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Calculate the number of bits needed to represent this number
-    pub const fn bits(self) -> Inner {
+    pub(crate) const fn bits(self) -> Inner {
         let mut i = LIMBS - 1;
         while i > 0 && self.limbs[i].0 == 0 {
             i -= 1;


### PR DESCRIPTION
We can eventually expose these as part of the public API, but I'd like to nitpick the names first.

I'd also like to immediately cut a release in order to update the repo location, so for now I'm removing these from the public API then we can add them back after some discussion.

cc @mikelodder7