### PR TITLE
v0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.8 (2021-09-14)
+### Added
+- Implement constant-time division and modulo operations
+
+### Changed
+- Moved from RustCrypto/utils to RustCrypto/crypto-bigint repo ([#2])
+
+[#2]: https://github.com/RustCrypto/formats/pull/2
+
 ## 0.2.7 (2021-09-12)
 ### Added
 - `UInt::shl_vartime` 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "generic-array",
  "hex-literal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.2.7" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.8" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/crypto-bigint/0.2.7"
+    html_root_url = "https://docs.rs/crypto-bigint/0.2.8"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- Implement constant-time division and modulo operations

### Changed
- Moved from RustCrypto/utils to RustCrypto/crypto-bigint repo ([#2])

[#2]: https://github.com/RustCrypto/formats/pull/2