### PR TITLE
make div similar to other interfaces

### DIFF
--- a/proptests/tests/equivalence.rs
+++ b/proptests/tests/equivalence.rs
@@ -109,7 +109,7 @@ proptest! {
 
         if !b_bi.is_zero() {
             let expected = to_uint(a_bi / b_bi);
-            let actual = a.wrapping_div(b);
+            let actual = a.wrapping_div(&b);
 
             assert_eq!(expected, actual);
         }
@@ -122,7 +122,7 @@ proptest! {
 
         if b_bi.is_zero() {
             let expected = to_uint(a_bi % b_bi);
-            let actual = a.wrapping_rem(b);
+            let actual = a.wrapping_rem(&b);
 
             assert_eq!(expected, actual);
         }

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -31,7 +31,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     ///
     /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
     #[inline]
-    pub(crate) const fn ct_select(a: UInt<LIMBS>, b: UInt<LIMBS>, c: Inner) -> UInt<LIMBS> {
+    pub(crate) const fn ct_select(a: UInt<LIMBS>, b: UInt<LIMBS>, c: Inner) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
 
         let mut i = 0;
@@ -63,7 +63,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     ///
     /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
     #[inline]
-    pub(crate) const fn ct_cmp(&self, rhs: Self) -> SignedInner {
+    pub(crate) const fn ct_cmp(&self, rhs: &Self) -> SignedInner {
         let mut gt = 0;
         let mut lt = 0;
         let mut i = LIMBS;


### PR DESCRIPTION
Div methods were taking a copy instead of a reference where the other arithmetic methods were taking a reference. This makes them identifical.