### PR TITLE
Fix build without `rand` crate feature

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -64,7 +64,6 @@ jobs:
           profile: minimal
           override: true
       - run: ${{ matrix.deps }}
-      - run: cargo test --target ${{ matrix.target }} --release --no-default-features
       - run: cargo test --target ${{ matrix.target }} --release
       - run: cargo test --target ${{ matrix.target }} --release --features generic-array
       - run: cargo test --target ${{ matrix.target }} --release --features zeroize
@@ -112,7 +111,6 @@ jobs:
           profile: minimal
           override: true
       - run: cargo install cross
-      - run: cross test --target ${{ matrix.target }} --release --no-default-features
       - run: cross test --target ${{ matrix.target }} --release
       - run: cross test --target ${{ matrix.target }} --release --features generic-array
       - run: cross test --target ${{ matrix.target }} --release --features zeroize

--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -32,6 +32,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release
       - run: cargo build --target ${{ matrix.target }} --release --features generic-array
       - run: cargo build --target ${{ matrix.target }} --release --features zeroize
@@ -63,6 +64,7 @@ jobs:
           profile: minimal
           override: true
       - run: ${{ matrix.deps }}
+      - run: cargo test --target ${{ matrix.target }} --release --no-default-features
       - run: cargo test --target ${{ matrix.target }} --release
       - run: cargo test --target ${{ matrix.target }} --release --features generic-array
       - run: cargo test --target ${{ matrix.target }} --release --features zeroize
@@ -110,6 +112,7 @@ jobs:
           profile: minimal
           override: true
       - run: cargo install cross
+      - run: cross test --target ${{ matrix.target }} --release --no-default-features
       - run: cross test --target ${{ matrix.target }} --release
       - run: cross test --target ${{ matrix.target }} --release --features generic-array
       - run: cross test --target ${{ matrix.target }} --release --features zeroize

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -1,6 +1,8 @@
 //! Wrapper type for non-zero integers.
 
-use crate::{Encoding, Integer, Random};
+#[cfg(feature = "rand")]
+use crate::Random;
+use crate::{Encoding, Integer};
 use core::{fmt, ops::Deref};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 


### PR DESCRIPTION
The recent `NonZero` addition broke builds with `default-features = false`. I will add CI checks too.