### PR TITLE
v0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.10 (2021-09-21)
+### Added
+- `ArrayDecoding` trait ([#12])
+- `NonZero` wrapper ([#13], [#16])
+- Impl `Div`/`Rem` for `NonZero<UInt>` ([#14])
+
+[#12]: https://github.com/RustCrypto/formats/pull/12
+[#13]: https://github.com/RustCrypto/formats/pull/13
+[#14]: https://github.com/RustCrypto/formats/pull/14
+[#16]: https://github.com/RustCrypto/formats/pull/16
+
 ## 0.2.9 (2021-09-16)
 ### Added
 - `UInt::sqrt` ([#9])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "generic-array",
  "hex-literal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.2.9" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.10" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/crypto-bigint/0.2.9"
+    html_root_url = "https://docs.rs/crypto-bigint/0.2.10"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `ArrayDecoding` trait ([#12])
- `NonZero` wrapper ([#13], [#16])
- Impl `Div`/`Rem` for `NonZero<UInt>` ([#14])

[#12]: https://github.com/RustCrypto/formats/pull/12
[#13]: https://github.com/RustCrypto/formats/pull/13
[#14]: https://github.com/RustCrypto/formats/pull/14
[#16]: https://github.com/RustCrypto/formats/pull/16