### PR TITLE
Rust 2021 edition upgrade

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
+            rust: 1.56.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -55,7 +55,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
+            rust: 1.56.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -78,13 +78,13 @@ jobs:
         include:
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
+            rust: 1.56.0 # MSRV
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.51.0 # MSRV
+            rust: 1.56.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
 
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.51.0
+          toolchain: 1.56.0
           components: clippy
           override: true
           profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
+version = "0.3.0-pre"
 dependencies = [
  "generic-array",
  "hex-literal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.2.11" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,
@@ -8,12 +8,13 @@ no_std-friendly implementations of modern formulas using const generics.
 """
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
-edition = "2018"
 repository = "https://github.com/RustCrypto/crypto-bigint"
 categories = ["algorithms", "cryptography", "data-structures", "mathematics", "no-std"]
 keywords = ["arbitrary", "crypto", "bignum", "integer", "precision"]
 readme = "README.md"
 resolver = "2"
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 subtle = { version = "2.4", default-features = false }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ using const generics.
 
 ## Minimum Supported Rust Version
 
-**Rust 1.51** at a minimum.
+**Rust 1.56** at a minimum.
 
 ## License
 
@@ -52,7 +52,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/crypto-bigint/actions/workflows/crypto-bigint.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/crypto-bigint/actions/workflows/crypto-bigint.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300602-crypto-bigint
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! of modern formulas implemented using const generics.
 //!
 //! # Minimum Supported Rust Version
-//! **Rust 1.51** at a minimum.
+//! **Rust 1.56** at a minimum.
 //!
 //! # Goals
 //! - No heap allocations i.e. `no_std`-friendly.
@@ -30,7 +30,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/crypto-bigint/0.2.11"
+    html_root_url = "https://docs.rs/crypto-bigint/0.3.0-pre"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -289,7 +289,7 @@ where
     UInt<LIMBS>: Integer,
 {
     fn rem_assign(&mut self, rhs: &NonZero<UInt<LIMBS>>) {
-        let (r, _) = self.ct_reduce(&rhs);
+        let (r, _) = self.ct_reduce(rhs);
         *self = r
     }
 }


### PR DESCRIPTION
Bumps `edition = "2021"` and adds `rust-version = 1.56`.

This is the first in a set of breaking changes proposed in #20, and as such bumps the version to v0.3.0-pre (not for release).