### PR TITLE
`Zero` trait

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -17,6 +17,7 @@ mod sub;
 #[cfg(feature = "rand")]
 mod rand;
 
+use crate::Zero;
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable};
 
@@ -112,6 +113,10 @@ impl ConditionallySelectable for Limb {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Self(Inner::conditional_select(&a.0, &b.0, choice))
     }
+}
+
+impl Zero for Limb {
+    const ZERO: Self = Self::ZERO;
 }
 
 impl fmt::Display for Limb {

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "rand")]
 use crate::Random;
-use crate::{Encoding, Integer, UInt};
+use crate::{Encoding, Integer, Limb, UInt, Zero};
 use core::{
     fmt,
     num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8},
@@ -18,7 +18,18 @@ use rand_core::{CryptoRng, RngCore};
 
 /// Wrapper type for non-zero integers.
 #[derive(Copy, Clone, Default, Eq, PartialEq, PartialOrd, Ord)]
-pub struct NonZero<T: Integer>(T);
+pub struct NonZero<T: Zero>(T);
+
+impl<T> NonZero<T>
+where
+    T: Zero,
+{
+    /// Create a new non-zero integer.
+    pub fn new(n: T) -> CtOption<Self> {
+        let is_zero = n.is_zero();
+        CtOption::new(Self(n), !is_zero)
+    }
+}
 
 impl<T> NonZero<T>
 where
@@ -29,51 +40,197 @@ where
 
     /// Maximum value this integer can express.
     pub const MAX: Self = Self(T::MAX);
+}
 
-    /// Create a new non-zero integer.
-    pub fn new(n: T) -> CtOption<Self> {
-        CtOption::new(Self(n), !n.is_zero())
-    }
-
+impl<T> NonZero<T>
+where
+    T: Encoding + Zero,
+{
     /// Decode from big endian bytes.
-    pub fn from_be_bytes(bytes: T::Repr) -> CtOption<Self>
-    where
-        T: Encoding,
-    {
+    pub fn from_be_bytes(bytes: T::Repr) -> CtOption<Self> {
         Self::new(T::from_be_bytes(bytes))
     }
 
     /// Decode from little endian bytes.
-    pub fn from_le_bytes(bytes: T::Repr) -> CtOption<Self>
-    where
-        T: Encoding,
-    {
+    pub fn from_le_bytes(bytes: T::Repr) -> CtOption<Self> {
         Self::new(T::from_le_bytes(bytes))
     }
+}
 
+#[cfg(feature = "generic-array")]
+#[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
+impl<T> NonZero<T>
+where
+    T: ArrayEncoding + Zero,
+{
     /// Decode a non-zero integer from big endian bytes.
-    #[cfg(feature = "generic-array")]
-    pub fn from_be_byte_array(bytes: ByteArray<T>) -> CtOption<Self>
-    where
-        T: ArrayEncoding,
-    {
+    pub fn from_be_byte_array(bytes: ByteArray<T>) -> CtOption<Self> {
         Self::new(T::from_be_byte_array(bytes))
     }
 
     /// Decode a non-zero integer from big endian bytes.
-    #[cfg(feature = "generic-array")]
-    pub fn from_le_byte_array(bytes: ByteArray<T>) -> CtOption<Self>
-    where
-        T: ArrayEncoding,
-    {
+    pub fn from_le_byte_array(bytes: ByteArray<T>) -> CtOption<Self> {
         Self::new(T::from_be_byte_array(bytes))
     }
 }
 
-impl<const LIMBS: usize> NonZero<UInt<LIMBS>>
+impl<T> AsRef<T> for NonZero<T>
 where
-    UInt<LIMBS>: Integer,
+    T: Zero,
 {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> ConditionallySelectable for NonZero<T>
+where
+    T: ConditionallySelectable + Zero,
+{
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        Self(T::conditional_select(&a.0, &b.0, choice))
+    }
+}
+
+impl<T> ConstantTimeEq for NonZero<T>
+where
+    T: Zero,
+{
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0.ct_eq(&other.0)
+    }
+}
+
+impl<T> Deref for NonZero<T>
+where
+    T: Zero,
+{
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+#[cfg(feature = "rand")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+impl<T> Random for NonZero<T>
+where
+    T: Random + Zero,
+{
+    /// Generate a random `NonZero<T>`.
+    fn random(mut rng: impl CryptoRng + RngCore) -> Self {
+        // Use rejection sampling to eliminate zero values.
+        // While this method isn't constant-time, the attacker shouldn't learn
+        // anything about unrelated outputs so long as `rng` is a secure `CryptoRng`.
+        loop {
+            if let Some(result) = Self::new(T::random(&mut rng)).into() {
+                break result;
+            }
+        }
+    }
+}
+
+impl<T> fmt::Display for NonZero<T>
+where
+    T: fmt::Display + Zero,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl<T> fmt::Binary for NonZero<T>
+where
+    T: fmt::Binary + Zero,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Binary::fmt(&self.0, f)
+    }
+}
+
+impl<T> fmt::Octal for NonZero<T>
+where
+    T: fmt::Octal + Zero,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Octal::fmt(&self.0, f)
+    }
+}
+
+impl<T> fmt::LowerHex for NonZero<T>
+where
+    T: fmt::LowerHex + Zero,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl<T> fmt::UpperHex for NonZero<T>
+where
+    T: fmt::UpperHex + Zero,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.0, f)
+    }
+}
+
+impl NonZero<Limb> {
+    /// Create a [`NonZero<Limb>`] from a [`NonZeroU8`] (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<NonZeroU8>` when stable
+    pub const fn from_u8(n: NonZeroU8) -> Self {
+        Self(Limb::from_u8(n.get()))
+    }
+
+    /// Create a [`NonZero<Limb>`] from a [`NonZeroU16`] (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<NonZeroU16>` when stable
+    pub const fn from_u16(n: NonZeroU16) -> Self {
+        Self(Limb::from_u16(n.get()))
+    }
+
+    /// Create a [`NonZero<Limb>`] from a [`NonZeroU32`] (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<NonZeroU32>` when stable
+    pub const fn from_u32(n: NonZeroU32) -> Self {
+        Self(Limb::from_u32(n.get()))
+    }
+
+    /// Create a [`NonZero<Limb>`] from a [`NonZeroU64`] (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<NonZeroU64>` when stable
+    #[cfg(target_pointer_width = "64")]
+    #[cfg_attr(docsrs, doc(cfg(target_pointer_width = "64")))]
+    pub const fn from_u64(n: NonZeroU64) -> Self {
+        Self(Limb::from_u64(n.get()))
+    }
+}
+
+impl From<NonZeroU8> for NonZero<Limb> {
+    fn from(integer: NonZeroU8) -> Self {
+        Self::from_u8(integer)
+    }
+}
+
+impl From<NonZeroU16> for NonZero<Limb> {
+    fn from(integer: NonZeroU16) -> Self {
+        Self::from_u16(integer)
+    }
+}
+
+impl From<NonZeroU32> for NonZero<Limb> {
+    fn from(integer: NonZeroU32) -> Self {
+        Self::from_u32(integer)
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+#[cfg_attr(docsrs, doc(cfg(target_pointer_width = "64")))]
+impl From<NonZeroU64> for NonZero<Limb> {
+    fn from(integer: NonZeroU64) -> Self {
+        Self::from_u64(integer)
+    }
+}
+
+impl<const LIMBS: usize> NonZero<UInt<LIMBS>> {
     /// Create a [`NonZero<UInt>`] from a [`NonZeroU8`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU8>` when stable
     pub const fn from_u8(n: NonZeroU8) -> Self {
@@ -105,148 +262,31 @@ where
     }
 }
 
-impl<T> AsRef<T> for NonZero<T>
-where
-    T: Integer,
-{
-    fn as_ref(&self) -> &T {
-        &self.0
-    }
-}
-
-impl<T> ConditionallySelectable for NonZero<T>
-where
-    T: Integer,
-{
-    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        Self(T::conditional_select(&a.0, &b.0, choice))
-    }
-}
-
-impl<T> ConstantTimeEq for NonZero<T>
-where
-    T: Integer,
-{
-    fn ct_eq(&self, other: &Self) -> Choice {
-        self.0.ct_eq(&other.0)
-    }
-}
-
-impl<T> Deref for NonZero<T>
-where
-    T: Integer,
-{
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        &self.0
-    }
-}
-
-#[cfg(feature = "rand")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
-impl<T> Random for NonZero<T>
-where
-    T: Integer + Random,
-{
-    /// Generate a random `NonZero<T>`.
-    fn random(mut rng: impl CryptoRng + RngCore) -> Self {
-        // Use rejection sampling to eliminate zero values.
-        // While this method isn't constant-time, the attacker shouldn't learn
-        // anything about unrelated outputs so long as `rng` is a secure `CryptoRng`.
-        loop {
-            if let Some(result) = Self::new(T::random(&mut rng)).into() {
-                break result;
-            }
-        }
-    }
-}
-
-impl<T> fmt::Display for NonZero<T>
-where
-    T: Integer + fmt::Display,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.0, f)
-    }
-}
-
-impl<T> fmt::Binary for NonZero<T>
-where
-    T: Integer + fmt::Binary,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Binary::fmt(&self.0, f)
-    }
-}
-
-impl<T> fmt::Octal for NonZero<T>
-where
-    T: Integer + fmt::Octal,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Octal::fmt(&self.0, f)
-    }
-}
-
-impl<T> fmt::LowerHex for NonZero<T>
-where
-    T: Integer + fmt::LowerHex,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::LowerHex::fmt(&self.0, f)
-    }
-}
-
-impl<T> fmt::UpperHex for NonZero<T>
-where
-    T: Integer + fmt::UpperHex,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::UpperHex::fmt(&self.0, f)
-    }
-}
-
-impl<const LIMBS: usize> From<NonZeroU8> for NonZero<UInt<LIMBS>>
-where
-    UInt<LIMBS>: Integer,
-{
+impl<const LIMBS: usize> From<NonZeroU8> for NonZero<UInt<LIMBS>> {
     fn from(integer: NonZeroU8) -> Self {
         Self::from_u8(integer)
     }
 }
 
-impl<const LIMBS: usize> From<NonZeroU16> for NonZero<UInt<LIMBS>>
-where
-    UInt<LIMBS>: Integer,
-{
+impl<const LIMBS: usize> From<NonZeroU16> for NonZero<UInt<LIMBS>> {
     fn from(integer: NonZeroU16) -> Self {
         Self::from_u16(integer)
     }
 }
 
-impl<const LIMBS: usize> From<NonZeroU32> for NonZero<UInt<LIMBS>>
-where
-    UInt<LIMBS>: Integer,
-{
+impl<const LIMBS: usize> From<NonZeroU32> for NonZero<UInt<LIMBS>> {
     fn from(integer: NonZeroU32) -> Self {
         Self::from_u32(integer)
     }
 }
 
-impl<const LIMBS: usize> From<NonZeroU64> for NonZero<UInt<LIMBS>>
-where
-    UInt<LIMBS>: Integer,
-{
+impl<const LIMBS: usize> From<NonZeroU64> for NonZero<UInt<LIMBS>> {
     fn from(integer: NonZeroU64) -> Self {
         Self::from_u64(integer)
     }
 }
 
-impl<const LIMBS: usize> From<NonZeroU128> for NonZero<UInt<LIMBS>>
-where
-    UInt<LIMBS>: Integer,
-{
+impl<const LIMBS: usize> From<NonZeroU128> for NonZero<UInt<LIMBS>> {
     fn from(integer: NonZeroU128) -> Self {
         Self::from_u128(integer)
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -22,7 +22,6 @@ pub trait Integer:
     + Debug
     + Default
     + Div<NonZero<Self>, Output = Self>
-    + Encoding
     + Eq
     + From<u64>
     + Ord
@@ -30,20 +29,13 @@ pub trait Integer:
     + Send
     + Sized
     + Sync
+    + Zero
 {
-    /// The value `0`.
-    const ZERO: Self;
-
     /// The value `1`.
     const ONE: Self;
 
     /// Maximum value this integer can express.
     const MAX: Self;
-
-    /// Is this integer value equal to zero?
-    fn is_zero(&self) -> Choice {
-        self.ct_eq(&Self::ZERO)
-    }
 
     /// Is this integer value an odd number?
     fn is_odd(&self) -> Choice;
@@ -51,6 +43,17 @@ pub trait Integer:
     /// Is this integer value an even number?
     fn is_even(&self) -> Choice {
         !self.is_odd()
+    }
+}
+
+/// Zero values.
+pub trait Zero: ConstantTimeEq + Sized {
+    /// The value `0`.
+    const ZERO: Self;
+
+    /// Is this integer value equal to zero?
+    fn is_zero(&self) -> Choice {
+        self.ct_eq(&Self::ZERO)
     }
 }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -15,6 +15,7 @@ mod bit_and;
 mod bit_not;
 mod bit_or;
 mod bit_xor;
+mod bits;
 mod cmp;
 mod div;
 mod encoding;
@@ -30,11 +31,10 @@ mod sub_mod;
 #[cfg(feature = "generic-array")]
 mod array;
 
-mod bits;
 #[cfg(feature = "rand")]
 mod rand;
 
-use crate::{Concat, Encoding, Integer, Limb, Split};
+use crate::{Concat, Encoding, Integer, Limb, Split, Zero};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable};
 
@@ -126,17 +126,17 @@ impl<const LIMBS: usize> Default for UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Integer for UInt<LIMBS>
-where
-    Self: Encoding,
-{
-    const ZERO: Self = Self::ZERO;
+impl<const LIMBS: usize> Integer for UInt<LIMBS> {
     const ONE: Self = Self::ONE;
     const MAX: Self = Self::MAX;
 
     fn is_odd(&self) -> Choice {
         self.is_odd()
     }
+}
+
+impl<const LIMBS: usize> Zero for UInt<LIMBS> {
+    const ZERO: Self = Self::ZERO;
 }
 
 impl<const LIMBS: usize> fmt::Display for UInt<LIMBS> {


### PR DESCRIPTION
Extracts a `Zero` trait from the `Integer` trait which contains only the associated `ZERO` constant and the `is_zero` method with a default implementation.

Changes the mandatory bound for `NonZero` to be the `Zero` trait rather than the much more restrictive `Integer`

This makes it possible to impl `Zero` on `Limb` even though it doesn't impl the full set of `Integer` traits, and therefore use `NonZero<Limb>`.