### PR TITLE
Fix `random_mod` performance for small moduli; `NonZero` moduli

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -8,6 +8,7 @@ mod bit_and;
 mod bit_not;
 mod bit_or;
 mod bit_xor;
+mod bits;
 mod cmp;
 mod encoding;
 mod from;
@@ -98,6 +99,12 @@ impl Limb {
 
     /// Maximum value this [`Limb`] can express.
     pub const MAX: Self = Limb(Inner::MAX);
+
+    /// Size of the inner integer in bits.
+    pub const BIT_SIZE: usize = BIT_SIZE;
+
+    /// Size of the inner integer in bytes.
+    pub const BYTE_SIZE: usize = BYTE_SIZE;
 
     /// Return `a` if `c`!=0 or `b` if `c`==0.
     ///

--- a/src/limb/add.rs
+++ b/src/limb/add.rs
@@ -1,7 +1,7 @@
 //! Limb addition
 
 use super::{Inner, Limb, Wide};
-use crate::{Encoding, Wrapping};
+use crate::Wrapping;
 use core::ops::{Add, AddAssign};
 use subtle::CtOption;
 
@@ -16,18 +16,24 @@ impl Limb {
         (Limb(ret as Inner), Limb((ret >> Self::BIT_SIZE) as Inner))
     }
 
-    /// Perform wrapping addition, discarding overflow.
-    #[inline(always)]
-    pub const fn wrapping_add(&self, rhs: Self) -> Self {
-        Limb(self.0.wrapping_add(rhs.0))
-    }
-
     /// Perform checked addition, returning a [`CtOption`] which `is_some` only
     /// if the operation did not overflow.
     #[inline]
     pub fn checked_add(&self, rhs: Self) -> CtOption<Self> {
         let (result, carry) = self.adc(rhs, Limb::ZERO);
         CtOption::new(result, carry.is_zero())
+    }
+
+    /// Perform saturating addition.
+    #[inline]
+    pub fn saturating_add(&self, rhs: Self) -> Self {
+        Limb(self.0.saturating_add(rhs.0))
+    }
+
+    /// Perform wrapping addition, discarding overflow.
+    #[inline(always)]
+    pub const fn wrapping_add(&self, rhs: Self) -> Self {
+        Limb(self.0.wrapping_add(rhs.0))
     }
 }
 

--- a/src/limb/bits.rs
+++ b/src/limb/bits.rs
@@ -1,0 +1,8 @@
+use super::{Limb, BIT_SIZE};
+
+impl Limb {
+    /// Calculate the number of bits needed to represent this number.
+    pub const fn bits(self) -> usize {
+        BIT_SIZE - (self.0.leading_zeros() as usize)
+    }
+}

--- a/src/limb/mul.rs
+++ b/src/limb/mul.rs
@@ -1,7 +1,7 @@
 //! Limb multiplication
 
 use super::{Inner, Limb, Wide};
-use crate::{Encoding, Wrapping};
+use crate::Wrapping;
 use core::ops::{Mul, MulAssign};
 use subtle::CtOption;
 

--- a/src/limb/rand.rs
+++ b/src/limb/rand.rs
@@ -1,20 +1,45 @@
 //! Random number generator support
 
-use super::Limb;
+use super::{Limb, BYTE_SIZE};
+use crate::{Encoding, NonZero, Random, RandomMod};
 use rand_core::{CryptoRng, RngCore};
+use subtle::ConstantTimeLess;
 
-impl Limb {
-    /// Generate a random limb
+impl Random for Limb {
     #[cfg(target_pointer_width = "32")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
-    pub fn random(mut rng: impl CryptoRng + RngCore) -> Self {
+    fn random(mut rng: impl CryptoRng + RngCore) -> Self {
         Self(rng.next_u32())
     }
 
-    /// Generate a random limb
     #[cfg(target_pointer_width = "64")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
-    pub fn random(mut rng: impl CryptoRng + RngCore) -> Self {
+    fn random(mut rng: impl CryptoRng + RngCore) -> Self {
         Self(rng.next_u64())
+    }
+}
+
+impl RandomMod for Limb {
+    fn random_mod(mut rng: impl CryptoRng + RngCore, modulus: &NonZero<Self>) -> Self {
+        let mut bytes = <Self as Encoding>::Repr::default();
+
+        // TODO(tarcieri): use `div_ceil` when available
+        // See: https://github.com/rust-lang/rust/issues/88581
+        let mut n_bytes = modulus.bits() / 8;
+
+        // Ensure the randomly generated value can always be larger than
+        // the modulus in order to ensure a uniform distribution
+        if n_bytes < BYTE_SIZE {
+            n_bytes += 1;
+        }
+
+        loop {
+            rng.fill_bytes(&mut bytes[..n_bytes]);
+            let n = Limb::from_le_bytes(bytes);
+
+            if n.ct_lt(modulus).into() {
+                return n;
+            }
+        }
     }
 }

--- a/src/limb/sub.rs
+++ b/src/limb/sub.rs
@@ -1,7 +1,7 @@
 //! Limb subtraction
 
 use super::{Inner, Limb, Wide};
-use crate::{Encoding, Wrapping};
+use crate::Wrapping;
 use core::ops::{Sub, SubAssign};
 use subtle::CtOption;
 
@@ -16,19 +16,25 @@ impl Limb {
         (Limb(ret as Inner), Limb((ret >> Self::BIT_SIZE) as Inner))
     }
 
-    /// Perform wrapping subtraction, discarding underflow and wrapping around
-    /// the boundary of the type.
-    #[inline(always)]
-    pub const fn wrapping_sub(&self, rhs: Self) -> Self {
-        Limb(self.0.wrapping_sub(rhs.0))
-    }
-
     /// Perform checked subtraction, returning a [`CtOption`] which `is_some`
     /// only if the operation did not overflow.
     #[inline]
     pub fn checked_sub(&self, rhs: Self) -> CtOption<Self> {
         let (result, underflow) = self.sbb(rhs, Limb::ZERO);
         CtOption::new(result, underflow.is_zero())
+    }
+
+    /// Perform saturating subtraction.
+    #[inline]
+    pub fn saturating_sub(&self, rhs: Self) -> Self {
+        Limb(self.0.saturating_sub(rhs.0))
+    }
+
+    /// Perform wrapping subtraction, discarding underflow and wrapping around
+    /// the boundary of the type.
+    #[inline(always)]
+    pub const fn wrapping_sub(&self, rhs: Self) -> Self {
+        Limb(self.0.wrapping_sub(rhs.0))
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -68,7 +68,7 @@ pub trait Random: Sized {
 /// Modular random number generation support.
 #[cfg(feature = "rand")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
-pub trait RandomMod: Sized {
+pub trait RandomMod: Sized + Zero {
     /// Generate a cryptographically secure random number which is less than
     /// a given `modulus`.
     ///
@@ -80,7 +80,7 @@ pub trait RandomMod: Sized {
     /// issue so long as the underlying random number generator is truly a
     /// [`CryptoRng`], where previous outputs are unrelated to subsequent
     /// outputs and do not reveal information about the RNG's internal state.
-    fn random_mod(rng: impl CryptoRng + RngCore, modulus: &Self) -> Self;
+    fn random_mod(rng: impl CryptoRng + RngCore, modulus: &NonZero<Self>) -> Self;
 }
 
 /// Compute `self + rhs mod p`.

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -2,8 +2,8 @@ use crate::limb::{Inner, BIT_SIZE};
 use crate::{Limb, UInt};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
-    /// Calculate the number of bits needed to represent this number
-    pub(crate) const fn bits(self) -> Inner {
+    /// Calculate the number of bits needed to represent this number.
+    pub const fn bits(self) -> usize {
         let mut i = LIMBS - 1;
         while i > 0 && self.limbs[i].0 == 0 {
             i -= 1;
@@ -17,6 +17,6 @@ impl<const LIMBS: usize> UInt<LIMBS> {
             Limb::ZERO,
             !self.limbs[0].is_nonzero() & !Limb(i as Inner).is_nonzero(),
         )
-        .0
+        .0 as usize
     }
 }

--- a/src/uint/sub_mod.rs
+++ b/src/uint/sub_mod.rs
@@ -45,18 +45,18 @@ impl_sub_mod!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
 
 #[cfg(all(test, feature = "rand"))]
 mod tests {
-    use crate::UInt;
+    use crate::{Limb, NonZero, Random, UInt};
+    use rand_core::SeedableRng;
 
     macro_rules! test_sub_mod {
         ($size:expr, $test_name:ident) => {
             #[test]
             fn $test_name() {
-                use crate::Limb;
-                use rand_core::SeedableRng;
-
                 let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
-
-                let moduli = [UInt::<$size>::random(&mut rng), UInt::random(&mut rng)];
+                let moduli = [
+                    NonZero::<UInt<$size>>::random(&mut rng),
+                    NonZero::<UInt<$size>>::random(&mut rng),
+                ];
 
                 for p in &moduli {
                     let base_cases = [
@@ -79,7 +79,7 @@ mod tests {
                             let (a, b) = if a < b { (b, a) } else { (a, b) };
 
                             let c = a.sub_mod(&b, p);
-                            assert!(c < *p, "not reduced");
+                            assert!(c < **p, "not reduced");
                             assert_eq!(c, a.wrapping_sub(&b), "result incorrect");
                         }
                     }
@@ -89,10 +89,10 @@ mod tests {
                         let b = UInt::<$size>::random_mod(&mut rng, p);
 
                         let c = a.sub_mod(&b, p);
-                        assert!(c < *p, "not reduced: {} >= {} ", c, p);
+                        assert!(c < **p, "not reduced: {} >= {} ", c, p);
 
                         let x = a.wrapping_sub(&b);
-                        if a >= b && x < *p {
+                        if a >= b && x < **p {
                             assert_eq!(c, x, "incorrect result");
                         }
                     }


### PR DESCRIPTION
Changes the modulus for `random_mod` to be `NonZero`.

Changes the algorithm used by `random_mod` to generate a number that can be represented by the same number of bytes as the modulus.

Such a number can still be larger than the modulus, but is much more likely not to overflow than a "full-width" number provided the modulus is small relative to the width.

Closes #3 cc @Sc00bz 