### PR TITLE
Make `limb` module private; rename `limb::Inner` to `LimbUInt`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,16 +44,23 @@ mod macros;
 #[cfg(feature = "generic-array")]
 mod array;
 mod checked;
-pub mod limb;
+mod limb;
 mod non_zero;
 mod traits;
 mod uint;
 mod wrapping;
 
 pub use crate::{
-    checked::Checked, limb::Limb, non_zero::NonZero, traits::*, uint::*, wrapping::Wrapping,
+    checked::Checked,
+    limb::{Limb, LimbUInt, WideLimbUInt},
+    non_zero::NonZero,
+    traits::*,
+    uint::*,
+    wrapping::Wrapping,
 };
 pub use subtle;
+
+pub(crate) use limb::{LimbInt, WideLimbInt};
 
 #[cfg(feature = "generic-array")]
 pub use {

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -29,66 +29,50 @@ compile_error!("this crate builds on 32-bit and 64-bit platforms only");
 // 32-bit definitions
 //
 
-/// Size of the inner integer in bits.
-#[cfg(target_pointer_width = "32")]
-pub const BIT_SIZE: usize = 32;
-
-/// Size of the inner integer in bytes.
-#[cfg(target_pointer_width = "32")]
-pub const BYTE_SIZE: usize = 4;
-
 /// Inner integer type that the [`Limb`] newtype wraps.
 #[cfg(target_pointer_width = "32")]
-pub type Inner = u32;
+pub type LimbUInt = u32;
 
-/// SignedInner integer type that the [`Limb`] newtype wraps.
+/// Signed integer type that corresponds to [`LimbUInt`].
 #[cfg(target_pointer_width = "32")]
-pub(crate) type SignedInner = i32;
+pub(crate) type LimbInt = i32;
 
-/// Wide integer type: double the width of [`Inner`].
+/// Unsigned wide integer type: double the width of [`LimbUInt`].
 #[cfg(target_pointer_width = "32")]
-pub type Wide = u64;
+pub type WideLimbUInt = u64;
 
-/// SignedInner integer type: double the width of [`Limb`].
+/// Signed wide integer type: double the width of [`Limb`].
 #[cfg(target_pointer_width = "32")]
-pub(crate) type SignedWide = i64;
+pub(crate) type WideLimbInt = i64;
 
 //
 // 64-bit definitions
 //
 
-/// Size of the inner integer in bits.
+/// Unsigned integer type that the [`Limb`] newtype wraps.
 #[cfg(target_pointer_width = "64")]
-pub const BIT_SIZE: usize = 64;
+pub type LimbUInt = u64;
 
-/// Size of the inner integer in bytes.
+/// Signed integer type that corresponds to [`LimbUInt`].
 #[cfg(target_pointer_width = "64")]
-pub const BYTE_SIZE: usize = 8;
+pub(crate) type LimbInt = i64;
 
-/// Inner integer type that the [`Limb`] newtype wraps.
+/// Wide integer type: double the width of [`LimbUInt`].
 #[cfg(target_pointer_width = "64")]
-pub type Inner = u64;
+pub type WideLimbUInt = u128;
 
-/// SignedInner integer type that the [`Limb`] newtype wraps.
+/// Signed wide integer type: double the width of [`Limb`].
 #[cfg(target_pointer_width = "64")]
-pub(crate) type SignedInner = i64;
-
-/// Wide integer type: double the width of [`Inner`].
-#[cfg(target_pointer_width = "64")]
-pub type Wide = u128;
-
-/// SignedInner integer type: double the width of [`Limb`].
-#[cfg(target_pointer_width = "64")]
-pub(crate) type SignedWide = i128;
+pub(crate) type WideLimbInt = i128;
 
 /// Highest bit in a [`Limb`].
-pub(crate) const HI_BIT: usize = BIT_SIZE - 1;
+pub(crate) const HI_BIT: usize = Limb::BIT_SIZE - 1;
 
 /// Big integers are represented as an array of smaller CPU word-size integers
 /// called "limbs".
 #[derive(Copy, Clone, Debug, Default, Hash)]
 #[repr(transparent)]
-pub struct Limb(pub Inner);
+pub struct Limb(pub LimbUInt);
 
 impl Limb {
     /// The value `0`.
@@ -98,19 +82,31 @@ impl Limb {
     pub const ONE: Self = Limb(1);
 
     /// Maximum value this [`Limb`] can express.
-    pub const MAX: Self = Limb(Inner::MAX);
+    pub const MAX: Self = Limb(LimbUInt::MAX);
+
+    // 32-bit
 
     /// Size of the inner integer in bits.
-    pub const BIT_SIZE: usize = BIT_SIZE;
-
+    #[cfg(target_pointer_width = "32")]
+    pub const BIT_SIZE: usize = 32;
     /// Size of the inner integer in bytes.
-    pub const BYTE_SIZE: usize = BYTE_SIZE;
+    #[cfg(target_pointer_width = "32")]
+    pub const BYTE_SIZE: usize = 4;
+
+    // 64-bit
+
+    /// Size of the inner integer in bits.
+    #[cfg(target_pointer_width = "64")]
+    pub const BIT_SIZE: usize = 64;
+    /// Size of the inner integer in bytes.
+    #[cfg(target_pointer_width = "64")]
+    pub const BYTE_SIZE: usize = 8;
 
     /// Return `a` if `c`!=0 or `b` if `c`==0.
     ///
     /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
     #[inline]
-    pub(crate) const fn ct_select(a: Self, b: Self, c: Inner) -> Self {
+    pub(crate) const fn ct_select(a: Self, b: Self, c: LimbUInt) -> Self {
         Self(a.0 ^ (c & (a.0 ^ b.0)))
     }
 }
@@ -118,7 +114,7 @@ impl Limb {
 impl ConditionallySelectable for Limb {
     #[inline]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        Self(Inner::conditional_select(&a.0, &b.0, choice))
+        Self(LimbUInt::conditional_select(&a.0, &b.0, choice))
     }
 }
 

--- a/src/limb/add.rs
+++ b/src/limb/add.rs
@@ -1,6 +1,6 @@
 //! Limb addition
 
-use super::{Inner, Limb, Wide};
+use super::{Limb, LimbUInt, WideLimbUInt};
 use crate::{Checked, Wrapping};
 use core::ops::{Add, AddAssign};
 use subtle::CtOption;
@@ -9,11 +9,14 @@ impl Limb {
     /// Computes `self + rhs + carry`, returning the result along with the new carry.
     #[inline(always)]
     pub const fn adc(self, rhs: Limb, carry: Limb) -> (Limb, Limb) {
-        let a = self.0 as Wide;
-        let b = rhs.0 as Wide;
-        let carry = carry.0 as Wide;
+        let a = self.0 as WideLimbUInt;
+        let b = rhs.0 as WideLimbUInt;
+        let carry = carry.0 as WideLimbUInt;
         let ret = a + b + carry;
-        (Limb(ret as Inner), Limb((ret >> Self::BIT_SIZE) as Inner))
+        (
+            Limb(ret as LimbUInt),
+            Limb((ret >> Self::BIT_SIZE) as LimbUInt),
+        )
     }
 
     /// Perform checked addition, returning a [`CtOption`] which `is_some` only

--- a/src/limb/bits.rs
+++ b/src/limb/bits.rs
@@ -1,8 +1,8 @@
-use super::{Limb, BIT_SIZE};
+use super::Limb;
 
 impl Limb {
     /// Calculate the number of bits needed to represent this number.
     pub const fn bits(self) -> usize {
-        BIT_SIZE - (self.0.leading_zeros() as usize)
+        Limb::BIT_SIZE - (self.0.leading_zeros() as usize)
     }
 }

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -1,6 +1,6 @@
 //! Limb comparisons
 
-use super::{Inner, Limb, SignedInner, SignedWide, BIT_SIZE, HI_BIT};
+use super::{Limb, LimbInt, LimbUInt, WideLimbInt, HI_BIT};
 use core::cmp::Ordering;
 use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
@@ -34,18 +34,18 @@ impl Limb {
     ///
     /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
     #[inline]
-    pub(crate) const fn is_nonzero(self) -> Inner {
-        let inner = self.0 as SignedInner;
-        ((inner | inner.saturating_neg()) >> HI_BIT) as Inner
+    pub(crate) const fn is_nonzero(self) -> LimbUInt {
+        let inner = self.0 as LimbInt;
+        ((inner | inner.saturating_neg()) >> HI_BIT) as LimbUInt
     }
 
     #[inline]
-    pub(crate) const fn ct_cmp(lhs: Self, rhs: Self) -> SignedInner {
-        let a = lhs.0 as SignedWide;
-        let b = rhs.0 as SignedWide;
-        let gt = ((b - a) >> BIT_SIZE) & 1;
-        let lt = ((a - b) >> BIT_SIZE) & 1 & !gt;
-        (gt as SignedInner) - (lt as SignedInner)
+    pub(crate) const fn ct_cmp(lhs: Self, rhs: Self) -> LimbInt {
+        let a = lhs.0 as WideLimbInt;
+        let b = rhs.0 as WideLimbInt;
+        let gt = ((b - a) >> Limb::BIT_SIZE) & 1;
+        let lt = ((a - b) >> Limb::BIT_SIZE) & 1 & !gt;
+        (gt as LimbInt) - (lt as LimbInt)
     }
 }
 

--- a/src/limb/encoding.rs
+++ b/src/limb/encoding.rs
@@ -1,11 +1,11 @@
 //! Limb encoding
 
-use super::{Inner, Limb};
+use super::{Limb, LimbUInt};
 use crate::Encoding;
 
 impl Encoding for Limb {
-    const BIT_SIZE: usize = super::BIT_SIZE;
-    const BYTE_SIZE: usize = super::BYTE_SIZE;
+    const BIT_SIZE: usize = Self::BIT_SIZE;
+    const BYTE_SIZE: usize = Self::BYTE_SIZE;
 
     #[cfg(target_pointer_width = "32")]
     type Repr = [u8; 4];
@@ -14,12 +14,12 @@ impl Encoding for Limb {
 
     #[inline]
     fn from_be_bytes(bytes: Self::Repr) -> Self {
-        Limb(Inner::from_be_bytes(bytes))
+        Limb(LimbUInt::from_be_bytes(bytes))
     }
 
     #[inline]
     fn from_le_bytes(bytes: Self::Repr) -> Self {
-        Limb(Inner::from_le_bytes(bytes))
+        Limb(LimbUInt::from_le_bytes(bytes))
     }
 
     #[inline]

--- a/src/limb/from.rs
+++ b/src/limb/from.rs
@@ -1,24 +1,24 @@
 //! `From`-like conversions for [`Limb`].
 
-use super::{Inner, Limb, Wide};
+use super::{Limb, LimbUInt, WideLimbUInt};
 
 impl Limb {
     /// Create a [`Limb`] from a `u8` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u8>` when stable
     pub const fn from_u8(n: u8) -> Self {
-        Limb(n as Inner)
+        Limb(n as LimbUInt)
     }
 
     /// Create a [`Limb`] from a `u16` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u16>` when stable
     pub const fn from_u16(n: u16) -> Self {
-        Limb(n as Inner)
+        Limb(n as LimbUInt)
     }
 
     /// Create a [`Limb`] from a `u32` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u32>` when stable
     pub const fn from_u32(n: u32) -> Self {
-        Limb(n as Inner)
+        Limb(n as LimbUInt)
     }
 
     /// Create a [`Limb`] from a `u64` integer (const-friendly)
@@ -60,16 +60,16 @@ impl From<u64> for Limb {
     }
 }
 
-impl From<Limb> for Inner {
+impl From<Limb> for LimbUInt {
     #[inline]
-    fn from(limb: Limb) -> Inner {
+    fn from(limb: Limb) -> LimbUInt {
         limb.0
     }
 }
 
-impl From<Limb> for Wide {
+impl From<Limb> for WideLimbUInt {
     #[inline]
-    fn from(limb: Limb) -> Wide {
+    fn from(limb: Limb) -> WideLimbUInt {
         limb.0.into()
     }
 }

--- a/src/limb/rand.rs
+++ b/src/limb/rand.rs
@@ -1,6 +1,6 @@
 //! Random number generator support
 
-use super::{Limb, BYTE_SIZE};
+use super::Limb;
 use crate::{Encoding, NonZero, Random, RandomMod};
 use rand_core::{CryptoRng, RngCore};
 use subtle::ConstantTimeLess;
@@ -29,7 +29,7 @@ impl RandomMod for Limb {
 
         // Ensure the randomly generated value can always be larger than
         // the modulus in order to ensure a uniform distribution
-        if n_bytes < BYTE_SIZE {
+        if n_bytes < Self::BYTE_SIZE {
             n_bytes += 1;
         }
 

--- a/src/limb/sub.rs
+++ b/src/limb/sub.rs
@@ -1,6 +1,6 @@
 //! Limb subtraction
 
-use super::{Inner, Limb, Wide};
+use super::{Limb, LimbUInt, WideLimbUInt};
 use crate::{Checked, Wrapping};
 use core::ops::{Sub, SubAssign};
 use subtle::CtOption;
@@ -9,11 +9,14 @@ impl Limb {
     /// Computes `self - (rhs + borrow)`, returning the result along with the new borrow.
     #[inline(always)]
     pub const fn sbb(self, rhs: Limb, borrow: Limb) -> (Limb, Limb) {
-        let a = self.0 as Wide;
-        let b = rhs.0 as Wide;
-        let borrow = (borrow.0 >> (Self::BIT_SIZE - 1)) as Wide;
+        let a = self.0 as WideLimbUInt;
+        let b = rhs.0 as WideLimbUInt;
+        let borrow = (borrow.0 >> (Self::BIT_SIZE - 1)) as WideLimbUInt;
         let ret = a.wrapping_sub(b + borrow);
-        (Limb(ret as Inner), Limb((ret >> Self::BIT_SIZE) as Inner))
+        (
+            Limb(ret as LimbUInt),
+            Limb((ret >> Self::BIT_SIZE) as LimbUInt),
+        )
     }
 
     /// Perform checked subtraction, returning a [`CtOption`] which `is_some`

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -14,7 +14,7 @@ macro_rules! const_assert {
 #[macro_export]
 macro_rules! nlimbs {
     ($bits:expr) => {
-        $bits / $crate::limb::BIT_SIZE
+        $bits / $crate::Limb::BIT_SIZE
     };
 }
 

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -1,5 +1,4 @@
-use crate::limb::{Inner, BIT_SIZE};
-use crate::{Limb, UInt};
+use crate::{Limb, LimbUInt, UInt};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Calculate the number of bits needed to represent this number.
@@ -10,12 +9,12 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         }
 
         let limb = self.limbs[i].0;
-        let bits = (BIT_SIZE * (i + 1)) as Inner - limb.leading_zeros() as Inner;
+        let bits = (Limb::BIT_SIZE * (i + 1)) as LimbUInt - limb.leading_zeros() as LimbUInt;
 
         Limb::ct_select(
             Limb(bits),
             Limb::ZERO,
-            !self.limbs[0].is_nonzero() & !Limb(i as Inner).is_nonzero(),
+            !self.limbs[0].is_nonzero() & !Limb(i as LimbUInt).is_nonzero(),
         )
         .0 as usize
     }

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -3,8 +3,7 @@
 //! By default these are all constant-time and use the `subtle` crate.
 
 use super::UInt;
-use crate::limb::{Inner, SignedInner, SignedWide, BIT_SIZE};
-use crate::Limb;
+use crate::{Limb, LimbInt, LimbUInt, WideLimbInt};
 use core::cmp::Ordering;
 use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
@@ -31,7 +30,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     ///
     /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
     #[inline]
-    pub(crate) const fn ct_select(a: UInt<LIMBS>, b: UInt<LIMBS>, c: Inner) -> Self {
+    pub(crate) const fn ct_select(a: UInt<LIMBS>, b: UInt<LIMBS>, c: LimbUInt) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
 
         let mut i = 0;
@@ -47,7 +46,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     ///
     /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
     #[inline]
-    pub(crate) const fn ct_is_nonzero(&self) -> Inner {
+    pub(crate) const fn ct_is_nonzero(&self) -> LimbUInt {
         let mut b = 0;
         let mut i = 0;
         while i < LIMBS {
@@ -63,19 +62,19 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     ///
     /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
     #[inline]
-    pub(crate) const fn ct_cmp(&self, rhs: &Self) -> SignedInner {
+    pub(crate) const fn ct_cmp(&self, rhs: &Self) -> LimbInt {
         let mut gt = 0;
         let mut lt = 0;
         let mut i = LIMBS;
 
         while i > 0 {
-            let a = self.limbs[i - 1].0 as SignedWide;
-            let b = rhs.limbs[i - 1].0 as SignedWide;
-            gt |= ((b - a) >> BIT_SIZE) & 1 & !lt;
-            lt |= ((a - b) >> BIT_SIZE) & 1 & !gt;
+            let a = self.limbs[i - 1].0 as WideLimbInt;
+            let b = rhs.limbs[i - 1].0 as WideLimbInt;
+            gt |= ((b - a) >> Limb::BIT_SIZE) & 1 & !lt;
+            lt |= ((a - b) >> Limb::BIT_SIZE) & 1 & !gt;
             i -= 1;
         }
-        (gt as SignedInner) - (lt as SignedInner)
+        (gt as LimbInt) - (lt as LimbInt)
     }
 }
 

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -6,21 +6,21 @@ mod decoder;
 mod rlp;
 
 use super::UInt;
-use crate::{limb, Encoding};
+use crate::{Encoding, Limb};
 use decoder::Decoder;
 
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Create a new [`UInt`] from the provided big endian bytes.
     pub const fn from_be_slice(bytes: &[u8]) -> Self {
         const_assert!(
-            bytes.len() == limb::BYTE_SIZE * LIMBS,
+            bytes.len() == Limb::BYTE_SIZE * LIMBS,
             "bytes are not the expected size"
         );
 
         let mut decoder = Decoder::new();
         let mut i = 0;
 
-        while i < limb::BYTE_SIZE * LIMBS {
+        while i < Limb::BYTE_SIZE * LIMBS {
             i += 1;
             decoder = decoder.add_byte(bytes[bytes.len() - i]);
         }
@@ -33,14 +33,14 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         let bytes = hex.as_bytes();
 
         const_assert!(
-            bytes.len() == limb::BYTE_SIZE * LIMBS * 2,
+            bytes.len() == Limb::BYTE_SIZE * LIMBS * 2,
             "hex string is not the expected size"
         );
 
         let mut decoder = Decoder::new();
         let mut i = 0;
 
-        while i < limb::BYTE_SIZE * LIMBS * 2 {
+        while i < Limb::BYTE_SIZE * LIMBS * 2 {
             i += 2;
             let offset = bytes.len() - i;
             let byte = decode_hex_byte([bytes[offset], bytes[offset + 1]]);
@@ -53,14 +53,14 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     /// Create a new [`UInt`] from the provided little endian bytes.
     pub const fn from_le_slice(bytes: &[u8]) -> Self {
         const_assert!(
-            bytes.len() == limb::BYTE_SIZE * LIMBS,
+            bytes.len() == Limb::BYTE_SIZE * LIMBS,
             "bytes are not the expected size"
         );
 
         let mut decoder = Decoder::new();
         let mut i = 0;
 
-        while i < limb::BYTE_SIZE * LIMBS {
+        while i < Limb::BYTE_SIZE * LIMBS {
             decoder = decoder.add_byte(bytes[i]);
             i += 1;
         }
@@ -73,14 +73,14 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         let bytes = hex.as_bytes();
 
         const_assert!(
-            bytes.len() == limb::BYTE_SIZE * LIMBS * 2,
+            bytes.len() == Limb::BYTE_SIZE * LIMBS * 2,
             "bytes are not the expected size"
         );
 
         let mut decoder = Decoder::new();
         let mut i = 0;
 
-        while i < limb::BYTE_SIZE * LIMBS * 2 {
+        while i < Limb::BYTE_SIZE * LIMBS * 2 {
             let byte = decode_hex_byte([bytes[i], bytes[i + 1]]);
             decoder = decoder.add_byte(byte);
             i += 2;
@@ -94,14 +94,14 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     #[inline]
     #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
     pub(crate) fn write_be_bytes(&self, out: &mut [u8]) {
-        debug_assert_eq!(out.len(), limb::BYTE_SIZE * LIMBS);
+        debug_assert_eq!(out.len(), Limb::BYTE_SIZE * LIMBS);
 
         for (src, dst) in self
             .limbs
             .iter()
             .rev()
             .cloned()
-            .zip(out.chunks_exact_mut(limb::BYTE_SIZE))
+            .zip(out.chunks_exact_mut(Limb::BYTE_SIZE))
         {
             dst.copy_from_slice(&src.to_be_bytes());
         }
@@ -112,13 +112,13 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     #[inline]
     #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
     pub(crate) fn write_le_bytes(&self, out: &mut [u8]) {
-        debug_assert_eq!(out.len(), limb::BYTE_SIZE * LIMBS);
+        debug_assert_eq!(out.len(), Limb::BYTE_SIZE * LIMBS);
 
         for (src, dst) in self
             .limbs
             .iter()
             .cloned()
-            .zip(out.chunks_exact_mut(limb::BYTE_SIZE))
+            .zip(out.chunks_exact_mut(Limb::BYTE_SIZE))
         {
             dst.copy_from_slice(&src.to_le_bytes());
         }

--- a/src/uint/encoding/decoder.rs
+++ b/src/uint/encoding/decoder.rs
@@ -1,4 +1,4 @@
-use crate::{limb, Limb, UInt};
+use crate::{Limb, LimbUInt, UInt};
 
 /// [`UInt`] decoder.
 #[derive(Clone, Debug)]
@@ -27,13 +27,13 @@ impl<const LIMBS: usize> Decoder<LIMBS> {
 
     /// Add a byte onto the [`UInt`] being decoded.
     pub const fn add_byte(mut self, byte: u8) -> Self {
-        if self.bytes == limb::BYTE_SIZE {
+        if self.bytes == Limb::BYTE_SIZE {
             const_assert!(self.index < LIMBS, "too many bytes in UInt");
             self.index += 1;
             self.bytes = 0;
         }
 
-        self.limbs[self.index].0 |= (byte as limb::Inner) << (self.bytes * 8);
+        self.limbs[self.index].0 |= (byte as LimbUInt) << (self.bytes * 8);
         self.bytes += 1;
         self
     }
@@ -43,7 +43,7 @@ impl<const LIMBS: usize> Decoder<LIMBS> {
     pub const fn finish(self) -> UInt<LIMBS> {
         const_assert!(self.index == LIMBS - 1, "decoded UInt is missing limbs");
         const_assert!(
-            self.bytes == limb::BYTE_SIZE,
+            self.bytes == Limb::BYTE_SIZE,
             "decoded UInt is missing bytes"
         );
         UInt { limbs: self.limbs }

--- a/src/uint/from.rs
+++ b/src/uint/from.rs
@@ -1,6 +1,6 @@
 //! `From`-like conversions for [`UInt`].
 
-use crate::{limb, Limb, Split, UInt, U128, U64};
+use crate::{Limb, LimbUInt, Split, UInt, U128, U64};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Create a [`UInt`] from a `u8` (const-friendly)
@@ -8,7 +8,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     pub const fn from_u8(n: u8) -> Self {
         const_assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
-        limbs[0].0 = n as limb::Inner;
+        limbs[0].0 = n as LimbUInt;
         Self { limbs }
     }
 
@@ -17,7 +17,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     pub const fn from_u16(n: u16) -> Self {
         const_assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
-        limbs[0].0 = n as limb::Inner;
+        limbs[0].0 = n as LimbUInt;
         Self { limbs }
     }
 
@@ -26,7 +26,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     pub const fn from_u32(n: u32) -> Self {
         const_assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
-        limbs[0].0 = n as limb::Inner;
+        limbs[0].0 = n as LimbUInt;
         Self { limbs }
     }
 
@@ -47,7 +47,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     pub const fn from_u64(n: u64) -> Self {
         const_assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
-        limbs[0].0 = n as limb::Inner;
+        limbs[0].0 = n as LimbUInt;
         Self { limbs }
     }
 
@@ -55,7 +55,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     // TODO(tarcieri): replace with `const impl From<u128>` when stable
     pub const fn from_u128(n: u128) -> Self {
         const_assert!(
-            LIMBS >= (128 / limb::BIT_SIZE),
+            LIMBS >= (128 / Limb::BIT_SIZE),
             "number of limbs must be greater than zero"
         );
 
@@ -79,11 +79,11 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         Self { limbs }
     }
 
-    /// Create a [`UInt`] from an array of the [`limb::Inner`]
+    /// Create a [`UInt`] from an array of the [`LimbUInt`]
     /// unsigned integer type.
-    // TODO(tarcieri): replace with `const impl From<[limb::Inner; LIMBS]>` when stable
+    // TODO(tarcieri): replace with `const impl From<[LimbUInt; LIMBS]>` when stable
     #[inline]
-    pub const fn from_uint_array(arr: [limb::Inner; LIMBS]) -> Self {
+    pub const fn from_uint_array(arr: [LimbUInt; LIMBS]) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;
 
@@ -95,10 +95,10 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         Self { limbs }
     }
 
-    /// Create an array of [`limb::Inner`] unsigned integer type from a [`UInt`].
+    /// Create an array of [`LimbUInt`] unsigned integers from a [`UInt`].
     #[inline]
     // TODO(tarcieri): replace with `const impl From<Self> for [limb::Inner; LIMBS]` when stable
-    pub const fn to_uint_array(self) -> [limb::Inner; LIMBS] {
+    pub const fn to_uint_array(self) -> [LimbUInt; LIMBS] {
         let mut arr = [0; LIMBS];
         let mut i = 0;
 
@@ -138,7 +138,7 @@ impl<const LIMBS: usize> From<u32> for UInt<LIMBS> {
 impl<const LIMBS: usize> From<u64> for UInt<LIMBS> {
     fn from(n: u64) -> Self {
         // TODO(tarcieri): const where clause when possible
-        debug_assert!(LIMBS >= (64 / limb::BIT_SIZE), "not enough limbs");
+        debug_assert!(LIMBS >= (64 / Limb::BIT_SIZE), "not enough limbs");
         Self::from_u64(n)
     }
 }
@@ -146,7 +146,7 @@ impl<const LIMBS: usize> From<u64> for UInt<LIMBS> {
 impl<const LIMBS: usize> From<u128> for UInt<LIMBS> {
     fn from(n: u128) -> Self {
         // TODO(tarcieri): const where clause when possible
-        debug_assert!(LIMBS >= (128 / limb::BIT_SIZE), "not enough limbs");
+        debug_assert!(LIMBS >= (128 / Limb::BIT_SIZE), "not enough limbs");
         Self::from_u128(n)
     }
 }
@@ -174,14 +174,14 @@ impl From<U128> for u128 {
     }
 }
 
-impl<const LIMBS: usize> From<[limb::Inner; LIMBS]> for UInt<LIMBS> {
-    fn from(arr: [limb::Inner; LIMBS]) -> Self {
+impl<const LIMBS: usize> From<[LimbUInt; LIMBS]> for UInt<LIMBS> {
+    fn from(arr: [LimbUInt; LIMBS]) -> Self {
         Self::from_uint_array(arr)
     }
 }
 
-impl<const LIMBS: usize> From<UInt<LIMBS>> for [limb::Inner; LIMBS] {
-    fn from(n: UInt<LIMBS>) -> [limb::Inner; LIMBS] {
+impl<const LIMBS: usize> From<UInt<LIMBS>> for [LimbUInt; LIMBS] {
+    fn from(n: UInt<LIMBS>) -> [LimbUInt; LIMBS] {
         n.to_uint_array()
     }
 }
@@ -206,7 +206,7 @@ impl<const LIMBS: usize> From<Limb> for UInt<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{limb, Limb, U128};
+    use crate::{Limb, LimbUInt, U128};
 
     #[cfg(target_pointer_width = "32")]
     use crate::U64 as UIntEx;
@@ -243,7 +243,7 @@ mod tests {
     fn array_round_trip() {
         let arr1 = [1, 2];
         let n = UIntEx::from(arr1);
-        let arr2: [limb::Inner; 2] = n.into();
+        let arr2: [LimbUInt; 2] = n.into();
         assert_eq!(arr1, arr2);
     }
 }

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -1,8 +1,6 @@
 //! [`UInt`] bitwise left shift operations.
 
-use super::UInt;
-use crate::limb::{Inner, BIT_SIZE};
-use crate::Limb;
+use crate::{Limb, LimbUInt, UInt};
 use core::ops::{Shl, ShlAssign};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
@@ -16,15 +14,16 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     pub const fn shl_vartime(&self, n: usize) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
 
-        if n >= BIT_SIZE * LIMBS {
+        if n >= Limb::BIT_SIZE * LIMBS {
             return Self { limbs };
         }
 
-        let shift_num = n / BIT_SIZE;
-        let rem = n % BIT_SIZE;
-        let nz = Limb(rem as Inner).is_nonzero();
-        let lshift_rem = rem as Inner;
-        let rshift_rem = Limb::ct_select(Limb::ZERO, Limb((BIT_SIZE - rem) as Inner), nz).0;
+        let shift_num = n / Limb::BIT_SIZE;
+        let rem = n % Limb::BIT_SIZE;
+        let nz = Limb(rem as LimbUInt).is_nonzero();
+        let lshift_rem = rem as LimbUInt;
+        let rshift_rem =
+            Limb::ct_select(Limb::ZERO, Limb((Limb::BIT_SIZE - rem) as LimbUInt), nz).0;
 
         let mut i = LIMBS - 1;
         while i > shift_num {

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -1,7 +1,7 @@
 //! [`UInt`] bitwise right shift operations.
 
 use super::UInt;
-use crate::{limb, Limb};
+use crate::Limb;
 use core::ops::{Shr, ShrAssign};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
@@ -13,11 +13,11 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     /// to `self`.
     #[inline(always)]
     pub const fn shr_vartime(&self, shift: usize) -> Self {
-        let full_shifts = shift / limb::BIT_SIZE;
-        let small_shift = shift & (limb::BIT_SIZE - 1);
+        let full_shifts = shift / Limb::BIT_SIZE;
+        let small_shift = shift & (Limb::BIT_SIZE - 1);
         let mut limbs = [Limb::ZERO; LIMBS];
 
-        if shift > limb::BIT_SIZE * LIMBS {
+        if shift > Limb::BIT_SIZE * LIMBS {
             return Self { limbs };
         }
 
@@ -34,7 +34,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
                 let mut lo = self.limbs[i + full_shifts].0 >> small_shift;
 
                 if i < (LIMBS - 1) - full_shifts {
-                    lo |= self.limbs[i + full_shifts + 1].0 << (limb::BIT_SIZE - small_shift);
+                    lo |= self.limbs[i + full_shifts + 1].0 << (Limb::BIT_SIZE - small_shift);
                 }
 
                 limbs[i] = Limb(lo);

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -1,7 +1,7 @@
 //! [`UInt`] square root operations.
 
 use super::UInt;
-use crate::limb::Inner;
+use crate::limb::LimbUInt;
 use crate::Limb;
 use subtle::{ConstantTimeEq, CtOption};
 
@@ -26,8 +26,8 @@ impl<const LIMBS: usize> UInt<LIMBS> {
             // Sometimes an increase is too far, especially with large
             // powers, and then takes a long time to walk back.  The upper
             // bound is based on bit size, so saturate on that.
-            let res = Limb::ct_cmp(Limb(xn.bits() as Inner), Limb(max_bits as Inner)) - 1;
-            let le = Limb::is_nonzero(Limb(res as Inner));
+            let res = Limb::ct_cmp(Limb(xn.bits() as LimbUInt), Limb(max_bits as LimbUInt)) - 1;
+            let le = Limb::is_nonzero(Limb(res as LimbUInt));
             guess = Self::ct_select(cap, xn, le);
             xn = {
                 let q = self.wrapping_div(&guess);
@@ -37,7 +37,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         }
 
         // Repeat while guess decreases.
-        while guess.ct_cmp(&xn) == 1 && xn.ct_is_nonzero() == Inner::MAX {
+        while guess.ct_cmp(&xn) == 1 && xn.ct_is_nonzero() == LimbUInt::MAX {
             guess = xn;
             xn = {
                 let q = self.wrapping_div(&guess);


### PR DESCRIPTION
Also promotes `limb::BIT_SIZE` and `limb::BYTE_SIZE` to inherent constants of the `Limb` type.