### PR TITLE
Expand rustc lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,15 @@
     html_root_url = "https://docs.rs/crypto-bigint/0.3.0-pre"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![warn(
+    missing_docs,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    rust_2018_idioms,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications
+)]
 
 #[cfg(all(feature = "alloc", test))]
 extern crate alloc;

--- a/src/limb/from.rs
+++ b/src/limb/from.rs
@@ -18,6 +18,7 @@ impl Limb {
     /// Create a [`Limb`] from a `u32` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u32>` when stable
     pub const fn from_u32(n: u32) -> Self {
+        #[allow(trivial_numeric_casts)]
         Limb(n as LimbUInt)
     }
 

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -17,7 +17,7 @@ use crate::{ArrayEncoding, ByteArray};
 use rand_core::{CryptoRng, RngCore};
 
 /// Wrapper type for non-zero integers.
-#[derive(Copy, Clone, Default, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct NonZero<T: Zero>(T);
 
 impl<T> NonZero<T>

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -2,6 +2,7 @@ use crate::{Limb, LimbUInt, UInt};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Calculate the number of bits needed to represent this number.
+    #[allow(trivial_numeric_casts)]
     pub const fn bits(self) -> usize {
         let mut i = LIMBS - 1;
         while i > 0 && self.limbs[i].0 == 0 {

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -19,7 +19,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
     pub(crate) const fn ct_div_rem(&self, rhs: &Self) -> (Self, Self, u8) {
-        let mut bd = self.bits().saturating_sub(rhs.bits()) as usize;
+        let mut bd = self.bits().saturating_sub(rhs.bits());
         let mut rem = *self;
         let mut quo = Self::ZERO;
 
@@ -59,7 +59,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
     pub(crate) const fn ct_reduce(&self, rhs: &Self) -> (Self, u8) {
-        let mut bd = self.bits().saturating_sub(rhs.bits()) as usize;
+        let mut bd = self.bits().saturating_sub(rhs.bits());
         let mut rem = *self;
 
         let mut c = rhs.shl_vartime(bd);

--- a/src/uint/from.rs
+++ b/src/uint/from.rs
@@ -23,6 +23,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
 
     /// Create a [`UInt`] from a `u32` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u32>` when stable
+    #[allow(trivial_numeric_casts)]
     pub const fn from_u32(n: u32) -> Self {
         const_assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
@@ -47,7 +48,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     pub const fn from_u64(n: u64) -> Self {
         const_assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
-        limbs[0].0 = n as LimbUInt;
+        limbs[0].0 = n;
         Self { limbs }
     }
 

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -10,7 +10,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     ///
     /// Callers can check if `self` is a square by squaring the result
     pub const fn sqrt(&self) -> Self {
-        let max_bits = ((self.bits() + 1) >> 1) as usize;
+        let max_bits = (self.bits() + 1) >> 1;
         let cap = Self::ONE.shl_vartime(max_bits);
         let mut guess = cap; // ≥ √(`self`)
         let mut xn = {

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -8,7 +8,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 ///
 /// This is analogous to [`core::num::Wrapping`] but allows this crate to
 /// define trait impls for this type.
-#[derive(Copy, Clone, Default, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Wrapping<T>(pub T);
 
 impl<T: Zero> Zero for Wrapping<T> {


### PR DESCRIPTION
Adds a number of additional lints as a `#![warn(...)]` directive, including `trivial_numeric_casts`, which caught a number of redundancies.