### PR TITLE
Documentation improvements

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -35,10 +35,10 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features generic-array
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rand
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rand_core
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rlp
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features zeroize
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,generic-array,rand,rlp,zeroize
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,generic-array,rand_core,rlp,zeroize
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,13 @@ hex-literal = "0.3"
 num-bigint = "0.4"
 num-traits = "0.2"
 proptest = "1"
+rand_core = { version = "0.6", features = ["std"] }
 rand_chacha = "0.3"
 
 [features]
 default = ["rand"]
 alloc = []
-rand = ["rand_core"]
+rand = ["rand_core/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/checked.rs
+++ b/src/checked.rs
@@ -1,6 +1,5 @@
 //! Checked arithmetic.
 
-use core::ops::Deref;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 /// Provides intentionally-checked arithmetic on `T`.
@@ -23,14 +22,6 @@ where
 {
     fn default() -> Self {
         Self::new(T::default())
-    }
-}
-
-impl<T> Deref for Checked<T> {
-    type Target = CtOption<T>;
-
-    fn deref(&self) -> &CtOption<T> {
-        &self.0
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,29 +1,124 @@
-//! Pure Rust implementation of a big integer library designed for cryptography.
+#![doc = include_str!("../README.md")]
+
+//! ## Usage
 //!
-//! # About
-//! This library has been designed  from the ground-up for use in cryptographic
-//! applications. It provides constant-time, `no_std`-friendly implementations
-//! of modern formulas implemented using const generics.
+//! This crate defines a [`UInt`] type which is const generic around an inner
+//! [`Limb`] array, where a [`Limb`] is a newtype for a word-sized integer.
+//! Thus large integers are represented as a arrays of smaller integers which
+//! are sized appropriately for the CPU, giving us some assurances of how
+//! arithmetic operations over those smaller integers will behave.
 //!
-//! # Minimum Supported Rust Version
-//! **Rust 1.56** at a minimum.
+//! To obtain appropriately sized integers regardless of what a given CPU's
+//! word size happens to be, a number of portable type aliases are provided for
+//! integer sizes commonly used in cryptography, for example:
+//! [`U128`], [`U384`], [`U256`], [`U2048`], [`U3072`], [`U4096`].
 //!
-//! # Goals
-//! - No heap allocations i.e. `no_std`-friendly.
-//! - Constant-time by default using traits from the [`subtle`] crate.
-//! - Leverage what is possible today with const generics on `stable` rust.
-//! - Support `const fn` as much as possible, including decoding big integers from
-//!   bytes/hex and performing arithmetic operations on them, with the goal of
-//!   being able to compute values at compile-time.
+//! ### `const fn` usage
 //!
-//! # Status
-//! This library presently provides only a baseline level of functionality.
-//! It's new, unaudited, and may contain bugs. We recommend that it only be
-//! used in an experimental capacity for now.
+//! The [`UInt`] type provides a number of `const fn` inherent methods which
+//! can be used for initializing and performing arithmetic on big integers in
+//! const contexts:
 //!
-//! Please see the [feature wishlist tracking ticket] for more information.
+//! ```
+//! use crypto_bigint::U256;
 //!
-//! [feature wishlist tracking ticket]: https://github.com/RustCrypto/crypto-bigint/issues/1
+//! // Parse a constant from a big endian hexadecimal string.
+//! pub const MODULUS: U256 =
+//!     U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
+//!
+//! // Compute `MODULUS` shifted right by 1 at compile time
+//! pub const MODULUS_SHR1: U256 = MODULUS.shr_vartime(1);
+//! ```
+//!
+//! ### Trait-based usage
+//!
+//! The [`UInt`] type itself does not implement the standard arithmetic traits
+//! such as [`Add`], [`Sub`], [`Mul`], and [`Div`].
+//!
+//! To use these traits you must first pick a wrapper type which determines
+//! overflow behavior: [`Wrapping`] or [`Checked`].
+//!
+//! #### Wrapping arithmetic
+//!
+//! ```
+//! use crypto_bigint::{U256, Wrapping};
+//!
+//! let a = Wrapping(U256::MAX);
+//! let b = Wrapping(U256::ONE);
+//! let c = a + b;
+//!
+//! // `MAX` + 1 wraps back around to zero
+//! assert_eq!(c.0, U256::ZERO);
+//! ```
+//!
+//! #### Checked arithmetic
+//!
+//! ```
+//! use crypto_bigint::{U256, Checked};
+//!
+//! let a = Checked::new(U256::ONE);
+//! let b = Checked::new(U256::from(2u8));
+//! let c = a + b;
+//! assert_eq!(c.0.unwrap(), U256::from(3u8))
+//! ```
+//!
+//! ### Modular arithmetic
+//!
+//! This library has initial support for modular arithmetic in the form of the
+//! [`AddMod`], [`SubMod`], [`NegMod`], and [`MulMod`] traits, as well as the
+//! support for the [`Rem`] trait when used with a [`NonZero`] operand.
+//!
+//! ```
+//! use crypto_bigint::{AddMod, U256};
+//!
+//! // mod 3
+//! let modulus = U256::from(3u8);
+//!
+//! // 1 + 1 mod 3 = 2
+//! let a = U256::ONE.add_mod(&U256::ONE, &modulus);
+//! assert_eq!(a, U256::from(2u8));
+//!
+//! // 2 + 1 mod 3 = 0
+//! let b = a.add_mod(&U256::ONE, &modulus);
+//! assert_eq!(b, U256::ZERO);
+//! ```
+//!
+//! ### Random number generation
+//!
+//! When the `rand_core` or `rand` features of this crate are enabled, it's
+//! possible to generate random numbers using any [`CryptoRng`] by using the
+//! [`Random`] trait:
+//!
+//! ```
+//! # #[cfg(feature = "rand")]
+//! # {
+//! use crypto_bigint::{Random, U256, rand_core::OsRng};
+//!
+//! let n = U256::random(&mut OsRng);
+//! # }
+//! ```
+//!
+//! #### Modular random number generation
+//!
+//! The [`RandomMod`] trait supports generating random numbers with a uniform
+//! distribution around a given [`NonZero`] modulus.
+//!
+//! ```
+//! # #[cfg(feature = "rand")]
+//! # {
+//! use crypto_bigint::{NonZero, RandomMod, U256, rand_core::OsRng};
+//!
+//! let modulus = NonZero::new(U256::from(3u8)).unwrap();
+//! let n = U256::random_mod(&mut OsRng, &modulus);
+//! # }
+//! ```
+//!
+//! [`Add`]: core::ops::Add
+//! [`Div`]: core::ops::Div
+//! [`Mul`]: core::ops::Mul
+//! [`Rem`]: core::ops::Rem
+//! [`Sub`]: core::ops::Sub
+//! [`CryptoRng`]: rand_core::CryptoRng
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -75,6 +170,9 @@ pub use {
     self::array::{ArrayDecoding, ArrayEncoding, ByteArray},
     generic_array::{self, typenum::consts},
 };
+
+#[cfg(feature = "rand_core")]
+pub use rand_core;
 
 #[cfg(feature = "rlp")]
 pub use rlp;

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -15,7 +15,7 @@ mod from;
 mod mul;
 mod sub;
 
-#[cfg(feature = "rand")]
+#[cfg(feature = "rand_core")]
 mod rand;
 
 use crate::Zero;

--- a/src/limb/rand.rs
+++ b/src/limb/rand.rs
@@ -5,20 +5,20 @@ use crate::{Encoding, NonZero, Random, RandomMod};
 use rand_core::{CryptoRng, RngCore};
 use subtle::ConstantTimeLess;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 impl Random for Limb {
     #[cfg(target_pointer_width = "32")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
     fn random(mut rng: impl CryptoRng + RngCore) -> Self {
         Self(rng.next_u32())
     }
 
     #[cfg(target_pointer_width = "64")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
     fn random(mut rng: impl CryptoRng + RngCore) -> Self {
         Self(rng.next_u64())
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 impl RandomMod for Limb {
     fn random_mod(mut rng: impl CryptoRng + RngCore, modulus: &NonZero<Self>) -> Self {
         let mut bytes = <Self as Encoding>::Repr::default();

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -1,7 +1,5 @@
 //! Wrapper type for non-zero integers.
 
-#[cfg(feature = "rand")]
-use crate::Random;
 use crate::{Encoding, Integer, Limb, UInt, Zero};
 use core::{
     fmt,
@@ -13,8 +11,11 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 #[cfg(feature = "generic-array")]
 use crate::{ArrayEncoding, ByteArray};
 
-#[cfg(feature = "rand")]
-use rand_core::{CryptoRng, RngCore};
+#[cfg(feature = "rand_core")]
+use {
+    crate::Random,
+    rand_core::{CryptoRng, RngCore},
+};
 
 /// Wrapper type for non-zero integers.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
@@ -112,8 +113,8 @@ where
     }
 }
 
-#[cfg(feature = "rand")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+#[cfg(feature = "rand_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 impl<T> Random for NonZero<T>
 where
     T: Random + Zero,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -8,7 +8,7 @@ use subtle::{
     CtOption,
 };
 
-#[cfg(feature = "rand")]
+#[cfg(feature = "rand_core")]
 use rand_core::{CryptoRng, RngCore};
 
 /// Integer type.
@@ -62,16 +62,16 @@ pub trait Zero: ConstantTimeEq + Sized {
 }
 
 /// Random number generation support.
-#[cfg(feature = "rand")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+#[cfg(feature = "rand_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 pub trait Random: Sized {
     /// Generate a cryptographically secure random value.
     fn random(rng: impl CryptoRng + RngCore) -> Self;
 }
 
 /// Modular random number generation support.
-#[cfg(feature = "rand")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+#[cfg(feature = "rand_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 pub trait RandomMod: Sized + Zero {
     /// Generate a cryptographically secure random number which is less than
     /// a given `modulus`.

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -31,7 +31,7 @@ mod sub_mod;
 #[cfg(feature = "generic-array")]
 mod array;
 
-#[cfg(feature = "rand")]
+#[cfg(feature = "rand_core")]
 mod rand;
 
 use crate::{Concat, Encoding, Integer, Limb, Split, Zero};

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -6,7 +6,7 @@ use crate::{Limb, NonZero, Random, RandomMod};
 use rand_core::{CryptoRng, RngCore};
 use subtle::ConstantTimeLess;
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 impl<const LIMBS: usize> Random for UInt<LIMBS> {
     /// Generate a cryptographically secure random [`UInt`].
     fn random(mut rng: impl CryptoRng + RngCore) -> Self {
@@ -20,7 +20,7 @@ impl<const LIMBS: usize> Random for UInt<LIMBS> {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 impl<const LIMBS: usize> RandomMod for UInt<LIMBS> {
     /// Generate a cryptographically secure random [`UInt`] which is less than
     /// a given `modulus`.


### PR DESCRIPTION
Uses the new `doc = include_str!(...)` feature to include the README.md in the rustdoc.

Adds a "Usage" section to the rustdoc which gives a basic tour of the crate including the `UInt` type and various traits that operate on it.