### PR TITLE
Reduce number of inherent methods

### DIFF
--- a/src/limb/add.rs
+++ b/src/limb/add.rs
@@ -1,6 +1,6 @@
 //! Limb addition
 
-use crate::{Checked, CheckedAdd, Limb, LimbUInt, WideLimbUInt, Wrapping};
+use crate::{Checked, CheckedAdd, Limb, LimbUInt, WideLimbUInt, Wrapping, Zero};
 use core::ops::{Add, AddAssign};
 use subtle::CtOption;
 

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -5,12 +5,6 @@ use core::cmp::Ordering;
 use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
 impl Limb {
-    /// Is this limb equal to zero?
-    #[inline]
-    pub fn is_zero(&self) -> Choice {
-        self.ct_eq(&Self::ZERO)
-    }
-
     /// Is this limb an odd number?
     #[inline]
     pub fn is_odd(&self) -> Choice {
@@ -106,7 +100,7 @@ impl PartialEq for Limb {
 
 #[cfg(test)]
 mod tests {
-    use crate::Limb;
+    use crate::{Limb, Zero};
     use core::cmp::Ordering;
     use subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 

--- a/src/limb/mul.rs
+++ b/src/limb/mul.rs
@@ -1,6 +1,6 @@
 //! Limb multiplication
 
-use crate::{Checked, CheckedMul, Limb, LimbUInt, WideLimbUInt, Wrapping};
+use crate::{Checked, CheckedMul, Limb, LimbUInt, WideLimbUInt, Wrapping, Zero};
 use core::ops::{Mul, MulAssign};
 use subtle::CtOption;
 

--- a/src/limb/sub.rs
+++ b/src/limb/sub.rs
@@ -1,6 +1,6 @@
 //! Limb subtraction
 
-use crate::{Checked, CheckedSub, Limb, LimbUInt, WideLimbUInt, Wrapping};
+use crate::{Checked, CheckedSub, Limb, LimbUInt, WideLimbUInt, Wrapping, Zero};
 use core::ops::{Sub, SubAssign};
 use subtle::CtOption;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -42,9 +42,17 @@ pub trait Integer:
     const MAX: Self;
 
     /// Is this integer value an odd number?
+    ///
+    /// # Returns
+    ///
+    /// If odd, returns `Choice(1)`. Otherwise, returns `Choice(0)`.
     fn is_odd(&self) -> Choice;
 
     /// Is this integer value an even number?
+    ///
+    /// # Returns
+    ///
+    /// If even, returns `Choice(1)`. Otherwise, returns `Choice(0)`.
     fn is_even(&self) -> Choice {
         !self.is_odd()
     }
@@ -55,7 +63,11 @@ pub trait Zero: ConstantTimeEq + Sized {
     /// The value `0`.
     const ZERO: Self;
 
-    /// Is this integer value equal to zero?
+    /// Determine if this value is equal to zero.
+    ///
+    /// # Returns
+    ///
+    /// If zero, returns `Choice(1)`. Otherwise, returns `Choice(0)`.
     fn is_zero(&self) -> Choice {
         self.ct_eq(&Self::ZERO)
     }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -131,7 +131,10 @@ impl<const LIMBS: usize> Integer for UInt<LIMBS> {
     const MAX: Self = Self::MAX;
 
     fn is_odd(&self) -> Choice {
-        self.is_odd()
+        self.limbs
+            .first()
+            .map(|limb| limb.is_odd())
+            .unwrap_or_else(|| Choice::from(0))
     }
 }
 

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -1,6 +1,6 @@
 //! [`UInt`] addition operations.
 
-use crate::{Checked, CheckedAdd, Limb, UInt, Wrapping};
+use crate::{Checked, CheckedAdd, Limb, UInt, Wrapping, Zero};
 use core::ops::{Add, AddAssign};
 use subtle::CtOption;
 

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -3,29 +3,11 @@
 //! By default these are all constant-time and use the `subtle` crate.
 
 use super::UInt;
-use crate::{Limb, LimbInt, LimbUInt, WideLimbInt};
+use crate::{Limb, LimbInt, LimbUInt, WideLimbInt, Zero};
 use core::cmp::Ordering;
 use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
-    /// Determine if this [`UInt`] is equal to zero.
-    ///
-    /// # Returns
-    ///
-    /// If zero, return `Choice(1)`.  Otherwise, return `Choice(0)`.
-    pub fn is_zero(&self) -> Choice {
-        self.ct_eq(&Self::ZERO)
-    }
-
-    /// Is this [`UInt`] an odd number?
-    #[inline]
-    pub fn is_odd(&self) -> Choice {
-        self.limbs
-            .first()
-            .map(|limb| limb.is_odd())
-            .unwrap_or_else(|| Choice::from(0))
-    }
-
     /// Return `a` if `c`!=0 or `b` if `c`==0.
     ///
     /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
@@ -135,7 +117,7 @@ impl<const LIMBS: usize> PartialEq for UInt<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::U128;
+    use crate::{Integer, Zero, U128};
     use subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
     #[test]

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -1,7 +1,6 @@
 //! [`UInt`] addition operations.
 
-use super::UInt;
-use crate::{Checked, CheckedMul, Concat, Limb, Wrapping};
+use crate::{Checked, CheckedMul, Concat, Limb, UInt, Wrapping, Zero};
 use core::ops::{Mul, MulAssign};
 use subtle::CtOption;
 
@@ -166,7 +165,7 @@ impl<const LIMBS: usize> MulAssign<&Checked<UInt<LIMBS>>> for Checked<UInt<LIMBS
 
 #[cfg(test)]
 mod tests {
-    use crate::{CheckedMul, Split, U64};
+    use crate::{CheckedMul, Split, Zero, U64};
 
     #[test]
     fn mul_wide_zero_and_one() {

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -1,7 +1,7 @@
 //! [`UInt`] addition operations.
 
 use super::UInt;
-use crate::{Checked, CheckedSub, Limb, Wrapping};
+use crate::{Checked, CheckedSub, Limb, Wrapping, Zero};
 use core::ops::{Sub, SubAssign};
 use subtle::CtOption;
 


### PR DESCRIPTION
Uses traits consistently for `is_zero`, `is_odd`, and `is_even`