### PR TITLE
v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.11 (2011-10-16)
+## 0.3.0 (2021-11-14)
+### Added
+- Bitwise `Xor`/`Not` operations ([#27])
+- `Zero` trait ([#35])
+- `Checked*` traits ([#41])
+- `prelude` module ([#45])
+- `saturating_*` ops ([#47])
+
+### Changed
+- Rust 2021 edition upgrade; MSRV 1.56 ([#33])
+- Reverse ordering of `UInt::mul_wide` return tuple ([#34])
+- Have `Div` and `Rem` impls always take `NonZero` args ([#39])
+- Rename `limb::Inner` to `LimbUInt` ([#40])
+- Make `limb` module private ([#40])
+- Use `Zero`/`Integer` traits for `is_zero`, `is_odd`, and `is_even` ([#46])
+
+### Fixed
+- `random_mod` performance for small moduli ([#36])
+- `NonZero` moduli ([#36])
+
+### Removed
+- Deprecated `LIMB_BYTES` constant ([#43])
+
+[#27]: https://github.com/RustCrypto/crypto-bigint/pull/27
+[#33]: https://github.com/RustCrypto/crypto-bigint/pull/33
+[#34]: https://github.com/RustCrypto/crypto-bigint/pull/34
+[#35]: https://github.com/RustCrypto/crypto-bigint/pull/35
+[#36]: https://github.com/RustCrypto/crypto-bigint/pull/36
+[#39]: https://github.com/RustCrypto/crypto-bigint/pull/39
+[#40]: https://github.com/RustCrypto/crypto-bigint/pull/40
+[#41]: https://github.com/RustCrypto/crypto-bigint/pull/41
+[#43]: https://github.com/RustCrypto/crypto-bigint/pull/43
+[#45]: https://github.com/RustCrypto/crypto-bigint/pull/45
+[#46]: https://github.com/RustCrypto/crypto-bigint/pull/46
+[#47]: https://github.com/RustCrypto/crypto-bigint/pull/47
+
+## 0.2.11 (2021-10-16)
 ### Added
 - `AddMod` proptests ([#24])
 - Bitwise `And`/`Or` operations ([#25])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.0-pre.1"
+version = "0.3.0"
 dependencies = [
  "generic-array",
  "hex-literal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.3.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,
@@ -23,7 +23,7 @@ subtle = { version = "2.4", default-features = false }
 generic-array = { version = "0.14", optional = true }
 rand_core = { version = "0.6", optional = true }
 rlp = { version = "0.5", optional = true, default-features = false }
-zeroize = { version = ">=1, <1.5", optional = true,  default-features = false }
+zeroize = { version = "1", optional = true,  default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/crypto-bigint/0.3.0-pre.1"
+    html_root_url = "https://docs.rs/crypto-bigint/0.3.0"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(


### PR DESCRIPTION
### Added
- Bitwise `Xor`/`Not` operations ([#27])
- `Zero` trait ([#35])
- `Checked*` traits ([#41])
- `prelude` module ([#45])
- `saturating_*` ops ([#47])

### Changed
- Rust 2021 edition upgrade; MSRV 1.56 ([#33])
- Reverse ordering of `UInt::mul_wide` return tuple ([#34])
- Have `Div` and `Rem` impls always take `NonZero` args ([#39])
- Rename `limb::Inner` to `LimbUInt` ([#40])
- Make `limb` module private ([#40])
- Use `Zero`/`Integer` traits for `is_zero`, `is_odd`, and `is_even` ([#46])

### Fixed
- `random_mod` performance for small moduli ([#36])
- `NonZero` moduli ([#36])

### Removed
- Deprecated `LIMB_BYTES` constant ([#43])

[#27]: https://github.com/RustCrypto/crypto-bigint/pull/27
[#33]: https://github.com/RustCrypto/crypto-bigint/pull/33
[#34]: https://github.com/RustCrypto/crypto-bigint/pull/34
[#35]: https://github.com/RustCrypto/crypto-bigint/pull/35
[#36]: https://github.com/RustCrypto/crypto-bigint/pull/36
[#39]: https://github.com/RustCrypto/crypto-bigint/pull/39
[#40]: https://github.com/RustCrypto/crypto-bigint/pull/40
[#41]: https://github.com/RustCrypto/crypto-bigint/pull/41
[#43]: https://github.com/RustCrypto/crypto-bigint/pull/43
[#45]: https://github.com/RustCrypto/crypto-bigint/pull/45
[#46]: https://github.com/RustCrypto/crypto-bigint/pull/46
[#47]: https://github.com/RustCrypto/crypto-bigint/pull/47