### PR TITLE
Add bitwise ops to `Integer` trait

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,7 +2,7 @@
 
 use crate::{Limb, NonZero};
 use core::fmt::Debug;
-use core::ops::{Div, Rem};
+use core::ops::{BitAnd, BitOr, BitXor, Div, Not, Rem, Shl, Shr};
 use subtle::{
     Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
     CtOption,
@@ -15,6 +15,9 @@ use rand_core::{CryptoRng, RngCore};
 pub trait Integer:
     'static
     + AsRef<[Limb]>
+    + BitAnd
+    + BitOr
+    + BitXor
     + for<'a> CheckedAdd<&'a Self, Output = Self>
     + for<'a> CheckedSub<&'a Self, Output = Self>
     + for<'a> CheckedMul<&'a Self, Output = Self>
@@ -28,10 +31,13 @@ pub trait Integer:
     + Div<NonZero<Self>, Output = Self>
     + Eq
     + From<u64>
+    + Not
     + Ord
     + Rem<NonZero<Self>, Output = Self>
     + Send
     + Sized
+    + Shl<usize>
+    + Shr<usize>
     + Sync
     + Zero
 {

--- a/src/uint/bit_and.rs
+++ b/src/uint/bit_and.rs
@@ -20,17 +20,64 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         Self { limbs }
     }
 
-    /// Perform wrapping bitwise and.
+    /// Perform wrapping bitwise `AND`.
+    ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
     pub const fn wrapping_and(&self, rhs: &Self) -> Self {
         self.bitand(rhs)
     }
 
-    /// Perform checked bitwise and, returning a [`CtOption`] which `is_some` always
+    /// Perform checked bitwise `AND`, returning a [`CtOption`] which `is_some` always
     pub fn checked_and(&self, rhs: &Self) -> CtOption<Self> {
         let result = self.bitand(rhs);
         CtOption::new(result, Choice::from(1))
+    }
+}
+
+impl<const LIMBS: usize> BitAnd for UInt<LIMBS> {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> UInt<LIMBS> {
+        self.bitand(&rhs)
+    }
+}
+
+impl<const LIMBS: usize> BitAnd<&UInt<LIMBS>> for UInt<LIMBS> {
+    type Output = UInt<LIMBS>;
+
+    fn bitand(self, rhs: &UInt<LIMBS>) -> UInt<LIMBS> {
+        (&self).bitand(rhs)
+    }
+}
+
+impl<const LIMBS: usize> BitAnd<UInt<LIMBS>> for &UInt<LIMBS> {
+    type Output = UInt<LIMBS>;
+
+    fn bitand(self, rhs: UInt<LIMBS>) -> UInt<LIMBS> {
+        self.bitand(&rhs)
+    }
+}
+
+impl<const LIMBS: usize> BitAnd<&UInt<LIMBS>> for &UInt<LIMBS> {
+    type Output = UInt<LIMBS>;
+
+    fn bitand(self, rhs: &UInt<LIMBS>) -> UInt<LIMBS> {
+        self.bitand(rhs)
+    }
+}
+
+impl<const LIMBS: usize> BitAndAssign for UInt<LIMBS> {
+    #[allow(clippy::assign_op_pattern)]
+    fn bitand_assign(&mut self, other: Self) {
+        *self = *self & other;
+    }
+}
+
+impl<const LIMBS: usize> BitAndAssign<&UInt<LIMBS>> for UInt<LIMBS> {
+    #[allow(clippy::assign_op_pattern)]
+    fn bitand_assign(&mut self, other: &Self) {
+        *self = *self & other;
     }
 }
 

--- a/src/uint/bit_not.rs
+++ b/src/uint/bit_not.rs
@@ -20,6 +20,14 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
+impl<const LIMBS: usize> Not for UInt<LIMBS> {
+    type Output = Self;
+
+    fn not(self) -> <Self as Not>::Output {
+        (&self).not()
+    }
+}
+
 impl<const LIMBS: usize> Not for Wrapping<UInt<LIMBS>> {
     type Output = Self;
 

--- a/src/uint/bit_or.rs
+++ b/src/uint/bit_or.rs
@@ -20,17 +20,62 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         Self { limbs }
     }
 
-    /// Perform wrapping bitwise or.
+    /// Perform wrapping bitwise `OR`.
+    ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
     pub const fn wrapping_or(&self, rhs: &Self) -> Self {
         self.bitor(rhs)
     }
 
-    /// Perform checked bitwise or, returning a [`CtOption`] which `is_some` always
+    /// Perform checked bitwise `OR`, returning a [`CtOption`] which `is_some` always
     pub fn checked_or(&self, rhs: &Self) -> CtOption<Self> {
         let result = self.bitor(rhs);
         CtOption::new(result, Choice::from(1))
+    }
+}
+
+impl<const LIMBS: usize> BitOr for UInt<LIMBS> {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> UInt<LIMBS> {
+        self.bitor(&rhs)
+    }
+}
+
+impl<const LIMBS: usize> BitOr<&UInt<LIMBS>> for UInt<LIMBS> {
+    type Output = UInt<LIMBS>;
+
+    fn bitor(self, rhs: &UInt<LIMBS>) -> UInt<LIMBS> {
+        (&self).bitor(rhs)
+    }
+}
+
+impl<const LIMBS: usize> BitOr<UInt<LIMBS>> for &UInt<LIMBS> {
+    type Output = UInt<LIMBS>;
+
+    fn bitor(self, rhs: UInt<LIMBS>) -> UInt<LIMBS> {
+        self.bitor(&rhs)
+    }
+}
+
+impl<const LIMBS: usize> BitOr<&UInt<LIMBS>> for &UInt<LIMBS> {
+    type Output = UInt<LIMBS>;
+
+    fn bitor(self, rhs: &UInt<LIMBS>) -> UInt<LIMBS> {
+        self.bitor(rhs)
+    }
+}
+
+impl<const LIMBS: usize> BitOrAssign for UInt<LIMBS> {
+    fn bitor_assign(&mut self, other: Self) {
+        *self = *self | other;
+    }
+}
+
+impl<const LIMBS: usize> BitOrAssign<&UInt<LIMBS>> for UInt<LIMBS> {
+    fn bitor_assign(&mut self, other: &Self) {
+        *self = *self | other;
     }
 }
 

--- a/src/uint/bit_xor.rs
+++ b/src/uint/bit_xor.rs
@@ -20,17 +20,62 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         Self { limbs }
     }
 
-    /// Perform wrapping bitwise xor.
+    /// Perform wrapping bitwise `XOR``.
+    ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
     pub const fn wrapping_xor(&self, rhs: &Self) -> Self {
         self.bitxor(rhs)
     }
 
-    /// Perform checked bitwise xor, returning a [`CtOption`] which `is_some` always
+    /// Perform checked bitwise `XOR`, returning a [`CtOption`] which `is_some` always
     pub fn checked_xor(&self, rhs: &Self) -> CtOption<Self> {
         let result = self.bitxor(rhs);
         CtOption::new(result, Choice::from(1))
+    }
+}
+
+impl<const LIMBS: usize> BitXor for UInt<LIMBS> {
+    type Output = Self;
+
+    fn bitxor(self, rhs: Self) -> UInt<LIMBS> {
+        self.bitxor(&rhs)
+    }
+}
+
+impl<const LIMBS: usize> BitXor<&UInt<LIMBS>> for UInt<LIMBS> {
+    type Output = UInt<LIMBS>;
+
+    fn bitxor(self, rhs: &UInt<LIMBS>) -> UInt<LIMBS> {
+        (&self).bitxor(rhs)
+    }
+}
+
+impl<const LIMBS: usize> BitXor<UInt<LIMBS>> for &UInt<LIMBS> {
+    type Output = UInt<LIMBS>;
+
+    fn bitxor(self, rhs: UInt<LIMBS>) -> UInt<LIMBS> {
+        self.bitxor(&rhs)
+    }
+}
+
+impl<const LIMBS: usize> BitXor<&UInt<LIMBS>> for &UInt<LIMBS> {
+    type Output = UInt<LIMBS>;
+
+    fn bitxor(self, rhs: &UInt<LIMBS>) -> UInt<LIMBS> {
+        self.bitxor(rhs)
+    }
+}
+
+impl<const LIMBS: usize> BitXorAssign for UInt<LIMBS> {
+    fn bitxor_assign(&mut self, other: Self) {
+        *self = *self ^ other;
+    }
+}
+
+impl<const LIMBS: usize> BitXorAssign<&UInt<LIMBS>> for UInt<LIMBS> {
+    fn bitxor_assign(&mut self, other: &Self) {
+        *self = *self ^ other;
     }
 }
 


### PR DESCRIPTION
Adds the following bitwise operations:

- `BitAnd`
- `BitOr`
- `BitXor`
- `Shl`
- `Shr`

Additionally adds impls of the `Bit*` traits on `UInt<LIMBS>` directly, in addition to the existing impls on `Wrapping<UInt<LIMBS>>`.

This is safe because there is no difference between the "wrapping" or "checked" versions of these operations: they always succeed and there is no "wrapping" behavior to worry about.

This is debatably a breaking change but one that is extremely unlikely to cause any problems in practice, especially since `crypto-bigint` v0.3 was just released. To be on the safe side though, these changes will immediately be published in a v0.3.1 release, and the current v0.3.0 yanked so as to prevent any potential incompatibilities.