### PR TITLE
v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 (2021-11-14)
+## 0.3.1 (2021-11-17)
+### Added
+- Bitwise ops to `Integer` trait ([#51])
+
+[#51]: https://github.com/RustCrypto/crypto-bigint/pull/51
+
+## 0.3.0 (2021-11-14) [YANKED]
 ### Added
 - Bitwise `Xor`/`Not` operations ([#27])
 - `Zero` trait ([#35])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "generic-array",
  "hex-literal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/crypto-bigint/0.3.0"
+    html_root_url = "https://docs.rs/crypto-bigint/0.3.1"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(


### PR DESCRIPTION
### Added
- Bitwise ops to `Integer` trait ([#51])

[#51]: https://github.com/RustCrypto/crypto-bigint/pull/51