### PR TITLE
Use `const_panic`; MSRV 1.57

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.57.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -55,7 +55,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.57.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -78,13 +78,13 @@ jobs:
         include:
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.57.0 # MSRV
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.57.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
 
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.56.0
+          toolchain: 1.57.0
           components: clippy
           override: true
           profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.2"
+version = "0.4.0-pre"
 dependencies = [
  "generic-array",
  "hex-literal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.3.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,
@@ -14,7 +14,7 @@ keywords = ["arbitrary", "crypto", "bignum", "integer", "precision"]
 readme = "README.md"
 resolver = "2"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 subtle = { version = "2.4", default-features = false }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ using const generics.
 
 ## Minimum Supported Rust Version
 
-**Rust 1.56** at a minimum.
+This crate requires **Rust 1.57** at a minimum.
+
+We may change the MSRV in the future, but it will be accompanied by a minor
+version bump.
 
 ## License
 
@@ -52,7 +55,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/crypto-bigint/actions/workflows/crypto-bigint.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/crypto-bigint/actions/workflows/crypto-bigint.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300602-crypto-bigint
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_root_url = "https://docs.rs/crypto-bigint/0.3.2"
+    html_root_url = "https://docs.rs/crypto-bigint/0.4.0-pre"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(
@@ -142,7 +142,7 @@
 extern crate alloc;
 
 #[macro_use]
-mod macros;
+mod nlimbs;
 
 #[cfg(feature = "generic-array")]
 mod array;

--- a/src/nlimbs.rs
+++ b/src/nlimbs.rs
@@ -1,16 +1,5 @@
-//! Macros
-
-/// Constant panicking assertion.
-// TODO(tarcieri): use const panic when stable.
-// See: https://github.com/rust-lang/rust/issues/51999
-macro_rules! const_assert {
-    ($bool:expr, $msg:expr) => {
-        [$msg][!$bool as usize]
-    };
-}
-
 /// Calculate the number of limbs required to represent the given number of bits.
-// TODO(tarcieri): replace with `const_evaluatable_checked` (e.g. a `const fn`) when stable
+// TODO(tarcieri): replace with `generic_const_exprs` (rust-lang/rust#76560) when stable
 #[macro_export]
 macro_rules! nlimbs {
     ($bits:expr) => {

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -242,7 +242,7 @@ impl<const LIMBS: usize> NonZero<UInt<LIMBS>> {
             }
             i += 1;
         }
-        const_assert!(found_non_zero, "found zero");
+        assert!(found_non_zero, "found zero");
         Self(n)
     }
 

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -103,7 +103,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     /// This function exists, so that all operations are accounted for in the wrapping operations.
     pub const fn wrapping_div(&self, rhs: &Self) -> Self {
         let (q, _, c) = self.ct_div_rem(rhs);
-        const_assert!(c == 1, "divide by zero");
+        assert!(c == 1, "divide by zero");
         q
     }
 
@@ -119,7 +119,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     /// This function exists, so that all operations are accounted for in the wrapping operations.
     pub const fn wrapping_rem(&self, rhs: &Self) -> Self {
         let (r, c) = self.ct_reduce(rhs);
-        const_assert!(c == 1, "modulo zero");
+        assert!(c == 1, "modulo zero");
         r
     }
 

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -12,7 +12,7 @@ use decoder::Decoder;
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Create a new [`UInt`] from the provided big endian bytes.
     pub const fn from_be_slice(bytes: &[u8]) -> Self {
-        const_assert!(
+        assert!(
             bytes.len() == Limb::BYTE_SIZE * LIMBS,
             "bytes are not the expected size"
         );
@@ -32,7 +32,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     pub const fn from_be_hex(hex: &str) -> Self {
         let bytes = hex.as_bytes();
 
-        const_assert!(
+        assert!(
             bytes.len() == Limb::BYTE_SIZE * LIMBS * 2,
             "hex string is not the expected size"
         );
@@ -52,7 +52,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
 
     /// Create a new [`UInt`] from the provided little endian bytes.
     pub const fn from_le_slice(bytes: &[u8]) -> Self {
-        const_assert!(
+        assert!(
             bytes.len() == Limb::BYTE_SIZE * LIMBS,
             "bytes are not the expected size"
         );
@@ -72,7 +72,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     pub const fn from_le_hex(hex: &str) -> Self {
         let bytes = hex.as_bytes();
 
-        const_assert!(
+        assert!(
             bytes.len() == Limb::BYTE_SIZE * LIMBS * 2,
             "bytes are not the expected size"
         );
@@ -137,7 +137,7 @@ const fn decode_hex_byte(bytes: [u8; 2]) -> u8 {
             b @ b'a'..=b'f' => 10 + b - b'a',
             b @ b'A'..=b'F' => 10 + b - b'A',
             b => {
-                const_assert!(
+                assert!(
                     matches!(b, b'0'..=b'9' | b'a' ..= b'f' | b'A'..=b'F'),
                     "invalid hex byte"
                 );

--- a/src/uint/encoding/decoder.rs
+++ b/src/uint/encoding/decoder.rs
@@ -28,7 +28,7 @@ impl<const LIMBS: usize> Decoder<LIMBS> {
     /// Add a byte onto the [`UInt`] being decoded.
     pub const fn add_byte(mut self, byte: u8) -> Self {
         if self.bytes == Limb::BYTE_SIZE {
-            const_assert!(self.index < LIMBS, "too many bytes in UInt");
+            assert!(self.index < LIMBS, "too many bytes in UInt");
             self.index += 1;
             self.bytes = 0;
         }
@@ -41,8 +41,8 @@ impl<const LIMBS: usize> Decoder<LIMBS> {
     /// Finish decoding a [`UInt`], returning a decoded value only if we've
     /// received the expected number of bytes.
     pub const fn finish(self) -> UInt<LIMBS> {
-        const_assert!(self.index == LIMBS - 1, "decoded UInt is missing limbs");
-        const_assert!(
+        assert!(self.index == LIMBS - 1, "decoded UInt is missing limbs");
+        assert!(
             self.bytes == Limb::BYTE_SIZE,
             "decoded UInt is missing bytes"
         );

--- a/src/uint/from.rs
+++ b/src/uint/from.rs
@@ -6,7 +6,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     /// Create a [`UInt`] from a `u8` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u8>` when stable
     pub const fn from_u8(n: u8) -> Self {
-        const_assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
         limbs[0].0 = n as LimbUInt;
         Self { limbs }
@@ -15,7 +15,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     /// Create a [`UInt`] from a `u16` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u16>` when stable
     pub const fn from_u16(n: u16) -> Self {
-        const_assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
         limbs[0].0 = n as LimbUInt;
         Self { limbs }
@@ -25,7 +25,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     // TODO(tarcieri): replace with `const impl From<u32>` when stable
     #[allow(trivial_numeric_casts)]
     pub const fn from_u32(n: u32) -> Self {
-        const_assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
         limbs[0].0 = n as LimbUInt;
         Self { limbs }
@@ -35,7 +35,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     // TODO(tarcieri): replace with `const impl From<u64>` when stable
     #[cfg(target_pointer_width = "32")]
     pub const fn from_u64(n: u64) -> Self {
-        const_assert!(LIMBS >= 2, "number of limbs must be two or greater");
+        assert!(LIMBS >= 2, "number of limbs must be two or greater");
         let mut limbs = [Limb::ZERO; LIMBS];
         limbs[0].0 = (n & 0xFFFFFFFF) as u32;
         limbs[1].0 = (n >> 32) as u32;
@@ -46,7 +46,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     // TODO(tarcieri): replace with `const impl From<u64>` when stable
     #[cfg(target_pointer_width = "64")]
     pub const fn from_u64(n: u64) -> Self {
-        const_assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
         limbs[0].0 = n;
         Self { limbs }
@@ -55,7 +55,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     /// Create a [`UInt`] from a `u128` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u128>` when stable
     pub const fn from_u128(n: u128) -> Self {
-        const_assert!(
+        assert!(
             LIMBS >= (128 / Limb::BIT_SIZE),
             "number of limbs must be greater than zero"
         );


### PR DESCRIPTION
Replaces the previous `const_assert!` macro hack with a proper `assert!` leveraging the newly stabilized support for panicking in const contexts.