### PR TITLE
Serde implementation

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -38,8 +38,9 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features generic-array
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rand_core
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rlp
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features zeroize
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,der,generic-array,rand_core,rlp,zeroize
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,der,generic-array,rand_core,rlp,serde,zeroize
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,8 +76,7 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "rlp",
- "serde",
- "serde-big-array",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -303,11 +308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 
 [[package]]
-name = "serde-big-array"
-version = "0.4.0"
+name = "serdect"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01890a6856e9a7fbb42f3bc847957b61aeaf024fe99f6abc76d137ed1799dc80"
+checksum = "038fce1bf4d74b9b30ea7dcd59df75ba8ec669a5dcb3cc64fbfcef7334ced32c"
 dependencies = [
+ "base16ct",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +60,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "crypto-bigint"
 version = "0.4.0-pre.0"
 dependencies = [
+ "bincode",
  "der",
  "generic-array",
  "hex-literal",
@@ -60,6 +70,8 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "rlp",
+ "serde",
+ "serde-big-array",
  "subtle",
  "zeroize",
 ]
@@ -282,6 +294,21 @@ dependencies = [
  "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+
+[[package]]
+name = "serde-big-array"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01890a6856e9a7fbb42f3bc847957b61aeaf024fe99f6abc76d137ed1799dc80"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,12 @@ der = { version = "=0.6.0-pre.3", optional = true, default-features = false }
 generic-array = { version = "0.14", optional = true }
 rand_core = { version = "0.6", optional = true }
 rlp = { version = "0.5", optional = true, default-features = false }
+serde_ = { version = "1", package = "serde", optional = true, default-features = false }
+serde-big-array = { version = "0.4", optional = true }
 zeroize = { version = "1", optional = true,  default-features = false }
 
 [dev-dependencies]
+bincode = "1"
 hex-literal = "0.3"
 num-bigint = "0.4"
 num-traits = "0.2"
@@ -38,6 +41,7 @@ rand_chacha = "0.3"
 default = ["rand"]
 alloc = []
 rand = ["rand_core/std"]
+serde = ["serde_", "serde-big-array"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ der = { version = "=0.6.0-pre.3", optional = true, default-features = false }
 generic-array = { version = "0.14", optional = true }
 rand_core = { version = "0.6", optional = true }
 rlp = { version = "0.5", optional = true, default-features = false }
-serde_ = { version = "1", package = "serde", optional = true, default-features = false }
-serde-big-array = { version = "0.4", optional = true }
+serdect = { version = "0.1", optional = true, default-features = false }
 zeroize = { version = "1", optional = true,  default-features = false }
 
 [dev-dependencies]
@@ -41,7 +40,7 @@ rand_chacha = "0.3"
 default = ["rand"]
 alloc = []
 rand = ["rand_core/std"]
-serde = ["serde_", "serde-big-array"]
+serde = ["serdect"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/checked.rs
+++ b/src/checked.rs
@@ -87,13 +87,12 @@ impl<'de, T: Copy + Serialize> Serialize for Checked<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "serde"))]
 mod tests {
     use crate::{Checked, U64};
     use subtle::{Choice, ConstantTimeEq, CtOption};
 
     #[test]
-    #[cfg(feature = "serde")]
     fn serde() {
         let test = Checked::new(U64::from_u64(0x0011223344556677));
 
@@ -114,7 +113,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
     fn serde_owned() {
         let test = Checked::new(U64::from_u64(0x0011223344556677));
 

--- a/src/checked.rs
+++ b/src/checked.rs
@@ -3,7 +3,7 @@
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Provides intentionally-checked arithmetic on `T`.
 ///
@@ -68,11 +68,8 @@ impl<'de, T: Default + Deserialize<'de>> Deserialize<'de> for Checked<T> {
         D: Deserializer<'de>,
     {
         let value = Option::<T>::deserialize(deserializer)?;
-
-        Ok(Self(match value {
-            Some(value) => CtOption::new(value, Choice::from(1)),
-            None => CtOption::new(T::default(), Choice::from(0)),
-        }))
+        let choice = Choice::from(value.is_some() as u8);
+        Ok(Self(CtOption::new(value.unwrap_or_default(), choice)))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,9 @@
 #[cfg(all(feature = "alloc", test))]
 extern crate alloc;
 
+#[cfg(feature = "serde")]
+extern crate serde_ as serde;
+
 #[macro_use]
 mod nlimbs;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,9 +141,6 @@
 #[cfg(all(feature = "alloc", test))]
 extern crate alloc;
 
-#[cfg(feature = "serde")]
-extern crate serde_ as serde;
-
 #[macro_use]
 mod nlimbs;
 

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -22,6 +22,9 @@ use crate::Zero;
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
 #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
 compile_error!("this crate builds on 32-bit and 64-bit platforms only");
 
@@ -140,6 +143,28 @@ impl fmt::UpperHex for Limb {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::UpperHex::fmt(&self.0, f)
+    }
+}
+
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+impl<'de> Deserialize<'de> for Limb {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Self(LimbUInt::deserialize(deserializer)?))
+    }
+}
+
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+impl<'de> Serialize for Limb {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
     }
 }
 

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -23,7 +23,7 @@ use core::fmt;
 use subtle::{Choice, ConditionallySelectable};
 
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
 compile_error!("this crate builds on 32-bit and 64-bit platforms only");

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -18,7 +18,7 @@ use {
 };
 
 #[cfg(feature = "serde")]
-use serde::{
+use serdect::serde::{
     de::{Error, Unexpected},
     Deserialize, Deserializer, Serialize, Serializer,
 };

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -17,6 +17,12 @@ use {
     rand_core::{CryptoRng, RngCore},
 };
 
+#[cfg(feature = "serde")]
+use serde::{
+    de::{Error, Unexpected},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
 /// Wrapper type for non-zero integers.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct NonZero<T: Zero>(T);
@@ -304,5 +310,79 @@ impl<const LIMBS: usize> From<NonZeroU64> for NonZero<UInt<LIMBS>> {
 impl<const LIMBS: usize> From<NonZeroU128> for NonZero<UInt<LIMBS>> {
     fn from(integer: NonZeroU128) -> Self {
         Self::from_u128(integer)
+    }
+}
+
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+impl<'de, T: Deserialize<'de> + Zero> Deserialize<'de> for NonZero<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value: T = T::deserialize(deserializer)?;
+
+        if bool::from(value.is_zero()) {
+            Err(D::Error::invalid_value(
+                Unexpected::Other("zero"),
+                &"a non-zero value",
+            ))
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+impl<'de, T: Serialize + Zero> Serialize for NonZero<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{NonZero, U64};
+    #[cfg(feature = "serde")]
+    use bincode::ErrorKind;
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde() {
+        let test =
+            Option::<NonZero<U64>>::from(NonZero::new(U64::from_u64(0x0011223344556677))).unwrap();
+
+        let serialized = bincode::serialize(&test).unwrap();
+        let deserialized: NonZero<U64> = bincode::deserialize(&serialized).unwrap();
+
+        assert_eq!(test, deserialized);
+
+        let serialized = bincode::serialize(&U64::ZERO).unwrap();
+        assert!(matches!(
+            *bincode::deserialize::<NonZero<U64>>(&serialized).unwrap_err(),
+            ErrorKind::Custom(message) if message == "invalid value: zero, expected a non-zero value"
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_owned() {
+        let test =
+            Option::<NonZero<U64>>::from(NonZero::new(U64::from_u64(0x0011223344556677))).unwrap();
+
+        let serialized = bincode::serialize(&test).unwrap();
+        let deserialized: NonZero<U64> = bincode::deserialize_from(serialized.as_slice()).unwrap();
+
+        assert_eq!(test, deserialized);
+
+        let serialized = bincode::serialize(&U64::ZERO).unwrap();
+        assert!(matches!(
+            *bincode::deserialize_from::<_, NonZero<U64>>(serialized.as_slice()).unwrap_err(),
+            ErrorKind::Custom(message) if message == "invalid value: zero, expected a non-zero value"
+        ));
     }
 }

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -344,14 +344,12 @@ impl<'de, T: Serialize + Zero> Serialize for NonZero<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "serde"))]
 mod tests {
     use crate::{NonZero, U64};
-    #[cfg(feature = "serde")]
     use bincode::ErrorKind;
 
     #[test]
-    #[cfg(feature = "serde")]
     fn serde() {
         let test =
             Option::<NonZero<U64>>::from(NonZero::new(U64::from_u64(0x0011223344556677))).unwrap();
@@ -369,7 +367,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
     fn serde_owned() {
         let test =
             Option::<NonZero<U64>>::from(NonZero::new(U64::from_u64(0x0011223344556677))).unwrap();

--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -20,7 +20,7 @@ macro_rules! impl_uint_aliases {
                 }
 
                 fn from_le_bytes(bytes: Self::Repr) -> Self {
-                    Self::from_be_slice(&bytes)
+                    Self::from_le_slice(&bytes)
                 }
 
                 #[inline]

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -82,12 +82,11 @@ impl<'de, T: Serialize> Serialize for Wrapping<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "serde"))]
 mod tests {
     use crate::{Wrapping, U64};
 
     #[test]
-    #[cfg(feature = "serde")]
     fn serde() {
         const TEST: Wrapping<U64> = Wrapping(U64::from_u64(0x0011223344556677));
 
@@ -98,7 +97,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
     fn serde_owned() {
         const TEST: Wrapping<U64> = Wrapping(U64::from_u64(0x0011223344556677));
 

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Provides intentionally-wrapped arithmetic on `T`.
 ///

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -4,6 +4,9 @@ use crate::Zero;
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
 /// Provides intentionally-wrapped arithmetic on `T`.
 ///
 /// This is analogous to [`core::num::Wrapping`] but allows this crate to
@@ -54,5 +57,54 @@ impl<T: ConditionallySelectable> ConditionallySelectable for Wrapping<T> {
 impl<T: ConstantTimeEq> ConstantTimeEq for Wrapping<T> {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
+    }
+}
+
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Wrapping<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Self(T::deserialize(deserializer)?))
+    }
+}
+
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+impl<'de, T: Serialize> Serialize for Wrapping<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Wrapping, U64};
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde() {
+        const TEST: Wrapping<U64> = Wrapping(U64::from_u64(0x0011223344556677));
+
+        let serialized = bincode::serialize(&TEST).unwrap();
+        let deserialized: Wrapping<U64> = bincode::deserialize(&serialized).unwrap();
+
+        assert_eq!(TEST, deserialized);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_owned() {
+        const TEST: Wrapping<U64> = Wrapping(U64::from_u64(0x0011223344556677));
+
+        let serialized = bincode::serialize(&TEST).unwrap();
+        let deserialized: Wrapping<U64> = bincode::deserialize_from(serialized.as_slice()).unwrap();
+
+        assert_eq!(TEST, deserialized);
     }
 }


### PR DESCRIPTION
Implemented `serde::Deserialize` and `serde::Serialize` for all types. This might be a bit overkill, implementing it for `UInt` might have been enough.

As serde currently doesn't support const generics (serde-rs/serde#1937), I used [serde-big-array](https://crates.io/crates/serde-big-array) for the `UInt` implementation. The dependency is quiet minimal, this PR also spawned est31/serde-big-array#14 to make sure that the dependency is as minimal as possible.

I hope the tests are appropriate enough.