### PR TITLE
Pad limbs with zeros when displaying hexadecimal representation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@
 //! [`Sub`]: core::ops::Sub
 //! [`CryptoRng`]: rand_core::CryptoRng
 
-#![no_std]
+//#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@
 //! [`Sub`]: core::ops::Sub
 //! [`CryptoRng`]: rand_core::CryptoRng
 
-//#![no_std]
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -132,14 +132,14 @@ impl fmt::Display for Limb {
 impl fmt::LowerHex for Limb {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::LowerHex::fmt(&self.0, f)
+        write!(f, "{:0width$x}", &self.0, width = Self::BYTE_SIZE * 2)
     }
 }
 
 impl fmt::UpperHex for Limb {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::UpperHex::fmt(&self.0, f)
+        write!(f, "{:0width$X}", &self.0, width = Self::BYTE_SIZE * 2)
     }
 }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -245,6 +245,18 @@ mod tests {
 
         use alloc::string::ToString;
         assert_eq!(hex, n.to_string());
+
+        let hex = "AAAAAAAABBBBBBBB0000000000000000";
+        let n = U128::from_be_hex(hex);
+        assert_eq!(hex, n.to_string());
+
+        let hex = "AAAAAAAABBBBBBBB00000000DDDDDDDD";
+        let n = U128::from_be_hex(hex);
+        assert_eq!(hex, n.to_string());
+
+        let hex = "AAAAAAAABBBBBBBB0CCCCCCCDDDDDDDD";
+        let n = U128::from_be_hex(hex);
+        assert_eq!(hex, n.to_string());
     }
 
     #[test]


### PR DESCRIPTION
Limbs use the default `u64`/`u32` `LowerHex` and `UpperHex` implementations when displaying hexadecimal output. This is problematic because when someone creates a number from big-endian hex, e.g.:
```
let hex = "AAAAAAAABBBBBBBB0000000CDDDDDDDD";
let n = U128::from_be_hex(hex);
```
then `n.to_string()` ouputs `AAAAAAAABBBBBBBBCDDDDDDDD` instead of the original `hex`. If the second limb is simply `0`, then the output is `AAAAAAAABBBBBBBB0`.