### PR TITLE
v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.0 (2022-05-08)
+## 0.4.1 (2022-05-10)
+### Fixed
+- Bug in `from_le_slice` ([#82])
+
+[#82]: https://github.com/RustCrypto/crypto-bigint/pull/82
+
+## 0.4.0 (2022-05-08) [YANKED]
+
+NOTE: this release was yanked due to [#82].
+
 ### Added
 - Const-friendly `NonZero` from `UInt` ([#56])
 - Optional `der` feature ([#61], [#80])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "der",
  "generic-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.4.0"
+version = "0.4.1"
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,


### PR DESCRIPTION
### Fixed
- Bug in `from_le_slice` ([#82])

[#82]: https://github.com/RustCrypto/crypto-bigint/pull/82