### PR TITLE
Rename `LimbUInt` => `Word`, `WideLimbUInt` => `WideWord`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ mod wrapping;
 
 pub use crate::{
     checked::Checked,
-    limb::{Limb, LimbUInt, WideLimbUInt},
+    limb::{Limb, WideWord, Word},
     non_zero::NonZero,
     traits::*,
     uint::*,
@@ -162,7 +162,11 @@ pub use crate::{
 };
 pub use subtle;
 
-pub(crate) use limb::{LimbInt, WideLimbInt};
+// TODO(tarcieri): remove these in the next breaking release
+#[allow(deprecated)]
+pub use crate::limb::{LimbUInt, WideLimbUInt};
+
+pub(crate) use limb::{SignedWord, WideSignedWord};
 
 #[cfg(feature = "generic-array")]
 pub use {

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -34,19 +34,19 @@ compile_error!("this crate builds on 32-bit and 64-bit platforms only");
 
 /// Inner integer type that the [`Limb`] newtype wraps.
 #[cfg(target_pointer_width = "32")]
-pub type LimbUInt = u32;
+pub type Word = u32;
 
-/// Signed integer type that corresponds to [`LimbUInt`].
+/// Signed integer type that corresponds to [`Word`].
 #[cfg(target_pointer_width = "32")]
-pub(crate) type LimbInt = i32;
+pub(crate) type SignedWord = i32;
 
-/// Unsigned wide integer type: double the width of [`LimbUInt`].
+/// Unsigned wide integer type: double the width of [`Word`].
 #[cfg(target_pointer_width = "32")]
-pub type WideLimbUInt = u64;
+pub type WideWord = u64;
 
 /// Signed wide integer type: double the width of [`Limb`].
 #[cfg(target_pointer_width = "32")]
-pub(crate) type WideLimbInt = i64;
+pub(crate) type WideSignedWord = i64;
 
 //
 // 64-bit definitions
@@ -54,19 +54,33 @@ pub(crate) type WideLimbInt = i64;
 
 /// Unsigned integer type that the [`Limb`] newtype wraps.
 #[cfg(target_pointer_width = "64")]
-pub type LimbUInt = u64;
+pub type Word = u64;
 
-/// Signed integer type that corresponds to [`LimbUInt`].
+/// Signed integer type that corresponds to [`Word`].
 #[cfg(target_pointer_width = "64")]
-pub(crate) type LimbInt = i64;
+pub(crate) type SignedWord = i64;
 
-/// Wide integer type: double the width of [`LimbUInt`].
+/// Wide integer type: double the width of [`Word`].
 #[cfg(target_pointer_width = "64")]
-pub type WideLimbUInt = u128;
+pub type WideWord = u128;
 
-/// Signed wide integer type: double the width of [`Limb`].
+/// Signed wide integer type: double the width of [`SignedWord`].
 #[cfg(target_pointer_width = "64")]
-pub(crate) type WideLimbInt = i128;
+pub(crate) type WideSignedWord = i128;
+
+//
+// Deprecated legacy names
+//
+
+// TODO(tarcieri): remove these in the next breaking release
+
+/// Deprecated: unsigned integer type that the [`Limb`] newtype wraps.
+#[deprecated(since = "0.4.8", note = "please use `Word` instead")]
+pub type LimbUInt = Word;
+
+/// Deprecated: wide integer type which is double the width of [`Word`].
+#[deprecated(since = "0.4.8", note = "please use `WideWord` instead")]
+pub type WideLimbUInt = WideWord;
 
 /// Highest bit in a [`Limb`].
 pub(crate) const HI_BIT: usize = Limb::BIT_SIZE - 1;
@@ -75,7 +89,7 @@ pub(crate) const HI_BIT: usize = Limb::BIT_SIZE - 1;
 /// called "limbs".
 #[derive(Copy, Clone, Debug, Default, Hash)]
 #[repr(transparent)]
-pub struct Limb(pub LimbUInt);
+pub struct Limb(pub Word);
 
 impl Limb {
     /// The value `0`.
@@ -85,7 +99,7 @@ impl Limb {
     pub const ONE: Self = Limb(1);
 
     /// Maximum value this [`Limb`] can express.
-    pub const MAX: Self = Limb(LimbUInt::MAX);
+    pub const MAX: Self = Limb(Word::MAX);
 
     // 32-bit
 
@@ -109,7 +123,7 @@ impl Limb {
     ///
     /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
     #[inline]
-    pub(crate) const fn ct_select(a: Self, b: Self, c: LimbUInt) -> Self {
+    pub(crate) const fn ct_select(a: Self, b: Self, c: Word) -> Self {
         Self(a.0 ^ (c & (a.0 ^ b.0)))
     }
 }
@@ -117,7 +131,7 @@ impl Limb {
 impl ConditionallySelectable for Limb {
     #[inline]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        Self(LimbUInt::conditional_select(&a.0, &b.0, choice))
+        Self(Word::conditional_select(&a.0, &b.0, choice))
     }
 }
 
@@ -153,7 +167,7 @@ impl<'de> Deserialize<'de> for Limb {
     where
         D: Deserializer<'de>,
     {
-        Ok(Self(LimbUInt::deserialize(deserializer)?))
+        Ok(Self(Word::deserialize(deserializer)?))
     }
 }
 

--- a/src/limb/add.rs
+++ b/src/limb/add.rs
@@ -1,6 +1,6 @@
 //! Limb addition
 
-use crate::{Checked, CheckedAdd, Limb, LimbUInt, WideLimbUInt, Wrapping, Zero};
+use crate::{Checked, CheckedAdd, Limb, WideWord, Word, Wrapping, Zero};
 use core::ops::{Add, AddAssign};
 use subtle::CtOption;
 
@@ -8,14 +8,11 @@ impl Limb {
     /// Computes `self + rhs + carry`, returning the result along with the new carry.
     #[inline(always)]
     pub const fn adc(self, rhs: Limb, carry: Limb) -> (Limb, Limb) {
-        let a = self.0 as WideLimbUInt;
-        let b = rhs.0 as WideLimbUInt;
-        let carry = carry.0 as WideLimbUInt;
+        let a = self.0 as WideWord;
+        let b = rhs.0 as WideWord;
+        let carry = carry.0 as WideWord;
         let ret = a + b + carry;
-        (
-            Limb(ret as LimbUInt),
-            Limb((ret >> Self::BIT_SIZE) as LimbUInt),
-        )
+        (Limb(ret as Word), Limb((ret >> Self::BIT_SIZE) as Word))
     }
 
     /// Perform saturating addition.

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -1,6 +1,6 @@
 //! Limb comparisons
 
-use super::{Limb, LimbInt, LimbUInt, WideLimbInt, HI_BIT};
+use super::{Limb, SignedWord, WideSignedWord, Word, HI_BIT};
 use core::cmp::Ordering;
 use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
@@ -28,18 +28,18 @@ impl Limb {
     ///
     /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
     #[inline]
-    pub(crate) const fn is_nonzero(self) -> LimbUInt {
-        let inner = self.0 as LimbInt;
-        ((inner | inner.saturating_neg()) >> HI_BIT) as LimbUInt
+    pub(crate) const fn is_nonzero(self) -> Word {
+        let inner = self.0 as SignedWord;
+        ((inner | inner.saturating_neg()) >> HI_BIT) as Word
     }
 
     #[inline]
-    pub(crate) const fn ct_cmp(lhs: Self, rhs: Self) -> LimbInt {
-        let a = lhs.0 as WideLimbInt;
-        let b = rhs.0 as WideLimbInt;
+    pub(crate) const fn ct_cmp(lhs: Self, rhs: Self) -> SignedWord {
+        let a = lhs.0 as WideSignedWord;
+        let b = rhs.0 as WideSignedWord;
         let gt = ((b - a) >> Limb::BIT_SIZE) & 1;
         let lt = ((a - b) >> Limb::BIT_SIZE) & 1 & !gt;
-        (gt as LimbInt) - (lt as LimbInt)
+        (gt as SignedWord) - (lt as SignedWord)
     }
 }
 

--- a/src/limb/encoding.rs
+++ b/src/limb/encoding.rs
@@ -1,6 +1,6 @@
 //! Limb encoding
 
-use super::{Limb, LimbUInt};
+use super::{Limb, Word};
 use crate::Encoding;
 
 impl Encoding for Limb {
@@ -14,12 +14,12 @@ impl Encoding for Limb {
 
     #[inline]
     fn from_be_bytes(bytes: Self::Repr) -> Self {
-        Limb(LimbUInt::from_be_bytes(bytes))
+        Limb(Word::from_be_bytes(bytes))
     }
 
     #[inline]
     fn from_le_bytes(bytes: Self::Repr) -> Self {
-        Limb(LimbUInt::from_le_bytes(bytes))
+        Limb(Word::from_le_bytes(bytes))
     }
 
     #[inline]
@@ -39,7 +39,7 @@ mod test {
     use proptest::prelude::*;
 
     prop_compose! {
-        fn limb()(inner in any::<LimbUInt>()) -> Limb {
+        fn limb()(inner in any::<Word>()) -> Limb {
             Limb(inner)
         }
     }

--- a/src/limb/from.rs
+++ b/src/limb/from.rs
@@ -1,25 +1,25 @@
 //! `From`-like conversions for [`Limb`].
 
-use super::{Limb, LimbUInt, WideLimbUInt};
+use super::{Limb, WideWord, Word};
 
 impl Limb {
     /// Create a [`Limb`] from a `u8` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u8>` when stable
     pub const fn from_u8(n: u8) -> Self {
-        Limb(n as LimbUInt)
+        Limb(n as Word)
     }
 
     /// Create a [`Limb`] from a `u16` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u16>` when stable
     pub const fn from_u16(n: u16) -> Self {
-        Limb(n as LimbUInt)
+        Limb(n as Word)
     }
 
     /// Create a [`Limb`] from a `u32` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u32>` when stable
     pub const fn from_u32(n: u32) -> Self {
         #[allow(trivial_numeric_casts)]
-        Limb(n as LimbUInt)
+        Limb(n as Word)
     }
 
     /// Create a [`Limb`] from a `u64` integer (const-friendly)
@@ -61,16 +61,16 @@ impl From<u64> for Limb {
     }
 }
 
-impl From<Limb> for LimbUInt {
+impl From<Limb> for Word {
     #[inline]
-    fn from(limb: Limb) -> LimbUInt {
+    fn from(limb: Limb) -> Word {
         limb.0
     }
 }
 
-impl From<Limb> for WideLimbUInt {
+impl From<Limb> for WideWord {
     #[inline]
-    fn from(limb: Limb) -> WideLimbUInt {
+    fn from(limb: Limb) -> WideWord {
         limb.0.into()
     }
 }

--- a/src/limb/sub.rs
+++ b/src/limb/sub.rs
@@ -1,6 +1,6 @@
 //! Limb subtraction
 
-use crate::{Checked, CheckedSub, Limb, LimbUInt, WideLimbUInt, Wrapping, Zero};
+use crate::{Checked, CheckedSub, Limb, WideWord, Word, Wrapping, Zero};
 use core::ops::{Sub, SubAssign};
 use subtle::CtOption;
 
@@ -8,14 +8,11 @@ impl Limb {
     /// Computes `self - (rhs + borrow)`, returning the result along with the new borrow.
     #[inline(always)]
     pub const fn sbb(self, rhs: Limb, borrow: Limb) -> (Limb, Limb) {
-        let a = self.0 as WideLimbUInt;
-        let b = rhs.0 as WideLimbUInt;
-        let borrow = (borrow.0 >> (Self::BIT_SIZE - 1)) as WideLimbUInt;
+        let a = self.0 as WideWord;
+        let b = rhs.0 as WideWord;
+        let borrow = (borrow.0 >> (Self::BIT_SIZE - 1)) as WideWord;
         let ret = a.wrapping_sub(b + borrow);
-        (
-            Limb(ret as LimbUInt),
-            Limb((ret >> Self::BIT_SIZE) as LimbUInt),
-        )
+        (Limb(ret as Word), Limb((ret >> Self::BIT_SIZE) as Word))
     }
 
     /// Perform saturating subtraction.

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -1,4 +1,4 @@
-use crate::{Limb, LimbUInt, UInt};
+use crate::{Limb, UInt, Word};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Calculate the number of bits needed to represent this number.
@@ -10,12 +10,12 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         }
 
         let limb = self.limbs[i].0;
-        let bits = (Limb::BIT_SIZE * (i + 1)) as LimbUInt - limb.leading_zeros() as LimbUInt;
+        let bits = (Limb::BIT_SIZE * (i + 1)) as Word - limb.leading_zeros() as Word;
 
         Limb::ct_select(
             Limb(bits),
             Limb::ZERO,
-            !self.limbs[0].is_nonzero() & !Limb(i as LimbUInt).is_nonzero(),
+            !self.limbs[0].is_nonzero() & !Limb(i as Word).is_nonzero(),
         )
         .0 as usize
     }

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -3,7 +3,7 @@
 //! By default these are all constant-time and use the `subtle` crate.
 
 use super::UInt;
-use crate::{Limb, LimbInt, LimbUInt, WideLimbInt, Zero};
+use crate::{Limb, SignedWord, WideSignedWord, Word, Zero};
 use core::cmp::Ordering;
 use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
@@ -12,7 +12,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     ///
     /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
     #[inline]
-    pub(crate) const fn ct_select(a: UInt<LIMBS>, b: UInt<LIMBS>, c: LimbUInt) -> Self {
+    pub(crate) const fn ct_select(a: UInt<LIMBS>, b: UInt<LIMBS>, c: Word) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
 
         let mut i = 0;
@@ -28,7 +28,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     ///
     /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
     #[inline]
-    pub(crate) const fn ct_is_nonzero(&self) -> LimbUInt {
+    pub(crate) const fn ct_is_nonzero(&self) -> Word {
         let mut b = 0;
         let mut i = 0;
         while i < LIMBS {
@@ -44,19 +44,19 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     ///
     /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
     #[inline]
-    pub(crate) const fn ct_cmp(&self, rhs: &Self) -> LimbInt {
+    pub(crate) const fn ct_cmp(&self, rhs: &Self) -> SignedWord {
         let mut gt = 0;
         let mut lt = 0;
         let mut i = LIMBS;
 
         while i > 0 {
-            let a = self.limbs[i - 1].0 as WideLimbInt;
-            let b = rhs.limbs[i - 1].0 as WideLimbInt;
+            let a = self.limbs[i - 1].0 as WideSignedWord;
+            let b = rhs.limbs[i - 1].0 as WideSignedWord;
             gt |= ((b - a) >> Limb::BIT_SIZE) & 1 & !lt;
             lt |= ((a - b) >> Limb::BIT_SIZE) & 1 & !gt;
             i -= 1;
         }
-        (gt as LimbInt) - (lt as LimbInt)
+        (gt as SignedWord) - (lt as SignedWord)
     }
 }
 

--- a/src/uint/encoding/decoder.rs
+++ b/src/uint/encoding/decoder.rs
@@ -1,4 +1,4 @@
-use crate::{Limb, LimbUInt, UInt};
+use crate::{Limb, UInt, Word};
 
 /// [`UInt`] decoder.
 #[derive(Clone, Debug)]
@@ -33,7 +33,7 @@ impl<const LIMBS: usize> Decoder<LIMBS> {
             self.bytes = 0;
         }
 
-        self.limbs[self.index].0 |= (byte as LimbUInt) << (self.bytes * 8);
+        self.limbs[self.index].0 |= (byte as Word) << (self.bytes * 8);
         self.bytes += 1;
         self
     }

--- a/src/uint/from.rs
+++ b/src/uint/from.rs
@@ -1,6 +1,6 @@
 //! `From`-like conversions for [`UInt`].
 
-use crate::{Limb, LimbUInt, Split, UInt, U128, U64};
+use crate::{Limb, Split, UInt, Word, U128, U64};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Create a [`UInt`] from a `u8` (const-friendly)
@@ -8,7 +8,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     pub const fn from_u8(n: u8) -> Self {
         assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
-        limbs[0].0 = n as LimbUInt;
+        limbs[0].0 = n as Word;
         Self { limbs }
     }
 
@@ -17,7 +17,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     pub const fn from_u16(n: u16) -> Self {
         assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
-        limbs[0].0 = n as LimbUInt;
+        limbs[0].0 = n as Word;
         Self { limbs }
     }
 
@@ -27,7 +27,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     pub const fn from_u32(n: u32) -> Self {
         assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
-        limbs[0].0 = n as LimbUInt;
+        limbs[0].0 = n as Word;
         Self { limbs }
     }
 
@@ -78,37 +78,6 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         }
 
         Self { limbs }
-    }
-
-    /// Create a [`UInt`] from an array of the [`LimbUInt`]
-    /// unsigned integer type.
-    // TODO(tarcieri): replace with `const impl From<[LimbUInt; LIMBS]>` when stable
-    #[inline]
-    pub const fn from_uint_array(arr: [LimbUInt; LIMBS]) -> Self {
-        let mut limbs = [Limb::ZERO; LIMBS];
-        let mut i = 0;
-
-        while i < LIMBS {
-            limbs[i] = Limb(arr[i]);
-            i += 1;
-        }
-
-        Self { limbs }
-    }
-
-    /// Create an array of [`LimbUInt`] unsigned integers from a [`UInt`].
-    #[inline]
-    // TODO(tarcieri): replace with `const impl From<Self> for [limb::Inner; LIMBS]` when stable
-    pub const fn to_uint_array(self) -> [LimbUInt; LIMBS] {
-        let mut arr = [0; LIMBS];
-        let mut i = 0;
-
-        while i < LIMBS {
-            arr[i] = self.limbs[i].0;
-            i += 1;
-        }
-
-        arr
     }
 }
 
@@ -175,14 +144,14 @@ impl From<U128> for u128 {
     }
 }
 
-impl<const LIMBS: usize> From<[LimbUInt; LIMBS]> for UInt<LIMBS> {
-    fn from(arr: [LimbUInt; LIMBS]) -> Self {
-        Self::from_uint_array(arr)
+impl<const LIMBS: usize> From<[Word; LIMBS]> for UInt<LIMBS> {
+    fn from(arr: [Word; LIMBS]) -> Self {
+        Self::from_words(arr)
     }
 }
 
-impl<const LIMBS: usize> From<UInt<LIMBS>> for [LimbUInt; LIMBS] {
-    fn from(n: UInt<LIMBS>) -> [LimbUInt; LIMBS] {
+impl<const LIMBS: usize> From<UInt<LIMBS>> for [Word; LIMBS] {
+    fn from(n: UInt<LIMBS>) -> [Word; LIMBS] {
         *n.as_ref()
     }
 }
@@ -207,7 +176,7 @@ impl<const LIMBS: usize> From<Limb> for UInt<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Limb, LimbUInt, U128};
+    use crate::{Limb, Word, U128};
 
     #[cfg(target_pointer_width = "32")]
     use crate::U64 as UIntEx;
@@ -244,7 +213,7 @@ mod tests {
     fn array_round_trip() {
         let arr1 = [1, 2];
         let n = UIntEx::from(arr1);
-        let arr2: [LimbUInt; 2] = n.into();
+        let arr2: [Word; 2] = n.into();
         assert_eq!(arr1, arr2);
     }
 }

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -1,6 +1,6 @@
 //! [`UInt`] bitwise left shift operations.
 
-use crate::{Limb, LimbUInt, UInt};
+use crate::{Limb, UInt, Word};
 use core::ops::{Shl, ShlAssign};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
@@ -20,10 +20,9 @@ impl<const LIMBS: usize> UInt<LIMBS> {
 
         let shift_num = n / Limb::BIT_SIZE;
         let rem = n % Limb::BIT_SIZE;
-        let nz = Limb(rem as LimbUInt).is_nonzero();
-        let lshift_rem = rem as LimbUInt;
-        let rshift_rem =
-            Limb::ct_select(Limb::ZERO, Limb((Limb::BIT_SIZE - rem) as LimbUInt), nz).0;
+        let nz = Limb(rem as Word).is_nonzero();
+        let lshift_rem = rem as Word;
+        let rshift_rem = Limb::ct_select(Limb::ZERO, Limb((Limb::BIT_SIZE - rem) as Word), nz).0;
 
         let mut i = LIMBS - 1;
         while i > shift_num {

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -1,7 +1,7 @@
 //! [`UInt`] square root operations.
 
 use super::UInt;
-use crate::{Limb, LimbUInt};
+use crate::{Limb, Word};
 use subtle::{ConstantTimeEq, CtOption};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
@@ -25,8 +25,8 @@ impl<const LIMBS: usize> UInt<LIMBS> {
             // Sometimes an increase is too far, especially with large
             // powers, and then takes a long time to walk back.  The upper
             // bound is based on bit size, so saturate on that.
-            let res = Limb::ct_cmp(Limb(xn.bits() as LimbUInt), Limb(max_bits as LimbUInt)) - 1;
-            let le = Limb::is_nonzero(Limb(res as LimbUInt));
+            let res = Limb::ct_cmp(Limb(xn.bits() as Word), Limb(max_bits as Word)) - 1;
+            let le = Limb::is_nonzero(Limb(res as Word));
             guess = Self::ct_select(cap, xn, le);
             xn = {
                 let q = self.wrapping_div(&guess);
@@ -36,7 +36,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         }
 
         // Repeat while guess decreases.
-        while guess.ct_cmp(&xn) == 1 && xn.ct_is_nonzero() == LimbUInt::MAX {
+        while guess.ct_cmp(&xn) == 1 && xn.ct_is_nonzero() == Word::MAX {
             guess = xn;
             xn = {
                 let q = self.wrapping_div(&guess);


### PR DESCRIPTION
Also internally renames (Wide)`LimbUInt` => (Wide)`SignedWord`.

These names are slightly less unwieldy.

Note: breaking change.