### PR TITLE
v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.4 (2022-06-02)
+### Added
+- `UInt::as_uint_array` ([#91])
+
+[#91]: https://github.com/RustCrypto/crypto-bigint/pull/91
+
 ## 0.4.3 (2022-05-31)
 ### Added
 - Impl `AsRef`/`AsMut<[LimbUInt]>` for `UInt` ([#89])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "der",
  "generic-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.4.3"
+version = "0.4.4"
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,


### PR DESCRIPTION
### Added
- `UInt::as_uint_array` ([#91])

[#91]: https://github.com/RustCrypto/crypto-bigint/pull/91