### PR TITLE
v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.6 (2022-06-12)
+### Added
+- Impl `ArrayEncoding` for `U576` ([#96])
+
+[#96]: https://github.com/RustCrypto/crypto-bigint/pull/96
+
 ## 0.4.5 (2022-06-12)
 ### Added
 - `serde` support ([#73])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "bincode",
  "der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.4.5"
+version = "0.4.6"
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,


### PR DESCRIPTION
### Added
- Impl `ArrayEncoding` for `U576` ([#96])

[#96]: https://github.com/RustCrypto/crypto-bigint/pull/96