### PR TITLE
Use const generic impls of `*Mod` traits

### DIFF
--- a/src/uint/add_mod.rs
+++ b/src/uint/add_mod.rs
@@ -32,23 +32,15 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
-macro_rules! impl_add_mod {
-    ($($size:expr),+) => {
-        $(
-            impl AddMod for UInt<$size> {
-                type Output = Self;
+impl<const LIMBS: usize> AddMod for UInt<LIMBS> {
+    type Output = Self;
 
-                fn add_mod(&self, rhs: &Self, p: &Self) -> Self {
-                    debug_assert!(self < p);
-                    debug_assert!(rhs < p);
-                    self.add_mod(rhs, p)
-                }
-            }
-        )+
-    };
+    fn add_mod(&self, rhs: &Self, p: &Self) -> Self {
+        debug_assert!(self < p);
+        debug_assert!(rhs < p);
+        self.add_mod(rhs, p)
+    }
 }
-
-impl_add_mod!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
 
 #[cfg(test)]
 mod tests {

--- a/src/uint/neg_mod.rs
+++ b/src/uint/neg_mod.rs
@@ -51,19 +51,11 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
-macro_rules! impl_neg_mod {
-    ($($size:expr),+) => {
-        $(
-            impl NegMod for UInt<$size> {
-                type Output = Self;
+impl<const LIMBS: usize> NegMod for UInt<LIMBS> {
+    type Output = Self;
 
-                fn neg_mod(&self, p: &Self) -> Self {
-                    debug_assert!(self < p);
-                    self.neg_mod(p)
-                }
-            }
-        )+
-    };
+    fn neg_mod(&self, p: &Self) -> Self {
+        debug_assert!(self < p);
+        self.neg_mod(p)
+    }
 }
-
-impl_neg_mod!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);

--- a/src/uint/sub_mod.rs
+++ b/src/uint/sub_mod.rs
@@ -25,23 +25,15 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
-macro_rules! impl_sub_mod {
-    ($($size:expr),+) => {
-        $(
-            impl SubMod for UInt<$size> {
-                type Output = Self;
+impl<const LIMBS: usize> SubMod for UInt<LIMBS> {
+    type Output = Self;
 
-                fn sub_mod(&self, rhs: &Self, p: &Self) -> Self {
-                    debug_assert!(self < p);
-                    debug_assert!(rhs < p);
-                    self.sub_mod(rhs, p)
-                }
-            }
-        )+
-    };
+    fn sub_mod(&self, rhs: &Self, p: &Self) -> Self {
+        debug_assert!(self < p);
+        debug_assert!(rhs < p);
+        self.sub_mod(rhs, p)
+    }
 }
-
-impl_sub_mod!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
 
 #[cfg(all(test, feature = "rand"))]
 mod tests {


### PR DESCRIPTION
The core implementations of these traits are already const generic, so there's no reason the trait impls shouldn't also be.