### PR TITLE
v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.7 (2022-06-12)
+### Added
+- `Encoding` tests ([#93])
+
+### Changed
+- Use const generic impls of `*Mod` traits ([#98])
+
+[#93]: https://github.com/RustCrypto/crypto-bigint/pull/93
+[#98]: https://github.com/RustCrypto/crypto-bigint/pull/98
+
 ## 0.4.6 (2022-06-12)
 ### Added
 - Impl `ArrayEncoding` for `U576` ([#96])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "bincode",
  "der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.4.6"
+version = "0.4.7"
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,


### PR DESCRIPTION
### Added
- `Encoding` tests ([#93])

### Changed
- Use const generic impls of `*Mod` traits ([#98])

[#93]: https://github.com/RustCrypto/crypto-bigint/pull/93
[#98]: https://github.com/RustCrypto/crypto-bigint/pull/98