### PR TITLE
CI: fix `cross` builds

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -80,13 +80,9 @@ jobs:
         include:
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.57.0 # MSRV
-          - target: aarch64-unknown-linux-gnu
             rust: stable
 
-          # PPC32
-          - target: powerpc-unknown-linux-gnu
-            rust: 1.57.0 # MSRV
+          # PPC32 (big endian)
           - target: powerpc-unknown-linux-gnu
             rust: stable
 


### PR DESCRIPTION
The new MSRV for `cross` is 1.58.1.

However, rather than deal with that, this PR just removes the `cross` checks for MSRV 1.57.0 (i.e. `crypto-bigint` MSRV) and only runs `cross` on `stable`, which should simplify future maintenance.