### PR TITLE
v0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.8 (2022-06-30)
+### Added
+- `Word` as a replacement for `LimbUInt` ([#88])
+- `WideWord` as a replacement for `WideLimbUInt` ([#88])
+- `UInt::*_words` as a replacement for `UInt::*_uint_array` ([#88])
+
+### Changed
+- Deprecated `*LimbUInt` and `UInt::*_uint_array` ([#88])
+
+[#88]: https://github.com/RustCrypto/crypto-bigint/pull/88
+
 ## 0.4.7 (2022-06-12)
 ### Added
 - `Encoding` tests ([#93])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "bincode",
  "der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.4.7"
+version = "0.4.8"
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,


### PR DESCRIPTION
### Added
- `Word` as a replacement for `LimbUInt` ([#88])
- `WideWord` as a replacement for `WideLimbUInt` ([#88])
- `UInt::*_words` as a replacement for `UInt::*_uint_array` ([#88])

### Changed
- Deprecated `*LimbUInt` and `UInt::*_uint_array` ([#88])

[#88]: https://github.com/RustCrypto/crypto-bigint/pull/88