### PR TITLE
uint: Relax bounds for UInt::add_mod and UInt::sub_mod

### DIFF
--- a/src/uint/add_mod.rs
+++ b/src/uint/add_mod.rs
@@ -5,7 +5,7 @@ use crate::{AddMod, Limb, UInt};
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Computes `self + rhs mod p` in constant time.
     ///
-    /// Assumes `self` and `rhs` are `< p`.
+    /// Assumes `self + rhs` as unbounded integer is `< 2p`.
     pub const fn add_mod(&self, rhs: &UInt<LIMBS>, p: &UInt<LIMBS>) -> UInt<LIMBS> {
         let (w, carry) = self.adc(rhs, Limb::ZERO);
 

--- a/src/uint/sub_mod.rs
+++ b/src/uint/sub_mod.rs
@@ -5,7 +5,7 @@ use crate::{Limb, SubMod, UInt};
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Computes `self - rhs mod p` in constant time.
     ///
-    /// Assumes `self` and `rhs` are `< p`.
+    /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
     pub const fn sub_mod(&self, rhs: &UInt<LIMBS>, p: &UInt<LIMBS>) -> UInt<LIMBS> {
         let (mut out, borrow) = self.sbb(rhs, Limb::ZERO);
 


### PR DESCRIPTION
In some applications involving modulo arithmetic, there are occasions where one knows that a certain number `x` that needs to
be reduced is not much larger than the modulus `p`. In particular, if one knows `x < 2p`, one can simply reduce it by calling `x.sub_mod(&p, &p)`. This works due to the nature of the `sub_mod` implementation. However, it is currently unspecified behavior, as the documentation of `sub_mod` requires `x < p`.

This commit relaxes the requirement for `UInt::sub_mod` and analogously for `UInt::add_mod`, so that above-mentioned behavior doesn't change in a future update.

The traits `AddMod` and `SubMod` still have the original requirements, so one needs to call `UInt::add_mod` or `UInt::sub_mod` explicitly when relying on this behavior.