### PR TITLE
uint: Optimize neg_mod by simply calling sub_mod

### DIFF
--- a/src/uint/neg_mod.rs
+++ b/src/uint/neg_mod.rs
@@ -1,53 +1,11 @@
 //! [`UInt`] subtraction modulus operations.
 
-use crate::{Limb, NegMod, UInt};
+use crate::{NegMod, UInt};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Computes `-a mod p` in constant time.
     pub const fn neg_mod(&self, p: &Self) -> Self {
-        let mut tmp = [Limb::ZERO; LIMBS];
-
-        // Subtract `a` from `p` to negate. Ignore the final
-        // borrow because it cannot underflow; a is guaranteed to
-        // be in the field.
-        let mut borrow = Limb::ZERO;
-        let mut i = 0;
-
-        while i < LIMBS {
-            let (l, b) = p.limbs[i].sbb(self.limbs[i], borrow);
-            tmp[i] = l;
-            borrow = b;
-
-            i += 1;
-        }
-
-        // `tmp` could be `p` if `a` was zero. Create a mask that is
-        // zero if `a` was zero, and `Limb::MAX` if self was nonzero.
-        // FIXME: constant time comparison
-        let mut self_or = self.limbs[0];
-        let mut i = 1;
-
-        while i < LIMBS {
-            self_or = self_or.bitor(self.limbs[i]);
-            i += 1;
-        }
-
-        let v = if self_or.eq_vartime(&Limb::ZERO) {
-            Limb::ONE
-        } else {
-            Limb::ZERO
-        };
-
-        let mask = v.wrapping_sub(Limb::ONE);
-
-        let mut i = 0;
-
-        while i < LIMBS {
-            tmp[i] = tmp[i].bitand(mask);
-            i += 1;
-        }
-
-        UInt::new(tmp)
+        Self::ZERO.sub_mod(self, p)
     }
 }
 
@@ -57,5 +15,38 @@ impl<const LIMBS: usize> NegMod for UInt<LIMBS> {
     fn neg_mod(&self, p: &Self) -> Self {
         debug_assert!(self < p);
         self.neg_mod(p)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::U256;
+
+    #[test]
+    fn neg_mod_random() {
+        let x =
+            U256::from_be_hex("8d16e171674b4e6d8529edba4593802bf30b8cb161dd30aa8e550d41380007c2");
+        let p =
+            U256::from_be_hex("928334a4e4be0843ec225a4c9c61df34bdc7a81513e4b6f76f2bfa3148e2e1b5");
+
+        let actual = x.neg_mod(&p);
+        let expected =
+            U256::from_be_hex("056c53337d72b9d666f86c9256ce5f08cabc1b63b207864ce0d6ecf010e2d9f3");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn neg_mod_zero() {
+        let x =
+            U256::from_be_hex("0000000000000000000000000000000000000000000000000000000000000000");
+        let p =
+            U256::from_be_hex("928334a4e4be0843ec225a4c9c61df34bdc7a81513e4b6f76f2bfa3148e2e1b5");
+
+        let actual = x.neg_mod(&p);
+        let expected =
+            U256::from_be_hex("0000000000000000000000000000000000000000000000000000000000000000");
+
+        assert_eq!(expected, actual);
     }
 }


### PR DESCRIPTION
The new implementation uses 2 instead of 3 iterations over the limbs.