### PR TITLE
uint: Implement modulo operations for special moduli

### DIFF
--- a/src/uint.rs
+++ b/src/uint.rs
@@ -22,6 +22,7 @@ mod encoding;
 mod from;
 mod inv_mod;
 mod mul;
+mod mul_mod;
 mod neg_mod;
 mod shl;
 mod shr;

--- a/src/uint/add_mod.rs
+++ b/src/uint/add_mod.rs
@@ -30,6 +30,22 @@ impl<const LIMBS: usize> UInt<LIMBS> {
 
         res
     }
+
+    /// Computes `self + rhs mod p` in constant time for the special modulus
+    /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
+    ///
+    /// Assumes `self + rhs` as unbounded integer is `< 2p`.
+    pub const fn add_mod_special(&self, rhs: &Self, c: Limb) -> Self {
+        // `UInt::adc` also works with a carry greater than 1.
+        let (out, carry) = self.adc(rhs, c);
+
+        // If overflow occurred, then above addition of `c` already accounts
+        // for the overflow. Otherwise, we need to subtract `c` again, which
+        // in that case cannot underflow.
+        let l = carry.0.wrapping_sub(1) & c.0;
+        let (out, _) = out.sbb(&UInt::from_word(l), Limb::ZERO);
+        out
+    }
 }
 
 impl<const LIMBS: usize> AddMod for UInt<LIMBS> {
@@ -42,9 +58,10 @@ impl<const LIMBS: usize> AddMod for UInt<LIMBS> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "rand"))]
 mod tests {
-    use crate::U256;
+    use crate::{Limb, NonZero, Random, RandomMod, UInt, U256};
+    use rand_core::SeedableRng;
 
     // TODO(tarcieri): additional tests + proptests
 
@@ -63,4 +80,60 @@ mod tests {
 
         assert_eq!(expected, actual);
     }
+
+    macro_rules! test_add_mod_special {
+        ($size:expr, $test_name:ident) => {
+            #[test]
+            fn $test_name() {
+                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+                let moduli = [
+                    NonZero::<Limb>::random(&mut rng),
+                    NonZero::<Limb>::random(&mut rng),
+                ];
+
+                for special in &moduli {
+                    let p = &NonZero::new(UInt::ZERO.wrapping_sub(&UInt::from_word(special.0)))
+                        .unwrap();
+
+                    let minus_one = p.wrapping_sub(&UInt::ONE);
+
+                    let base_cases = [
+                        (UInt::ZERO, UInt::ZERO, UInt::ZERO),
+                        (UInt::ONE, UInt::ZERO, UInt::ONE),
+                        (UInt::ZERO, UInt::ONE, UInt::ONE),
+                        (minus_one, UInt::ONE, UInt::ZERO),
+                        (UInt::ONE, minus_one, UInt::ZERO),
+                    ];
+                    for (a, b, c) in &base_cases {
+                        let x = a.add_mod_special(b, *special.as_ref());
+                        assert_eq!(*c, x, "{} + {} mod {} = {} != {}", a, b, p, x, c);
+                    }
+
+                    for _i in 0..100 {
+                        let a = UInt::<$size>::random_mod(&mut rng, p);
+                        let b = UInt::<$size>::random_mod(&mut rng, p);
+
+                        let c = a.add_mod_special(&b, *special.as_ref());
+                        assert!(c < **p, "not reduced: {} >= {} ", c, p);
+
+                        let expected = a.add_mod(&b, p);
+                        assert_eq!(c, expected, "incorrect result");
+                    }
+                }
+            }
+        };
+    }
+
+    test_add_mod_special!(1, add_mod_special_1);
+    test_add_mod_special!(2, add_mod_special_2);
+    test_add_mod_special!(3, add_mod_special_3);
+    test_add_mod_special!(4, add_mod_special_4);
+    test_add_mod_special!(5, add_mod_special_5);
+    test_add_mod_special!(6, add_mod_special_6);
+    test_add_mod_special!(7, add_mod_special_7);
+    test_add_mod_special!(8, add_mod_special_8);
+    test_add_mod_special!(9, add_mod_special_9);
+    test_add_mod_special!(10, add_mod_special_10);
+    test_add_mod_special!(11, add_mod_special_11);
+    test_add_mod_special!(12, add_mod_special_12);
 }

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -1,0 +1,131 @@
+//! [`UInt`] multiplication modulus operations.
+
+use crate::{Limb, UInt, WideWord, Word};
+
+impl<const LIMBS: usize> UInt<LIMBS> {
+    /// Computes `self * rhs mod p` in constant time for the special modulus
+    /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
+    /// For the modulus reduction, this function implements Algorithm 14.47 from
+    /// the "Handbook of Applied Cryptography", by A. Menezes, P. van Oorschot,
+    /// and S. Vanstone, CRC Press, 1996.
+    pub const fn mul_mod_special(&self, rhs: &Self, c: Limb) -> Self {
+        // We implicitly assume `LIMBS > 0`, because `UInt<0>` doesn't compile.
+        // Still the case `LIMBS == 1` needs special handling.
+        if LIMBS == 1 {
+            let prod = self.limbs[0].0 as WideWord * rhs.limbs[0].0 as WideWord;
+            let reduced = prod % Word::MIN.wrapping_sub(c.0) as WideWord;
+            return Self::from_word(reduced as Word);
+        }
+
+        let (lo, hi) = self.mul_wide(rhs);
+
+        // Now use Algorithm 14.47 for the reduction
+        let (lo, carry) = mac_by_limb(lo, hi, c, Limb::ZERO);
+
+        let (lo, carry) = {
+            let rhs = (carry.0 + 1) as WideWord * c.0 as WideWord;
+            lo.adc(&Self::from_wide_word(rhs), Limb::ZERO)
+        };
+
+        let (lo, _) = {
+            let rhs = carry.0.wrapping_sub(1) & c.0;
+            lo.sbb(&Self::from_word(rhs), Limb::ZERO)
+        };
+
+        lo
+    }
+}
+
+/// Computes `a + (b * c) + carry`, returning the result along with the new carry.
+const fn mac_by_limb<const LIMBS: usize>(
+    mut a: UInt<LIMBS>,
+    b: UInt<LIMBS>,
+    c: Limb,
+    mut carry: Limb,
+) -> (UInt<LIMBS>, Limb) {
+    let mut i = 0;
+
+    while i < LIMBS {
+        let (n, c) = a.limbs[i].mac(b.limbs[i], c, carry);
+        a.limbs[i] = n;
+        carry = c;
+        i += 1;
+    }
+
+    (a, carry)
+}
+
+#[cfg(all(test, feature = "rand"))]
+mod tests {
+    use crate::{Limb, NonZero, Random, RandomMod, UInt};
+    use rand_core::SeedableRng;
+
+    macro_rules! test_mul_mod_special {
+        ($size:expr, $test_name:ident) => {
+            #[test]
+            fn $test_name() {
+                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+                let moduli = [
+                    NonZero::<Limb>::random(&mut rng),
+                    NonZero::<Limb>::random(&mut rng),
+                ];
+
+                for special in &moduli {
+                    let p = &NonZero::new(UInt::ZERO.wrapping_sub(&UInt::from_word(special.0)))
+                        .unwrap();
+
+                    let minus_one = p.wrapping_sub(&UInt::ONE);
+
+                    let base_cases = [
+                        (UInt::ZERO, UInt::ZERO, UInt::ZERO),
+                        (UInt::ONE, UInt::ZERO, UInt::ZERO),
+                        (UInt::ZERO, UInt::ONE, UInt::ZERO),
+                        (UInt::ONE, UInt::ONE, UInt::ONE),
+                        (minus_one, minus_one, UInt::ONE),
+                        (minus_one, UInt::ONE, minus_one),
+                        (UInt::ONE, minus_one, minus_one),
+                    ];
+                    for (a, b, c) in &base_cases {
+                        let x = a.mul_mod_special(&b, *special.as_ref());
+                        assert_eq!(*c, x, "{} * {} mod {} = {} != {}", a, b, p, x, c);
+                    }
+
+                    for _i in 0..100 {
+                        let a = UInt::<$size>::random_mod(&mut rng, p);
+                        let b = UInt::<$size>::random_mod(&mut rng, p);
+
+                        let c = a.mul_mod_special(&b, *special.as_ref());
+                        assert!(c < **p, "not reduced: {} >= {} ", c, p);
+
+                        let expected = {
+                            let (lo, hi) = a.mul_wide(&b);
+                            let mut prod = UInt::<{ 2 * $size }>::ZERO;
+                            prod.limbs[..$size].clone_from_slice(&lo.limbs);
+                            prod.limbs[$size..].clone_from_slice(&hi.limbs);
+                            let mut modulus = UInt::ZERO;
+                            modulus.limbs[..$size].clone_from_slice(&p.as_ref().limbs);
+                            let reduced = prod.reduce(&modulus).unwrap();
+                            let mut expected = UInt::ZERO;
+                            expected.limbs[..].clone_from_slice(&reduced.limbs[..$size]);
+                            expected
+                        };
+                        assert_eq!(c, expected, "incorrect result");
+                    }
+                }
+            }
+        };
+    }
+
+    test_mul_mod_special!(1, mul_mod_special_1);
+    test_mul_mod_special!(2, mul_mod_special_2);
+    test_mul_mod_special!(3, mul_mod_special_3);
+    test_mul_mod_special!(4, mul_mod_special_4);
+    test_mul_mod_special!(5, mul_mod_special_5);
+    test_mul_mod_special!(6, mul_mod_special_6);
+    test_mul_mod_special!(7, mul_mod_special_7);
+    test_mul_mod_special!(8, mul_mod_special_8);
+    test_mul_mod_special!(9, mul_mod_special_9);
+    test_mul_mod_special!(10, mul_mod_special_10);
+    test_mul_mod_special!(11, mul_mod_special_11);
+    test_mul_mod_special!(12, mul_mod_special_12);
+}

--- a/src/uint/neg_mod.rs
+++ b/src/uint/neg_mod.rs
@@ -1,11 +1,17 @@
-//! [`UInt`] subtraction modulus operations.
+//! [`UInt`] negation modulus operations.
 
-use crate::{NegMod, UInt};
+use crate::{Limb, NegMod, UInt};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Computes `-a mod p` in constant time.
     pub const fn neg_mod(&self, p: &Self) -> Self {
         Self::ZERO.sub_mod(self, p)
+    }
+
+    /// Computes `-a mod p` in constant time for the special modulus
+    /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
+    pub const fn neg_mod_special(&self, c: Limb) -> Self {
+        Self::ZERO.sub_mod_special(self, c)
     }
 }
 

--- a/src/uint/sub_mod.rs
+++ b/src/uint/sub_mod.rs
@@ -23,6 +23,21 @@ impl<const LIMBS: usize> UInt<LIMBS> {
 
         out
     }
+
+    /// Computes `self - rhs mod p` in constant time for the special modulus
+    /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
+    ///
+    /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
+    pub const fn sub_mod_special(&self, rhs: &Self, c: Limb) -> Self {
+        let (out, borrow) = self.sbb(rhs, Limb::ZERO);
+
+        // If underflow occurred, then we need to subtract `c` to account for
+        // the underflow. This cannot underflow due to the assumption
+        // `self - rhs >= -p`.
+        let l = borrow.0 & c.0;
+        let (out, _) = out.sbb(&UInt::from_word(l), Limb::ZERO);
+        out
+    }
 }
 
 impl<const LIMBS: usize> SubMod for UInt<LIMBS> {
@@ -93,6 +108,49 @@ mod tests {
         };
     }
 
+    macro_rules! test_sub_mod_special {
+        ($size:expr, $test_name:ident) => {
+            #[test]
+            fn $test_name() {
+                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+                let moduli = [
+                    NonZero::<Limb>::random(&mut rng),
+                    NonZero::<Limb>::random(&mut rng),
+                ];
+
+                for special in &moduli {
+                    let p = &NonZero::new(UInt::ZERO.wrapping_sub(&UInt::from_word(special.0)))
+                        .unwrap();
+
+                    let minus_one = p.wrapping_sub(&UInt::ONE);
+
+                    let base_cases = [
+                        (UInt::ZERO, UInt::ZERO, UInt::ZERO),
+                        (UInt::ONE, UInt::ZERO, UInt::ONE),
+                        (UInt::ZERO, UInt::ONE, minus_one),
+                        (minus_one, minus_one, UInt::ZERO),
+                        (UInt::ZERO, minus_one, UInt::ONE),
+                    ];
+                    for (a, b, c) in &base_cases {
+                        let x = a.sub_mod_special(&b, *special.as_ref());
+                        assert_eq!(*c, x, "{} - {} mod {} = {} != {}", a, b, p, x, c);
+                    }
+
+                    for _i in 0..100 {
+                        let a = UInt::<$size>::random_mod(&mut rng, p);
+                        let b = UInt::<$size>::random_mod(&mut rng, p);
+
+                        let c = a.sub_mod_special(&b, *special.as_ref());
+                        assert!(c < **p, "not reduced: {} >= {} ", c, p);
+
+                        let expected = a.sub_mod(&b, p);
+                        assert_eq!(c, expected, "incorrect result");
+                    }
+                }
+            }
+        };
+    }
+
     // Test requires 1-limb is capable of representing a 64-bit integer
     #[cfg(target_pointer_width = "64")]
     test_sub_mod!(1, sub1);
@@ -108,4 +166,17 @@ mod tests {
     test_sub_mod!(10, sub10);
     test_sub_mod!(11, sub11);
     test_sub_mod!(12, sub12);
+
+    test_sub_mod_special!(1, sub_mod_special_1);
+    test_sub_mod_special!(2, sub_mod_special_2);
+    test_sub_mod_special!(3, sub_mod_special_3);
+    test_sub_mod_special!(4, sub_mod_special_4);
+    test_sub_mod_special!(5, sub_mod_special_5);
+    test_sub_mod_special!(6, sub_mod_special_6);
+    test_sub_mod_special!(7, sub_mod_special_7);
+    test_sub_mod_special!(8, sub_mod_special_8);
+    test_sub_mod_special!(9, sub_mod_special_9);
+    test_sub_mod_special!(10, sub_mod_special_10);
+    test_sub_mod_special!(11, sub_mod_special_11);
+    test_sub_mod_special!(12, sub_mod_special_12);
 }


### PR DESCRIPTION
For a project of mine where the modulus can be chosen to be close to `UInt::MAX`, I created optimized implementations of modular operations. I thought maybe others can benefit from them, too, so I ported my implementation to the crypto-bigint crate.

This commit implements modulo operations (`neg`, `add`, `sub`, `mul`) for special moduli that are so close to `MAX` that the difference to overflow fits in a single `Limb`. For such moduli, these new implementations are much faster than the existing generic modulus implementations. (For `mul` there's no comparison since there's no corresponding generic modulus implementation, yet.)

For `U256`, I benchmarked the generic against the specialized implementations using criterion-rs on Intel Core i7-8565U @ 1.80GHz and obtained the following average times. Note that I used a `const` modulus known at compile-time, which enables some compiler optimizations after inlining. With a modulus known only at runtime, times might differ.

| | `U256::add_mod` | `U256::sub_mod` | `U256::mul_mod` |
|-|-|-|-|
| generic (after #109 got merged) | 10.857 ns | 9.6262 ns | not implemented |
| `_special` | 3.8276 ns | 4.1339 ns | 20.188 ns |
