### PR TITLE
Faster decoding for UInt

### DIFF
--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -16,11 +16,11 @@ macro_rules! impl_uint_aliases {
                 type Repr = [u8; $bits / 8];
 
                 fn from_be_bytes(bytes: Self::Repr) -> Self {
-                    Self::from_be_slice(&bytes)
+                    $crate::uint::encoding::uint_from_be_bytes(&bytes)
                 }
 
                 fn from_le_bytes(bytes: Self::Repr) -> Self {
-                    Self::from_le_slice(&bytes)
+                    $crate::uint::encoding::uint_from_le_bytes(&bytes)
                 }
 
                 #[inline]


### PR DESCRIPTION
On this machine these changes take `Encoding::from_{le|be}_bytes` from around 200ns to around 3ns for a U256. It adds non-const (but still constant-time) methods for decoding UInts from a byte array.

Restricting the input to an array allows the assert to be optimized out, as is the `unreachable!()` panicking according to godbolt. But there may be a cleaner way to obtain the fixed-size chunks (for example, copying into an intermediate buffer), and in future `slice::as_chunks` could be applicable.