### PR TITLE
Add left, right bitshift for Limb

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -13,6 +13,8 @@ mod cmp;
 mod encoding;
 mod from;
 mod mul;
+mod shl;
+mod shr;
 mod sub;
 
 #[cfg(feature = "rand_core")]

--- a/src/limb/shl.rs
+++ b/src/limb/shl.rs
@@ -1,0 +1,73 @@
+//! Limb left bitshift
+
+use crate::{Limb, Word};
+use core::ops::{Shl, ShlAssign};
+
+impl Limb {
+    /// Computes `self << rhs`.
+    #[inline(always)]
+    pub const fn shl(self, rhs: Self) -> Self {
+        Limb(self.0 << rhs.0)
+    }
+}
+
+impl Shl for Limb {
+    type Output = Self;
+
+    #[inline(always)]
+    fn shl(self, rhs: Self) -> Self::Output {
+        self.shl(rhs)
+    }
+}
+
+impl Shl<usize> for Limb {
+    type Output = Self;
+
+    #[inline(always)]
+    fn shl(self, rhs: usize) -> Self::Output {
+        self.shl(Limb(rhs as Word))
+    }
+}
+
+impl ShlAssign for Limb {
+    #[inline(always)]
+    fn shl_assign(&mut self, other: Self) {
+        *self = self.shl(other);
+    }
+}
+
+impl ShlAssign<usize> for Limb {
+    #[inline(always)]
+    fn shl_assign(&mut self, other: usize) {
+        *self = self.shl(Limb(other as Word));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Limb;
+
+    #[test]
+    fn shl1() {
+        assert_eq!(Limb(1) << 1, Limb(2));
+    }
+
+    #[test]
+    fn shl2() {
+        assert_eq!(Limb(1) << 2, Limb(4));
+    }
+
+    #[test]
+    fn shl_assign1() {
+        let mut l = Limb(1);
+        l <<= 1;
+        assert_eq!(l, Limb(2));
+    }
+
+    #[test]
+    fn shl_assign2() {
+        let mut l = Limb(1);
+        l <<= 2;
+        assert_eq!(l, Limb(4));
+    }
+}

--- a/src/limb/shr.rs
+++ b/src/limb/shr.rs
@@ -1,0 +1,73 @@
+//! Limb right bitshift
+
+use crate::{Limb, Word};
+use core::ops::{Shr, ShrAssign};
+
+impl Limb {
+    /// Computes `self >> rhs`.
+    #[inline(always)]
+    pub const fn shr(self, rhs: Self) -> Self {
+        Limb(self.0 >> rhs.0)
+    }
+}
+
+impl Shr for Limb {
+    type Output = Self;
+
+    #[inline(always)]
+    fn shr(self, rhs: Self) -> Self::Output {
+        self.shr(rhs)
+    }
+}
+
+impl Shr<usize> for Limb {
+    type Output = Self;
+
+    #[inline(always)]
+    fn shr(self, rhs: usize) -> Self::Output {
+        self.shr(Limb(rhs as Word))
+    }
+}
+
+impl ShrAssign for Limb {
+    #[inline(always)]
+    fn shr_assign(&mut self, other: Self) {
+        *self = self.shr(other);
+    }
+}
+
+impl ShrAssign<usize> for Limb {
+    #[inline(always)]
+    fn shr_assign(&mut self, other: usize) {
+        *self = self.shr(Limb(other as Word));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Limb;
+
+    #[test]
+    fn shr1() {
+        assert_eq!(Limb(2) >> 1, Limb(1));
+    }
+
+    #[test]
+    fn shr2() {
+        assert_eq!(Limb(16) >> 2, Limb(4));
+    }
+
+    #[test]
+    fn shr_assign1() {
+        let mut l = Limb::ONE;
+        l >>= 1;
+        assert_eq!(l, Limb::ZERO);
+    }
+
+    #[test]
+    fn shr_assign2() {
+        let mut l = Limb(32);
+        l >>= 2;
+        assert_eq!(l, Limb(8));
+    }
+}

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -430,8 +430,8 @@ mod tests {
         b.limbs[b.limbs.len() - 1] = Limb(Word::MAX);
         let q = a.wrapping_div(&b);
         assert_eq!(q, UInt::ZERO);
-        a.limbs[a.limbs.len() - 1] = Limb(1 << HI_BIT - 7);
-        b.limbs[b.limbs.len() - 1] = Limb(0x82 << HI_BIT - 7);
+        a.limbs[a.limbs.len() - 1] = Limb(1 << (HI_BIT - 7));
+        b.limbs[b.limbs.len() - 1] = Limb(0x82 << (HI_BIT - 7));
         let q = a.wrapping_div(&b);
         assert_eq!(q, UInt::ZERO);
     }
@@ -483,8 +483,8 @@ mod tests {
         b.limbs[b.limbs.len() - 1] = Limb(Word::MAX);
         let r = a.wrapping_rem(&b);
         assert_eq!(r, UInt::ZERO);
-        a.limbs[a.limbs.len() - 1] = Limb(1 << HI_BIT - 7);
-        b.limbs[b.limbs.len() - 1] = Limb(0x82 << HI_BIT - 7);
+        a.limbs[a.limbs.len() - 1] = Limb(1 << (HI_BIT - 7));
+        b.limbs[b.limbs.len() - 1] = Limb(0x82 << (HI_BIT - 7));
         let r = a.wrapping_rem(&b);
         assert_eq!(r, a);
     }


### PR DESCRIPTION
Convenience methods to avoid wrapping and unwrapping the Limb.