### PR TITLE
Add a public LIMBS constant to UInt

### DIFF
--- a/src/uint.rs
+++ b/src/uint.rs
@@ -78,6 +78,9 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     /// The value `1`.
     pub const ONE: Self = Self::from_u8(1);
 
+    /// The number of limbs used on this platform.
+    pub const LIMBS: usize = LIMBS;
+
     /// Maximum value this [`UInt`] can express.
     pub const MAX: Self = Self {
         limbs: [Limb::MAX; LIMBS],


### PR DESCRIPTION
This is something I've found myself reaching for. It allows for `U256::LIMBS` (f.ex) to be used in a const context, instead of having to import the `nlimbs!` macro.