### PR TITLE
Add bit accessor methods

### DIFF
--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -2,15 +2,19 @@ use crate::{Limb, UInt, Word};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
     /// Get the value of the bit at position `index`, as a 0- or 1-valued Word.
-    #[inline]
-    pub const fn bit(self, index: usize) -> Word {
-        assert!(index < LIMBS * Limb::BIT_SIZE);
-        (self.limbs[index / Limb::BIT_SIZE].0 >> (index % Limb::BIT_SIZE)) & 1
+    /// Returns 0 for indices out of range.
+    #[inline(always)]
+    pub const fn bit_vartime(self, index: usize) -> Word {
+        if index >= LIMBS * Limb::BIT_SIZE {
+            0
+        } else {
+            (self.limbs[index / Limb::BIT_SIZE].0 >> (index % Limb::BIT_SIZE)) & 1
+        }
     }
 
     /// Calculate the number of bits needed to represent this number.
     #[allow(trivial_numeric_casts)]
-    pub const fn bits(self) -> usize {
+    pub const fn bits_vartime(self) -> usize {
         let mut i = LIMBS - 1;
         while i > 0 && self.limbs[i].0 == 0 {
             i -= 1;
@@ -30,13 +34,15 @@ impl<const LIMBS: usize> UInt<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::U64;
+    use crate::U128;
 
     #[test]
-    fn bit_get_ok() {
-        let u = U64::from_be_hex("d201000000010000");
-        assert_eq!(u.bit(0), 0);
-        assert_eq!(u.bit(1), 0);
-        assert_eq!(u.bit(16), 1);
+    fn bit_vartime_ok() {
+        let u = U128::from_be_hex("f0010000000000000001000000010000");
+        assert_eq!(u.bit_vartime(0), 0);
+        assert_eq!(u.bit_vartime(1), 0);
+        assert_eq!(u.bit_vartime(16), 1);
+        assert_eq!(u.bit_vartime(127), 1);
+        assert_eq!(u.bit_vartime(130), 0);
     }
 }

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -1,6 +1,13 @@
 use crate::{Limb, UInt, Word};
 
 impl<const LIMBS: usize> UInt<LIMBS> {
+    /// Get the value of the bit at position `index`, as a 0- or 1-valued Word.
+    #[inline]
+    pub const fn bit(self, index: usize) -> Word {
+        assert!(index < LIMBS * Limb::BIT_SIZE);
+        (self.limbs[index / Limb::BIT_SIZE].0 >> (index % Limb::BIT_SIZE)) & 1
+    }
+
     /// Calculate the number of bits needed to represent this number.
     #[allow(trivial_numeric_casts)]
     pub const fn bits(self) -> usize {
@@ -18,5 +25,18 @@ impl<const LIMBS: usize> UInt<LIMBS> {
             !self.limbs[0].is_nonzero() & !Limb(i as Word).is_nonzero(),
         )
         .0 as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::U64;
+
+    #[test]
+    fn bit_get_ok() {
+        let u = U64::from_be_hex("d201000000010000");
+        assert_eq!(u.bit(0), 0);
+        assert_eq!(u.bit(1), 0);
+        assert_eq!(u.bit(16), 1);
     }
 }

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -13,6 +13,13 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 
     /// Calculate the number of bits needed to represent this number.
+    #[deprecated(note = "please use `bits_vartime` instead")]
+    #[inline(always)]
+    pub const fn bits(self) -> usize {
+        self.bits_vartime()
+    }
+
+    /// Calculate the number of bits needed to represent this number.
     #[allow(trivial_numeric_casts)]
     pub const fn bits_vartime(self) -> usize {
         let mut i = LIMBS - 1;

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -17,7 +17,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
     pub(crate) const fn ct_div_rem(&self, rhs: &Self) -> (Self, Self, u8) {
-        let mb = rhs.bits();
+        let mb = rhs.bits_vartime();
         let mut bd = (LIMBS * Limb::BIT_SIZE) - mb;
         let mut rem = *self;
         let mut quo = Self::ZERO;
@@ -49,7 +49,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
     pub(crate) const fn ct_reduce(&self, rhs: &Self) -> (Self, u8) {
-        let mb = rhs.bits();
+        let mb = rhs.bits_vartime();
         let mut bd = (LIMBS * Limb::BIT_SIZE) - mb;
         let mut rem = *self;
         let mut c = rhs.shl_vartime(bd);

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -37,7 +37,7 @@ impl<const LIMBS: usize> RandomMod for UInt<LIMBS> {
 
         // TODO(tarcieri): use `div_ceil` when available
         // See: https://github.com/rust-lang/rust/issues/88581
-        let mut n_limbs = modulus.bits() / Limb::BIT_SIZE;
+        let mut n_limbs = modulus.bits_vartime() / Limb::BIT_SIZE;
         if n_limbs < LIMBS {
             n_limbs += 1;
         }

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -10,7 +10,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     ///
     /// Callers can check if `self` is a square by squaring the result
     pub const fn sqrt(&self) -> Self {
-        let max_bits = (self.bits() + 1) >> 1;
+        let max_bits = (self.bits_vartime() + 1) >> 1;
         let cap = Self::ONE.shl_vartime(max_bits);
         let mut guess = cap; // ≥ √(`self`)
         let mut xn = {
@@ -25,7 +25,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
             // Sometimes an increase is too far, especially with large
             // powers, and then takes a long time to walk back.  The upper
             // bound is based on bit size, so saturate on that.
-            let res = Limb::ct_cmp(Limb(xn.bits() as Word), Limb(max_bits as Word)) - 1;
+            let res = Limb::ct_cmp(Limb(xn.bits_vartime() as Word), Limb(max_bits as Word)) - 1;
             let le = Limb::is_nonzero(Limb(res as Word));
             guess = Self::ct_select(cap, xn, le);
             xn = {


### PR DESCRIPTION
This adds `UInt::bit_vartime(index)` for accessing the value of the bit at a given index. It's trivial to cast the result to u8 or bool so I leave that up to the caller, to avoid casting the value twice.

For consistency and accuracy, `bits` is renamed to `bits_vartime`.