### PR TITLE
ci: add Dependabot configuration to keep GitHub Actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Add Dependabot configuration to automatically open PRs for outdated actions.

Inspired by https://github.com/RustCrypto/hashes/pull/410#issuecomment-1252658128.