### PR TITLE
Bump version to `v0.5.0-pre`; remove deprecations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.0-pre"
 dependencies = [
  "bincode",
  "der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.0-pre"
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,10 +177,6 @@ pub use crate::{
 };
 pub use subtle;
 
-// TODO(tarcieri): remove these in the next breaking release
-#[allow(deprecated)]
-pub use crate::limb::{LimbUInt, WideLimbUInt};
-
 pub(crate) use limb::{SignedWord, WideSignedWord};
 
 #[cfg(feature = "generic-array")]

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -70,20 +70,6 @@ pub type WideWord = u128;
 #[cfg(target_pointer_width = "64")]
 pub(crate) type WideSignedWord = i128;
 
-//
-// Deprecated legacy names
-//
-
-// TODO(tarcieri): remove these in the next breaking release
-
-/// Deprecated: unsigned integer type that the [`Limb`] newtype wraps.
-#[deprecated(since = "0.4.8", note = "please use `Word` instead")]
-pub type LimbUInt = Word;
-
-/// Deprecated: wide integer type which is double the width of [`Word`].
-#[deprecated(since = "0.4.8", note = "please use `WideWord` instead")]
-pub type WideLimbUInt = WideWord;
-
 /// Highest bit in a [`Limb`].
 pub(crate) const HI_BIT: usize = Limb::BIT_SIZE - 1;
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -145,24 +145,6 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         }
     }
 
-    /// Deprecated: borrow the inner limbs as an array of [`Word`]s.
-    #[deprecated(since = "0.4.8", note = "please use `as_words` instead")]
-    pub const fn as_uint_array(&self) -> &[Word; LIMBS] {
-        self.as_words()
-    }
-
-    /// Deprecated: create a [`UInt`] from an array of [`Word`]s.
-    #[deprecated(since = "0.4.8", note = "please use `from_words` instead")]
-    pub const fn from_uint_array(words: [Word; LIMBS]) -> Self {
-        Self::from_words(words)
-    }
-
-    /// Deprecated: create an array of [`Word`]s from a [`UInt`].
-    #[deprecated(since = "0.4.8", note = "please use `to_words` instead")]
-    pub const fn to_uint_array(self) -> [Word; LIMBS] {
-        self.to_words()
-    }
-
     /// Borrow the limbs of this [`UInt`].
     // TODO(tarcieri): rename to `as_limbs` for consistency with `as_words`
     pub const fn limbs(&self) -> &[Limb; LIMBS] {

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -13,13 +13,6 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 
     /// Calculate the number of bits needed to represent this number.
-    #[deprecated(note = "please use `bits_vartime` instead")]
-    #[inline(always)]
-    pub const fn bits(self) -> usize {
-        self.bits_vartime()
-    }
-
-    /// Calculate the number of bits needed to represent this number.
     #[allow(trivial_numeric_casts)]
     pub const fn bits_vartime(self) -> usize {
         let mut i = LIMBS - 1;


### PR DESCRIPTION
Breaking changes were introduced in #130, so this bumps the crate's version to a prerelease to denote that. It will be bumped to `pre.0` for an actual crate release.

Also removes all deprecated APIs.