### PR TITLE
Rename `UInt` => `Uint`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 
 //! ## Usage
 //!
-//! This crate defines a [`UInt`] type which is const generic around an inner
+//! This crate defines a [`Uint`] type which is const generic around an inner
 //! [`Limb`] array, where a [`Limb`] is a newtype for a word-sized integer.
 //! Thus large integers are represented as a arrays of smaller integers which
 //! are sized appropriately for the CPU, giving us some assurances of how
@@ -33,7 +33,7 @@
 //!
 //! ### `const fn` usage
 //!
-//! The [`UInt`] type provides a number of `const fn` inherent methods which
+//! The [`Uint`] type provides a number of `const fn` inherent methods which
 //! can be used for initializing and performing arithmetic on big integers in
 //! const contexts:
 //!
@@ -59,7 +59,7 @@
 //!
 //! ### Trait-based usage
 //!
-//! The [`UInt`] type itself does not implement the standard arithmetic traits
+//! The [`Uint`] type itself does not implement the standard arithmetic traits
 //! such as [`Add`], [`Sub`], [`Mul`], and [`Div`].
 //!
 //! To use these traits you must first pick a wrapper type which determines

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -1,6 +1,6 @@
 //! Wrapper type for non-zero integers.
 
-use crate::{Encoding, Integer, Limb, UInt, Zero};
+use crate::{Encoding, Integer, Limb, Uint, Zero};
 use core::{
     fmt,
     num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8},
@@ -237,9 +237,9 @@ impl From<NonZeroU64> for NonZero<Limb> {
     }
 }
 
-impl<const LIMBS: usize> NonZero<UInt<LIMBS>> {
-    /// Create a [`NonZero<UInt>`] from a [`UInt`] (const-friendly)
-    pub const fn from_uint(n: UInt<LIMBS>) -> Self {
+impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
+    /// Create a [`NonZero<Uint>`] from a [`Uint`] (const-friendly)
+    pub const fn from_uint(n: Uint<LIMBS>) -> Self {
         let mut i = 0;
         let mut found_non_zero = false;
         while i < LIMBS {
@@ -252,62 +252,62 @@ impl<const LIMBS: usize> NonZero<UInt<LIMBS>> {
         Self(n)
     }
 
-    /// Create a [`NonZero<UInt>`] from a [`NonZeroU8`] (const-friendly)
+    /// Create a [`NonZero<Uint>`] from a [`NonZeroU8`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU8>` when stable
     pub const fn from_u8(n: NonZeroU8) -> Self {
-        Self(UInt::from_u8(n.get()))
+        Self(Uint::from_u8(n.get()))
     }
 
-    /// Create a [`NonZero<UInt>`] from a [`NonZeroU16`] (const-friendly)
+    /// Create a [`NonZero<Uint>`] from a [`NonZeroU16`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU16>` when stable
     pub const fn from_u16(n: NonZeroU16) -> Self {
-        Self(UInt::from_u16(n.get()))
+        Self(Uint::from_u16(n.get()))
     }
 
-    /// Create a [`NonZero<UInt>`] from a [`NonZeroU32`] (const-friendly)
+    /// Create a [`NonZero<Uint>`] from a [`NonZeroU32`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU32>` when stable
     pub const fn from_u32(n: NonZeroU32) -> Self {
-        Self(UInt::from_u32(n.get()))
+        Self(Uint::from_u32(n.get()))
     }
 
-    /// Create a [`NonZero<UInt>`] from a [`NonZeroU64`] (const-friendly)
+    /// Create a [`NonZero<Uint>`] from a [`NonZeroU64`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU64>` when stable
     pub const fn from_u64(n: NonZeroU64) -> Self {
-        Self(UInt::from_u64(n.get()))
+        Self(Uint::from_u64(n.get()))
     }
 
-    /// Create a [`NonZero<UInt>`] from a [`NonZeroU128`] (const-friendly)
+    /// Create a [`NonZero<Uint>`] from a [`NonZeroU128`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU128>` when stable
     pub const fn from_u128(n: NonZeroU128) -> Self {
-        Self(UInt::from_u128(n.get()))
+        Self(Uint::from_u128(n.get()))
     }
 }
 
-impl<const LIMBS: usize> From<NonZeroU8> for NonZero<UInt<LIMBS>> {
+impl<const LIMBS: usize> From<NonZeroU8> for NonZero<Uint<LIMBS>> {
     fn from(integer: NonZeroU8) -> Self {
         Self::from_u8(integer)
     }
 }
 
-impl<const LIMBS: usize> From<NonZeroU16> for NonZero<UInt<LIMBS>> {
+impl<const LIMBS: usize> From<NonZeroU16> for NonZero<Uint<LIMBS>> {
     fn from(integer: NonZeroU16) -> Self {
         Self::from_u16(integer)
     }
 }
 
-impl<const LIMBS: usize> From<NonZeroU32> for NonZero<UInt<LIMBS>> {
+impl<const LIMBS: usize> From<NonZeroU32> for NonZero<Uint<LIMBS>> {
     fn from(integer: NonZeroU32) -> Self {
         Self::from_u32(integer)
     }
 }
 
-impl<const LIMBS: usize> From<NonZeroU64> for NonZero<UInt<LIMBS>> {
+impl<const LIMBS: usize> From<NonZeroU64> for NonZero<Uint<LIMBS>> {
     fn from(integer: NonZeroU64) -> Self {
         Self::from_u64(integer)
     }
 }
 
-impl<const LIMBS: usize> From<NonZeroU128> for NonZero<UInt<LIMBS>> {
+impl<const LIMBS: usize> From<NonZeroU128> for NonZero<Uint<LIMBS>> {
     fn from(integer: NonZeroU128) -> Self {
         Self::from_u128(integer)
     }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -60,23 +60,23 @@ use zeroize::DefaultIsZeroes;
 /// # Encoding support
 /// This type supports many different types of encodings, either via the
 /// [`Encoding`][`crate::Encoding`] trait or various `const fn` decoding and
-/// encoding functions that can be used with [`UInt`] constants.
+/// encoding functions that can be used with [`Uint`] constants.
 ///
 /// Optional crate features for encoding (off-by-default):
 /// - `generic-array`: enables [`ArrayEncoding`][`crate::ArrayEncoding`] trait which can be used to
-///   [`UInt`] as `GenericArray<u8, N>` and a [`ArrayDecoding`][`crate::ArrayDecoding`] trait which
-///   can be used to `GenericArray<u8, N>` as [`UInt`].
+///   [`Uint`] as `GenericArray<u8, N>` and a [`ArrayDecoding`][`crate::ArrayDecoding`] trait which
+///   can be used to `GenericArray<u8, N>` as [`Uint`].
 /// - `rlp`: support for [Recursive Length Prefix (RLP)][RLP] encoding.
 ///
 /// [RLP]: https://eth.wiki/fundamentals/rlp
 // TODO(tarcieri): make generic around a specified number of bits.
 #[derive(Copy, Clone, Debug, Hash)]
-pub struct UInt<const LIMBS: usize> {
+pub struct Uint<const LIMBS: usize> {
     /// Inner limb array. Stored from least significant to most significant.
     limbs: [Limb; LIMBS],
 }
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// The value `0`.
     pub const ZERO: Self = Self::from_u8(0);
 
@@ -86,17 +86,17 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     /// The number of limbs used on this platform.
     pub const LIMBS: usize = LIMBS;
 
-    /// Maximum value this [`UInt`] can express.
+    /// Maximum value this [`Uint`] can express.
     pub const MAX: Self = Self {
         limbs: [Limb::MAX; LIMBS],
     };
 
-    /// Const-friendly [`UInt`] constructor.
+    /// Const-friendly [`Uint`] constructor.
     pub const fn new(limbs: [Limb; LIMBS]) -> Self {
         Self { limbs }
     }
 
-    /// Create a [`UInt`] from an array of [`Word`]s (i.e. word-sized unsigned
+    /// Create a [`Uint`] from an array of [`Word`]s (i.e. word-sized unsigned
     /// integers).
     #[inline]
     pub const fn from_words(arr: [Word; LIMBS]) -> Self {
@@ -112,7 +112,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 
     /// Create an array of [`Word`]s (i.e. word-sized unsigned integers) from
-    /// a [`UInt`].
+    /// a [`Uint`].
     #[inline]
     pub const fn to_words(self) -> [Word; LIMBS] {
         let mut arr = [0; LIMBS];
@@ -145,52 +145,52 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         }
     }
 
-    /// Borrow the limbs of this [`UInt`].
+    /// Borrow the limbs of this [`Uint`].
     // TODO(tarcieri): rename to `as_limbs` for consistency with `as_words`
     pub const fn limbs(&self) -> &[Limb; LIMBS] {
         &self.limbs
     }
 
-    /// Borrow the limbs of this [`UInt`] mutably.
+    /// Borrow the limbs of this [`Uint`] mutably.
     // TODO(tarcieri): rename to `as_limbs_mut` for consistency with `as_words_mut`
     pub fn limbs_mut(&mut self) -> &mut [Limb; LIMBS] {
         &mut self.limbs
     }
 
-    /// Convert this [`UInt`] into its inner limbs.
+    /// Convert this [`Uint`] into its inner limbs.
     // TODO(tarcieri): rename to `to_limbs` for consistency with `to_words`
     pub const fn into_limbs(self) -> [Limb; LIMBS] {
         self.limbs
     }
 }
 
-impl<const LIMBS: usize> AsRef<[Word; LIMBS]> for UInt<LIMBS> {
+impl<const LIMBS: usize> AsRef<[Word; LIMBS]> for Uint<LIMBS> {
     fn as_ref(&self) -> &[Word; LIMBS] {
         self.as_words()
     }
 }
 
-impl<const LIMBS: usize> AsMut<[Word; LIMBS]> for UInt<LIMBS> {
+impl<const LIMBS: usize> AsMut<[Word; LIMBS]> for Uint<LIMBS> {
     fn as_mut(&mut self) -> &mut [Word; LIMBS] {
         self.as_words_mut()
     }
 }
 
 // TODO(tarcieri): eventually phase this out in favor of `limbs()`?
-impl<const LIMBS: usize> AsRef<[Limb]> for UInt<LIMBS> {
+impl<const LIMBS: usize> AsRef<[Limb]> for Uint<LIMBS> {
     fn as_ref(&self) -> &[Limb] {
         self.limbs()
     }
 }
 
 // TODO(tarcieri): eventually phase this out in favor of `limbs_mut()`?
-impl<const LIMBS: usize> AsMut<[Limb]> for UInt<LIMBS> {
+impl<const LIMBS: usize> AsMut<[Limb]> for Uint<LIMBS> {
     fn as_mut(&mut self) -> &mut [Limb] {
         self.limbs_mut()
     }
 }
 
-impl<const LIMBS: usize> ConditionallySelectable for UInt<LIMBS> {
+impl<const LIMBS: usize> ConditionallySelectable for Uint<LIMBS> {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
 
@@ -202,13 +202,13 @@ impl<const LIMBS: usize> ConditionallySelectable for UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Default for UInt<LIMBS> {
+impl<const LIMBS: usize> Default for Uint<LIMBS> {
     fn default() -> Self {
         Self::ZERO
     }
 }
 
-impl<const LIMBS: usize> Integer for UInt<LIMBS> {
+impl<const LIMBS: usize> Integer for Uint<LIMBS> {
     const ONE: Self = Self::ONE;
     const MAX: Self = Self::MAX;
 
@@ -220,17 +220,17 @@ impl<const LIMBS: usize> Integer for UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Zero for UInt<LIMBS> {
+impl<const LIMBS: usize> Zero for Uint<LIMBS> {
     const ZERO: Self = Self::ZERO;
 }
 
-impl<const LIMBS: usize> fmt::Display for UInt<LIMBS> {
+impl<const LIMBS: usize> fmt::Display for Uint<LIMBS> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::UpperHex::fmt(self, f)
     }
 }
 
-impl<const LIMBS: usize> fmt::LowerHex for UInt<LIMBS> {
+impl<const LIMBS: usize> fmt::LowerHex for Uint<LIMBS> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for limb in self.limbs.iter().rev() {
             fmt::LowerHex::fmt(limb, f)?;
@@ -239,7 +239,7 @@ impl<const LIMBS: usize> fmt::LowerHex for UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> fmt::UpperHex for UInt<LIMBS> {
+impl<const LIMBS: usize> fmt::UpperHex for Uint<LIMBS> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for limb in self.limbs.iter().rev() {
             fmt::UpperHex::fmt(limb, f)?;
@@ -250,9 +250,9 @@ impl<const LIMBS: usize> fmt::UpperHex for UInt<LIMBS> {
 
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
-impl<'de, const LIMBS: usize> Deserialize<'de> for UInt<LIMBS>
+impl<'de, const LIMBS: usize> Deserialize<'de> for Uint<LIMBS>
 where
-    UInt<LIMBS>: Encoding,
+    Uint<LIMBS>: Encoding,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -267,9 +267,9 @@ where
 
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
-impl<'de, const LIMBS: usize> Serialize for UInt<LIMBS>
+impl<'de, const LIMBS: usize> Serialize for Uint<LIMBS>
 where
-    UInt<LIMBS>: Encoding,
+    Uint<LIMBS>: Encoding,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -281,7 +281,7 @@ where
 
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-impl<const LIMBS: usize> DefaultIsZeroes for UInt<LIMBS> {}
+impl<const LIMBS: usize> DefaultIsZeroes for Uint<LIMBS> {}
 
 // TODO(tarcieri): use `const_evaluatable_checked` when stable to make generic around bits.
 macro_rules! impl_uint_aliases {
@@ -289,7 +289,7 @@ macro_rules! impl_uint_aliases {
         $(
             #[doc = $doc]
             #[doc="unsigned big integer."]
-            pub type $name = UInt<{nlimbs!($bits)}>;
+            pub type $name = Uint<{nlimbs!($bits)}>;
 
             impl Encoding for $name {
                 const BIT_SIZE: usize = $bits;

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -1,10 +1,10 @@
-//! [`UInt`] addition operations.
+//! [`Uint`] addition operations.
 
-use crate::{Checked, CheckedAdd, Limb, UInt, Word, Wrapping, Zero};
+use crate::{Checked, CheckedAdd, Limb, Uint, Word, Wrapping, Zero};
 use core::ops::{Add, AddAssign};
 use subtle::CtOption;
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `a + b + carry`, returning the result along with the new carry.
     #[inline(always)]
     pub const fn adc(&self, rhs: &Self, mut carry: Limb) -> (Self, Limb) {
@@ -39,14 +39,14 @@ impl<const LIMBS: usize> UInt<LIMBS> {
 
     /// Perform wrapping addition, returning the overflow bit as a `Word` that is either 0...0 or 1...1.
     pub(crate) const fn conditional_wrapping_add(&self, rhs: &Self, choice: Word) -> (Self, Word) {
-        let actual_rhs = UInt::ct_select(UInt::ZERO, *rhs, choice);
+        let actual_rhs = Uint::ct_select(Uint::ZERO, *rhs, choice);
         let (sum, carry) = self.adc(&actual_rhs, Limb::ZERO);
 
         (sum, carry.0.wrapping_mul(Word::MAX))
     }
 }
 
-impl<const LIMBS: usize> CheckedAdd<&UInt<LIMBS>> for UInt<LIMBS> {
+impl<const LIMBS: usize> CheckedAdd<&Uint<LIMBS>> for Uint<LIMBS> {
     type Output = Self;
 
     fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
@@ -55,54 +55,54 @@ impl<const LIMBS: usize> CheckedAdd<&UInt<LIMBS>> for UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Add for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> Add for Wrapping<Uint<LIMBS>> {
     type Output = Self;
 
-    fn add(self, rhs: Self) -> Wrapping<UInt<LIMBS>> {
+    fn add(self, rhs: Self) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.wrapping_add(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> Add<&Wrapping<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Add<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn add(self, rhs: &Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn add(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.wrapping_add(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> Add<Wrapping<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Add<Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn add(self, rhs: Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn add(self, rhs: Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.wrapping_add(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> Add<&Wrapping<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Add<&Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn add(self, rhs: &Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn add(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.wrapping_add(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> AddAssign for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> AddAssign for Wrapping<Uint<LIMBS>> {
     fn add_assign(&mut self, other: Self) {
         *self = *self + other;
     }
 }
 
-impl<const LIMBS: usize> AddAssign<&Wrapping<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> AddAssign<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
     fn add_assign(&mut self, other: &Self) {
         *self = *self + other;
     }
 }
 
-impl<const LIMBS: usize> Add for Checked<UInt<LIMBS>> {
+impl<const LIMBS: usize> Add for Checked<Uint<LIMBS>> {
     type Output = Self;
 
-    fn add(self, rhs: Self) -> Checked<UInt<LIMBS>> {
+    fn add(self, rhs: Self) -> Checked<Uint<LIMBS>> {
         Checked(
             self.0
                 .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(&rhs))),
@@ -110,10 +110,10 @@ impl<const LIMBS: usize> Add for Checked<UInt<LIMBS>> {
     }
 }
 
-impl<const LIMBS: usize> Add<&Checked<UInt<LIMBS>>> for Checked<UInt<LIMBS>> {
-    type Output = Checked<UInt<LIMBS>>;
+impl<const LIMBS: usize> Add<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS>> {
+    type Output = Checked<Uint<LIMBS>>;
 
-    fn add(self, rhs: &Checked<UInt<LIMBS>>) -> Checked<UInt<LIMBS>> {
+    fn add(self, rhs: &Checked<Uint<LIMBS>>) -> Checked<Uint<LIMBS>> {
         Checked(
             self.0
                 .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(&rhs))),
@@ -121,10 +121,10 @@ impl<const LIMBS: usize> Add<&Checked<UInt<LIMBS>>> for Checked<UInt<LIMBS>> {
     }
 }
 
-impl<const LIMBS: usize> Add<Checked<UInt<LIMBS>>> for &Checked<UInt<LIMBS>> {
-    type Output = Checked<UInt<LIMBS>>;
+impl<const LIMBS: usize> Add<Checked<Uint<LIMBS>>> for &Checked<Uint<LIMBS>> {
+    type Output = Checked<Uint<LIMBS>>;
 
-    fn add(self, rhs: Checked<UInt<LIMBS>>) -> Checked<UInt<LIMBS>> {
+    fn add(self, rhs: Checked<Uint<LIMBS>>) -> Checked<Uint<LIMBS>> {
         Checked(
             self.0
                 .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(&rhs))),
@@ -132,10 +132,10 @@ impl<const LIMBS: usize> Add<Checked<UInt<LIMBS>>> for &Checked<UInt<LIMBS>> {
     }
 }
 
-impl<const LIMBS: usize> Add<&Checked<UInt<LIMBS>>> for &Checked<UInt<LIMBS>> {
-    type Output = Checked<UInt<LIMBS>>;
+impl<const LIMBS: usize> Add<&Checked<Uint<LIMBS>>> for &Checked<Uint<LIMBS>> {
+    type Output = Checked<Uint<LIMBS>>;
 
-    fn add(self, rhs: &Checked<UInt<LIMBS>>) -> Checked<UInt<LIMBS>> {
+    fn add(self, rhs: &Checked<Uint<LIMBS>>) -> Checked<Uint<LIMBS>> {
         Checked(
             self.0
                 .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(&rhs))),
@@ -143,13 +143,13 @@ impl<const LIMBS: usize> Add<&Checked<UInt<LIMBS>>> for &Checked<UInt<LIMBS>> {
     }
 }
 
-impl<const LIMBS: usize> AddAssign for Checked<UInt<LIMBS>> {
+impl<const LIMBS: usize> AddAssign for Checked<Uint<LIMBS>> {
     fn add_assign(&mut self, other: Self) {
         *self = *self + other;
     }
 }
 
-impl<const LIMBS: usize> AddAssign<&Checked<UInt<LIMBS>>> for Checked<UInt<LIMBS>> {
+impl<const LIMBS: usize> AddAssign<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS>> {
     fn add_assign(&mut self, other: &Self) {
         *self = *self + other;
     }

--- a/src/uint/array.rs
+++ b/src/uint/array.rs
@@ -1,4 +1,4 @@
-//! `generic-array` integration with `UInt`.
+//! `generic-array` integration with `Uint`.
 // TODO(tarcieri): completely phase out `generic-array` when const generics are powerful enough
 
 use crate::{ArrayDecoding, ArrayEncoding, ByteArray};
@@ -81,25 +81,25 @@ mod tests {
     use hex_literal::hex;
 
     #[cfg(target_pointer_width = "32")]
-    use crate::U64 as UIntEx;
+    use crate::U64 as UintEx;
 
     #[cfg(target_pointer_width = "64")]
-    use crate::U128 as UIntEx;
+    use crate::U128 as UintEx;
 
-    /// Byte array that corresponds to `UIntEx`
-    type ByteArray = crate::ByteArray<UIntEx>;
+    /// Byte array that corresponds to `UintEx`
+    type ByteArray = crate::ByteArray<UintEx>;
 
     #[test]
     #[cfg(target_pointer_width = "32")]
     fn from_be_byte_array() {
-        let n = UIntEx::from_be_byte_array(hex!("0011223344556677").into());
+        let n = UintEx::from_be_byte_array(hex!("0011223344556677").into());
         assert_eq!(n.limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn from_be_byte_array() {
-        let n = UIntEx::from_be_byte_array(hex!("00112233445566778899aabbccddeeff").into());
+        let n = UintEx::from_be_byte_array(hex!("00112233445566778899aabbccddeeff").into());
         assert_eq!(
             n.limbs(),
             &[Limb(0x8899aabbccddeeff), Limb(0x0011223344556677)]
@@ -109,14 +109,14 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "32")]
     fn from_le_byte_array() {
-        let n = UIntEx::from_le_byte_array(hex!("7766554433221100").into());
+        let n = UintEx::from_le_byte_array(hex!("7766554433221100").into());
         assert_eq!(n.limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn from_le_byte_array() {
-        let n = UIntEx::from_le_byte_array(hex!("ffeeddccbbaa99887766554433221100").into());
+        let n = UintEx::from_le_byte_array(hex!("ffeeddccbbaa99887766554433221100").into());
         assert_eq!(
             n.limbs(),
             &[Limb(0x8899aabbccddeeff), Limb(0x0011223344556677)]
@@ -127,7 +127,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     fn to_be_byte_array() {
         let expected_bytes = ByteArray::from(hex!("0011223344556677"));
-        let actual_bytes = UIntEx::from_be_byte_array(expected_bytes).to_be_byte_array();
+        let actual_bytes = UintEx::from_be_byte_array(expected_bytes).to_be_byte_array();
         assert_eq!(expected_bytes, actual_bytes);
     }
 
@@ -135,7 +135,7 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn to_be_byte_array() {
         let expected_bytes = ByteArray::from(hex!("00112233445566778899aabbccddeeff"));
-        let actual_bytes = UIntEx::from_be_byte_array(expected_bytes).to_be_byte_array();
+        let actual_bytes = UintEx::from_be_byte_array(expected_bytes).to_be_byte_array();
         assert_eq!(expected_bytes, actual_bytes);
     }
 
@@ -143,7 +143,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     fn to_le_byte_array() {
         let expected_bytes = ByteArray::from(hex!("7766554433221100"));
-        let actual_bytes = UIntEx::from_le_byte_array(expected_bytes).to_le_byte_array();
+        let actual_bytes = UintEx::from_le_byte_array(expected_bytes).to_le_byte_array();
         assert_eq!(expected_bytes, actual_bytes);
     }
 
@@ -151,7 +151,7 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn to_le_byte_array() {
         let expected_bytes = ByteArray::from(hex!("ffeeddccbbaa99887766554433221100"));
-        let actual_bytes = UIntEx::from_le_byte_array(expected_bytes).to_le_byte_array();
+        let actual_bytes = UintEx::from_le_byte_array(expected_bytes).to_le_byte_array();
         assert_eq!(expected_bytes, actual_bytes);
     }
 

--- a/src/uint/bit_and.rs
+++ b/src/uint/bit_and.rs
@@ -1,11 +1,11 @@
-//! [`UInt`] bitwise and operations.
+//! [`Uint`] bitwise and operations.
 
-use super::UInt;
+use super::Uint;
 use crate::{Limb, Wrapping};
 use core::ops::{BitAnd, BitAndAssign};
 use subtle::{Choice, CtOption};
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `a & b`.
     #[inline(always)]
     pub const fn bitand(&self, rhs: &Self) -> Self {
@@ -35,93 +35,93 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> BitAnd for UInt<LIMBS> {
+impl<const LIMBS: usize> BitAnd for Uint<LIMBS> {
     type Output = Self;
 
-    fn bitand(self, rhs: Self) -> UInt<LIMBS> {
+    fn bitand(self, rhs: Self) -> Uint<LIMBS> {
         self.bitand(&rhs)
     }
 }
 
-impl<const LIMBS: usize> BitAnd<&UInt<LIMBS>> for UInt<LIMBS> {
-    type Output = UInt<LIMBS>;
+impl<const LIMBS: usize> BitAnd<&Uint<LIMBS>> for Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
 
     #[allow(clippy::needless_borrow)]
-    fn bitand(self, rhs: &UInt<LIMBS>) -> UInt<LIMBS> {
+    fn bitand(self, rhs: &Uint<LIMBS>) -> Uint<LIMBS> {
         (&self).bitand(rhs)
     }
 }
 
-impl<const LIMBS: usize> BitAnd<UInt<LIMBS>> for &UInt<LIMBS> {
-    type Output = UInt<LIMBS>;
+impl<const LIMBS: usize> BitAnd<Uint<LIMBS>> for &Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
 
-    fn bitand(self, rhs: UInt<LIMBS>) -> UInt<LIMBS> {
+    fn bitand(self, rhs: Uint<LIMBS>) -> Uint<LIMBS> {
         self.bitand(&rhs)
     }
 }
 
-impl<const LIMBS: usize> BitAnd<&UInt<LIMBS>> for &UInt<LIMBS> {
-    type Output = UInt<LIMBS>;
+impl<const LIMBS: usize> BitAnd<&Uint<LIMBS>> for &Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
 
-    fn bitand(self, rhs: &UInt<LIMBS>) -> UInt<LIMBS> {
+    fn bitand(self, rhs: &Uint<LIMBS>) -> Uint<LIMBS> {
         self.bitand(rhs)
     }
 }
 
-impl<const LIMBS: usize> BitAndAssign for UInt<LIMBS> {
+impl<const LIMBS: usize> BitAndAssign for Uint<LIMBS> {
     #[allow(clippy::assign_op_pattern)]
     fn bitand_assign(&mut self, other: Self) {
         *self = *self & other;
     }
 }
 
-impl<const LIMBS: usize> BitAndAssign<&UInt<LIMBS>> for UInt<LIMBS> {
+impl<const LIMBS: usize> BitAndAssign<&Uint<LIMBS>> for Uint<LIMBS> {
     #[allow(clippy::assign_op_pattern)]
     fn bitand_assign(&mut self, other: &Self) {
         *self = *self & other;
     }
 }
 
-impl<const LIMBS: usize> BitAnd for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> BitAnd for Wrapping<Uint<LIMBS>> {
     type Output = Self;
 
-    fn bitand(self, rhs: Self) -> Wrapping<UInt<LIMBS>> {
+    fn bitand(self, rhs: Self) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.bitand(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> BitAnd<&Wrapping<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> BitAnd<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn bitand(self, rhs: &Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn bitand(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.bitand(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> BitAnd<Wrapping<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> BitAnd<Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn bitand(self, rhs: Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn bitand(self, rhs: Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.bitand(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> BitAnd<&Wrapping<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> BitAnd<&Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn bitand(self, rhs: &Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn bitand(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.bitand(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> BitAndAssign for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> BitAndAssign for Wrapping<Uint<LIMBS>> {
     #[allow(clippy::assign_op_pattern)]
     fn bitand_assign(&mut self, other: Self) {
         *self = *self & other;
     }
 }
 
-impl<const LIMBS: usize> BitAndAssign<&Wrapping<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> BitAndAssign<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
     #[allow(clippy::assign_op_pattern)]
     fn bitand_assign(&mut self, other: &Self) {
         *self = *self & other;

--- a/src/uint/bit_not.rs
+++ b/src/uint/bit_not.rs
@@ -1,10 +1,10 @@
-//! [`UInt`] bitwise not operations.
+//! [`Uint`] bitwise not operations.
 
-use super::UInt;
+use super::Uint;
 use crate::{Limb, Wrapping};
 use core::ops::Not;
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `!a`.
     #[inline(always)]
     pub const fn not(&self) -> Self {
@@ -20,7 +20,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Not for UInt<LIMBS> {
+impl<const LIMBS: usize> Not for Uint<LIMBS> {
     type Output = Self;
 
     #[allow(clippy::needless_borrow)]
@@ -29,7 +29,7 @@ impl<const LIMBS: usize> Not for UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Not for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> Not for Wrapping<Uint<LIMBS>> {
     type Output = Self;
 
     fn not(self) -> <Self as Not>::Output {

--- a/src/uint/bit_or.rs
+++ b/src/uint/bit_or.rs
@@ -1,11 +1,11 @@
-//! [`UInt`] bitwise or operations.
+//! [`Uint`] bitwise or operations.
 
-use super::UInt;
+use super::Uint;
 use crate::{Limb, Wrapping};
 use core::ops::{BitOr, BitOrAssign};
 use subtle::{Choice, CtOption};
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `a & b`.
     #[inline(always)]
     pub const fn bitor(&self, rhs: &Self) -> Self {
@@ -35,90 +35,90 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> BitOr for UInt<LIMBS> {
+impl<const LIMBS: usize> BitOr for Uint<LIMBS> {
     type Output = Self;
 
-    fn bitor(self, rhs: Self) -> UInt<LIMBS> {
+    fn bitor(self, rhs: Self) -> Uint<LIMBS> {
         self.bitor(&rhs)
     }
 }
 
-impl<const LIMBS: usize> BitOr<&UInt<LIMBS>> for UInt<LIMBS> {
-    type Output = UInt<LIMBS>;
+impl<const LIMBS: usize> BitOr<&Uint<LIMBS>> for Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
 
     #[allow(clippy::needless_borrow)]
-    fn bitor(self, rhs: &UInt<LIMBS>) -> UInt<LIMBS> {
+    fn bitor(self, rhs: &Uint<LIMBS>) -> Uint<LIMBS> {
         (&self).bitor(rhs)
     }
 }
 
-impl<const LIMBS: usize> BitOr<UInt<LIMBS>> for &UInt<LIMBS> {
-    type Output = UInt<LIMBS>;
+impl<const LIMBS: usize> BitOr<Uint<LIMBS>> for &Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
 
-    fn bitor(self, rhs: UInt<LIMBS>) -> UInt<LIMBS> {
+    fn bitor(self, rhs: Uint<LIMBS>) -> Uint<LIMBS> {
         self.bitor(&rhs)
     }
 }
 
-impl<const LIMBS: usize> BitOr<&UInt<LIMBS>> for &UInt<LIMBS> {
-    type Output = UInt<LIMBS>;
+impl<const LIMBS: usize> BitOr<&Uint<LIMBS>> for &Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
 
-    fn bitor(self, rhs: &UInt<LIMBS>) -> UInt<LIMBS> {
+    fn bitor(self, rhs: &Uint<LIMBS>) -> Uint<LIMBS> {
         self.bitor(rhs)
     }
 }
 
-impl<const LIMBS: usize> BitOrAssign for UInt<LIMBS> {
+impl<const LIMBS: usize> BitOrAssign for Uint<LIMBS> {
     fn bitor_assign(&mut self, other: Self) {
         *self = *self | other;
     }
 }
 
-impl<const LIMBS: usize> BitOrAssign<&UInt<LIMBS>> for UInt<LIMBS> {
+impl<const LIMBS: usize> BitOrAssign<&Uint<LIMBS>> for Uint<LIMBS> {
     fn bitor_assign(&mut self, other: &Self) {
         *self = *self | other;
     }
 }
 
-impl<const LIMBS: usize> BitOr for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> BitOr for Wrapping<Uint<LIMBS>> {
     type Output = Self;
 
-    fn bitor(self, rhs: Self) -> Wrapping<UInt<LIMBS>> {
+    fn bitor(self, rhs: Self) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.bitor(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> BitOr<&Wrapping<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> BitOr<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn bitor(self, rhs: &Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn bitor(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.bitor(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> BitOr<Wrapping<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> BitOr<Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn bitor(self, rhs: Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn bitor(self, rhs: Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.bitor(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> BitOr<&Wrapping<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> BitOr<&Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn bitor(self, rhs: &Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn bitor(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.bitor(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> BitOrAssign for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> BitOrAssign for Wrapping<Uint<LIMBS>> {
     fn bitor_assign(&mut self, other: Self) {
         *self = *self | other;
     }
 }
 
-impl<const LIMBS: usize> BitOrAssign<&Wrapping<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> BitOrAssign<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
     fn bitor_assign(&mut self, other: &Self) {
         *self = *self | other;
     }

--- a/src/uint/bit_xor.rs
+++ b/src/uint/bit_xor.rs
@@ -1,11 +1,11 @@
-//! [`UInt`] bitwise xor operations.
+//! [`Uint`] bitwise xor operations.
 
-use super::UInt;
+use super::Uint;
 use crate::{Limb, Wrapping};
 use core::ops::{BitXor, BitXorAssign};
 use subtle::{Choice, CtOption};
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `a ^ b`.
     #[inline(always)]
     pub const fn bitxor(&self, rhs: &Self) -> Self {
@@ -35,90 +35,90 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> BitXor for UInt<LIMBS> {
+impl<const LIMBS: usize> BitXor for Uint<LIMBS> {
     type Output = Self;
 
-    fn bitxor(self, rhs: Self) -> UInt<LIMBS> {
+    fn bitxor(self, rhs: Self) -> Uint<LIMBS> {
         self.bitxor(&rhs)
     }
 }
 
-impl<const LIMBS: usize> BitXor<&UInt<LIMBS>> for UInt<LIMBS> {
-    type Output = UInt<LIMBS>;
+impl<const LIMBS: usize> BitXor<&Uint<LIMBS>> for Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
 
     #[allow(clippy::needless_borrow)]
-    fn bitxor(self, rhs: &UInt<LIMBS>) -> UInt<LIMBS> {
+    fn bitxor(self, rhs: &Uint<LIMBS>) -> Uint<LIMBS> {
         (&self).bitxor(rhs)
     }
 }
 
-impl<const LIMBS: usize> BitXor<UInt<LIMBS>> for &UInt<LIMBS> {
-    type Output = UInt<LIMBS>;
+impl<const LIMBS: usize> BitXor<Uint<LIMBS>> for &Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
 
-    fn bitxor(self, rhs: UInt<LIMBS>) -> UInt<LIMBS> {
+    fn bitxor(self, rhs: Uint<LIMBS>) -> Uint<LIMBS> {
         self.bitxor(&rhs)
     }
 }
 
-impl<const LIMBS: usize> BitXor<&UInt<LIMBS>> for &UInt<LIMBS> {
-    type Output = UInt<LIMBS>;
+impl<const LIMBS: usize> BitXor<&Uint<LIMBS>> for &Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
 
-    fn bitxor(self, rhs: &UInt<LIMBS>) -> UInt<LIMBS> {
+    fn bitxor(self, rhs: &Uint<LIMBS>) -> Uint<LIMBS> {
         self.bitxor(rhs)
     }
 }
 
-impl<const LIMBS: usize> BitXorAssign for UInt<LIMBS> {
+impl<const LIMBS: usize> BitXorAssign for Uint<LIMBS> {
     fn bitxor_assign(&mut self, other: Self) {
         *self = *self ^ other;
     }
 }
 
-impl<const LIMBS: usize> BitXorAssign<&UInt<LIMBS>> for UInt<LIMBS> {
+impl<const LIMBS: usize> BitXorAssign<&Uint<LIMBS>> for Uint<LIMBS> {
     fn bitxor_assign(&mut self, other: &Self) {
         *self = *self ^ other;
     }
 }
 
-impl<const LIMBS: usize> BitXor for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> BitXor for Wrapping<Uint<LIMBS>> {
     type Output = Self;
 
-    fn bitxor(self, rhs: Self) -> Wrapping<UInt<LIMBS>> {
+    fn bitxor(self, rhs: Self) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.bitxor(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> BitXor<&Wrapping<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> BitXor<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn bitxor(self, rhs: &Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn bitxor(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.bitxor(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> BitXor<Wrapping<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> BitXor<Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn bitxor(self, rhs: Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn bitxor(self, rhs: Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.bitxor(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> BitXor<&Wrapping<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> BitXor<&Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn bitxor(self, rhs: &Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn bitxor(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.bitxor(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> BitXorAssign for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> BitXorAssign for Wrapping<Uint<LIMBS>> {
     fn bitxor_assign(&mut self, other: Self) {
         *self = *self ^ other;
     }
 }
 
-impl<const LIMBS: usize> BitXorAssign<&Wrapping<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> BitXorAssign<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
     fn bitxor_assign(&mut self, other: &Self) {
         *self = *self ^ other;
     }

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -1,6 +1,6 @@
-use crate::{Limb, UInt, Word};
+use crate::{Limb, Uint, Word};
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Get the value of the bit at position `index`, as a 0- or 1-valued Word.
     /// Returns 0 for indices out of range.
     #[inline(always)]

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -1,18 +1,18 @@
-//! [`UInt`] comparisons.
+//! [`Uint`] comparisons.
 //!
 //! By default these are all constant-time and use the `subtle` crate.
 
-use super::UInt;
+use super::Uint;
 use crate::{limb::HI_BIT, Limb, SignedWord, WideSignedWord, Word, Zero};
 use core::cmp::Ordering;
 use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Return `a` if `c`==0 or `b` if `c`==`Word::MAX`.
     ///
     /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
     #[inline]
-    pub(crate) const fn ct_select(a: UInt<LIMBS>, b: UInt<LIMBS>, c: Word) -> Self {
+    pub(crate) const fn ct_select(a: Uint<LIMBS>, b: Uint<LIMBS>, c: Word) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
 
         let mut i = 0;
@@ -21,11 +21,11 @@ impl<const LIMBS: usize> UInt<LIMBS> {
             i += 1;
         }
 
-        UInt { limbs }
+        Uint { limbs }
     }
 
     #[inline]
-    pub(crate) const fn ct_swap(a: UInt<LIMBS>, b: UInt<LIMBS>, c: Word) -> (Self, Self) {
+    pub(crate) const fn ct_swap(a: Uint<LIMBS>, b: Uint<LIMBS>, c: Word) -> (Self, Self) {
         let new_a = Self::ct_select(a, b, c);
         let new_b = Self::ct_select(b, a, c);
 
@@ -87,14 +87,14 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> ConstantTimeEq for UInt<LIMBS> {
+impl<const LIMBS: usize> ConstantTimeEq for Uint<LIMBS> {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
         Choice::from((!self.ct_not_eq(other) as u8) & 1)
     }
 }
 
-impl<const LIMBS: usize> ConstantTimeGreater for UInt<LIMBS> {
+impl<const LIMBS: usize> ConstantTimeGreater for Uint<LIMBS> {
     #[inline]
     fn ct_gt(&self, other: &Self) -> Choice {
         let underflow = other.sbb(self, Limb::ZERO).1;
@@ -102,7 +102,7 @@ impl<const LIMBS: usize> ConstantTimeGreater for UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> ConstantTimeLess for UInt<LIMBS> {
+impl<const LIMBS: usize> ConstantTimeLess for Uint<LIMBS> {
     #[inline]
     fn ct_lt(&self, other: &Self) -> Choice {
         let underflow = self.sbb(other, Limb::ZERO).1;
@@ -110,9 +110,9 @@ impl<const LIMBS: usize> ConstantTimeLess for UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Eq for UInt<LIMBS> {}
+impl<const LIMBS: usize> Eq for Uint<LIMBS> {}
 
-impl<const LIMBS: usize> Ord for UInt<LIMBS> {
+impl<const LIMBS: usize> Ord for Uint<LIMBS> {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.ct_cmp(other) {
             -1 => Ordering::Less,
@@ -126,13 +126,13 @@ impl<const LIMBS: usize> Ord for UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> PartialOrd for UInt<LIMBS> {
+impl<const LIMBS: usize> PartialOrd for Uint<LIMBS> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<const LIMBS: usize> PartialEq for UInt<LIMBS> {
+impl<const LIMBS: usize> PartialEq for Uint<LIMBS> {
     fn eq(&self, other: &Self) -> bool {
         self.ct_eq(other).into()
     }

--- a/src/uint/concat.rs
+++ b/src/uint/concat.rs
@@ -5,7 +5,7 @@ macro_rules! impl_concat {
             impl $name {
                 /// Concatenate the two values, with `self` as most significant and `rhs`
                 /// as the least significant.
-                pub const fn concat(&self, rhs: &Self) -> UInt<{nlimbs!($bits) * 2}> {
+                pub const fn concat(&self, rhs: &Self) -> Uint<{nlimbs!($bits) * 2}> {
                     let mut limbs = [Limb::ZERO; nlimbs!($bits) * 2];
                     let mut i = 0;
                     let mut j = 0;
@@ -23,20 +23,20 @@ macro_rules! impl_concat {
                         j += 1;
                     }
 
-                    UInt { limbs }
+                    Uint { limbs }
                 }
             }
 
             impl Concat for $name {
-                type Output = UInt<{nlimbs!($bits) * 2}>;
+                type Output = Uint<{nlimbs!($bits) * 2}>;
 
                 fn concat(&self, rhs: &Self) -> Self::Output {
                     self.concat(rhs)
                 }
             }
 
-            impl From<($name, $name)> for UInt<{nlimbs!($bits) * 2}> {
-                fn from(nums: ($name, $name)) -> UInt<{nlimbs!($bits) * 2}> {
+            impl From<($name, $name)> for Uint<{nlimbs!($bits) * 2}> {
+                fn from(nums: ($name, $name)) -> Uint<{nlimbs!($bits) * 2}> {
                     nums.0.concat(&nums.1)
                 }
             }

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -1,12 +1,12 @@
-//! [`UInt`] division operations.
+//! [`Uint`] division operations.
 
-use super::UInt;
+use super::Uint;
 use crate::limb::Word;
 use crate::{Integer, Limb, NonZero, Wrapping};
 use core::ops::{Div, DivAssign, Rem, RemAssign};
 use subtle::{Choice, CtOption};
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self` / `rhs`, returns the quotient (q), remainder (r)
     /// and 1 for is_some or 0 for is_none. The results can be wrapped in [`CtOption`].
     /// NOTE: Use only if you need to access const fn. Otherwise use `div_rem` because
@@ -86,7 +86,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         let (mut lower, mut upper) = lower_upper;
 
         // Factor of the modulus, split into two halves
-        let mut c = Self::shl_vartime_wide((*rhs, UInt::ZERO), bd);
+        let mut c = Self::shl_vartime_wide((*rhs, Uint::ZERO), bd);
 
         loop {
             let (lower_sub, borrow) = lower.sbb(&c.0, Limb::ZERO);
@@ -106,7 +106,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 
     /// Computes `self` % 2^k. Faster than reduce since its a power of 2.
-    /// Limited to 2^16-1 since UInt doesn't support higher.
+    /// Limited to 2^16-1 since Uint doesn't support higher.
     pub const fn reduce2k(&self, k: usize) -> Self {
         let highest = (LIMBS - 1) as u32;
         let index = k as u32 / (Limb::BIT_SIZE as u32);
@@ -178,218 +178,218 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Div<&NonZero<UInt<LIMBS>>> for &UInt<LIMBS>
+impl<const LIMBS: usize> Div<&NonZero<Uint<LIMBS>>> for &Uint<LIMBS>
 where
-    UInt<LIMBS>: Integer,
+    Uint<LIMBS>: Integer,
 {
-    type Output = UInt<LIMBS>;
+    type Output = Uint<LIMBS>;
 
-    fn div(self, rhs: &NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn div(self, rhs: &NonZero<Uint<LIMBS>>) -> Self::Output {
         *self / *rhs
     }
 }
 
-impl<const LIMBS: usize> Div<&NonZero<UInt<LIMBS>>> for UInt<LIMBS>
+impl<const LIMBS: usize> Div<&NonZero<Uint<LIMBS>>> for Uint<LIMBS>
 where
-    UInt<LIMBS>: Integer,
+    Uint<LIMBS>: Integer,
 {
-    type Output = UInt<LIMBS>;
+    type Output = Uint<LIMBS>;
 
-    fn div(self, rhs: &NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn div(self, rhs: &NonZero<Uint<LIMBS>>) -> Self::Output {
         self / *rhs
     }
 }
 
-impl<const LIMBS: usize> Div<NonZero<UInt<LIMBS>>> for &UInt<LIMBS>
+impl<const LIMBS: usize> Div<NonZero<Uint<LIMBS>>> for &Uint<LIMBS>
 where
-    UInt<LIMBS>: Integer,
+    Uint<LIMBS>: Integer,
 {
-    type Output = UInt<LIMBS>;
+    type Output = Uint<LIMBS>;
 
-    fn div(self, rhs: NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn div(self, rhs: NonZero<Uint<LIMBS>>) -> Self::Output {
         *self / rhs
     }
 }
 
-impl<const LIMBS: usize> Div<NonZero<UInt<LIMBS>>> for UInt<LIMBS>
+impl<const LIMBS: usize> Div<NonZero<Uint<LIMBS>>> for Uint<LIMBS>
 where
-    UInt<LIMBS>: Integer,
+    Uint<LIMBS>: Integer,
 {
-    type Output = UInt<LIMBS>;
+    type Output = Uint<LIMBS>;
 
-    fn div(self, rhs: NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn div(self, rhs: NonZero<Uint<LIMBS>>) -> Self::Output {
         let (q, _, _) = self.ct_div_rem(&rhs);
         q
     }
 }
 
-impl<const LIMBS: usize> DivAssign<&NonZero<UInt<LIMBS>>> for UInt<LIMBS>
+impl<const LIMBS: usize> DivAssign<&NonZero<Uint<LIMBS>>> for Uint<LIMBS>
 where
-    UInt<LIMBS>: Integer,
+    Uint<LIMBS>: Integer,
 {
-    fn div_assign(&mut self, rhs: &NonZero<UInt<LIMBS>>) {
+    fn div_assign(&mut self, rhs: &NonZero<Uint<LIMBS>>) {
         let (q, _, _) = self.ct_div_rem(rhs);
         *self = q
     }
 }
 
-impl<const LIMBS: usize> DivAssign<NonZero<UInt<LIMBS>>> for UInt<LIMBS>
+impl<const LIMBS: usize> DivAssign<NonZero<Uint<LIMBS>>> for Uint<LIMBS>
 where
-    UInt<LIMBS>: Integer,
+    Uint<LIMBS>: Integer,
 {
-    fn div_assign(&mut self, rhs: NonZero<UInt<LIMBS>>) {
+    fn div_assign(&mut self, rhs: NonZero<Uint<LIMBS>>) {
         *self /= &rhs;
     }
 }
 
-impl<const LIMBS: usize> Div<NonZero<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Div<NonZero<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn div(self, rhs: NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn div(self, rhs: NonZero<Uint<LIMBS>>) -> Self::Output {
         Wrapping(self.0.wrapping_div(rhs.as_ref()))
     }
 }
 
-impl<const LIMBS: usize> Div<NonZero<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Div<NonZero<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn div(self, rhs: NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn div(self, rhs: NonZero<Uint<LIMBS>>) -> Self::Output {
         *self / rhs
     }
 }
 
-impl<const LIMBS: usize> Div<&NonZero<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Div<&NonZero<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn div(self, rhs: &NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn div(self, rhs: &NonZero<Uint<LIMBS>>) -> Self::Output {
         *self / *rhs
     }
 }
 
-impl<const LIMBS: usize> Div<&NonZero<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Div<&NonZero<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn div(self, rhs: &NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn div(self, rhs: &NonZero<Uint<LIMBS>>) -> Self::Output {
         self / *rhs
     }
 }
 
-impl<const LIMBS: usize> DivAssign<&NonZero<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
-    fn div_assign(&mut self, rhs: &NonZero<UInt<LIMBS>>) {
+impl<const LIMBS: usize> DivAssign<&NonZero<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    fn div_assign(&mut self, rhs: &NonZero<Uint<LIMBS>>) {
         *self = Wrapping(self.0.wrapping_div(rhs.as_ref()))
     }
 }
 
-impl<const LIMBS: usize> DivAssign<NonZero<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
-    fn div_assign(&mut self, rhs: NonZero<UInt<LIMBS>>) {
+impl<const LIMBS: usize> DivAssign<NonZero<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    fn div_assign(&mut self, rhs: NonZero<Uint<LIMBS>>) {
         *self /= &rhs;
     }
 }
 
-impl<const LIMBS: usize> Rem<&NonZero<UInt<LIMBS>>> for &UInt<LIMBS>
+impl<const LIMBS: usize> Rem<&NonZero<Uint<LIMBS>>> for &Uint<LIMBS>
 where
-    UInt<LIMBS>: Integer,
+    Uint<LIMBS>: Integer,
 {
-    type Output = UInt<LIMBS>;
+    type Output = Uint<LIMBS>;
 
-    fn rem(self, rhs: &NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn rem(self, rhs: &NonZero<Uint<LIMBS>>) -> Self::Output {
         *self % *rhs
     }
 }
 
-impl<const LIMBS: usize> Rem<&NonZero<UInt<LIMBS>>> for UInt<LIMBS>
+impl<const LIMBS: usize> Rem<&NonZero<Uint<LIMBS>>> for Uint<LIMBS>
 where
-    UInt<LIMBS>: Integer,
+    Uint<LIMBS>: Integer,
 {
-    type Output = UInt<LIMBS>;
+    type Output = Uint<LIMBS>;
 
-    fn rem(self, rhs: &NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn rem(self, rhs: &NonZero<Uint<LIMBS>>) -> Self::Output {
         self % *rhs
     }
 }
 
-impl<const LIMBS: usize> Rem<NonZero<UInt<LIMBS>>> for &UInt<LIMBS>
+impl<const LIMBS: usize> Rem<NonZero<Uint<LIMBS>>> for &Uint<LIMBS>
 where
-    UInt<LIMBS>: Integer,
+    Uint<LIMBS>: Integer,
 {
-    type Output = UInt<LIMBS>;
+    type Output = Uint<LIMBS>;
 
-    fn rem(self, rhs: NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn rem(self, rhs: NonZero<Uint<LIMBS>>) -> Self::Output {
         *self % rhs
     }
 }
 
-impl<const LIMBS: usize> Rem<NonZero<UInt<LIMBS>>> for UInt<LIMBS>
+impl<const LIMBS: usize> Rem<NonZero<Uint<LIMBS>>> for Uint<LIMBS>
 where
-    UInt<LIMBS>: Integer,
+    Uint<LIMBS>: Integer,
 {
-    type Output = UInt<LIMBS>;
+    type Output = Uint<LIMBS>;
 
-    fn rem(self, rhs: NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn rem(self, rhs: NonZero<Uint<LIMBS>>) -> Self::Output {
         let (r, _) = self.ct_reduce(&rhs);
         r
     }
 }
 
-impl<const LIMBS: usize> RemAssign<&NonZero<UInt<LIMBS>>> for UInt<LIMBS>
+impl<const LIMBS: usize> RemAssign<&NonZero<Uint<LIMBS>>> for Uint<LIMBS>
 where
-    UInt<LIMBS>: Integer,
+    Uint<LIMBS>: Integer,
 {
-    fn rem_assign(&mut self, rhs: &NonZero<UInt<LIMBS>>) {
+    fn rem_assign(&mut self, rhs: &NonZero<Uint<LIMBS>>) {
         let (r, _) = self.ct_reduce(rhs);
         *self = r
     }
 }
 
-impl<const LIMBS: usize> RemAssign<NonZero<UInt<LIMBS>>> for UInt<LIMBS>
+impl<const LIMBS: usize> RemAssign<NonZero<Uint<LIMBS>>> for Uint<LIMBS>
 where
-    UInt<LIMBS>: Integer,
+    Uint<LIMBS>: Integer,
 {
-    fn rem_assign(&mut self, rhs: NonZero<UInt<LIMBS>>) {
+    fn rem_assign(&mut self, rhs: NonZero<Uint<LIMBS>>) {
         *self %= &rhs;
     }
 }
 
-impl<const LIMBS: usize> Rem<NonZero<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Rem<NonZero<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn rem(self, rhs: NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn rem(self, rhs: NonZero<Uint<LIMBS>>) -> Self::Output {
         Wrapping(self.0.wrapping_rem(rhs.as_ref()))
     }
 }
 
-impl<const LIMBS: usize> Rem<NonZero<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Rem<NonZero<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn rem(self, rhs: NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn rem(self, rhs: NonZero<Uint<LIMBS>>) -> Self::Output {
         *self % rhs
     }
 }
 
-impl<const LIMBS: usize> Rem<&NonZero<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Rem<&NonZero<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn rem(self, rhs: &NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn rem(self, rhs: &NonZero<Uint<LIMBS>>) -> Self::Output {
         *self % *rhs
     }
 }
 
-impl<const LIMBS: usize> Rem<&NonZero<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Rem<&NonZero<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn rem(self, rhs: &NonZero<UInt<LIMBS>>) -> Self::Output {
+    fn rem(self, rhs: &NonZero<Uint<LIMBS>>) -> Self::Output {
         self % *rhs
     }
 }
 
-impl<const LIMBS: usize> RemAssign<NonZero<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
-    fn rem_assign(&mut self, rhs: NonZero<UInt<LIMBS>>) {
+impl<const LIMBS: usize> RemAssign<NonZero<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    fn rem_assign(&mut self, rhs: NonZero<Uint<LIMBS>>) {
         *self %= &rhs;
     }
 }
 
-impl<const LIMBS: usize> RemAssign<&NonZero<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
-    fn rem_assign(&mut self, rhs: &NonZero<UInt<LIMBS>>) {
+impl<const LIMBS: usize> RemAssign<&NonZero<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    fn rem_assign(&mut self, rhs: &NonZero<Uint<LIMBS>>) {
         *self = Wrapping(self.0.wrapping_rem(rhs.as_ref()))
     }
 }
@@ -452,11 +452,11 @@ mod tests {
         let mut b = U256::ZERO;
         b.limbs[b.limbs.len() - 1] = Limb(Word::MAX);
         let q = a.wrapping_div(&b);
-        assert_eq!(q, UInt::ZERO);
+        assert_eq!(q, Uint::ZERO);
         a.limbs[a.limbs.len() - 1] = Limb(1 << (HI_BIT - 7));
         b.limbs[b.limbs.len() - 1] = Limb(0x82 << (HI_BIT - 7));
         let q = a.wrapping_div(&b);
-        assert_eq!(q, UInt::ZERO);
+        assert_eq!(q, Uint::ZERO);
     }
 
     #[test]
@@ -522,7 +522,7 @@ mod tests {
         let mut b = U256::ZERO;
         b.limbs[b.limbs.len() - 1] = Limb(Word::MAX);
         let r = a.wrapping_rem(&b);
-        assert_eq!(r, UInt::ZERO);
+        assert_eq!(r, Uint::ZERO);
         a.limbs[a.limbs.len() - 1] = Limb(1 << (HI_BIT - 7));
         b.limbs[b.limbs.len() - 1] = Limb(0x82 << (HI_BIT - 7));
         let r = a.wrapping_rem(&b);

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -1,4 +1,4 @@
-//! Const-friendly decoding operations for [`UInt`]
+//! Const-friendly decoding operations for [`Uint`]
 
 #[cfg(all(feature = "der", feature = "generic-array"))]
 mod der;
@@ -6,11 +6,11 @@ mod der;
 #[cfg(feature = "rlp")]
 mod rlp;
 
-use super::UInt;
+use super::Uint;
 use crate::{Encoding, Limb, Word};
 
-impl<const LIMBS: usize> UInt<LIMBS> {
-    /// Create a new [`UInt`] from the provided big endian bytes.
+impl<const LIMBS: usize> Uint<LIMBS> {
+    /// Create a new [`Uint`] from the provided big endian bytes.
     pub const fn from_be_slice(bytes: &[u8]) -> Self {
         assert!(
             bytes.len() == Limb::BYTE_SIZE * LIMBS,
@@ -31,10 +31,10 @@ impl<const LIMBS: usize> UInt<LIMBS> {
             i += 1;
         }
 
-        UInt::new(res)
+        Uint::new(res)
     }
 
-    /// Create a new [`UInt`] from the provided big endian hex string.
+    /// Create a new [`Uint`] from the provided big endian hex string.
     pub const fn from_be_hex(hex: &str) -> Self {
         let bytes = hex.as_bytes();
 
@@ -58,10 +58,10 @@ impl<const LIMBS: usize> UInt<LIMBS> {
             i += 1;
         }
 
-        UInt::new(res)
+        Uint::new(res)
     }
 
-    /// Create a new [`UInt`] from the provided little endian bytes.
+    /// Create a new [`Uint`] from the provided little endian bytes.
     pub const fn from_le_slice(bytes: &[u8]) -> Self {
         assert!(
             bytes.len() == Limb::BYTE_SIZE * LIMBS,
@@ -82,10 +82,10 @@ impl<const LIMBS: usize> UInt<LIMBS> {
             i += 1;
         }
 
-        UInt::new(res)
+        Uint::new(res)
     }
 
-    /// Create a new [`UInt`] from the provided little endian hex string.
+    /// Create a new [`Uint`] from the provided little endian hex string.
     pub const fn from_le_hex(hex: &str) -> Self {
         let bytes = hex.as_bytes();
 
@@ -109,10 +109,10 @@ impl<const LIMBS: usize> UInt<LIMBS> {
             i += 1;
         }
 
-        UInt::new(res)
+        Uint::new(res)
     }
 
-    /// Serialize this [`UInt`] as big-endian, writing it into the provided
+    /// Serialize this [`Uint`] as big-endian, writing it into the provided
     /// byte slice.
     #[inline]
     #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
@@ -130,7 +130,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         }
     }
 
-    /// Serialize this [`UInt`] as little-endian, writing it into the provided
+    /// Serialize this [`Uint`] as little-endian, writing it into the provided
     /// byte slice.
     #[inline]
     #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
@@ -183,16 +183,16 @@ mod tests {
     use {crate::U128, alloc::format};
 
     #[cfg(target_pointer_width = "32")]
-    use crate::U64 as UIntEx;
+    use crate::U64 as UintEx;
 
     #[cfg(target_pointer_width = "64")]
-    use crate::U128 as UIntEx;
+    use crate::U128 as UintEx;
 
     #[test]
     #[cfg(target_pointer_width = "32")]
     fn from_be_slice() {
         let bytes = hex!("0011223344556677");
-        let n = UIntEx::from_be_slice(&bytes);
+        let n = UintEx::from_be_slice(&bytes);
         assert_eq!(n.limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
@@ -200,7 +200,7 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn from_be_slice() {
         let bytes = hex!("00112233445566778899aabbccddeeff");
-        let n = UIntEx::from_be_slice(&bytes);
+        let n = UintEx::from_be_slice(&bytes);
         assert_eq!(
             n.limbs(),
             &[Limb(0x8899aabbccddeeff), Limb(0x0011223344556677)]
@@ -211,7 +211,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     fn from_le_slice() {
         let bytes = hex!("7766554433221100");
-        let n = UIntEx::from_le_slice(&bytes);
+        let n = UintEx::from_le_slice(&bytes);
         assert_eq!(n.limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
@@ -219,7 +219,7 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn from_le_slice() {
         let bytes = hex!("ffeeddccbbaa99887766554433221100");
-        let n = UIntEx::from_le_slice(&bytes);
+        let n = UintEx::from_le_slice(&bytes);
         assert_eq!(
             n.limbs(),
             &[Limb(0x8899aabbccddeeff), Limb(0x0011223344556677)]
@@ -229,14 +229,14 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "32")]
     fn from_be_hex() {
-        let n = UIntEx::from_be_hex("0011223344556677");
+        let n = UintEx::from_be_hex("0011223344556677");
         assert_eq!(n.limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn from_be_hex() {
-        let n = UIntEx::from_be_hex("00112233445566778899aabbccddeeff");
+        let n = UintEx::from_be_hex("00112233445566778899aabbccddeeff");
         assert_eq!(
             n.limbs(),
             &[Limb(0x8899aabbccddeeff), Limb(0x0011223344556677)]
@@ -246,14 +246,14 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "32")]
     fn from_le_hex() {
-        let n = UIntEx::from_le_hex("7766554433221100");
+        let n = UintEx::from_le_hex("7766554433221100");
         assert_eq!(n.limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn from_le_hex() {
-        let n = UIntEx::from_le_hex("ffeeddccbbaa99887766554433221100");
+        let n = UintEx::from_le_hex("ffeeddccbbaa99887766554433221100");
         assert_eq!(
             n.limbs(),
             &[Limb(0x8899aabbccddeeff), Limb(0x0011223344556677)]

--- a/src/uint/encoding/der.rs
+++ b/src/uint/encoding/der.rs
@@ -1,42 +1,42 @@
-//! Support for decoding/encoding [`UInt`] as an ASN.1 DER `INTEGER`.
+//! Support for decoding/encoding [`Uint`] as an ASN.1 DER `INTEGER`.
 
-use crate::{generic_array::GenericArray, ArrayEncoding, UInt};
+use crate::{generic_array::GenericArray, ArrayEncoding, Uint};
 use ::der::{
     asn1::{AnyRef, UIntRef},
     DecodeValue, EncodeValue, FixedTag, Length, Tag,
 };
 
 #[cfg_attr(docsrs, doc(cfg(feature = "der")))]
-impl<'a, const LIMBS: usize> TryFrom<AnyRef<'a>> for UInt<LIMBS>
+impl<'a, const LIMBS: usize> TryFrom<AnyRef<'a>> for Uint<LIMBS>
 where
-    UInt<LIMBS>: ArrayEncoding,
+    Uint<LIMBS>: ArrayEncoding,
 {
     type Error = der::Error;
 
-    fn try_from(any: AnyRef<'a>) -> der::Result<UInt<LIMBS>> {
+    fn try_from(any: AnyRef<'a>) -> der::Result<Uint<LIMBS>> {
         UIntRef::try_from(any)?.try_into()
     }
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "der")))]
-impl<'a, const LIMBS: usize> TryFrom<UIntRef<'a>> for UInt<LIMBS>
+impl<'a, const LIMBS: usize> TryFrom<UIntRef<'a>> for Uint<LIMBS>
 where
-    UInt<LIMBS>: ArrayEncoding,
+    Uint<LIMBS>: ArrayEncoding,
 {
     type Error = der::Error;
 
-    fn try_from(bytes: UIntRef<'a>) -> der::Result<UInt<LIMBS>> {
+    fn try_from(bytes: UIntRef<'a>) -> der::Result<Uint<LIMBS>> {
         let mut array = GenericArray::default();
         let offset = array.len().saturating_sub(bytes.len().try_into()?);
         array[offset..].copy_from_slice(bytes.as_bytes());
-        Ok(UInt::from_be_byte_array(array))
+        Ok(Uint::from_be_byte_array(array))
     }
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "der")))]
-impl<'a, const LIMBS: usize> DecodeValue<'a> for UInt<LIMBS>
+impl<'a, const LIMBS: usize> DecodeValue<'a> for Uint<LIMBS>
 where
-    UInt<LIMBS>: ArrayEncoding,
+    Uint<LIMBS>: ArrayEncoding,
 {
     fn decode_value<R: der::Reader<'a>>(reader: &mut R, header: der::Header) -> der::Result<Self> {
         UIntRef::decode_value(reader, header)?.try_into()
@@ -44,9 +44,9 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "der")))]
-impl<const LIMBS: usize> EncodeValue for UInt<LIMBS>
+impl<const LIMBS: usize> EncodeValue for Uint<LIMBS>
 where
-    UInt<LIMBS>: ArrayEncoding,
+    Uint<LIMBS>: ArrayEncoding,
 {
     fn value_len(&self) -> der::Result<Length> {
         // TODO(tarcieri): more efficient length calculation
@@ -61,9 +61,9 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "der")))]
-impl<const LIMBS: usize> FixedTag for UInt<LIMBS>
+impl<const LIMBS: usize> FixedTag for Uint<LIMBS>
 where
-    UInt<LIMBS>: ArrayEncoding,
+    Uint<LIMBS>: ArrayEncoding,
 {
     const TAG: Tag = Tag::Integer;
 }

--- a/src/uint/encoding/rlp.rs
+++ b/src/uint/encoding/rlp.rs
@@ -1,10 +1,10 @@
 //! Recursive Length Prefix (RLP) encoding support.
 
-use crate::{Encoding, UInt};
+use crate::{Encoding, Uint};
 use rlp::{DecoderError, Rlp, RlpStream};
 
 #[cfg_attr(docsrs, doc(cfg(feature = "rlp")))]
-impl<const LIMBS: usize> rlp::Encodable for UInt<LIMBS>
+impl<const LIMBS: usize> rlp::Encodable for Uint<LIMBS>
 where
     Self: Encoding,
 {
@@ -21,7 +21,7 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "rlp")))]
-impl<const LIMBS: usize> rlp::Decodable for UInt<LIMBS>
+impl<const LIMBS: usize> rlp::Decodable for Uint<LIMBS>
 where
     Self: Encoding,
     <Self as Encoding>::Repr: Default,

--- a/src/uint/from.rs
+++ b/src/uint/from.rs
@@ -1,9 +1,9 @@
-//! `From`-like conversions for [`UInt`].
+//! `From`-like conversions for [`Uint`].
 
-use crate::{Limb, UInt, WideWord, Word, U128, U64};
+use crate::{Limb, Uint, WideWord, Word, U128, U64};
 
-impl<const LIMBS: usize> UInt<LIMBS> {
-    /// Create a [`UInt`] from a `u8` (const-friendly)
+impl<const LIMBS: usize> Uint<LIMBS> {
+    /// Create a [`Uint`] from a `u8` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u8>` when stable
     pub const fn from_u8(n: u8) -> Self {
         assert!(LIMBS >= 1, "number of limbs must be greater than zero");
@@ -12,7 +12,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         Self { limbs }
     }
 
-    /// Create a [`UInt`] from a `u16` (const-friendly)
+    /// Create a [`Uint`] from a `u16` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u16>` when stable
     pub const fn from_u16(n: u16) -> Self {
         assert!(LIMBS >= 1, "number of limbs must be greater than zero");
@@ -21,7 +21,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         Self { limbs }
     }
 
-    /// Create a [`UInt`] from a `u32` (const-friendly)
+    /// Create a [`Uint`] from a `u32` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u32>` when stable
     #[allow(trivial_numeric_casts)]
     pub const fn from_u32(n: u32) -> Self {
@@ -31,7 +31,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         Self { limbs }
     }
 
-    /// Create a [`UInt`] from a `u64` (const-friendly)
+    /// Create a [`Uint`] from a `u64` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u64>` when stable
     #[cfg(target_pointer_width = "32")]
     pub const fn from_u64(n: u64) -> Self {
@@ -42,7 +42,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         Self { limbs }
     }
 
-    /// Create a [`UInt`] from a `u64` (const-friendly)
+    /// Create a [`Uint`] from a `u64` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u64>` when stable
     #[cfg(target_pointer_width = "64")]
     pub const fn from_u64(n: u64) -> Self {
@@ -52,7 +52,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         Self { limbs }
     }
 
-    /// Create a [`UInt`] from a `u128` (const-friendly)
+    /// Create a [`Uint`] from a `u128` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u128>` when stable
     pub const fn from_u128(n: u128) -> Self {
         assert!(
@@ -80,7 +80,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         Self { limbs }
     }
 
-    /// Create a [`UInt`] from a `Word` (const-friendly)
+    /// Create a [`Uint`] from a `Word` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<Word>` when stable
     pub const fn from_word(n: Word) -> Self {
         assert!(LIMBS >= 1, "number of limbs must be greater than zero");
@@ -89,7 +89,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         Self { limbs }
     }
 
-    /// Create a [`UInt`] from a `WideWord` (const-friendly)
+    /// Create a [`Uint`] from a `WideWord` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<WideWord>` when stable
     pub const fn from_wide_word(n: WideWord) -> Self {
         assert!(LIMBS >= 2, "number of limbs must be two or greater");
@@ -100,7 +100,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> From<u8> for UInt<LIMBS> {
+impl<const LIMBS: usize> From<u8> for Uint<LIMBS> {
     fn from(n: u8) -> Self {
         // TODO(tarcieri): const where clause when possible
         debug_assert!(LIMBS > 0, "limbs must be non-zero");
@@ -108,7 +108,7 @@ impl<const LIMBS: usize> From<u8> for UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> From<u16> for UInt<LIMBS> {
+impl<const LIMBS: usize> From<u16> for Uint<LIMBS> {
     fn from(n: u16) -> Self {
         // TODO(tarcieri): const where clause when possible
         debug_assert!(LIMBS > 0, "limbs must be non-zero");
@@ -116,7 +116,7 @@ impl<const LIMBS: usize> From<u16> for UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> From<u32> for UInt<LIMBS> {
+impl<const LIMBS: usize> From<u32> for Uint<LIMBS> {
     fn from(n: u32) -> Self {
         // TODO(tarcieri): const where clause when possible
         debug_assert!(LIMBS > 0, "limbs must be non-zero");
@@ -124,7 +124,7 @@ impl<const LIMBS: usize> From<u32> for UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> From<u64> for UInt<LIMBS> {
+impl<const LIMBS: usize> From<u64> for Uint<LIMBS> {
     fn from(n: u64) -> Self {
         // TODO(tarcieri): const where clause when possible
         debug_assert!(LIMBS >= (64 / Limb::BIT_SIZE), "not enough limbs");
@@ -132,7 +132,7 @@ impl<const LIMBS: usize> From<u64> for UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> From<u128> for UInt<LIMBS> {
+impl<const LIMBS: usize> From<u128> for Uint<LIMBS> {
     fn from(n: u128) -> Self {
         // TODO(tarcieri): const where clause when possible
         debug_assert!(LIMBS >= (128 / Limb::BIT_SIZE), "not enough limbs");
@@ -163,31 +163,31 @@ impl From<U128> for u128 {
     }
 }
 
-impl<const LIMBS: usize> From<[Word; LIMBS]> for UInt<LIMBS> {
+impl<const LIMBS: usize> From<[Word; LIMBS]> for Uint<LIMBS> {
     fn from(arr: [Word; LIMBS]) -> Self {
         Self::from_words(arr)
     }
 }
 
-impl<const LIMBS: usize> From<UInt<LIMBS>> for [Word; LIMBS] {
-    fn from(n: UInt<LIMBS>) -> [Word; LIMBS] {
+impl<const LIMBS: usize> From<Uint<LIMBS>> for [Word; LIMBS] {
+    fn from(n: Uint<LIMBS>) -> [Word; LIMBS] {
         *n.as_ref()
     }
 }
 
-impl<const LIMBS: usize> From<[Limb; LIMBS]> for UInt<LIMBS> {
+impl<const LIMBS: usize> From<[Limb; LIMBS]> for Uint<LIMBS> {
     fn from(limbs: [Limb; LIMBS]) -> Self {
         Self { limbs }
     }
 }
 
-impl<const LIMBS: usize> From<UInt<LIMBS>> for [Limb; LIMBS] {
-    fn from(n: UInt<LIMBS>) -> [Limb; LIMBS] {
+impl<const LIMBS: usize> From<Uint<LIMBS>> for [Limb; LIMBS] {
+    fn from(n: Uint<LIMBS>) -> [Limb; LIMBS] {
         n.limbs
     }
 }
 
-impl<const LIMBS: usize> From<Limb> for UInt<LIMBS> {
+impl<const LIMBS: usize> From<Limb> for Uint<LIMBS> {
     fn from(limb: Limb) -> Self {
         limb.0.into()
     }
@@ -198,26 +198,26 @@ mod tests {
     use crate::{Limb, Word, U128};
 
     #[cfg(target_pointer_width = "32")]
-    use crate::U64 as UIntEx;
+    use crate::U64 as UintEx;
 
     #[cfg(target_pointer_width = "64")]
-    use crate::U128 as UIntEx;
+    use crate::U128 as UintEx;
 
     #[test]
     fn from_u8() {
-        let n = UIntEx::from(42u8);
+        let n = UintEx::from(42u8);
         assert_eq!(n.limbs(), &[Limb(42), Limb(0)]);
     }
 
     #[test]
     fn from_u16() {
-        let n = UIntEx::from(42u16);
+        let n = UintEx::from(42u16);
         assert_eq!(n.limbs(), &[Limb(42), Limb(0)]);
     }
 
     #[test]
     fn from_u64() {
-        let n = UIntEx::from(42u64);
+        let n = UintEx::from(42u64);
         assert_eq!(n.limbs(), &[Limb(42), Limb(0)]);
     }
 
@@ -231,7 +231,7 @@ mod tests {
     #[test]
     fn array_round_trip() {
         let arr1 = [1, 2];
-        let n = UIntEx::from(arr1);
+        let n = UintEx::from(arr1);
         let arr2: [Word; 2] = n.into();
         assert_eq!(arr1, arr2);
     }

--- a/src/uint/modular.rs
+++ b/src/uint/modular.rs
@@ -1,6 +1,6 @@
 use subtle::CtOption;
 
-use crate::{UInt, Word};
+use crate::{Uint, Word};
 
 mod reduction;
 
@@ -40,12 +40,12 @@ where
     Self: Sized,
 {
     /// Computes the (reduced) exponentiation of a residue.
-    fn pow(self, exponent: &UInt<LIMBS>) -> Self {
+    fn pow(self, exponent: &Uint<LIMBS>) -> Self {
         self.pow_specific(exponent, LIMBS * Word::BITS as usize)
     }
 
     /// Computes the (reduced) exponentiation of a residue, here `exponent_bits` represents the number of bits to take into account for the exponent. Note that this value is leaked in the time pattern.
-    fn pow_specific(self, exponent: &UInt<LIMBS>, exponent_bits: usize) -> Self;
+    fn pow_specific(self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self;
 }
 
 /// Provides a consistent interface to invert a residue.
@@ -62,7 +62,7 @@ pub trait GenericResidue<const LIMBS: usize>:
     AddResidue + MulResidue + PowResidue<LIMBS> + InvResidue
 {
     /// Retrieves the integer currently encoded in this `Residue`, guaranteed to be reduced.
-    fn retrieve(&self) -> UInt<LIMBS>;
+    fn retrieve(&self) -> Uint<LIMBS>;
 }
 
 #[cfg(test)]
@@ -73,7 +73,7 @@ mod tests {
             constant_mod::Residue, constant_mod::ResidueParams, reduction::montgomery_reduction,
         },
         traits::Encoding,
-        UInt, U256, U64,
+        Uint, U256, U64,
     };
 
     impl_modulus!(
@@ -109,11 +109,11 @@ mod tests {
         // Divide the value R by R, which should equal 1
         assert_eq!(
             montgomery_reduction::<{ Modulus2::LIMBS }>(
-                (Modulus2::R, UInt::ZERO),
+                (Modulus2::R, Uint::ZERO),
                 Modulus2::MODULUS,
                 Modulus2::MOD_NEG_INV
             ),
-            UInt::ONE
+            Uint::ONE
         );
     }
 
@@ -122,7 +122,7 @@ mod tests {
         // Divide the value R^2 by R, which should equal R
         assert_eq!(
             montgomery_reduction::<{ Modulus2::LIMBS }>(
-                (Modulus2::R2, UInt::ZERO),
+                (Modulus2::R2, Uint::ZERO),
                 Modulus2::MODULUS,
                 Modulus2::MOD_NEG_INV
             ),
@@ -172,7 +172,7 @@ mod tests {
         let c = hi.concat(&lo);
         let red = c.reduce(&U256::ZERO.concat(&Modulus2::MODULUS)).unwrap();
         let (hi, lo) = red.split();
-        assert_eq!(hi, UInt::ZERO);
+        assert_eq!(hi, Uint::ZERO);
 
         assert_eq!(
             montgomery_reduction::<{ Modulus2::LIMBS }>(

--- a/src/uint/modular/add.rs
+++ b/src/uint/modular/add.rs
@@ -1,9 +1,9 @@
-use crate::UInt;
+use crate::Uint;
 
 pub(crate) const fn add_montgomery_form<const LIMBS: usize>(
-    a: &UInt<LIMBS>,
-    b: &UInt<LIMBS>,
-    modulus: &UInt<LIMBS>,
-) -> UInt<LIMBS> {
+    a: &Uint<LIMBS>,
+    b: &Uint<LIMBS>,
+    modulus: &Uint<LIMBS>,
+) -> Uint<LIMBS> {
     a.add_mod(b, modulus)
 }

--- a/src/uint/modular/constant_mod/const_add.rs
+++ b/src/uint/modular/constant_mod/const_add.rs
@@ -2,7 +2,7 @@ use core::ops::AddAssign;
 
 use crate::{
     modular::{add::add_montgomery_form, AddResidue},
-    UInt,
+    Uint,
 };
 
 use super::{Residue, ResidueParams};
@@ -27,10 +27,10 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     }
 }
 
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> AddAssign<&UInt<LIMBS>>
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> AddAssign<&Uint<LIMBS>>
     for Residue<MOD, LIMBS>
 {
-    fn add_assign(&mut self, rhs: &UInt<LIMBS>) {
+    fn add_assign(&mut self, rhs: &Uint<LIMBS>) {
         *self += &Residue::new(*rhs);
     }
 }

--- a/src/uint/modular/constant_mod/const_pow.rs
+++ b/src/uint/modular/constant_mod/const_pow.rs
@@ -1,26 +1,26 @@
 use crate::{
     modular::{pow::pow_montgomery_form, PowResidue},
-    UInt, Word,
+    Uint, Word,
 };
 
 use super::{Residue, ResidueParams};
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> PowResidue<LIMBS> for Residue<MOD, LIMBS> {
-    fn pow_specific(self, exponent: &UInt<LIMBS>, exponent_bits: usize) -> Self {
+    fn pow_specific(self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
         self.pow_specific(exponent, exponent_bits)
     }
 }
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// Performs modular exponentiation using Montgomery's ladder.
-    pub const fn pow(self, exponent: &UInt<LIMBS>) -> Residue<MOD, LIMBS> {
+    pub const fn pow(self, exponent: &Uint<LIMBS>) -> Residue<MOD, LIMBS> {
         self.pow_specific(exponent, LIMBS * Word::BITS as usize)
     }
 
     /// Performs modular exponentiation using Montgomery's ladder. `exponent_bits` represents the number of bits to take into account for the exponent. Note that this value is leaked in the time pattern.
     pub const fn pow_specific(
         self,
-        exponent: &UInt<LIMBS>,
+        exponent: &Uint<LIMBS>,
         exponent_bits: usize,
     ) -> Residue<MOD, LIMBS> {
         Self {

--- a/src/uint/modular/constant_mod/macros.rs
+++ b/src/uint/modular/constant_mod/macros.rs
@@ -8,24 +8,24 @@ macro_rules! impl_modulus {
         pub struct $name {}
         impl<const DLIMBS: usize> ResidueParams<{ nlimbs!(<$uint_type>::BIT_SIZE) }> for $name
         where
-            $crate::UInt<{ nlimbs!(<$uint_type>::BIT_SIZE) }>:
-                $crate::traits::Concat<Output = $crate::UInt<DLIMBS>>,
-            $crate::UInt<DLIMBS>: $crate::traits::Split<Output = $uint_type>,
+            $crate::Uint<{ nlimbs!(<$uint_type>::BIT_SIZE) }>:
+                $crate::traits::Concat<Output = $crate::Uint<DLIMBS>>,
+            $crate::Uint<DLIMBS>: $crate::traits::Split<Output = $uint_type>,
         {
             const LIMBS: usize = { nlimbs!(<$uint_type>::BIT_SIZE) };
-            const MODULUS: $crate::UInt<{ nlimbs!(<$uint_type>::BIT_SIZE) }> =
+            const MODULUS: $crate::Uint<{ nlimbs!(<$uint_type>::BIT_SIZE) }> =
                 <$uint_type>::from_be_hex($value);
-            const R: $crate::UInt<{ nlimbs!(<$uint_type>::BIT_SIZE) }> = $crate::UInt::MAX
+            const R: $crate::Uint<{ nlimbs!(<$uint_type>::BIT_SIZE) }> = $crate::Uint::MAX
                 .ct_reduce(&Self::MODULUS)
                 .0
-                .wrapping_add(&$crate::UInt::ONE);
-            const R2: $crate::UInt<{ nlimbs!(<$uint_type>::BIT_SIZE) }> =
-                $crate::UInt::ct_reduce_wide(Self::R.square_wide(), &Self::MODULUS).0;
+                .wrapping_add(&$crate::Uint::ONE);
+            const R2: $crate::Uint<{ nlimbs!(<$uint_type>::BIT_SIZE) }> =
+                $crate::Uint::ct_reduce_wide(Self::R.square_wide(), &Self::MODULUS).0;
             const MOD_NEG_INV: $crate::Limb = $crate::Limb(
                 $crate::Word::MIN
                     .wrapping_sub(Self::MODULUS.inv_mod2k($crate::Word::BITS as usize).limbs[0].0),
             );
-            const R3: $crate::UInt<{ nlimbs!(<$uint_type>::BIT_SIZE) }> =
+            const R3: $crate::Uint<{ nlimbs!(<$uint_type>::BIT_SIZE) }> =
                 $crate::uint::modular::reduction::montgomery_reduction(
                     Self::R2.square_wide(),
                     Self::MODULUS,

--- a/src/uint/modular/inv.rs
+++ b/src/uint/modular/inv.rs
@@ -1,11 +1,11 @@
-use crate::{modular::reduction::montgomery_reduction, Limb, UInt, Word};
+use crate::{modular::reduction::montgomery_reduction, Limb, Uint, Word};
 
 pub const fn inv_montgomery_form<const LIMBS: usize>(
-    x: UInt<LIMBS>,
-    modulus: UInt<LIMBS>,
-    r3: &UInt<LIMBS>,
+    x: Uint<LIMBS>,
+    modulus: Uint<LIMBS>,
+    r3: &Uint<LIMBS>,
     mod_neg_inv: Limb,
-) -> (UInt<LIMBS>, Word) {
+) -> (Uint<LIMBS>, Word) {
     let (inverse, error) = x.inv_odd_mod(modulus);
     (
         montgomery_reduction(inverse.mul_wide(r3), modulus, mod_neg_inv),

--- a/src/uint/modular/mul.rs
+++ b/src/uint/modular/mul.rs
@@ -1,22 +1,22 @@
-use crate::{Limb, UInt};
+use crate::{Limb, Uint};
 
 use super::reduction::montgomery_reduction;
 
 pub(crate) const fn mul_montgomery_form<const LIMBS: usize>(
-    a: &UInt<LIMBS>,
-    b: &UInt<LIMBS>,
-    modulus: UInt<LIMBS>,
+    a: &Uint<LIMBS>,
+    b: &Uint<LIMBS>,
+    modulus: Uint<LIMBS>,
     mod_neg_inv: Limb,
-) -> UInt<LIMBS> {
+) -> Uint<LIMBS> {
     let product = a.mul_wide(b);
     montgomery_reduction::<LIMBS>(product, modulus, mod_neg_inv)
 }
 
 pub(crate) const fn square_montgomery_form<const LIMBS: usize>(
-    a: &UInt<LIMBS>,
-    modulus: UInt<LIMBS>,
+    a: &Uint<LIMBS>,
+    modulus: Uint<LIMBS>,
     mod_neg_inv: Limb,
-) -> UInt<LIMBS> {
+) -> Uint<LIMBS> {
     let product = a.square_wide();
     montgomery_reduction::<LIMBS>(product, modulus, mod_neg_inv)
 }

--- a/src/uint/modular/pow.rs
+++ b/src/uint/modular/pow.rs
@@ -1,21 +1,21 @@
-use crate::{Limb, UInt, Word};
+use crate::{Limb, Uint, Word};
 
 use super::mul::{mul_montgomery_form, square_montgomery_form};
 
 /// Performs modular exponentiation using Montgomery's ladder. `exponent_bits` represents the number of bits to take into account for the exponent. Note that this value is leaked in the time pattern.
 pub const fn pow_montgomery_form<const LIMBS: usize>(
-    x: UInt<LIMBS>,
-    exponent: &UInt<LIMBS>,
+    x: Uint<LIMBS>,
+    exponent: &Uint<LIMBS>,
     exponent_bits: usize,
-    modulus: UInt<LIMBS>,
-    r: UInt<LIMBS>,
+    modulus: Uint<LIMBS>,
+    r: Uint<LIMBS>,
     mod_neg_inv: Limb,
-) -> UInt<LIMBS> {
-    let mut x1: UInt<LIMBS> = r;
-    let mut x2: UInt<LIMBS> = x;
+) -> Uint<LIMBS> {
+    let mut x1: Uint<LIMBS> = r;
+    let mut x2: Uint<LIMBS> = x;
 
-    // Shift the exponent all the way to the left so the leftmost bit is the MSB of the `UInt`
-    let mut n: UInt<LIMBS> = exponent.shl_vartime((LIMBS * Word::BITS as usize) - exponent_bits);
+    // Shift the exponent all the way to the left so the leftmost bit is the MSB of the `Uint`
+    let mut n: Uint<LIMBS> = exponent.shl_vartime((LIMBS * Word::BITS as usize) - exponent_bits);
 
     let mut i = 0;
     while i < exponent_bits {
@@ -23,14 +23,14 @@ pub const fn pow_montgomery_form<const LIMBS: usize>(
         let (next_n, overflow) = n.shl_1();
         n = next_n;
 
-        let mut product: UInt<LIMBS> = x1;
+        let mut product: Uint<LIMBS> = x1;
         product = mul_montgomery_form(&product, &x2, modulus, mod_neg_inv);
 
-        let mut square = UInt::ct_select(x1, x2, overflow);
+        let mut square = Uint::ct_select(x1, x2, overflow);
         square = square_montgomery_form(&square, modulus, mod_neg_inv);
 
-        x1 = UInt::<LIMBS>::ct_select(square, product, overflow);
-        x2 = UInt::<LIMBS>::ct_select(product, square, overflow);
+        x1 = Uint::<LIMBS>::ct_select(square, product, overflow);
+        x2 = Uint::<LIMBS>::ct_select(product, square, overflow);
 
         i += 1;
     }

--- a/src/uint/modular/reduction.rs
+++ b/src/uint/modular/reduction.rs
@@ -1,11 +1,11 @@
-use crate::{Limb, UInt, WideWord, Word};
+use crate::{Limb, Uint, WideWord, Word};
 
 /// Algorithm 14.32 in Handbook of Applied Cryptography (https://cacr.uwaterloo.ca/hac/about/chap14.pdf)
 pub(crate) const fn montgomery_reduction<const LIMBS: usize>(
-    lower_upper: (UInt<LIMBS>, UInt<LIMBS>),
-    modulus: UInt<LIMBS>,
+    lower_upper: (Uint<LIMBS>, Uint<LIMBS>),
+    modulus: Uint<LIMBS>,
     mod_neg_inv: Limb,
-) -> UInt<LIMBS> {
+) -> Uint<LIMBS> {
     let (mut lower, mut upper) = lower_upper;
 
     let mut meta_carry = 0;
@@ -51,7 +51,7 @@ pub(crate) const fn montgomery_reduction<const LIMBS: usize>(
     // Final reduction (at this point, the value is at most 2 * modulus)
     let must_reduce = (meta_carry as Word).saturating_mul(Word::MAX)
         | ((upper.ct_cmp(&modulus) != -1) as Word).saturating_mul(Word::MAX);
-    upper = upper.wrapping_sub(&UInt::ct_select(UInt::ZERO, modulus, must_reduce));
+    upper = upper.wrapping_sub(&Uint::ct_select(Uint::ZERO, modulus, must_reduce));
 
     upper
 }

--- a/src/uint/modular/runtime_mod/runtime_add.rs
+++ b/src/uint/modular/runtime_mod/runtime_add.rs
@@ -2,7 +2,7 @@ use core::ops::{Add, AddAssign};
 
 use crate::{
     modular::{add::add_montgomery_form, AddResidue},
-    UInt,
+    Uint,
 };
 
 use super::DynResidue;
@@ -31,8 +31,8 @@ impl<const LIMBS: usize> AddAssign for DynResidue<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> AddAssign<UInt<LIMBS>> for DynResidue<LIMBS> {
-    fn add_assign(&mut self, rhs: UInt<LIMBS>) {
+impl<const LIMBS: usize> AddAssign<Uint<LIMBS>> for DynResidue<LIMBS> {
+    fn add_assign(&mut self, rhs: Uint<LIMBS>) {
         self.montgomery_form = add_montgomery_form(
             &self.montgomery_form,
             &DynResidue::new(rhs, self.residue_params).montgomery_form,

--- a/src/uint/modular/runtime_mod/runtime_pow.rs
+++ b/src/uint/modular/runtime_mod/runtime_pow.rs
@@ -1,19 +1,19 @@
 use crate::{
     modular::{pow::pow_montgomery_form, PowResidue},
-    UInt,
+    Uint,
 };
 
 use super::DynResidue;
 
 impl<const LIMBS: usize> PowResidue<LIMBS> for DynResidue<LIMBS> {
-    fn pow_specific(self, exponent: &UInt<LIMBS>, exponent_bits: usize) -> Self {
+    fn pow_specific(self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
         self.pow_specific(exponent, exponent_bits)
     }
 }
 
 impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// Computes the (reduced) exponentiation of a residue, here `exponent_bits` represents the number of bits to take into account for the exponent. Note that this value is leaked in the time pattern.
-    pub const fn pow_specific(self, exponent: &UInt<LIMBS>, exponent_bits: usize) -> Self {
+    pub const fn pow_specific(self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
         Self {
             montgomery_form: pow_montgomery_form(
                 self.montgomery_form,

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -1,10 +1,10 @@
-//! [`UInt`] addition operations.
+//! [`Uint`] addition operations.
 
-use crate::{Checked, CheckedMul, Concat, Limb, UInt, Wrapping, Zero};
+use crate::{Checked, CheckedMul, Concat, Limb, Uint, Wrapping, Zero};
 use core::ops::{Mul, MulAssign};
 use subtle::CtOption;
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Compute "wide" multiplication, with a product twice the size of the input.
     ///
     /// Returns a tuple containing the `(lo, hi)` components of the product.
@@ -90,7 +90,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> CheckedMul<&UInt<LIMBS>> for UInt<LIMBS> {
+impl<const LIMBS: usize> CheckedMul<&Uint<LIMBS>> for Uint<LIMBS> {
     type Output = Self;
 
     fn checked_mul(&self, rhs: &Self) -> CtOption<Self> {
@@ -99,89 +99,89 @@ impl<const LIMBS: usize> CheckedMul<&UInt<LIMBS>> for UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Mul for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> Mul for Wrapping<Uint<LIMBS>> {
     type Output = Self;
 
-    fn mul(self, rhs: Self) -> Wrapping<UInt<LIMBS>> {
+    fn mul(self, rhs: Self) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.wrapping_mul(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> Mul<&Wrapping<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Mul<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn mul(self, rhs: &Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn mul(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.wrapping_mul(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> Mul<Wrapping<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Mul<Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn mul(self, rhs: Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn mul(self, rhs: Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.wrapping_mul(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> Mul<&Wrapping<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Mul<&Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn mul(self, rhs: &Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn mul(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.wrapping_mul(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> MulAssign for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> MulAssign for Wrapping<Uint<LIMBS>> {
     fn mul_assign(&mut self, other: Self) {
         *self = *self * other;
     }
 }
 
-impl<const LIMBS: usize> MulAssign<&Wrapping<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> MulAssign<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
     fn mul_assign(&mut self, other: &Self) {
         *self = *self * other;
     }
 }
 
-impl<const LIMBS: usize> Mul for Checked<UInt<LIMBS>> {
+impl<const LIMBS: usize> Mul for Checked<Uint<LIMBS>> {
     type Output = Self;
 
-    fn mul(self, rhs: Self) -> Checked<UInt<LIMBS>> {
+    fn mul(self, rhs: Self) -> Checked<Uint<LIMBS>> {
         Checked(self.0.and_then(|a| rhs.0.and_then(|b| a.checked_mul(&b))))
     }
 }
 
-impl<const LIMBS: usize> Mul<&Checked<UInt<LIMBS>>> for Checked<UInt<LIMBS>> {
-    type Output = Checked<UInt<LIMBS>>;
+impl<const LIMBS: usize> Mul<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS>> {
+    type Output = Checked<Uint<LIMBS>>;
 
-    fn mul(self, rhs: &Checked<UInt<LIMBS>>) -> Checked<UInt<LIMBS>> {
+    fn mul(self, rhs: &Checked<Uint<LIMBS>>) -> Checked<Uint<LIMBS>> {
         Checked(self.0.and_then(|a| rhs.0.and_then(|b| a.checked_mul(&b))))
     }
 }
 
-impl<const LIMBS: usize> Mul<Checked<UInt<LIMBS>>> for &Checked<UInt<LIMBS>> {
-    type Output = Checked<UInt<LIMBS>>;
+impl<const LIMBS: usize> Mul<Checked<Uint<LIMBS>>> for &Checked<Uint<LIMBS>> {
+    type Output = Checked<Uint<LIMBS>>;
 
-    fn mul(self, rhs: Checked<UInt<LIMBS>>) -> Checked<UInt<LIMBS>> {
+    fn mul(self, rhs: Checked<Uint<LIMBS>>) -> Checked<Uint<LIMBS>> {
         Checked(self.0.and_then(|a| rhs.0.and_then(|b| a.checked_mul(&b))))
     }
 }
 
-impl<const LIMBS: usize> Mul<&Checked<UInt<LIMBS>>> for &Checked<UInt<LIMBS>> {
-    type Output = Checked<UInt<LIMBS>>;
+impl<const LIMBS: usize> Mul<&Checked<Uint<LIMBS>>> for &Checked<Uint<LIMBS>> {
+    type Output = Checked<Uint<LIMBS>>;
 
-    fn mul(self, rhs: &Checked<UInt<LIMBS>>) -> Checked<UInt<LIMBS>> {
+    fn mul(self, rhs: &Checked<Uint<LIMBS>>) -> Checked<Uint<LIMBS>> {
         Checked(self.0.and_then(|a| rhs.0.and_then(|b| a.checked_mul(&b))))
     }
 }
 
-impl<const LIMBS: usize> MulAssign for Checked<UInt<LIMBS>> {
+impl<const LIMBS: usize> MulAssign for Checked<Uint<LIMBS>> {
     fn mul_assign(&mut self, other: Self) {
         *self = *self * other;
     }
 }
 
-impl<const LIMBS: usize> MulAssign<&Checked<UInt<LIMBS>>> for Checked<UInt<LIMBS>> {
+impl<const LIMBS: usize> MulAssign<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS>> {
     fn mul_assign(&mut self, other: &Self) {
         *self = *self * other;
     }

--- a/src/uint/neg.rs
+++ b/src/uint/neg.rs
@@ -1,8 +1,8 @@
 use core::ops::Neg;
 
-use crate::{UInt, Word, Wrapping};
+use crate::{Uint, Word, Wrapping};
 
-impl<const LIMBS: usize> Neg for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> Neg for Wrapping<Uint<LIMBS>> {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
@@ -11,12 +11,12 @@ impl<const LIMBS: usize> Neg for Wrapping<UInt<LIMBS>> {
     }
 }
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Negates based on `choice` by wrapping the integer.
-    pub(crate) const fn conditional_wrapping_neg(self, choice: Word) -> UInt<LIMBS> {
+    pub(crate) const fn conditional_wrapping_neg(self, choice: Word) -> Uint<LIMBS> {
         let (shifted, _) = self.shl_1();
         let negated_self = self.wrapping_sub(&shifted);
 
-        UInt::ct_select(self, negated_self, choice)
+        Uint::ct_select(self, negated_self, choice)
     }
 }

--- a/src/uint/neg_mod.rs
+++ b/src/uint/neg_mod.rs
@@ -1,8 +1,8 @@
-//! [`UInt`] negation modulus operations.
+//! [`Uint`] negation modulus operations.
 
-use crate::{Limb, NegMod, UInt};
+use crate::{Limb, NegMod, Uint};
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `-a mod p` in constant time.
     /// Assumes `self` is in `[0, p)`.
     pub const fn neg_mod(&self, p: &Self) -> Self {
@@ -25,7 +25,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> NegMod for UInt<LIMBS> {
+impl<const LIMBS: usize> NegMod for Uint<LIMBS> {
     type Output = Self;
 
     fn neg_mod(&self, p: &Self) -> Self {

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -1,13 +1,13 @@
 //! Random number generator support
 
-use super::UInt;
+use super::Uint;
 use crate::{Limb, NonZero, Random, RandomMod};
 use rand_core::{CryptoRng, RngCore};
 use subtle::ConstantTimeLess;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
-impl<const LIMBS: usize> Random for UInt<LIMBS> {
-    /// Generate a cryptographically secure random [`UInt`].
+impl<const LIMBS: usize> Random for Uint<LIMBS> {
+    /// Generate a cryptographically secure random [`Uint`].
     fn random(mut rng: impl CryptoRng + RngCore) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
 
@@ -20,8 +20,8 @@ impl<const LIMBS: usize> Random for UInt<LIMBS> {
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
-impl<const LIMBS: usize> RandomMod for UInt<LIMBS> {
-    /// Generate a cryptographically secure random [`UInt`] which is less than
+impl<const LIMBS: usize> RandomMod for Uint<LIMBS> {
+    /// Generate a cryptographically secure random [`Uint`] which is less than
     /// a given `modulus`.
     ///
     /// This function uses rejection sampling, a method which produces an

--- a/src/uint/resize.rs
+++ b/src/uint/resize.rs
@@ -1,12 +1,12 @@
-use super::UInt;
+use super::Uint;
 
-impl<const LIMBS: usize> UInt<LIMBS> {
-    /// Construct a `UInt<T>` from the unsigned integer value,
+impl<const LIMBS: usize> Uint<LIMBS> {
+    /// Construct a `Uint<T>` from the unsigned integer value,
     /// truncating the upper bits if the value is too large to be
     /// represented.
     #[inline(always)]
-    pub const fn resize<const T: usize>(&self) -> UInt<T> {
-        let mut res = UInt::ZERO;
+    pub const fn resize<const T: usize>(&self) -> Uint<T> {
+        let mut res = Uint::ZERO;
         let mut i = 0;
         let dim = if T < LIMBS { T } else { LIMBS };
         while i < dim {

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -1,9 +1,9 @@
-//! [`UInt`] bitwise left shift operations.
+//! [`Uint`] bitwise left shift operations.
 
-use crate::{limb::HI_BIT, Limb, UInt, Word};
+use crate::{limb::HI_BIT, Limb, Uint, Word};
 use core::ops::{Shl, ShlAssign};
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self << 1` in constant-time, returning the overflowing bit as a `Word` that is either 0...0 or 1...1.
     pub(crate) const fn shl_1(&self) -> (Self, Word) {
         let mut shifted_bits = [0; LIMBS];
@@ -30,7 +30,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         }
 
         (
-            UInt::new(limbs),
+            Uint::new(limbs),
             carry_bits[LIMBS - 1].wrapping_mul(Word::MAX),
         )
     }
@@ -89,31 +89,31 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Shl<usize> for UInt<LIMBS> {
-    type Output = UInt<LIMBS>;
+impl<const LIMBS: usize> Shl<usize> for Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
 
     /// NOTE: this operation is variable time with respect to `rhs` *ONLY*.
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
-    fn shl(self, rhs: usize) -> UInt<LIMBS> {
+    fn shl(self, rhs: usize) -> Uint<LIMBS> {
         self.shl_vartime(rhs)
     }
 }
 
-impl<const LIMBS: usize> Shl<usize> for &UInt<LIMBS> {
-    type Output = UInt<LIMBS>;
+impl<const LIMBS: usize> Shl<usize> for &Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
 
     /// NOTE: this operation is variable time with respect to `rhs` *ONLY*.
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
-    fn shl(self, rhs: usize) -> UInt<LIMBS> {
+    fn shl(self, rhs: usize) -> Uint<LIMBS> {
         self.shl_vartime(rhs)
     }
 }
 
-impl<const LIMBS: usize> ShlAssign<usize> for UInt<LIMBS> {
+impl<const LIMBS: usize> ShlAssign<usize> for Uint<LIMBS> {
     /// NOTE: this operation is variable time with respect to `rhs` *ONLY*.
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
@@ -125,7 +125,7 @@ impl<const LIMBS: usize> ShlAssign<usize> for UInt<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Limb, UInt, U128, U256};
+    use crate::{Limb, Uint, U128, U256};
 
     const N: U256 =
         U256::from_be_hex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
@@ -186,7 +186,7 @@ mod tests {
     #[test]
     fn shl_wide_1_1_128() {
         assert_eq!(
-            UInt::shl_vartime_wide((U128::ONE, U128::ONE), 128),
+            Uint::shl_vartime_wide((U128::ONE, U128::ONE), 128),
             (U128::ZERO, U128::ONE)
         );
     }
@@ -194,7 +194,7 @@ mod tests {
     #[test]
     fn shl_wide_max_0_1() {
         assert_eq!(
-            UInt::shl_vartime_wide((U128::MAX, U128::ZERO), 1),
+            Uint::shl_vartime_wide((U128::MAX, U128::ZERO), 1),
             (U128::MAX.sbb(&U128::ONE, Limb::ZERO).0, U128::ONE)
         );
     }
@@ -202,7 +202,7 @@ mod tests {
     #[test]
     fn shl_wide_max_max_256() {
         assert_eq!(
-            UInt::shl_vartime_wide((U128::MAX, U128::MAX), 256),
+            Uint::shl_vartime_wide((U128::MAX, U128::MAX), 256),
             (U128::ZERO, U128::ZERO)
         );
     }

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -1,10 +1,10 @@
-//! [`UInt`] bitwise right shift operations.
+//! [`Uint`] bitwise right shift operations.
 
-use super::UInt;
+use super::Uint;
 use crate::{limb::HI_BIT, Limb, Word};
 use core::ops::{Shr, ShrAssign};
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self >> 1` in constant-time, returning the overflowing bit as a `Word` that is either 0...0 or 1...1.
     pub(crate) const fn shr_1(&self) -> (Self, Word) {
         let mut shifted_bits = [0; LIMBS];
@@ -31,7 +31,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
         limbs[LIMBS - 1] = Limb(shifted_bits[LIMBS - 1]);
 
         (
-            UInt::new(limbs),
+            Uint::new(limbs),
             (carry_bits[0] >> HI_BIT).wrapping_mul(Word::MAX),
         )
     }
@@ -97,31 +97,31 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Shr<usize> for UInt<LIMBS> {
-    type Output = UInt<LIMBS>;
+impl<const LIMBS: usize> Shr<usize> for Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
 
     /// NOTE: this operation is variable time with respect to `rhs` *ONLY*.
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
-    fn shr(self, rhs: usize) -> UInt<LIMBS> {
+    fn shr(self, rhs: usize) -> Uint<LIMBS> {
         self.shr_vartime(rhs)
     }
 }
 
-impl<const LIMBS: usize> Shr<usize> for &UInt<LIMBS> {
-    type Output = UInt<LIMBS>;
+impl<const LIMBS: usize> Shr<usize> for &Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
 
     /// NOTE: this operation is variable time with respect to `rhs` *ONLY*.
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
-    fn shr(self, rhs: usize) -> UInt<LIMBS> {
+    fn shr(self, rhs: usize) -> Uint<LIMBS> {
         self.shr_vartime(rhs)
     }
 }
 
-impl<const LIMBS: usize> ShrAssign<usize> for UInt<LIMBS> {
+impl<const LIMBS: usize> ShrAssign<usize> for Uint<LIMBS> {
     fn shr_assign(&mut self, rhs: usize) {
         *self = self.shr_vartime(rhs);
     }
@@ -129,7 +129,7 @@ impl<const LIMBS: usize> ShrAssign<usize> for UInt<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{UInt, U128, U256};
+    use crate::{Uint, U128, U256};
 
     const N: U256 =
         U256::from_be_hex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
@@ -145,7 +145,7 @@ mod tests {
     #[test]
     fn shr_wide_1_1_128() {
         assert_eq!(
-            UInt::shr_vartime_wide((U128::ONE, U128::ONE), 128),
+            Uint::shr_vartime_wide((U128::ONE, U128::ONE), 128),
             (U128::ONE, U128::ZERO)
         );
     }
@@ -153,7 +153,7 @@ mod tests {
     #[test]
     fn shr_wide_0_max_1() {
         assert_eq!(
-            UInt::shr_vartime_wide((U128::ZERO, U128::MAX), 1),
+            Uint::shr_vartime_wide((U128::ZERO, U128::MAX), 1),
             (U128::ONE << 127, U128::MAX >> 1)
         );
     }
@@ -161,7 +161,7 @@ mod tests {
     #[test]
     fn shr_wide_max_max_256() {
         assert_eq!(
-            UInt::shr_vartime_wide((U128::MAX, U128::MAX), 256),
+            Uint::shr_vartime_wide((U128::MAX, U128::MAX), 256),
             (U128::ZERO, U128::ZERO)
         );
     }

--- a/src/uint/split.rs
+++ b/src/uint/split.rs
@@ -5,7 +5,7 @@ macro_rules! impl_split {
             impl $name {
                 /// Split this number in half, returning its high and low components
                 /// respectively.
-                pub const fn split(&self) -> (UInt<{nlimbs!($bits) / 2}>, UInt<{nlimbs!($bits) / 2}>) {
+                pub const fn split(&self) -> (Uint<{nlimbs!($bits) / 2}>, Uint<{nlimbs!($bits) / 2}>) {
                     let mut lo = [Limb::ZERO; nlimbs!($bits) / 2];
                     let mut hi = [Limb::ZERO; nlimbs!($bits) / 2];
                     let mut i = 0;
@@ -24,20 +24,20 @@ macro_rules! impl_split {
                         j += 1;
                     }
 
-                    (UInt { limbs: hi }, UInt { limbs: lo })
+                    (Uint { limbs: hi }, Uint { limbs: lo })
                 }
             }
 
             impl Split for $name {
-                type Output = UInt<{nlimbs!($bits) / 2}>;
+                type Output = Uint<{nlimbs!($bits) / 2}>;
 
                 fn split(&self) -> (Self::Output, Self::Output) {
                     self.split()
                 }
             }
 
-            impl From<$name> for (UInt<{nlimbs!($bits) / 2}>, UInt<{nlimbs!($bits) / 2}>) {
-                fn from(num: $name) -> (UInt<{nlimbs!($bits) / 2}>, UInt<{nlimbs!($bits) / 2}>) {
+            impl From<$name> for (Uint<{nlimbs!($bits) / 2}>, Uint<{nlimbs!($bits) / 2}>) {
+                fn from(num: $name) -> (Uint<{nlimbs!($bits) / 2}>, Uint<{nlimbs!($bits) / 2}>) {
                     num.split()
                 }
             }

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -1,10 +1,10 @@
-//! [`UInt`] square root operations.
+//! [`Uint`] square root operations.
 
-use super::UInt;
+use super::Uint;
 use crate::{Limb, Word};
 use subtle::{ConstantTimeEq, CtOption};
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes √(`self`)
     /// Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.13
     ///

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -1,11 +1,11 @@
-//! [`UInt`] addition operations.
+//! [`Uint`] addition operations.
 
-use super::UInt;
+use super::Uint;
 use crate::{Checked, CheckedSub, Limb, Word, Wrapping, Zero};
 use core::ops::{Sub, SubAssign};
 use subtle::CtOption;
 
-impl<const LIMBS: usize> UInt<LIMBS> {
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `a - (b + borrow)`, returning the result along with the new borrow.
     #[inline(always)]
     pub const fn sbb(&self, rhs: &Self, mut borrow: Limb) -> (Self, Limb) {
@@ -41,7 +41,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
 
     /// Perform wrapping subtraction, returning the underflow bit as a `Word` that is either 0...0 or 1...1.
     pub(crate) const fn conditional_wrapping_sub(&self, rhs: &Self, choice: Word) -> (Self, Word) {
-        let actual_rhs = UInt::ct_select(UInt::ZERO, *rhs, choice);
+        let actual_rhs = Uint::ct_select(Uint::ZERO, *rhs, choice);
         let (res, borrow) = self.sbb(&actual_rhs, Limb::ZERO);
 
         // Here we use a saturating multiplication to get the result to 0...0 or 1...1
@@ -49,7 +49,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> CheckedSub<&UInt<LIMBS>> for UInt<LIMBS> {
+impl<const LIMBS: usize> CheckedSub<&Uint<LIMBS>> for Uint<LIMBS> {
     type Output = Self;
 
     fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
@@ -58,54 +58,54 @@ impl<const LIMBS: usize> CheckedSub<&UInt<LIMBS>> for UInt<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Sub for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> Sub for Wrapping<Uint<LIMBS>> {
     type Output = Self;
 
-    fn sub(self, rhs: Self) -> Wrapping<UInt<LIMBS>> {
+    fn sub(self, rhs: Self) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.wrapping_sub(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> Sub<&Wrapping<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Sub<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn sub(self, rhs: &Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn sub(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.wrapping_sub(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> Sub<Wrapping<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Sub<Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn sub(self, rhs: Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn sub(self, rhs: Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.wrapping_sub(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> Sub<&Wrapping<UInt<LIMBS>>> for &Wrapping<UInt<LIMBS>> {
-    type Output = Wrapping<UInt<LIMBS>>;
+impl<const LIMBS: usize> Sub<&Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
+    type Output = Wrapping<Uint<LIMBS>>;
 
-    fn sub(self, rhs: &Wrapping<UInt<LIMBS>>) -> Wrapping<UInt<LIMBS>> {
+    fn sub(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
         Wrapping(self.0.wrapping_sub(&rhs.0))
     }
 }
 
-impl<const LIMBS: usize> SubAssign for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> SubAssign for Wrapping<Uint<LIMBS>> {
     fn sub_assign(&mut self, other: Self) {
         *self = *self - other;
     }
 }
 
-impl<const LIMBS: usize> SubAssign<&Wrapping<UInt<LIMBS>>> for Wrapping<UInt<LIMBS>> {
+impl<const LIMBS: usize> SubAssign<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
     fn sub_assign(&mut self, other: &Self) {
         *self = *self - other;
     }
 }
 
-impl<const LIMBS: usize> Sub for Checked<UInt<LIMBS>> {
+impl<const LIMBS: usize> Sub for Checked<Uint<LIMBS>> {
     type Output = Self;
 
-    fn sub(self, rhs: Self) -> Checked<UInt<LIMBS>> {
+    fn sub(self, rhs: Self) -> Checked<Uint<LIMBS>> {
         Checked(
             self.0
                 .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(&rhs))),
@@ -113,10 +113,10 @@ impl<const LIMBS: usize> Sub for Checked<UInt<LIMBS>> {
     }
 }
 
-impl<const LIMBS: usize> Sub<&Checked<UInt<LIMBS>>> for Checked<UInt<LIMBS>> {
-    type Output = Checked<UInt<LIMBS>>;
+impl<const LIMBS: usize> Sub<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS>> {
+    type Output = Checked<Uint<LIMBS>>;
 
-    fn sub(self, rhs: &Checked<UInt<LIMBS>>) -> Checked<UInt<LIMBS>> {
+    fn sub(self, rhs: &Checked<Uint<LIMBS>>) -> Checked<Uint<LIMBS>> {
         Checked(
             self.0
                 .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(&rhs))),
@@ -124,10 +124,10 @@ impl<const LIMBS: usize> Sub<&Checked<UInt<LIMBS>>> for Checked<UInt<LIMBS>> {
     }
 }
 
-impl<const LIMBS: usize> Sub<Checked<UInt<LIMBS>>> for &Checked<UInt<LIMBS>> {
-    type Output = Checked<UInt<LIMBS>>;
+impl<const LIMBS: usize> Sub<Checked<Uint<LIMBS>>> for &Checked<Uint<LIMBS>> {
+    type Output = Checked<Uint<LIMBS>>;
 
-    fn sub(self, rhs: Checked<UInt<LIMBS>>) -> Checked<UInt<LIMBS>> {
+    fn sub(self, rhs: Checked<Uint<LIMBS>>) -> Checked<Uint<LIMBS>> {
         Checked(
             self.0
                 .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(&rhs))),
@@ -135,10 +135,10 @@ impl<const LIMBS: usize> Sub<Checked<UInt<LIMBS>>> for &Checked<UInt<LIMBS>> {
     }
 }
 
-impl<const LIMBS: usize> Sub<&Checked<UInt<LIMBS>>> for &Checked<UInt<LIMBS>> {
-    type Output = Checked<UInt<LIMBS>>;
+impl<const LIMBS: usize> Sub<&Checked<Uint<LIMBS>>> for &Checked<Uint<LIMBS>> {
+    type Output = Checked<Uint<LIMBS>>;
 
-    fn sub(self, rhs: &Checked<UInt<LIMBS>>) -> Checked<UInt<LIMBS>> {
+    fn sub(self, rhs: &Checked<Uint<LIMBS>>) -> Checked<Uint<LIMBS>> {
         Checked(
             self.0
                 .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(&rhs))),
@@ -146,13 +146,13 @@ impl<const LIMBS: usize> Sub<&Checked<UInt<LIMBS>>> for &Checked<UInt<LIMBS>> {
     }
 }
 
-impl<const LIMBS: usize> SubAssign for Checked<UInt<LIMBS>> {
+impl<const LIMBS: usize> SubAssign for Checked<Uint<LIMBS>> {
     fn sub_assign(&mut self, other: Self) {
         *self = *self - other;
     }
 }
 
-impl<const LIMBS: usize> SubAssign<&Checked<UInt<LIMBS>>> for Checked<UInt<LIMBS>> {
+impl<const LIMBS: usize> SubAssign<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS>> {
     fn sub_assign(&mut self, other: &Self) {
         *self = *self - other;
     }


### PR DESCRIPTION
From https://rust-lang.github.io/api-guidelines/naming.html

> In UpperCamelCase, acronyms and contractions of compound words count
> as one word: use Uuid rather than UUID, Usize rather than USize or
> Stdin rather than StdIn.

Based on the `Usize` example, it's pretty clear we should be using `Uint` rather than `UInt`.

This is also consistent with `num-bigint`.