### PR TITLE
Rename `Uint` methods and other TODOs

### DIFF
--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -243,7 +243,7 @@ impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
         let mut i = 0;
         let mut found_non_zero = false;
         while i < LIMBS {
-            if n.limbs()[i].0 != 0 {
+            if n.as_limbs()[i].0 != 0 {
                 found_non_zero = true;
             }
             i += 1;

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -44,7 +44,7 @@ mod array;
 mod rand;
 
 use crate::{Concat, Encoding, Integer, Limb, Split, Word, Zero};
-use core::{fmt, mem};
+use core::fmt;
 use subtle::{Choice, ConditionallySelectable};
 
 #[cfg(feature = "serde")]
@@ -129,10 +129,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Borrow the inner limbs as an array of [`Word`]s.
     pub const fn as_words(&self) -> &[Word; LIMBS] {
         // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
-        #[allow(unsafe_code)]
+        #[allow(trivial_casts, unsafe_code)]
         unsafe {
-            // TODO(tarcieri): use &*((&self.limbs as *const _) as *const [Word; LIMBS])
-            mem::transmute(&self.limbs)
+            &*((&self.limbs as *const _) as *const [Word; LIMBS])
         }
     }
 
@@ -146,20 +145,17 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Borrow the limbs of this [`Uint`].
-    // TODO(tarcieri): rename to `as_limbs` for consistency with `as_words`
-    pub const fn limbs(&self) -> &[Limb; LIMBS] {
+    pub const fn as_limbs(&self) -> &[Limb; LIMBS] {
         &self.limbs
     }
 
     /// Borrow the limbs of this [`Uint`] mutably.
-    // TODO(tarcieri): rename to `as_limbs_mut` for consistency with `as_words_mut`
-    pub fn limbs_mut(&mut self) -> &mut [Limb; LIMBS] {
+    pub fn as_limbs_mut(&mut self) -> &mut [Limb; LIMBS] {
         &mut self.limbs
     }
 
     /// Convert this [`Uint`] into its inner limbs.
-    // TODO(tarcieri): rename to `to_limbs` for consistency with `to_words`
-    pub const fn into_limbs(self) -> [Limb; LIMBS] {
+    pub const fn to_limbs(self) -> [Limb; LIMBS] {
         self.limbs
     }
 }
@@ -176,17 +172,15 @@ impl<const LIMBS: usize> AsMut<[Word; LIMBS]> for Uint<LIMBS> {
     }
 }
 
-// TODO(tarcieri): eventually phase this out in favor of `limbs()`?
 impl<const LIMBS: usize> AsRef<[Limb]> for Uint<LIMBS> {
     fn as_ref(&self) -> &[Limb] {
-        self.limbs()
+        self.as_limbs()
     }
 }
 
-// TODO(tarcieri): eventually phase this out in favor of `limbs_mut()`?
 impl<const LIMBS: usize> AsMut<[Limb]> for Uint<LIMBS> {
     fn as_mut(&mut self) -> &mut [Limb] {
-        self.limbs_mut()
+        self.as_limbs_mut()
     }
 }
 

--- a/src/uint/array.rs
+++ b/src/uint/array.rs
@@ -93,7 +93,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     fn from_be_byte_array() {
         let n = UintEx::from_be_byte_array(hex!("0011223344556677").into());
-        assert_eq!(n.limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
+        assert_eq!(n.as_limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
     #[test]
@@ -101,7 +101,7 @@ mod tests {
     fn from_be_byte_array() {
         let n = UintEx::from_be_byte_array(hex!("00112233445566778899aabbccddeeff").into());
         assert_eq!(
-            n.limbs(),
+            n.as_limbs(),
             &[Limb(0x8899aabbccddeeff), Limb(0x0011223344556677)]
         );
     }
@@ -110,7 +110,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     fn from_le_byte_array() {
         let n = UintEx::from_le_byte_array(hex!("7766554433221100").into());
-        assert_eq!(n.limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
+        assert_eq!(n.as_limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
     #[test]
@@ -118,7 +118,7 @@ mod tests {
     fn from_le_byte_array() {
         let n = UintEx::from_le_byte_array(hex!("ffeeddccbbaa99887766554433221100").into());
         assert_eq!(
-            n.limbs(),
+            n.as_limbs(),
             &[Limb(0x8899aabbccddeeff), Limb(0x0011223344556677)]
         );
     }

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -193,7 +193,7 @@ mod tests {
     fn from_be_slice() {
         let bytes = hex!("0011223344556677");
         let n = UintEx::from_be_slice(&bytes);
-        assert_eq!(n.limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
+        assert_eq!(n.as_limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
     #[test]
@@ -202,7 +202,7 @@ mod tests {
         let bytes = hex!("00112233445566778899aabbccddeeff");
         let n = UintEx::from_be_slice(&bytes);
         assert_eq!(
-            n.limbs(),
+            n.as_limbs(),
             &[Limb(0x8899aabbccddeeff), Limb(0x0011223344556677)]
         );
     }
@@ -212,7 +212,7 @@ mod tests {
     fn from_le_slice() {
         let bytes = hex!("7766554433221100");
         let n = UintEx::from_le_slice(&bytes);
-        assert_eq!(n.limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
+        assert_eq!(n.as_limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
     #[test]
@@ -221,7 +221,7 @@ mod tests {
         let bytes = hex!("ffeeddccbbaa99887766554433221100");
         let n = UintEx::from_le_slice(&bytes);
         assert_eq!(
-            n.limbs(),
+            n.as_limbs(),
             &[Limb(0x8899aabbccddeeff), Limb(0x0011223344556677)]
         );
     }
@@ -230,7 +230,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     fn from_be_hex() {
         let n = UintEx::from_be_hex("0011223344556677");
-        assert_eq!(n.limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
+        assert_eq!(n.as_limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
     #[test]
@@ -238,7 +238,7 @@ mod tests {
     fn from_be_hex() {
         let n = UintEx::from_be_hex("00112233445566778899aabbccddeeff");
         assert_eq!(
-            n.limbs(),
+            n.as_limbs(),
             &[Limb(0x8899aabbccddeeff), Limb(0x0011223344556677)]
         );
     }
@@ -247,7 +247,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     fn from_le_hex() {
         let n = UintEx::from_le_hex("7766554433221100");
-        assert_eq!(n.limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
+        assert_eq!(n.as_limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
     #[test]
@@ -255,7 +255,7 @@ mod tests {
     fn from_le_hex() {
         let n = UintEx::from_le_hex("ffeeddccbbaa99887766554433221100");
         assert_eq!(
-            n.limbs(),
+            n.as_limbs(),
             &[Limb(0x8899aabbccddeeff), Limb(0x0011223344556677)]
         );
     }

--- a/src/uint/from.rs
+++ b/src/uint/from.rs
@@ -206,25 +206,25 @@ mod tests {
     #[test]
     fn from_u8() {
         let n = UintEx::from(42u8);
-        assert_eq!(n.limbs(), &[Limb(42), Limb(0)]);
+        assert_eq!(n.as_limbs(), &[Limb(42), Limb(0)]);
     }
 
     #[test]
     fn from_u16() {
         let n = UintEx::from(42u16);
-        assert_eq!(n.limbs(), &[Limb(42), Limb(0)]);
+        assert_eq!(n.as_limbs(), &[Limb(42), Limb(0)]);
     }
 
     #[test]
     fn from_u64() {
         let n = UintEx::from(42u64);
-        assert_eq!(n.limbs(), &[Limb(42), Limb(0)]);
+        assert_eq!(n.as_limbs(), &[Limb(42), Limb(0)]);
     }
 
     #[test]
     fn from_u128() {
         let n = U128::from(42u128);
-        assert_eq!(&n.limbs()[..2], &[Limb(42), Limb(0)]);
+        assert_eq!(&n.as_limbs()[..2], &[Limb(42), Limb(0)]);
         assert_eq!(u128::from(n), 42u128);
     }
 


### PR DESCRIPTION
Addresses a number of todos in `uint.rs` including renaming the following methods for consistency:

- `limbs` -> `as_limbs`
- `limbs_mut` -> `as_limbs_mut`
- `into_limbs` -> `to_limbs`