### PR TITLE
Use built-in traits for `(Dyn)Resiude`

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,10 +2,7 @@ use criterion::{
     criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, Criterion,
 };
 use crypto_bigint::{
-    modular::{
-        runtime_mod::{DynResidue, DynResidueParams},
-        PowResidue,
-    },
+    modular::runtime_mod::{DynResidue, DynResidueParams},
     NonZero, Random, Reciprocal, Uint, U256,
 };
 use rand_core::OsRng;

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -20,7 +20,7 @@ mod sub;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::Zero;
+use crate::{Bounded, Zero};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable};
 
@@ -114,6 +114,11 @@ impl Limb {
     pub(crate) const fn ct_select(a: Self, b: Self, c: Word) -> Self {
         Self(a.0 ^ (c & (a.0 ^ b.0)))
     }
+}
+
+impl Bounded for Limb {
+    const BITS: usize = Self::BITS;
+    const BYTES: usize = Self::BYTES;
 }
 
 impl ConditionallySelectable for Limb {

--- a/src/limb/encoding.rs
+++ b/src/limb/encoding.rs
@@ -4,9 +4,6 @@ use super::{Limb, Word};
 use crate::Encoding;
 
 impl Encoding for Limb {
-    const BITS: usize = Self::BITS;
-    const BYTES: usize = Self::BYTES;
-
     #[cfg(target_pointer_width = "32")]
     type Repr = [u8; 4];
     #[cfg(target_pointer_width = "64")]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -227,10 +227,14 @@ pub trait Encoding: Sized {
 }
 
 /// Support for optimized squaring
-pub trait Square {
+pub trait Square: Sized
+where
+    for<'a> &'a Self: core::ops::Mul<&'a Self, Output = Self>,
+{
     /// Computes the same as `self.mul(self)`, but may be more efficient.
-    fn square(&self) -> Self;
-    // TODO: can we provide a default implementation by depending on `Mul`?
+    fn square(&self) -> Self {
+        self * self
+    }
 }
 
 /// Constant-time exponentiation.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -202,14 +202,17 @@ pub trait Split<Rhs = Self> {
     fn split(&self) -> (Self::Output, Self::Output);
 }
 
-/// Encoding support.
-pub trait Encoding: Sized {
+/// Integers whose representation takes a bounded amount of space.
+pub trait Bounded {
     /// Size of this integer in bits.
     const BITS: usize;
 
     /// Size of this integer in bytes.
     const BYTES: usize;
+}
 
+/// Encoding support.
+pub trait Encoding: Sized {
     /// Byte array representation.
     type Repr: AsRef<[u8]> + AsMut<[u8]> + Copy + Clone + Sized;
 
@@ -241,14 +244,22 @@ where
 pub trait Pow<Exponent> {
     /// Raises to the `exponent` power.
     fn pow(&self, exponent: &Exponent) -> Self;
-    // TODO: can express via `pow_specific()` if there is a trait containing the integer's bit size
+}
 
+impl<T: PowBoundedExp<Exponent>, Exponent: Bounded> Pow<Exponent> for T {
+    fn pow(&self, exponent: &Exponent) -> Self {
+        self.pow_bounded_exp(exponent, Exponent::BITS)
+    }
+}
+
+/// Constant-time exponentiation with exponent of a bounded bit size.
+pub trait PowBoundedExp<Exponent> {
     /// Raises to the `exponent` power,
     /// with `exponent_bits` representing the number of (least significant) bits
     /// to take into account for the exponent.
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
-    fn pow_specific(&self, exponent: &Exponent, exponent_bits: usize) -> Self;
+    fn pow_bounded_exp(&self, exponent: &Exponent, exponent_bits: usize) -> Self;
 }
 
 /// Constant-time inversion.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -263,8 +263,10 @@ pub trait PowBoundedExp<Exponent> {
 }
 
 /// Constant-time inversion.
-pub trait Inv: Sized {
-    /// Computes the inverse. Returns [`CtOption`] that evaluates to `None`
-    /// if the number is not invertible.
-    fn inv(&self) -> CtOption<Self>;
+pub trait Invert: Sized {
+    /// Output of the inversion.
+    type Output;
+
+    /// Computes the inverse.
+    fn invert(&self) -> Self::Output;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -225,3 +225,31 @@ pub trait Encoding: Sized {
     /// Encode to little endian bytes.
     fn to_le_bytes(&self) -> Self::Repr;
 }
+
+/// Support for optimized squaring
+pub trait Square {
+    /// Computes the same as `self.mul(self)`, but may be more efficient.
+    fn square(&self) -> Self;
+    // TODO: can we provide a default implementation by depending on `Mul`?
+}
+
+/// Constant-time exponentiation.
+pub trait Pow<Exponent> {
+    /// Raises to the `exponent` power.
+    fn pow(&self, exponent: &Exponent) -> Self;
+    // TODO: can express via `pow_specific()` if there is a trait containing the integer's bit size
+
+    /// Raises to the `exponent` power,
+    /// with `exponent_bits` representing the number of (least significant) bits
+    /// to take into account for the exponent.
+    ///
+    /// NOTE: `exponent_bits` may be leaked in the time pattern.
+    fn pow_specific(&self, exponent: &Exponent, exponent_bits: usize) -> Self;
+}
+
+/// Constant-time inversion.
+pub trait Inv: Sized {
+    /// Computes the inverse. Returns [`CtOption`] that evaluates to `None`
+    /// if the number is not invertible.
+    fn inv(&self) -> CtOption<Self>;
+}

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -44,7 +44,7 @@ mod array;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{Concat, Encoding, Integer, Limb, Split, Word, Zero};
+use crate::{Bounded, Concat, Encoding, Integer, Limb, Split, Word, Zero};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable};
 
@@ -225,6 +225,11 @@ impl<const LIMBS: usize> Zero for Uint<LIMBS> {
     const ZERO: Self = Self::ZERO;
 }
 
+impl<const LIMBS: usize> Bounded for Uint<LIMBS> {
+    const BITS: usize = Self::BITS;
+    const BYTES: usize = Self::BYTES;
+}
+
 impl<const LIMBS: usize> fmt::Display for Uint<LIMBS> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::UpperHex::fmt(self, f)
@@ -293,8 +298,6 @@ macro_rules! impl_uint_aliases {
             pub type $name = Uint<{nlimbs!($bits)}>;
 
             impl Encoding for $name {
-                const BITS: usize = Self::BITS;
-                const BYTES: usize = Self::BYTES;
 
                 type Repr = [u8; $bits / 8];
 

--- a/src/uint/modular.rs
+++ b/src/uint/modular.rs
@@ -11,6 +11,16 @@ mod mul;
 mod pow;
 mod sub;
 
+/// A generalization for numbers kept in optimized representations (e.g. Montgomery)
+/// that can be converted back to the original form.
+pub trait Retrieve {
+    /// The original type.
+    type Output;
+
+    /// Convert the number back from the optimized representation.
+    fn retrieve(&self) -> Self::Output;
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/src/uint/modular.rs
+++ b/src/uint/modular.rs
@@ -1,7 +1,3 @@
-use subtle::CtOption;
-
-use crate::{Uint, Word};
-
 mod reduction;
 
 /// Implements `Residue`s, supporting modular arithmetic with a constant modulus.
@@ -14,68 +10,6 @@ mod inv;
 mod mul;
 mod pow;
 mod sub;
-
-/// Provides a consistent interface to add two residues of the same type together.
-pub trait AddResidue {
-    /// Computes the (reduced) sum of two residues.
-    fn add(&self, rhs: &Self) -> Self;
-}
-
-/// Provides a consistent interface to subtract two residues of the same type.
-pub trait SubResidue {
-    /// Computes the (reduced) difference of two residues.
-    fn sub(&self, rhs: &Self) -> Self;
-}
-
-/// Provides a consistent interface to multiply two residues of the same type together.
-pub trait MulResidue
-where
-    Self: Sized,
-{
-    /// Computes the (reduced) product of two residues.
-    fn mul(&self, rhs: &Self) -> Self;
-
-    /// Computes the same as `self.mul(self)`, but may be more efficient.
-    fn square(&self) -> Self {
-        self.mul(self)
-    }
-}
-
-/// Provides a consistent interface to exponentiate a residue.
-pub trait PowResidue<const LIMBS: usize>
-where
-    Self: Sized,
-{
-    /// Computes the (reduced) exponentiation of a residue.
-    fn pow(self, exponent: &Uint<LIMBS>) -> Self {
-        self.pow_specific(exponent, LIMBS * Word::BITS as usize)
-    }
-
-    /// Computes the (reduced) exponentiation of a residue,
-    /// here `exponent_bits` represents the number of bits to take into account for the exponent.
-    ///
-    /// NOTE: `exponent_bits` is leaked in the time pattern.
-    fn pow_specific(self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self;
-}
-
-/// Provides a consistent interface to invert a residue.
-pub trait InvResidue
-where
-    Self: Sized,
-{
-    /// Computes the (reduced) multiplicative inverse of the residue. Returns CtOption,
-    /// which is `None` if the residue was not invertible.
-    fn inv(self) -> CtOption<Self>;
-}
-
-/// The `GenericResidue` trait provides a consistent API
-/// for dealing with residues with a constant modulus.
-pub trait GenericResidue<const LIMBS: usize>:
-    AddResidue + MulResidue + PowResidue<LIMBS> + InvResidue
-{
-    /// Retrieves the integer currently encoded in this `Residue`, guaranteed to be reduced.
-    fn retrieve(&self) -> Uint<LIMBS>;
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/uint/modular/constant_mod.rs
+++ b/src/uint/modular/constant_mod.rs
@@ -12,6 +12,8 @@ mod const_add;
 mod const_inv;
 /// Multiplications between residues with a constant modulus
 mod const_mul;
+/// Negations of residues with a constant modulus
+mod const_neg;
 /// Exponentiation of residues with a constant modulus
 mod const_pow;
 /// Subtractions between residues with a constant modulus

--- a/src/uint/modular/constant_mod.rs
+++ b/src/uint/modular/constant_mod.rs
@@ -4,7 +4,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use crate::{Limb, Uint, Zero};
 
-use super::{reduction::montgomery_reduction, GenericResidue};
+use super::reduction::montgomery_reduction;
 
 /// Additions between residues with a constant modulus
 mod const_add;
@@ -87,12 +87,6 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
             MOD::MODULUS,
             MOD::MOD_NEG_INV,
         )
-    }
-}
-
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> GenericResidue<LIMBS> for Residue<MOD, LIMBS> {
-    fn retrieve(&self) -> Uint<LIMBS> {
-        self.retrieve()
     }
 }
 

--- a/src/uint/modular/constant_mod.rs
+++ b/src/uint/modular/constant_mod.rs
@@ -4,7 +4,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use crate::{Limb, Uint, Zero};
 
-use super::reduction::montgomery_reduction;
+use super::{reduction::montgomery_reduction, Retrieve};
 
 /// Additions between residues with a constant modulus
 mod const_add;
@@ -121,4 +121,11 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Default for Residue<MOD, LIM
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Zero for Residue<MOD, LIMBS> {
     const ZERO: Self = Self::ZERO;
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Retrieve for Residue<MOD, LIMBS> {
+    type Output = Uint<LIMBS>;
+    fn retrieve(&self) -> Self::Output {
+        self.retrieve()
+    }
 }

--- a/src/uint/modular/constant_mod/const_add.rs
+++ b/src/uint/modular/constant_mod/const_add.rs
@@ -1,21 +1,14 @@
-use core::ops::AddAssign;
+use core::ops::{Add, AddAssign};
 
-use crate::{
-    modular::{add::add_montgomery_form, AddResidue},
-    Uint,
-};
+use crate::modular::add::add_montgomery_form;
 
 use super::{Residue, ResidueParams};
 
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> AddResidue for Residue<MOD, LIMBS> {
-    fn add(&self, rhs: &Self) -> Self {
-        self.add(rhs)
-    }
-}
-
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
-    /// Adds two residues together.
-    pub const fn add(&self, rhs: &Self) -> Self {
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Add<&Residue<MOD, LIMBS>>
+    for &Residue<MOD, LIMBS>
+{
+    type Output = Residue<MOD, LIMBS>;
+    fn add(self, rhs: &Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
         Residue {
             montgomery_form: add_montgomery_form(
                 &self.montgomery_form,
@@ -24,14 +17,6 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
             ),
             phantom: core::marker::PhantomData,
         }
-    }
-}
-
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> AddAssign<&Uint<LIMBS>>
-    for Residue<MOD, LIMBS>
-{
-    fn add_assign(&mut self, rhs: &Uint<LIMBS>) {
-        *self += &Residue::new(*rhs);
     }
 }
 
@@ -59,8 +44,9 @@ mod tests {
 
         let y =
             U256::from_be_hex("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251");
+        let y_mod = const_residue!(y, Modulus);
 
-        x_mod += &y;
+        x_mod += &y_mod;
 
         let expected =
             U256::from_be_hex("1a2472fde50286541d97ca6a3592dd75beb9c9646e40c511b82496cfc3926956");

--- a/src/uint/modular/constant_mod/const_add.rs
+++ b/src/uint/modular/constant_mod/const_add.rs
@@ -4,12 +4,10 @@ use crate::modular::add::add_montgomery_form;
 
 use super::{Residue, ResidueParams};
 
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Add<&Residue<MOD, LIMBS>>
-    for &Residue<MOD, LIMBS>
-{
-    type Output = Residue<MOD, LIMBS>;
-    fn add(self, rhs: &Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
-        Residue {
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
+    /// Adds `rhs`.
+    pub const fn add(&self, rhs: &Residue<MOD, LIMBS>) -> Self {
+        Self {
             montgomery_form: add_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
@@ -20,9 +18,53 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Add<&Residue<MOD, LIMBS>>
     }
 }
 
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Add<&Residue<MOD, LIMBS>>
+    for &Residue<MOD, LIMBS>
+{
+    type Output = Residue<MOD, LIMBS>;
+    fn add(self, rhs: &Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
+        self.add(rhs)
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Add<Residue<MOD, LIMBS>>
+    for &Residue<MOD, LIMBS>
+{
+    type Output = Residue<MOD, LIMBS>;
+    #[allow(clippy::op_ref)]
+    fn add(self, rhs: Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
+        self + &rhs
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Add<&Residue<MOD, LIMBS>>
+    for Residue<MOD, LIMBS>
+{
+    type Output = Residue<MOD, LIMBS>;
+    #[allow(clippy::op_ref)]
+    fn add(self, rhs: &Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
+        &self + rhs
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Add<Residue<MOD, LIMBS>>
+    for Residue<MOD, LIMBS>
+{
+    type Output = Residue<MOD, LIMBS>;
+    fn add(self, rhs: Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
+        &self + &rhs
+    }
+}
+
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> AddAssign<&Self> for Residue<MOD, LIMBS> {
     fn add_assign(&mut self, rhs: &Self) {
-        *self = self.add(rhs);
+        *self = *self + rhs;
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> AddAssign<Self> for Residue<MOD, LIMBS> {
+    fn add_assign(&mut self, rhs: Self) {
+        *self += &rhs;
     }
 }
 

--- a/src/uint/modular/constant_mod/const_mul.rs
+++ b/src/uint/modular/constant_mod/const_mul.rs
@@ -10,12 +10,10 @@ use crate::{
 
 use super::{Residue, ResidueParams};
 
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Mul<&Residue<MOD, LIMBS>>
-    for &Residue<MOD, LIMBS>
-{
-    type Output = Residue<MOD, LIMBS>;
-    fn mul(self, rhs: &Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
-        Residue {
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
+    /// Multiplies by `rhs`.
+    pub const fn mul(&self, rhs: &Self) -> Self {
+        Self {
             montgomery_form: mul_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
@@ -27,9 +25,53 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Mul<&Residue<MOD, LIMBS>>
     }
 }
 
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Mul<&Residue<MOD, LIMBS>>
+    for &Residue<MOD, LIMBS>
+{
+    type Output = Residue<MOD, LIMBS>;
+    fn mul(self, rhs: &Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
+        self.mul(rhs)
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Mul<Residue<MOD, LIMBS>>
+    for &Residue<MOD, LIMBS>
+{
+    type Output = Residue<MOD, LIMBS>;
+    #[allow(clippy::op_ref)]
+    fn mul(self, rhs: Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
+        self * &rhs
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Mul<&Residue<MOD, LIMBS>>
+    for Residue<MOD, LIMBS>
+{
+    type Output = Residue<MOD, LIMBS>;
+    #[allow(clippy::op_ref)]
+    fn mul(self, rhs: &Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
+        &self * rhs
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Mul<Residue<MOD, LIMBS>>
+    for Residue<MOD, LIMBS>
+{
+    type Output = Residue<MOD, LIMBS>;
+    fn mul(self, rhs: Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
+        &self * &rhs
+    }
+}
+
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> MulAssign<&Self> for Residue<MOD, LIMBS> {
     fn mul_assign(&mut self, rhs: &Residue<MOD, LIMBS>) {
-        *self = self.mul(rhs);
+        *self = *self * rhs;
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> MulAssign<Self> for Residue<MOD, LIMBS> {
+    fn mul_assign(&mut self, rhs: Self) {
+        *self *= &rhs;
     }
 }
 

--- a/src/uint/modular/constant_mod/const_neg.rs
+++ b/src/uint/modular/constant_mod/const_neg.rs
@@ -1,0 +1,41 @@
+use core::ops::Neg;
+
+use super::{Residue, ResidueParams};
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
+    /// Negates the number.
+    pub const fn neg(&self) -> Self {
+        Self::ZERO.sub(self)
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Neg for Residue<MOD, LIMBS> {
+    type Output = Self;
+    fn neg(self) -> Self {
+        (&self).neg()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{const_residue, impl_modulus, modular::constant_mod::ResidueParams, U256};
+
+    impl_modulus!(
+        Modulus,
+        U256,
+        "15477BCCEFE197328255BFA79A1217899016D927EF460F4FF404029D24FA4409"
+    );
+
+    #[test]
+    fn test_negate() {
+        let x =
+            U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");
+        let x_mod = const_residue!(x, Modulus);
+
+        let res = -x_mod;
+        let expected =
+            U256::from_be_hex("089B67BB2C124F084701AD76E8750D321385E35044C74CE457301A2A9BE061B1");
+
+        assert_eq!(res.retrieve(), expected);
+    }
+}

--- a/src/uint/modular/constant_mod/const_pow.rs
+++ b/src/uint/modular/constant_mod/const_pow.rs
@@ -1,25 +1,20 @@
-use crate::{
-    modular::{pow::pow_montgomery_form, PowResidue},
-    Uint, Word,
-};
+use crate::{modular::pow::pow_montgomery_form, traits::Pow, Uint, Word};
 
 use super::{Residue, ResidueParams};
 
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> PowResidue<LIMBS> for Residue<MOD, LIMBS> {
-    fn pow_specific(self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
-        self.pow_specific(exponent, exponent_bits)
-    }
-}
-
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
-    /// Performs modular exponentiation using Montgomery's ladder.
-    pub const fn pow(self, exponent: &Uint<LIMBS>) -> Residue<MOD, LIMBS> {
+    /// Raises to the `exponent` power.
+    pub const fn pow(&self, exponent: &Uint<LIMBS>) -> Residue<MOD, LIMBS> {
         self.pow_specific(exponent, LIMBS * Word::BITS as usize)
     }
 
-    /// Performs modular exponentiation using Montgomery's ladder. `exponent_bits` represents the number of bits to take into account for the exponent. Note that this value is leaked in the time pattern.
+    /// Raises to the `exponent` power,
+    /// with `exponent_bits` representing the number of (least significant) bits
+    /// to take into account for the exponent.
+    ///
+    /// NOTE: `exponent_bits` may be leaked in the time pattern.
     pub const fn pow_specific(
-        self,
+        &self,
         exponent: &Uint<LIMBS>,
         exponent_bits: usize,
     ) -> Residue<MOD, LIMBS> {
@@ -34,6 +29,15 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
             ),
             phantom: core::marker::PhantomData,
         }
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Pow<Uint<LIMBS>> for Residue<MOD, LIMBS> {
+    fn pow(&self, exponent: &Uint<LIMBS>) -> Self {
+        self.pow(exponent)
+    }
+    fn pow_specific(&self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
+        self.pow_specific(exponent, exponent_bits)
     }
 }
 

--- a/src/uint/modular/constant_mod/const_pow.rs
+++ b/src/uint/modular/constant_mod/const_pow.rs
@@ -1,11 +1,11 @@
-use crate::{modular::pow::pow_montgomery_form, traits::Pow, Uint, Word};
+use crate::{modular::pow::pow_montgomery_form, PowBoundedExp, Uint};
 
 use super::{Residue, ResidueParams};
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// Raises to the `exponent` power.
     pub const fn pow(&self, exponent: &Uint<LIMBS>) -> Residue<MOD, LIMBS> {
-        self.pow_specific(exponent, LIMBS * Word::BITS as usize)
+        self.pow_bounded_exp(exponent, Uint::<LIMBS>::BITS)
     }
 
     /// Raises to the `exponent` power,
@@ -13,7 +13,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// to take into account for the exponent.
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
-    pub const fn pow_specific(
+    pub const fn pow_bounded_exp(
         &self,
         exponent: &Uint<LIMBS>,
         exponent_bits: usize,
@@ -32,12 +32,11 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     }
 }
 
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Pow<Uint<LIMBS>> for Residue<MOD, LIMBS> {
-    fn pow(&self, exponent: &Uint<LIMBS>) -> Self {
-        self.pow(exponent)
-    }
-    fn pow_specific(&self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
-        self.pow_specific(exponent, exponent_bits)
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> PowBoundedExp<Uint<LIMBS>>
+    for Residue<MOD, LIMBS>
+{
+    fn pow_bounded_exp(&self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
+        self.pow_bounded_exp(exponent, exponent_bits)
     }
 }
 

--- a/src/uint/modular/constant_mod/const_sub.rs
+++ b/src/uint/modular/constant_mod/const_sub.rs
@@ -4,12 +4,10 @@ use crate::modular::sub::sub_montgomery_form;
 
 use super::{Residue, ResidueParams};
 
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Sub<&Residue<MOD, LIMBS>>
-    for &Residue<MOD, LIMBS>
-{
-    type Output = Residue<MOD, LIMBS>;
-    fn sub(self, rhs: &Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
-        Residue {
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
+    /// Subtracts `rhs`.
+    pub const fn sub(&self, rhs: &Self) -> Self {
+        Self {
             montgomery_form: sub_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
@@ -20,9 +18,53 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Sub<&Residue<MOD, LIMBS>>
     }
 }
 
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Sub<&Residue<MOD, LIMBS>>
+    for &Residue<MOD, LIMBS>
+{
+    type Output = Residue<MOD, LIMBS>;
+    fn sub(self, rhs: &Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
+        self.sub(rhs)
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Sub<Residue<MOD, LIMBS>>
+    for &Residue<MOD, LIMBS>
+{
+    type Output = Residue<MOD, LIMBS>;
+    #[allow(clippy::op_ref)]
+    fn sub(self, rhs: Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
+        self - &rhs
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Sub<&Residue<MOD, LIMBS>>
+    for Residue<MOD, LIMBS>
+{
+    type Output = Residue<MOD, LIMBS>;
+    #[allow(clippy::op_ref)]
+    fn sub(self, rhs: &Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
+        &self - rhs
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Sub<Residue<MOD, LIMBS>>
+    for Residue<MOD, LIMBS>
+{
+    type Output = Residue<MOD, LIMBS>;
+    fn sub(self, rhs: Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
+        &self - &rhs
+    }
+}
+
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> SubAssign<&Self> for Residue<MOD, LIMBS> {
     fn sub_assign(&mut self, rhs: &Self) {
-        *self = self.sub(rhs);
+        *self = *self - rhs;
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> SubAssign<Self> for Residue<MOD, LIMBS> {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self -= &rhs;
     }
 }
 

--- a/src/uint/modular/constant_mod/const_sub.rs
+++ b/src/uint/modular/constant_mod/const_sub.rs
@@ -1,21 +1,14 @@
-use core::ops::SubAssign;
+use core::ops::{Sub, SubAssign};
 
-use crate::{
-    modular::{sub::sub_montgomery_form, SubResidue},
-    Uint,
-};
+use crate::modular::sub::sub_montgomery_form;
 
 use super::{Residue, ResidueParams};
 
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> SubResidue for Residue<MOD, LIMBS> {
-    fn sub(&self, rhs: &Self) -> Self {
-        self.sub(rhs)
-    }
-}
-
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
-    /// Adds two residues together.
-    pub const fn sub(&self, rhs: &Self) -> Self {
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Sub<&Residue<MOD, LIMBS>>
+    for &Residue<MOD, LIMBS>
+{
+    type Output = Residue<MOD, LIMBS>;
+    fn sub(self, rhs: &Residue<MOD, LIMBS>) -> Residue<MOD, LIMBS> {
         Residue {
             montgomery_form: sub_montgomery_form(
                 &self.montgomery_form,
@@ -24,14 +17,6 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
             ),
             phantom: core::marker::PhantomData,
         }
-    }
-}
-
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> SubAssign<&Uint<LIMBS>>
-    for Residue<MOD, LIMBS>
-{
-    fn sub_assign(&mut self, rhs: &Uint<LIMBS>) {
-        *self -= &Residue::new(*rhs);
     }
 }
 
@@ -59,8 +44,9 @@ mod tests {
 
         let y =
             U256::from_be_hex("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251");
+        let y_mod = const_residue!(y, Modulus);
 
-        x_mod -= &y;
+        x_mod -= &y_mod;
 
         let expected =
             U256::from_be_hex("6f357a71e1d5a03167f34879d469352add829491c6df41ddff65387d7ed56f56");

--- a/src/uint/modular/runtime_mod.rs
+++ b/src/uint/modular/runtime_mod.rs
@@ -1,6 +1,6 @@
 use crate::{Limb, Uint, Word};
 
-use super::{reduction::montgomery_reduction, GenericResidue};
+use super::reduction::montgomery_reduction;
 
 /// Additions between residues with a modulus set at runtime
 mod runtime_add;
@@ -93,11 +93,5 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
             montgomery_form: residue_params.r,
             residue_params,
         }
-    }
-}
-
-impl<const LIMBS: usize> GenericResidue<LIMBS> for DynResidue<LIMBS> {
-    fn retrieve(&self) -> Uint<LIMBS> {
-        self.retrieve()
     }
 }

--- a/src/uint/modular/runtime_mod.rs
+++ b/src/uint/modular/runtime_mod.rs
@@ -8,6 +8,8 @@ mod runtime_add;
 mod runtime_inv;
 /// Multiplications between residues with a modulus set at runtime
 mod runtime_mul;
+/// Negations of residues with a modulus set at runtime
+mod runtime_neg;
 /// Exponentiation of residues with a modulus set at runtime
 mod runtime_pow;
 /// Subtractions between residues with a modulus set at runtime

--- a/src/uint/modular/runtime_mod.rs
+++ b/src/uint/modular/runtime_mod.rs
@@ -1,6 +1,6 @@
 use crate::{Limb, Uint, Word};
 
-use super::reduction::montgomery_reduction;
+use super::{reduction::montgomery_reduction, Retrieve};
 
 /// Additions between residues with a modulus set at runtime
 mod runtime_add;
@@ -95,5 +95,12 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
             montgomery_form: residue_params.r,
             residue_params,
         }
+    }
+}
+
+impl<const LIMBS: usize> Retrieve for DynResidue<LIMBS> {
+    type Output = Uint<LIMBS>;
+    fn retrieve(&self) -> Self::Output {
+        self.retrieve()
     }
 }

--- a/src/uint/modular/runtime_mod/runtime_add.rs
+++ b/src/uint/modular/runtime_mod/runtime_add.rs
@@ -1,16 +1,14 @@
 use core::ops::{Add, AddAssign};
 
-use crate::{
-    modular::{add::add_montgomery_form, AddResidue},
-    Uint,
-};
+use crate::modular::add::add_montgomery_form;
 
 use super::DynResidue;
 
-impl<const LIMBS: usize> AddResidue for DynResidue<LIMBS> {
-    fn add(&self, rhs: &Self) -> Self {
+impl<const LIMBS: usize> Add<&DynResidue<LIMBS>> for &DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    fn add(self, rhs: &DynResidue<LIMBS>) -> DynResidue<LIMBS> {
         debug_assert_eq!(self.residue_params, rhs.residue_params);
-        Self {
+        DynResidue {
             montgomery_form: add_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
@@ -21,32 +19,9 @@ impl<const LIMBS: usize> AddResidue for DynResidue<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> AddAssign for DynResidue<LIMBS> {
-    fn add_assign(&mut self, rhs: Self) {
-        self.montgomery_form = add_montgomery_form(
-            &self.montgomery_form,
-            &rhs.montgomery_form,
-            &self.residue_params.modulus,
-        );
-    }
-}
-
-impl<const LIMBS: usize> AddAssign<Uint<LIMBS>> for DynResidue<LIMBS> {
-    fn add_assign(&mut self, rhs: Uint<LIMBS>) {
-        self.montgomery_form = add_montgomery_form(
-            &self.montgomery_form,
-            &DynResidue::new(rhs, self.residue_params).montgomery_form,
-            &self.residue_params.modulus,
-        );
-    }
-}
-
-impl<const LIMBS: usize> Add for DynResidue<LIMBS> {
-    type Output = DynResidue<LIMBS>;
-
-    fn add(mut self, rhs: Self) -> Self::Output {
-        self += rhs;
-        self
+impl<const LIMBS: usize> AddAssign<&DynResidue<LIMBS>> for DynResidue<LIMBS> {
+    fn add_assign(&mut self, rhs: &DynResidue<LIMBS>) {
+        *self = self.add(rhs);
     }
 }
 
@@ -69,8 +44,9 @@ mod tests {
 
         let y =
             U256::from_be_hex("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251");
+        let y_mod = DynResidue::new(y, params);
 
-        x_mod += y;
+        x_mod += &y_mod;
 
         let expected =
             U256::from_be_hex("1a2472fde50286541d97ca6a3592dd75beb9c9646e40c511b82496cfc3926956");

--- a/src/uint/modular/runtime_mod/runtime_add.rs
+++ b/src/uint/modular/runtime_mod/runtime_add.rs
@@ -4,11 +4,10 @@ use crate::modular::add::add_montgomery_form;
 
 use super::DynResidue;
 
-impl<const LIMBS: usize> Add<&DynResidue<LIMBS>> for &DynResidue<LIMBS> {
-    type Output = DynResidue<LIMBS>;
-    fn add(self, rhs: &DynResidue<LIMBS>) -> DynResidue<LIMBS> {
-        debug_assert_eq!(self.residue_params, rhs.residue_params);
-        DynResidue {
+impl<const LIMBS: usize> DynResidue<LIMBS> {
+    /// Adds `rhs`.
+    pub const fn add(&self, rhs: &Self) -> Self {
+        Self {
             montgomery_form: add_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
@@ -19,9 +18,46 @@ impl<const LIMBS: usize> Add<&DynResidue<LIMBS>> for &DynResidue<LIMBS> {
     }
 }
 
+impl<const LIMBS: usize> Add<&DynResidue<LIMBS>> for &DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    fn add(self, rhs: &DynResidue<LIMBS>) -> DynResidue<LIMBS> {
+        debug_assert_eq!(self.residue_params, rhs.residue_params);
+        self.add(rhs)
+    }
+}
+
+impl<const LIMBS: usize> Add<DynResidue<LIMBS>> for &DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    #[allow(clippy::op_ref)]
+    fn add(self, rhs: DynResidue<LIMBS>) -> DynResidue<LIMBS> {
+        self + &rhs
+    }
+}
+
+impl<const LIMBS: usize> Add<&DynResidue<LIMBS>> for DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    #[allow(clippy::op_ref)]
+    fn add(self, rhs: &DynResidue<LIMBS>) -> DynResidue<LIMBS> {
+        &self + rhs
+    }
+}
+
+impl<const LIMBS: usize> Add<DynResidue<LIMBS>> for DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    fn add(self, rhs: DynResidue<LIMBS>) -> DynResidue<LIMBS> {
+        &self + &rhs
+    }
+}
+
 impl<const LIMBS: usize> AddAssign<&DynResidue<LIMBS>> for DynResidue<LIMBS> {
     fn add_assign(&mut self, rhs: &DynResidue<LIMBS>) {
-        *self = self.add(rhs);
+        *self = *self + rhs;
+    }
+}
+
+impl<const LIMBS: usize> AddAssign<DynResidue<LIMBS>> for DynResidue<LIMBS> {
+    fn add_assign(&mut self, rhs: DynResidue<LIMBS>) {
+        *self += &rhs;
     }
 }
 

--- a/src/uint/modular/runtime_mod/runtime_inv.rs
+++ b/src/uint/modular/runtime_mod/runtime_inv.rs
@@ -1,6 +1,6 @@
 use subtle::{Choice, CtOption};
 
-use crate::{modular::inv::inv_montgomery_form, traits::Inv};
+use crate::{modular::inv::inv_montgomery_form, traits::Invert};
 
 use super::DynResidue;
 
@@ -9,7 +9,7 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// I.e. `self * self^-1 = 1`.
     /// If the number was invertible, the second element of the tuple is `1`,
     /// otherwise it is `0` (in which case the first element's value is unspecified).
-    pub const fn inv(&self) -> (Self, u8) {
+    pub const fn invert(&self) -> (Self, u8) {
         let (montgomery_form, is_some) = inv_montgomery_form(
             self.montgomery_form,
             self.residue_params.modulus,
@@ -26,9 +26,10 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Inv for DynResidue<LIMBS> {
-    fn inv(&self) -> CtOption<Self> {
-        let (value, is_some) = self.inv();
+impl<const LIMBS: usize> Invert for DynResidue<LIMBS> {
+    type Output = CtOption<Self>;
+    fn invert(&self) -> Self::Output {
+        let (value, is_some) = self.invert();
         CtOption::new(value, Choice::from(is_some))
     }
 }

--- a/src/uint/modular/runtime_mod/runtime_inv.rs
+++ b/src/uint/modular/runtime_mod/runtime_inv.rs
@@ -1,15 +1,16 @@
 use subtle::{Choice, CtOption};
 
-use crate::{
-    modular::{inv::inv_montgomery_form, InvResidue},
-    Word,
-};
+use crate::{modular::inv::inv_montgomery_form, traits::Inv};
 
 use super::DynResidue;
 
-impl<const LIMBS: usize> InvResidue for DynResidue<LIMBS> {
-    fn inv(self) -> CtOption<Self> {
-        let (montgomery_form, error) = inv_montgomery_form(
+impl<const LIMBS: usize> DynResidue<LIMBS> {
+    /// Computes the residue `self^-1` representing the multiplicative inverse of `self`.
+    /// I.e. `self * self^-1 = 1`.
+    /// If the number was invertible, the second element of the tuple is `1`,
+    /// otherwise it is `0` (in which case the first element's value is unspecified).
+    pub const fn inv(&self) -> (Self, u8) {
+        let (montgomery_form, is_some) = inv_montgomery_form(
             self.montgomery_form,
             self.residue_params.modulus,
             &self.residue_params.r3,
@@ -21,6 +22,13 @@ impl<const LIMBS: usize> InvResidue for DynResidue<LIMBS> {
             residue_params: self.residue_params,
         };
 
-        CtOption::new(value, Choice::from((error == Word::MAX) as u8))
+        (value, (is_some & 1) as u8)
+    }
+}
+
+impl<const LIMBS: usize> Inv for DynResidue<LIMBS> {
+    fn inv(&self) -> CtOption<Self> {
+        let (value, is_some) = self.inv();
+        CtOption::new(value, Choice::from(is_some))
     }
 }

--- a/src/uint/modular/runtime_mod/runtime_mul.rs
+++ b/src/uint/modular/runtime_mod/runtime_mul.rs
@@ -1,16 +1,17 @@
 use core::ops::{Mul, MulAssign};
 
-use crate::modular::{
-    mul::{mul_montgomery_form, square_montgomery_form},
-    MulResidue,
+use crate::{
+    modular::mul::{mul_montgomery_form, square_montgomery_form},
+    traits::Square,
 };
 
 use super::DynResidue;
 
-impl<const LIMBS: usize> MulResidue for DynResidue<LIMBS> {
-    fn mul(&self, rhs: &Self) -> Self {
+impl<const LIMBS: usize> Mul<&DynResidue<LIMBS>> for &DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    fn mul(self, rhs: &DynResidue<LIMBS>) -> DynResidue<LIMBS> {
         debug_assert_eq!(self.residue_params, rhs.residue_params);
-        Self {
+        DynResidue {
             montgomery_form: mul_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
@@ -20,7 +21,15 @@ impl<const LIMBS: usize> MulResidue for DynResidue<LIMBS> {
             residue_params: self.residue_params,
         }
     }
+}
 
+impl<const LIMBS: usize> MulAssign<&DynResidue<LIMBS>> for DynResidue<LIMBS> {
+    fn mul_assign(&mut self, rhs: &DynResidue<LIMBS>) {
+        *self = self.mul(rhs);
+    }
+}
+
+impl<const LIMBS: usize> Square for DynResidue<LIMBS> {
     fn square(&self) -> Self {
         Self {
             montgomery_form: square_montgomery_form(
@@ -30,26 +39,5 @@ impl<const LIMBS: usize> MulResidue for DynResidue<LIMBS> {
             ),
             residue_params: self.residue_params,
         }
-    }
-}
-
-impl<const LIMBS: usize> MulAssign for DynResidue<LIMBS> {
-    fn mul_assign(&mut self, rhs: Self) {
-        debug_assert_eq!(self.residue_params, rhs.residue_params);
-        self.montgomery_form = mul_montgomery_form(
-            &self.montgomery_form,
-            &rhs.montgomery_form,
-            self.residue_params.modulus,
-            self.residue_params.mod_neg_inv,
-        );
-    }
-}
-
-impl<const LIMBS: usize> Mul for DynResidue<LIMBS> {
-    type Output = DynResidue<LIMBS>;
-
-    fn mul(mut self, rhs: Self) -> Self::Output {
-        self *= rhs;
-        self
     }
 }

--- a/src/uint/modular/runtime_mod/runtime_mul.rs
+++ b/src/uint/modular/runtime_mod/runtime_mul.rs
@@ -7,11 +7,10 @@ use crate::{
 
 use super::DynResidue;
 
-impl<const LIMBS: usize> Mul<&DynResidue<LIMBS>> for &DynResidue<LIMBS> {
-    type Output = DynResidue<LIMBS>;
-    fn mul(self, rhs: &DynResidue<LIMBS>) -> DynResidue<LIMBS> {
-        debug_assert_eq!(self.residue_params, rhs.residue_params);
-        DynResidue {
+impl<const LIMBS: usize> DynResidue<LIMBS> {
+    /// Multiplies by `rhs`.
+    pub const fn mul(&self, rhs: &Self) -> Self {
+        Self {
             montgomery_form: mul_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
@@ -23,9 +22,46 @@ impl<const LIMBS: usize> Mul<&DynResidue<LIMBS>> for &DynResidue<LIMBS> {
     }
 }
 
+impl<const LIMBS: usize> Mul<&DynResidue<LIMBS>> for &DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    fn mul(self, rhs: &DynResidue<LIMBS>) -> DynResidue<LIMBS> {
+        debug_assert_eq!(self.residue_params, rhs.residue_params);
+        self.mul(rhs)
+    }
+}
+
+impl<const LIMBS: usize> Mul<DynResidue<LIMBS>> for &DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    #[allow(clippy::op_ref)]
+    fn mul(self, rhs: DynResidue<LIMBS>) -> DynResidue<LIMBS> {
+        self * &rhs
+    }
+}
+
+impl<const LIMBS: usize> Mul<&DynResidue<LIMBS>> for DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    #[allow(clippy::op_ref)]
+    fn mul(self, rhs: &DynResidue<LIMBS>) -> DynResidue<LIMBS> {
+        &self * rhs
+    }
+}
+
+impl<const LIMBS: usize> Mul<DynResidue<LIMBS>> for DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    fn mul(self, rhs: DynResidue<LIMBS>) -> DynResidue<LIMBS> {
+        &self * &rhs
+    }
+}
+
 impl<const LIMBS: usize> MulAssign<&DynResidue<LIMBS>> for DynResidue<LIMBS> {
     fn mul_assign(&mut self, rhs: &DynResidue<LIMBS>) {
-        *self = self.mul(rhs);
+        *self = *self * rhs;
+    }
+}
+
+impl<const LIMBS: usize> MulAssign<DynResidue<LIMBS>> for DynResidue<LIMBS> {
+    fn mul_assign(&mut self, rhs: DynResidue<LIMBS>) {
+        *self *= &rhs;
     }
 }
 

--- a/src/uint/modular/runtime_mod/runtime_neg.rs
+++ b/src/uint/modular/runtime_mod/runtime_neg.rs
@@ -1,0 +1,17 @@
+use core::ops::Neg;
+
+use super::DynResidue;
+
+impl<const LIMBS: usize> DynResidue<LIMBS> {
+    /// Negates the number.
+    pub const fn neg(&self) -> Self {
+        Self::zero(self.residue_params).sub(self)
+    }
+}
+
+impl<const LIMBS: usize> Neg for DynResidue<LIMBS> {
+    type Output = Self;
+    fn neg(self) -> Self {
+        (&self).neg()
+    }
+}

--- a/src/uint/modular/runtime_mod/runtime_pow.rs
+++ b/src/uint/modular/runtime_mod/runtime_pow.rs
@@ -1,11 +1,11 @@
-use crate::{modular::pow::pow_montgomery_form, traits::Pow, Uint, Word};
+use crate::{modular::pow::pow_montgomery_form, PowBoundedExp, Uint};
 
 use super::DynResidue;
 
 impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// Raises to the `exponent` power.
     pub const fn pow(&self, exponent: &Uint<LIMBS>) -> DynResidue<LIMBS> {
-        self.pow_specific(exponent, LIMBS * Word::BITS as usize)
+        self.pow_bounded_exp(exponent, Uint::<LIMBS>::BITS)
     }
 
     /// Raises to the `exponent` power,
@@ -13,7 +13,7 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// to take into account for the exponent.
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
-    pub const fn pow_specific(&self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
+    pub const fn pow_bounded_exp(&self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
         Self {
             montgomery_form: pow_montgomery_form(
                 self.montgomery_form,
@@ -28,12 +28,8 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Pow<Uint<LIMBS>> for DynResidue<LIMBS> {
-    fn pow(&self, exponent: &Uint<LIMBS>) -> Self {
-        self.pow(exponent)
-    }
-
-    fn pow_specific(&self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
-        self.pow_specific(exponent, exponent_bits)
+impl<const LIMBS: usize> PowBoundedExp<Uint<LIMBS>> for DynResidue<LIMBS> {
+    fn pow_bounded_exp(&self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
+        self.pow_bounded_exp(exponent, exponent_bits)
     }
 }

--- a/src/uint/modular/runtime_mod/runtime_pow.rs
+++ b/src/uint/modular/runtime_mod/runtime_pow.rs
@@ -1,22 +1,19 @@
-use crate::{
-    modular::{pow::pow_montgomery_form, PowResidue},
-    Uint,
-};
+use crate::{modular::pow::pow_montgomery_form, traits::Pow, Uint, Word};
 
 use super::DynResidue;
 
-impl<const LIMBS: usize> PowResidue<LIMBS> for DynResidue<LIMBS> {
-    fn pow_specific(self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
-        self.pow_specific(exponent, exponent_bits)
-    }
-}
-
 impl<const LIMBS: usize> DynResidue<LIMBS> {
-    /// Computes the (reduced) exponentiation of a residue,
-    /// here `exponent_bits` represents the number of bits to take into account for the exponent.
+    /// Raises to the `exponent` power.
+    pub const fn pow(&self, exponent: &Uint<LIMBS>) -> DynResidue<LIMBS> {
+        self.pow_specific(exponent, LIMBS * Word::BITS as usize)
+    }
+
+    /// Raises to the `exponent` power,
+    /// with `exponent_bits` representing the number of (least significant) bits
+    /// to take into account for the exponent.
     ///
-    /// NOTE: `exponent_bits` is leaked in the time pattern.
-    pub const fn pow_specific(self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
+    /// NOTE: `exponent_bits` may be leaked in the time pattern.
+    pub const fn pow_specific(&self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
         Self {
             montgomery_form: pow_montgomery_form(
                 self.montgomery_form,
@@ -28,5 +25,15 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
             ),
             residue_params: self.residue_params,
         }
+    }
+}
+
+impl<const LIMBS: usize> Pow<Uint<LIMBS>> for DynResidue<LIMBS> {
+    fn pow(&self, exponent: &Uint<LIMBS>) -> Self {
+        self.pow(exponent)
+    }
+
+    fn pow_specific(&self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
+        self.pow_specific(exponent, exponent_bits)
     }
 }

--- a/src/uint/modular/runtime_mod/runtime_sub.rs
+++ b/src/uint/modular/runtime_mod/runtime_sub.rs
@@ -4,11 +4,10 @@ use crate::modular::sub::sub_montgomery_form;
 
 use super::DynResidue;
 
-impl<const LIMBS: usize> Sub<&DynResidue<LIMBS>> for &DynResidue<LIMBS> {
-    type Output = DynResidue<LIMBS>;
-    fn sub(self, rhs: &DynResidue<LIMBS>) -> DynResidue<LIMBS> {
-        debug_assert_eq!(self.residue_params, rhs.residue_params);
-        DynResidue {
+impl<const LIMBS: usize> DynResidue<LIMBS> {
+    /// Subtracts `rhs`.
+    pub const fn sub(&self, rhs: &Self) -> Self {
+        Self {
             montgomery_form: sub_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
@@ -19,9 +18,46 @@ impl<const LIMBS: usize> Sub<&DynResidue<LIMBS>> for &DynResidue<LIMBS> {
     }
 }
 
+impl<const LIMBS: usize> Sub<&DynResidue<LIMBS>> for &DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    fn sub(self, rhs: &DynResidue<LIMBS>) -> DynResidue<LIMBS> {
+        debug_assert_eq!(self.residue_params, rhs.residue_params);
+        self.sub(rhs)
+    }
+}
+
+impl<const LIMBS: usize> Sub<DynResidue<LIMBS>> for &DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    #[allow(clippy::op_ref)]
+    fn sub(self, rhs: DynResidue<LIMBS>) -> DynResidue<LIMBS> {
+        self - &rhs
+    }
+}
+
+impl<const LIMBS: usize> Sub<&DynResidue<LIMBS>> for DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    #[allow(clippy::op_ref)]
+    fn sub(self, rhs: &DynResidue<LIMBS>) -> DynResidue<LIMBS> {
+        &self - rhs
+    }
+}
+
+impl<const LIMBS: usize> Sub<DynResidue<LIMBS>> for DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    fn sub(self, rhs: DynResidue<LIMBS>) -> DynResidue<LIMBS> {
+        &self - &rhs
+    }
+}
+
 impl<const LIMBS: usize> SubAssign<&DynResidue<LIMBS>> for DynResidue<LIMBS> {
     fn sub_assign(&mut self, rhs: &DynResidue<LIMBS>) {
-        *self = self.sub(rhs);
+        *self = *self - rhs;
+    }
+}
+
+impl<const LIMBS: usize> SubAssign<DynResidue<LIMBS>> for DynResidue<LIMBS> {
+    fn sub_assign(&mut self, rhs: DynResidue<LIMBS>) {
+        *self -= &rhs;
     }
 }
 

--- a/src/uint/modular/runtime_mod/runtime_sub.rs
+++ b/src/uint/modular/runtime_mod/runtime_sub.rs
@@ -1,16 +1,14 @@
 use core::ops::{Sub, SubAssign};
 
-use crate::{
-    modular::{sub::sub_montgomery_form, SubResidue},
-    Uint,
-};
+use crate::modular::sub::sub_montgomery_form;
 
 use super::DynResidue;
 
-impl<const LIMBS: usize> SubResidue for DynResidue<LIMBS> {
-    fn sub(&self, rhs: &Self) -> Self {
+impl<const LIMBS: usize> Sub<&DynResidue<LIMBS>> for &DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    fn sub(self, rhs: &DynResidue<LIMBS>) -> DynResidue<LIMBS> {
         debug_assert_eq!(self.residue_params, rhs.residue_params);
-        Self {
+        DynResidue {
             montgomery_form: sub_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
@@ -21,32 +19,9 @@ impl<const LIMBS: usize> SubResidue for DynResidue<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> SubAssign for DynResidue<LIMBS> {
-    fn sub_assign(&mut self, rhs: Self) {
-        self.montgomery_form = sub_montgomery_form(
-            &self.montgomery_form,
-            &rhs.montgomery_form,
-            &self.residue_params.modulus,
-        );
-    }
-}
-
-impl<const LIMBS: usize> SubAssign<Uint<LIMBS>> for DynResidue<LIMBS> {
-    fn sub_assign(&mut self, rhs: Uint<LIMBS>) {
-        self.montgomery_form = sub_montgomery_form(
-            &self.montgomery_form,
-            &DynResidue::new(rhs, self.residue_params).montgomery_form,
-            &self.residue_params.modulus,
-        );
-    }
-}
-
-impl<const LIMBS: usize> Sub for DynResidue<LIMBS> {
-    type Output = DynResidue<LIMBS>;
-
-    fn sub(mut self, rhs: Self) -> Self::Output {
-        self -= rhs;
-        self
+impl<const LIMBS: usize> SubAssign<&DynResidue<LIMBS>> for DynResidue<LIMBS> {
+    fn sub_assign(&mut self, rhs: &DynResidue<LIMBS>) {
+        *self = self.sub(rhs);
     }
 }
 
@@ -69,8 +44,9 @@ mod tests {
 
         let y =
             U256::from_be_hex("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251");
+        let y_mod = DynResidue::new(y, params);
 
-        x_mod -= y;
+        x_mod -= &y_mod;
 
         let expected =
             U256::from_be_hex("6f357a71e1d5a03167f34879d469352add829491c6df41ddff65387d7ed56f56");

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -1,10 +1,7 @@
 //! Equivalence tests between `num-bigint` and `crypto-bigint`
 
 use crypto_bigint::{
-    modular::{
-        runtime_mod::{DynResidue, DynResidueParams},
-        PowResidue,
-    },
+    modular::runtime_mod::{DynResidue, DynResidueParams},
     Encoding, Limb, NonZero, Word, U256,
 };
 use num_bigint::BigUint;

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -266,7 +266,7 @@ proptest! {
     }
 
     #[test]
-    fn residue_pow_specific(a in uint_mod_p(P), b in uint(), exponent_bits in any::<u8>()) {
+    fn residue_pow_bounded_exp(a in uint_mod_p(P), b in uint(), exponent_bits in any::<u8>()) {
 
         let b_masked = b & (U256::ONE << exponent_bits.into()).wrapping_sub(&U256::ONE);
 
@@ -278,7 +278,7 @@ proptest! {
 
         let params = DynResidueParams::new(P);
         let a_m = DynResidue::new(a, params);
-        let actual = a_m.pow_specific(&b, exponent_bits.into()).retrieve();
+        let actual = a_m.pow_bounded_exp(&b, exponent_bits.into()).retrieve();
 
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
- Remove `AddResidue`, `SubResidue`, `MulResidue`, `InvResidue`, `PowResidue`
- Impl `Add`, `Mul`, `Sub`, and `Neg` for `Residue` and `DynResidue` (also the combinations of by-ref and by-value, and the corresponding `const fn`s)
- Add `Pow`, `Invert` and `Square` traits, and impl them for `Residue` and `DynResidue`
- Add `PowBoundedExp` (hosting the former `pow_specific()` functionality) and a generic impl of `Pow` for `Bounded` exponents via this trait
- Remove `GenericResidue` trait
- Add `Retrieve` trait
- Add `Bounded` trait hosting `BITS` and `BYTES` constants which were formerly in `Encoding`
