### PR TITLE
Rename `BIT_SIZE` -> `BITS`, `BYTE_SIZE` -> `BYTES`

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -6,7 +6,7 @@ use crypto_bigint::{
         runtime_mod::{DynResidue, DynResidueParams},
         PowResidue,
     },
-    Encoding, NonZero, Random, Reciprocal, Uint, U256,
+    NonZero, Random, Reciprocal, Uint, U256,
 };
 use rand_core::OsRng;
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -87,7 +87,7 @@ fn bench_modpow<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
         .map(|_| U256::random(&mut OsRng) | U256::ONE)
         .collect::<Vec<_>>();
     let powers = (0..TEST_SET)
-        .map(|_| U256::random(&mut OsRng) | (U256::ONE << (U256::BIT_SIZE - 1)))
+        .map(|_| U256::random(&mut OsRng) | (U256::ONE << (U256::BITS - 1)))
         .collect::<Vec<_>>();
 
     let params = moduli

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -71,7 +71,7 @@ pub type WideWord = u128;
 pub(crate) type WideSignedWord = i128;
 
 /// Highest bit in a [`Limb`].
-pub(crate) const HI_BIT: usize = Limb::BIT_SIZE - 1;
+pub(crate) const HI_BIT: usize = Limb::BITS - 1;
 
 /// Big integers are represented as an array of smaller CPU word-size integers
 /// called "limbs".
@@ -93,19 +93,19 @@ impl Limb {
 
     /// Size of the inner integer in bits.
     #[cfg(target_pointer_width = "32")]
-    pub const BIT_SIZE: usize = 32;
+    pub const BITS: usize = 32;
     /// Size of the inner integer in bytes.
     #[cfg(target_pointer_width = "32")]
-    pub const BYTE_SIZE: usize = 4;
+    pub const BYTES: usize = 4;
 
     // 64-bit
 
     /// Size of the inner integer in bits.
     #[cfg(target_pointer_width = "64")]
-    pub const BIT_SIZE: usize = 64;
+    pub const BITS: usize = 64;
     /// Size of the inner integer in bytes.
     #[cfg(target_pointer_width = "64")]
-    pub const BYTE_SIZE: usize = 8;
+    pub const BYTES: usize = 8;
 
     /// Return `a` if `c`==0 or `b` if `c`==`Word::MAX`.
     ///
@@ -137,14 +137,14 @@ impl fmt::Display for Limb {
 impl fmt::LowerHex for Limb {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:0width$x}", &self.0, width = Self::BYTE_SIZE * 2)
+        write!(f, "{:0width$x}", &self.0, width = Self::BYTES * 2)
     }
 }
 
 impl fmt::UpperHex for Limb {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:0width$X}", &self.0, width = Self::BYTE_SIZE * 2)
+        write!(f, "{:0width$X}", &self.0, width = Self::BYTES * 2)
     }
 }
 

--- a/src/limb/add.rs
+++ b/src/limb/add.rs
@@ -12,7 +12,7 @@ impl Limb {
         let b = rhs.0 as WideWord;
         let carry = carry.0 as WideWord;
         let ret = a + b + carry;
-        (Limb(ret as Word), Limb((ret >> Self::BIT_SIZE) as Word))
+        (Limb(ret as Word), Limb((ret >> Self::BITS) as Word))
     }
 
     /// Perform saturating addition.

--- a/src/limb/bits.rs
+++ b/src/limb/bits.rs
@@ -3,7 +3,7 @@ use super::Limb;
 impl Limb {
     /// Calculate the number of bits needed to represent this number.
     pub const fn bits(self) -> usize {
-        Limb::BIT_SIZE - (self.0.leading_zeros() as usize)
+        Limb::BITS - (self.0.leading_zeros() as usize)
     }
 
     /// Calculate the number of leading zeros in the binary representation of this number.

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -37,8 +37,8 @@ impl Limb {
     pub(crate) const fn ct_cmp(lhs: Self, rhs: Self) -> SignedWord {
         let a = lhs.0 as WideSignedWord;
         let b = rhs.0 as WideSignedWord;
-        let gt = ((b - a) >> Limb::BIT_SIZE) & 1;
-        let lt = ((a - b) >> Limb::BIT_SIZE) & 1 & !gt;
+        let gt = ((b - a) >> Limb::BITS) & 1;
+        let lt = ((a - b) >> Limb::BITS) & 1 & !gt;
         (gt as SignedWord) - (lt as SignedWord)
     }
 
@@ -53,7 +53,7 @@ impl Limb {
 
         // If c == 0, then c and -c are both equal to zero;
         // otherwise, one or both will have its high bit set.
-        let d = (c | c.wrapping_neg()) >> (Limb::BIT_SIZE - 1);
+        let d = (c | c.wrapping_neg()) >> (Limb::BITS - 1);
 
         // Result is the opposite of the high bit (now shifted to low).
         // Convert 1 to Word::MAX.
@@ -65,7 +65,7 @@ impl Limb {
     pub(crate) const fn ct_lt(lhs: Self, rhs: Self) -> Word {
         let x = lhs.0;
         let y = rhs.0;
-        let bit = (((!x) & y) | (((!x) | y) & (x.wrapping_sub(y)))) >> (Limb::BIT_SIZE - 1);
+        let bit = (((!x) & y) | (((!x) | y) & (x.wrapping_sub(y)))) >> (Limb::BITS - 1);
         bit.wrapping_neg()
     }
 
@@ -74,7 +74,7 @@ impl Limb {
     pub(crate) const fn ct_le(lhs: Self, rhs: Self) -> Word {
         let x = lhs.0;
         let y = rhs.0;
-        let bit = (((!x) | y) & ((x ^ y) | !(y.wrapping_sub(x)))) >> (Limb::BIT_SIZE - 1);
+        let bit = (((!x) | y) & ((x ^ y) | !(y.wrapping_sub(x)))) >> (Limb::BITS - 1);
         bit.wrapping_neg()
     }
 }

--- a/src/limb/encoding.rs
+++ b/src/limb/encoding.rs
@@ -4,8 +4,8 @@ use super::{Limb, Word};
 use crate::Encoding;
 
 impl Encoding for Limb {
-    const BIT_SIZE: usize = Self::BIT_SIZE;
-    const BYTE_SIZE: usize = Self::BYTE_SIZE;
+    const BITS: usize = Self::BITS;
+    const BYTES: usize = Self::BYTES;
 
     #[cfg(target_pointer_width = "32")]
     type Repr = [u8; 4];

--- a/src/limb/mul.rs
+++ b/src/limb/mul.rs
@@ -13,7 +13,7 @@ impl Limb {
         let c = c.0 as WideWord;
         let carry = carry.0 as WideWord;
         let ret = a + (b * c) + carry;
-        (Limb(ret as Word), Limb((ret >> Self::BIT_SIZE) as Word))
+        (Limb(ret as Word), Limb((ret >> Self::BITS) as Word))
     }
 
     /// Perform saturating multiplication.
@@ -40,7 +40,7 @@ impl CheckedMul for Limb {
     #[inline]
     fn checked_mul(&self, rhs: Self) -> CtOption<Self> {
         let result = self.mul_wide(rhs);
-        let overflow = Limb((result >> Self::BIT_SIZE) as Word);
+        let overflow = Limb((result >> Self::BITS) as Word);
         CtOption::new(Limb(result as Word), overflow.is_zero())
     }
 }

--- a/src/limb/sub.rs
+++ b/src/limb/sub.rs
@@ -10,9 +10,9 @@ impl Limb {
     pub const fn sbb(self, rhs: Limb, borrow: Limb) -> (Limb, Limb) {
         let a = self.0 as WideWord;
         let b = rhs.0 as WideWord;
-        let borrow = (borrow.0 >> (Self::BIT_SIZE - 1)) as WideWord;
+        let borrow = (borrow.0 >> (Self::BITS - 1)) as WideWord;
         let ret = a.wrapping_sub(b + borrow);
-        (Limb(ret as Word), Limb((ret >> Self::BIT_SIZE) as Word))
+        (Limb(ret as Word), Limb((ret >> Self::BITS) as Word))
     }
 
     /// Perform saturating subtraction.

--- a/src/nlimbs.rs
+++ b/src/nlimbs.rs
@@ -3,7 +3,7 @@
 #[macro_export]
 macro_rules! nlimbs {
     ($bits:expr) => {
-        $bits / $crate::Limb::BIT_SIZE
+        $bits / $crate::Limb::BITS
     };
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -205,10 +205,10 @@ pub trait Split<Rhs = Self> {
 /// Encoding support.
 pub trait Encoding: Sized {
     /// Size of this integer in bits.
-    const BIT_SIZE: usize;
+    const BITS: usize;
 
     /// Size of this integer in bytes.
-    const BYTE_SIZE: usize;
+    const BYTES: usize;
 
     /// Byte array representation.
     type Repr: AsRef<[u8]> + AsMut<[u8]> + Copy + Clone + Sized;

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -92,6 +92,12 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         limbs: [Limb::MAX; LIMBS],
     };
 
+    /// Total size of the represented integer in bits.
+    pub const BITS: usize = LIMBS * Limb::BITS;
+
+    /// Total size of the represented integer in bytes.
+    pub const BYTES: usize = LIMBS * Limb::BYTES;
+
     /// Const-friendly [`Uint`] constructor.
     pub const fn new(limbs: [Limb; LIMBS]) -> Self {
         Self { limbs }
@@ -287,8 +293,8 @@ macro_rules! impl_uint_aliases {
             pub type $name = Uint<{nlimbs!($bits)}>;
 
             impl Encoding for $name {
-                const BITS: usize = $bits;
-                const BYTES: usize = $bits / 8;
+                const BITS: usize = Self::BITS;
+                const BYTES: usize = Self::BYTES;
 
                 type Repr = [u8; $bits / 8];
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -287,8 +287,8 @@ macro_rules! impl_uint_aliases {
             pub type $name = Uint<{nlimbs!($bits)}>;
 
             impl Encoding for $name {
-                const BIT_SIZE: usize = $bits;
-                const BYTE_SIZE: usize = $bits / 8;
+                const BITS: usize = $bits;
+                const BYTES: usize = $bits / 8;
 
                 type Repr = [u8; $bits / 8];
 

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -5,7 +5,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Returns 0 for indices out of range.
     #[inline(always)]
     pub const fn bit_vartime(self, index: usize) -> Word {
-        if index >= LIMBS * Limb::BITS {
+        if index >= Self::BITS {
             0
         } else {
             (self.limbs[index / Limb::BITS].0 >> (index % Limb::BITS)) & 1
@@ -69,7 +69,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Calculate the number of bits needed to represent this number.
     pub const fn bits(self) -> usize {
-        LIMBS * Limb::BITS - self.leading_zeros()
+        Self::BITS - self.leading_zeros()
     }
 
     /// Get the value of the bit at position `index`, as a 0- or 1-valued Word.

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -5,10 +5,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Returns 0 for indices out of range.
     #[inline(always)]
     pub const fn bit_vartime(self, index: usize) -> Word {
-        if index >= LIMBS * Limb::BIT_SIZE {
+        if index >= LIMBS * Limb::BITS {
             0
         } else {
-            (self.limbs[index / Limb::BIT_SIZE].0 >> (index % Limb::BIT_SIZE)) & 1
+            (self.limbs[index / Limb::BITS].0 >> (index % Limb::BITS)) & 1
         }
     }
 
@@ -21,7 +21,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
 
         let limb = self.limbs[i].0;
-        let bits = (Limb::BIT_SIZE * (i + 1)) as Word - limb.leading_zeros() as Word;
+        let bits = (Limb::BITS * (i + 1)) as Word - limb.leading_zeros() as Word;
 
         Limb::ct_select(
             Limb(bits),
@@ -69,14 +69,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Calculate the number of bits needed to represent this number.
     pub const fn bits(self) -> usize {
-        LIMBS * Limb::BIT_SIZE - self.leading_zeros()
+        LIMBS * Limb::BITS - self.leading_zeros()
     }
 
     /// Get the value of the bit at position `index`, as a 0- or 1-valued Word.
     /// Returns 0 for indices out of range.
     pub const fn bit(self, index: usize) -> Word {
-        let limb_num = Limb((index / Limb::BIT_SIZE) as Word);
-        let index_in_limb = index % Limb::BIT_SIZE;
+        let limb_num = Limb((index / Limb::BITS) as Word);
+        let index_in_limb = index % Limb::BITS;
         let index_mask = 1 << index_in_limb;
 
         let limbs = self.as_words();

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -64,8 +64,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         while i > 0 {
             let a = self.limbs[i - 1].0 as WideSignedWord;
             let b = rhs.limbs[i - 1].0 as WideSignedWord;
-            gt |= ((b - a) >> Limb::BIT_SIZE) & 1 & !lt;
-            lt |= ((a - b) >> Limb::BIT_SIZE) & 1 & !gt;
+            gt |= ((b - a) >> Limb::BITS) & 1 & !lt;
+            lt |= ((a - b) >> Limb::BITS) & 1 & !gt;
             i -= 1;
         }
         (gt as SignedWord) - (lt as SignedWord)

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -53,7 +53,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// to `self`.
     pub(crate) const fn ct_div_rem(&self, rhs: &Self) -> (Self, Self, u8) {
         let mb = rhs.bits_vartime();
-        let mut bd = (LIMBS * Limb::BIT_SIZE) - mb;
+        let mut bd = (LIMBS * Limb::BITS) - mb;
         let mut rem = *self;
         let mut quo = Self::ZERO;
         let mut c = rhs.shl_vartime(bd);
@@ -85,7 +85,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// to `self`.
     pub(crate) const fn ct_rem(&self, rhs: &Self) -> (Self, u8) {
         let mb = rhs.bits_vartime();
-        let mut bd = (LIMBS * Limb::BIT_SIZE) - mb;
+        let mut bd = (LIMBS * Limb::BITS) - mb;
         let mut rem = *self;
         let mut c = rhs.shl_vartime(bd);
 
@@ -114,8 +114,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     pub(crate) const fn ct_rem_wide(lower_upper: (Self, Self), rhs: &Self) -> (Self, u8) {
         let mb = rhs.bits_vartime();
 
-        // The number of bits to consider is two sets of limbs * BIT_SIZE - mb (modulus bitcount)
-        let mut bd = (2 * LIMBS * Limb::BIT_SIZE) - mb;
+        // The number of bits to consider is two sets of limbs * BITS - mb (modulus bitcount)
+        let mut bd = (2 * LIMBS * Limb::BITS) - mb;
 
         // The wide integer to reduce, split into two halves
         let (mut lower, mut upper) = lower_upper;
@@ -144,12 +144,12 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Limited to 2^16-1 since Uint doesn't support higher.
     pub const fn rem2k(&self, k: usize) -> Self {
         let highest = (LIMBS - 1) as u32;
-        let index = k as u32 / (Limb::BIT_SIZE as u32);
+        let index = k as u32 / (Limb::BITS as u32);
         let res = Limb::ct_cmp(Limb::from_u32(index), Limb::from_u32(highest)) - 1;
         let le = Limb::is_nonzero(Limb(res as Word));
         let word = Limb::ct_select(Limb::from_u32(highest), Limb::from_u32(index), le).0 as usize;
 
-        let base = k % Limb::BIT_SIZE;
+        let base = k % Limb::BITS;
         let mask = (1 << base) - 1;
         let mut out = *self;
 

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -53,7 +53,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// to `self`.
     pub(crate) const fn ct_div_rem(&self, rhs: &Self) -> (Self, Self, u8) {
         let mb = rhs.bits_vartime();
-        let mut bd = (LIMBS * Limb::BITS) - mb;
+        let mut bd = Self::BITS - mb;
         let mut rem = *self;
         let mut quo = Self::ZERO;
         let mut c = rhs.shl_vartime(bd);
@@ -85,7 +85,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// to `self`.
     pub(crate) const fn ct_rem(&self, rhs: &Self) -> (Self, u8) {
         let mb = rhs.bits_vartime();
-        let mut bd = (LIMBS * Limb::BITS) - mb;
+        let mut bd = Self::BITS - mb;
         let mut rem = *self;
         let mut c = rhs.shl_vartime(bd);
 
@@ -115,7 +115,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mb = rhs.bits_vartime();
 
         // The number of bits to consider is two sets of limbs * BITS - mb (modulus bitcount)
-        let mut bd = (2 * LIMBS * Limb::BITS) - mb;
+        let mut bd = (2 * Self::BITS) - mb;
 
         // The wide integer to reduce, split into two halves
         let (mut lower, mut upper) = lower_upper;

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -13,18 +13,18 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a new [`Uint`] from the provided big endian bytes.
     pub const fn from_be_slice(bytes: &[u8]) -> Self {
         assert!(
-            bytes.len() == Limb::BYTE_SIZE * LIMBS,
+            bytes.len() == Limb::BYTES * LIMBS,
             "bytes are not the expected size"
         );
 
         let mut res = [Limb::ZERO; LIMBS];
-        let mut buf = [0u8; Limb::BYTE_SIZE];
+        let mut buf = [0u8; Limb::BYTES];
         let mut i = 0;
 
         while i < LIMBS {
             let mut j = 0;
-            while j < Limb::BYTE_SIZE {
-                buf[j] = bytes[i * Limb::BYTE_SIZE + j];
+            while j < Limb::BYTES {
+                buf[j] = bytes[i * Limb::BYTES + j];
                 j += 1;
             }
             res[LIMBS - i - 1] = Limb(Word::from_be_bytes(buf));
@@ -39,18 +39,18 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let bytes = hex.as_bytes();
 
         assert!(
-            bytes.len() == Limb::BYTE_SIZE * LIMBS * 2,
+            bytes.len() == Limb::BYTES * LIMBS * 2,
             "hex string is not the expected size"
         );
 
         let mut res = [Limb::ZERO; LIMBS];
-        let mut buf = [0u8; Limb::BYTE_SIZE];
+        let mut buf = [0u8; Limb::BYTES];
         let mut i = 0;
 
         while i < LIMBS {
             let mut j = 0;
-            while j < Limb::BYTE_SIZE {
-                let offset = (i * Limb::BYTE_SIZE + j) * 2;
+            while j < Limb::BYTES {
+                let offset = (i * Limb::BYTES + j) * 2;
                 buf[j] = decode_hex_byte([bytes[offset], bytes[offset + 1]]);
                 j += 1;
             }
@@ -64,18 +64,18 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a new [`Uint`] from the provided little endian bytes.
     pub const fn from_le_slice(bytes: &[u8]) -> Self {
         assert!(
-            bytes.len() == Limb::BYTE_SIZE * LIMBS,
+            bytes.len() == Limb::BYTES * LIMBS,
             "bytes are not the expected size"
         );
 
         let mut res = [Limb::ZERO; LIMBS];
-        let mut buf = [0u8; Limb::BYTE_SIZE];
+        let mut buf = [0u8; Limb::BYTES];
         let mut i = 0;
 
         while i < LIMBS {
             let mut j = 0;
-            while j < Limb::BYTE_SIZE {
-                buf[j] = bytes[i * Limb::BYTE_SIZE + j];
+            while j < Limb::BYTES {
+                buf[j] = bytes[i * Limb::BYTES + j];
                 j += 1;
             }
             res[i] = Limb(Word::from_le_bytes(buf));
@@ -90,18 +90,18 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let bytes = hex.as_bytes();
 
         assert!(
-            bytes.len() == Limb::BYTE_SIZE * LIMBS * 2,
+            bytes.len() == Limb::BYTES * LIMBS * 2,
             "bytes are not the expected size"
         );
 
         let mut res = [Limb::ZERO; LIMBS];
-        let mut buf = [0u8; Limb::BYTE_SIZE];
+        let mut buf = [0u8; Limb::BYTES];
         let mut i = 0;
 
         while i < LIMBS {
             let mut j = 0;
-            while j < Limb::BYTE_SIZE {
-                let offset = (i * Limb::BYTE_SIZE + j) * 2;
+            while j < Limb::BYTES {
+                let offset = (i * Limb::BYTES + j) * 2;
                 buf[j] = decode_hex_byte([bytes[offset], bytes[offset + 1]]);
                 j += 1;
             }
@@ -117,14 +117,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     #[inline]
     #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
     pub(crate) fn write_be_bytes(&self, out: &mut [u8]) {
-        debug_assert_eq!(out.len(), Limb::BYTE_SIZE * LIMBS);
+        debug_assert_eq!(out.len(), Limb::BYTES * LIMBS);
 
         for (src, dst) in self
             .limbs
             .iter()
             .rev()
             .cloned()
-            .zip(out.chunks_exact_mut(Limb::BYTE_SIZE))
+            .zip(out.chunks_exact_mut(Limb::BYTES))
         {
             dst.copy_from_slice(&src.to_be_bytes());
         }
@@ -135,13 +135,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     #[inline]
     #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
     pub(crate) fn write_le_bytes(&self, out: &mut [u8]) {
-        debug_assert_eq!(out.len(), Limb::BYTE_SIZE * LIMBS);
+        debug_assert_eq!(out.len(), Limb::BYTES * LIMBS);
 
         for (src, dst) in self
             .limbs
             .iter()
             .cloned()
-            .zip(out.chunks_exact_mut(Limb::BYTE_SIZE))
+            .zip(out.chunks_exact_mut(Limb::BYTES))
         {
             dst.copy_from_slice(&src.to_le_bytes());
         }

--- a/src/uint/from.rs
+++ b/src/uint/from.rs
@@ -56,7 +56,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     // TODO(tarcieri): replace with `const impl From<u128>` when stable
     pub const fn from_u128(n: u128) -> Self {
         assert!(
-            LIMBS >= (128 / Limb::BIT_SIZE),
+            LIMBS >= (128 / Limb::BITS),
             "number of limbs must be greater than zero"
         );
 
@@ -95,7 +95,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         assert!(LIMBS >= 2, "number of limbs must be two or greater");
         let mut limbs = [Limb::ZERO; LIMBS];
         limbs[0].0 = n as Word;
-        limbs[1].0 = (n >> Limb::BIT_SIZE) as Word;
+        limbs[1].0 = (n >> Limb::BITS) as Word;
         Self { limbs }
     }
 }
@@ -127,7 +127,7 @@ impl<const LIMBS: usize> From<u32> for Uint<LIMBS> {
 impl<const LIMBS: usize> From<u64> for Uint<LIMBS> {
     fn from(n: u64) -> Self {
         // TODO(tarcieri): const where clause when possible
-        debug_assert!(LIMBS >= (64 / Limb::BIT_SIZE), "not enough limbs");
+        debug_assert!(LIMBS >= (64 / Limb::BITS), "not enough limbs");
         Self::from_u64(n)
     }
 }
@@ -135,7 +135,7 @@ impl<const LIMBS: usize> From<u64> for Uint<LIMBS> {
 impl<const LIMBS: usize> From<u128> for Uint<LIMBS> {
     fn from(n: u128) -> Self {
         // TODO(tarcieri): const where clause when possible
-        debug_assert!(LIMBS >= (128 / Limb::BIT_SIZE), "not enough limbs");
+        debug_assert!(LIMBS >= (128 / Limb::BITS), "not enough limbs");
         Self::from_u128(n)
     }
 }

--- a/src/uint/modular.rs
+++ b/src/uint/modular.rs
@@ -84,7 +84,6 @@ mod tests {
         modular::{
             constant_mod::Residue, constant_mod::ResidueParams, reduction::montgomery_reduction,
         },
-        traits::Encoding,
         NonZero, Uint, U256, U64,
     };
 

--- a/src/uint/modular/constant_mod/const_add.rs
+++ b/src/uint/modular/constant_mod/const_add.rs
@@ -43,9 +43,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> AddAssign<&Self> for Residue
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        const_residue, impl_modulus, modular::constant_mod::ResidueParams, traits::Encoding, U256,
-    };
+    use crate::{const_residue, impl_modulus, modular::constant_mod::ResidueParams, U256};
 
     impl_modulus!(
         Modulus,

--- a/src/uint/modular/constant_mod/const_inv.rs
+++ b/src/uint/modular/constant_mod/const_inv.rs
@@ -48,9 +48,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        const_residue, impl_modulus, modular::constant_mod::ResidueParams, traits::Encoding, U256,
-    };
+    use crate::{const_residue, impl_modulus, modular::constant_mod::ResidueParams, U256};
 
     impl_modulus!(
         Modulus,

--- a/src/uint/modular/constant_mod/const_pow.rs
+++ b/src/uint/modular/constant_mod/const_pow.rs
@@ -39,9 +39,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        const_residue, impl_modulus, modular::constant_mod::ResidueParams, traits::Encoding, U256,
-    };
+    use crate::{const_residue, impl_modulus, modular::constant_mod::ResidueParams, U256};
 
     impl_modulus!(
         Modulus,

--- a/src/uint/modular/constant_mod/const_sub.rs
+++ b/src/uint/modular/constant_mod/const_sub.rs
@@ -43,9 +43,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> SubAssign<&Self> for Residue
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        const_residue, impl_modulus, modular::constant_mod::ResidueParams, traits::Encoding, U256,
-    };
+    use crate::{const_residue, impl_modulus, modular::constant_mod::ResidueParams, U256};
 
     impl_modulus!(
         Modulus,

--- a/src/uint/modular/constant_mod/macros.rs
+++ b/src/uint/modular/constant_mod/macros.rs
@@ -6,26 +6,26 @@ macro_rules! impl_modulus {
     ($name:ident, $uint_type:ty, $value:expr) => {
         #[derive(Clone, Copy, PartialEq, Eq, Debug)]
         pub struct $name {}
-        impl<const DLIMBS: usize> ResidueParams<{ nlimbs!(<$uint_type>::BIT_SIZE) }> for $name
+        impl<const DLIMBS: usize> ResidueParams<{ nlimbs!(<$uint_type>::BITS) }> for $name
         where
-            $crate::Uint<{ nlimbs!(<$uint_type>::BIT_SIZE) }>:
+            $crate::Uint<{ nlimbs!(<$uint_type>::BITS) }>:
                 $crate::traits::Concat<Output = $crate::Uint<DLIMBS>>,
             $crate::Uint<DLIMBS>: $crate::traits::Split<Output = $uint_type>,
         {
-            const LIMBS: usize = { nlimbs!(<$uint_type>::BIT_SIZE) };
-            const MODULUS: $crate::Uint<{ nlimbs!(<$uint_type>::BIT_SIZE) }> =
+            const LIMBS: usize = { nlimbs!(<$uint_type>::BITS) };
+            const MODULUS: $crate::Uint<{ nlimbs!(<$uint_type>::BITS) }> =
                 <$uint_type>::from_be_hex($value);
-            const R: $crate::Uint<{ nlimbs!(<$uint_type>::BIT_SIZE) }> = $crate::Uint::MAX
+            const R: $crate::Uint<{ nlimbs!(<$uint_type>::BITS) }> = $crate::Uint::MAX
                 .ct_rem(&Self::MODULUS)
                 .0
                 .wrapping_add(&$crate::Uint::ONE);
-            const R2: $crate::Uint<{ nlimbs!(<$uint_type>::BIT_SIZE) }> =
+            const R2: $crate::Uint<{ nlimbs!(<$uint_type>::BITS) }> =
                 $crate::Uint::ct_rem_wide(Self::R.square_wide(), &Self::MODULUS).0;
             const MOD_NEG_INV: $crate::Limb = $crate::Limb(
                 $crate::Word::MIN
                     .wrapping_sub(Self::MODULUS.inv_mod2k($crate::Word::BITS as usize).limbs[0].0),
             );
-            const R3: $crate::Uint<{ nlimbs!(<$uint_type>::BIT_SIZE) }> =
+            const R3: $crate::Uint<{ nlimbs!(<$uint_type>::BITS) }> =
                 $crate::uint::modular::reduction::montgomery_reduction(
                     Self::R2.square_wide(),
                     Self::MODULUS,

--- a/src/uint/modular/pow.rs
+++ b/src/uint/modular/pow.rs
@@ -30,8 +30,8 @@ pub const fn pow_montgomery_form<const LIMBS: usize>(
         i += 1;
     }
 
-    let starting_limb = (exponent_bits - 1) / Limb::BIT_SIZE;
-    let starting_bit_in_limb = (exponent_bits - 1) % Limb::BIT_SIZE;
+    let starting_limb = (exponent_bits - 1) / Limb::BITS;
+    let starting_bit_in_limb = (exponent_bits - 1) % Limb::BITS;
     let starting_window = starting_bit_in_limb / WINDOW;
     let starting_window_mask = (1 << (starting_bit_in_limb % WINDOW + 1)) - 1;
 
@@ -45,7 +45,7 @@ pub const fn pow_montgomery_form<const LIMBS: usize>(
         let mut window_num = if limb_num == starting_limb {
             starting_window + 1
         } else {
-            Limb::BIT_SIZE / WINDOW
+            Limb::BITS / WINDOW
         };
         while window_num > 0 {
             window_num -= 1;

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -36,8 +36,8 @@ impl<const LIMBS: usize> RandomMod for Uint<LIMBS> {
         let mut n = Self::ZERO;
 
         let n_bits = modulus.as_ref().bits_vartime();
-        let n_limbs = (n_bits + Limb::BIT_SIZE - 1) / Limb::BIT_SIZE;
-        let mask = Limb::MAX >> (Limb::BIT_SIZE * n_limbs - n_bits);
+        let n_limbs = (n_bits + Limb::BITS - 1) / Limb::BITS;
+        let mask = Limb::MAX >> (Limb::BITS * n_limbs - n_bits);
 
         loop {
             for i in 0..n_limbs {

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -101,10 +101,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let (lower, mut upper) = lower_upper;
         let new_lower = lower.shl_vartime(n);
         upper = upper.shl_vartime(n);
-        if n >= LIMBS * Limb::BITS {
-            upper = upper.bitor(&lower.shl_vartime(n - LIMBS * Limb::BITS));
+        if n >= Self::BITS {
+            upper = upper.bitor(&lower.shl_vartime(n - Self::BITS));
         } else {
-            upper = upper.bitor(&lower.shr_vartime(LIMBS * Limb::BITS - n));
+            upper = upper.bitor(&lower.shr_vartime(Self::BITS - n));
         }
 
         (new_lower, upper)

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -35,7 +35,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         )
     }
 
-    /// Computes `self << shift` where `0 <= shift < Limb::BIT_SIZE`,
+    /// Computes `self << shift` where `0 <= shift < Limb::BITS`,
     /// returning the result and the carry.
     #[inline(always)]
     pub(crate) const fn shl_limb(&self, n: usize) -> (Self, Limb) {
@@ -43,7 +43,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         let nz = Limb(n as Word).is_nonzero();
         let lshift = n as Word;
-        let rshift = Limb::ct_select(Limb::ZERO, Limb((Limb::BIT_SIZE - n) as Word), nz).0;
+        let rshift = Limb::ct_select(Limb::ZERO, Limb((Limb::BITS - n) as Word), nz).0;
         let carry = Limb::ct_select(
             Limb::ZERO,
             Limb(self.limbs[LIMBS - 1].0.wrapping_shr(Word::BITS - n as u32)),
@@ -73,12 +73,12 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     pub const fn shl_vartime(&self, n: usize) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
 
-        if n >= Limb::BIT_SIZE * LIMBS {
+        if n >= Limb::BITS * LIMBS {
             return Self { limbs };
         }
 
-        let shift_num = n / Limb::BIT_SIZE;
-        let rem = n % Limb::BIT_SIZE;
+        let shift_num = n / Limb::BITS;
+        let rem = n % Limb::BITS;
 
         let mut i = LIMBS;
         while i > shift_num {
@@ -101,10 +101,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let (lower, mut upper) = lower_upper;
         let new_lower = lower.shl_vartime(n);
         upper = upper.shl_vartime(n);
-        if n >= LIMBS * Limb::BIT_SIZE {
-            upper = upper.bitor(&lower.shl_vartime(n - LIMBS * Limb::BIT_SIZE));
+        if n >= LIMBS * Limb::BITS {
+            upper = upper.bitor(&lower.shl_vartime(n - LIMBS * Limb::BITS));
         } else {
-            upper = upper.bitor(&lower.shr_vartime(LIMBS * Limb::BIT_SIZE - n));
+            upper = upper.bitor(&lower.shr_vartime(LIMBS * Limb::BITS - n));
         }
 
         (new_lower, upper)

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -87,10 +87,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let (mut lower, upper) = lower_upper;
         let new_upper = upper.shr_vartime(n);
         lower = lower.shr_vartime(n);
-        if n >= LIMBS * Limb::BITS {
-            lower = lower.bitor(&upper.shr_vartime(n - LIMBS * Limb::BITS));
+        if n >= Self::BITS {
+            lower = lower.bitor(&upper.shr_vartime(n - Self::BITS));
         } else {
-            lower = lower.bitor(&upper.shl_vartime(LIMBS * Limb::BITS - n));
+            lower = lower.bitor(&upper.shl_vartime(Self::BITS - n));
         }
 
         (lower, new_upper)

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -44,11 +44,11 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// to `self`.
     #[inline(always)]
     pub const fn shr_vartime(&self, shift: usize) -> Self {
-        let full_shifts = shift / Limb::BIT_SIZE;
-        let small_shift = shift & (Limb::BIT_SIZE - 1);
+        let full_shifts = shift / Limb::BITS;
+        let small_shift = shift & (Limb::BITS - 1);
         let mut limbs = [Limb::ZERO; LIMBS];
 
-        if shift > Limb::BIT_SIZE * LIMBS {
+        if shift > Limb::BITS * LIMBS {
             return Self { limbs };
         }
 
@@ -65,7 +65,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
                 let mut lo = self.limbs[i + full_shifts].0 >> small_shift;
 
                 if i < (LIMBS - 1) - full_shifts {
-                    lo |= self.limbs[i + full_shifts + 1].0 << (Limb::BIT_SIZE - small_shift);
+                    lo |= self.limbs[i + full_shifts + 1].0 << (Limb::BITS - small_shift);
                 }
 
                 limbs[i] = Limb(lo);
@@ -87,10 +87,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let (mut lower, upper) = lower_upper;
         let new_upper = upper.shr_vartime(n);
         lower = lower.shr_vartime(n);
-        if n >= LIMBS * Limb::BIT_SIZE {
-            lower = lower.bitor(&upper.shr_vartime(n - LIMBS * Limb::BIT_SIZE));
+        if n >= LIMBS * Limb::BITS {
+            lower = lower.bitor(&upper.shr_vartime(n - LIMBS * Limb::BITS));
         } else {
-            lower = lower.bitor(&upper.shl_vartime(LIMBS * Limb::BIT_SIZE - n));
+            lower = lower.bitor(&upper.shl_vartime(LIMBS * Limb::BITS - n));
         }
 
         (lower, new_upper)

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -22,9 +22,9 @@ fn to_biguint(uint: &U256) -> BigUint {
 }
 
 fn to_uint(big_uint: BigUint) -> U256 {
-    let mut input = [0u8; U256::BYTE_SIZE];
+    let mut input = [0u8; U256::BYTES];
     let encoded = big_uint.to_bytes_le();
-    let l = encoded.len().min(U256::BYTE_SIZE);
+    let l = encoded.len().min(U256::BYTES);
     input[..l].copy_from_slice(&encoded[..l]);
 
     U256::from_le_slice(&input)


### PR DESCRIPTION
Fixes #154

- rename `BIT_SIZE` to `BITS` and `BYTE_SIZE` to `BYTES` to match the constants in the primitive types
- add `BITS` and `BYTES` to `Uint` (instead of only having them in `Encoding`), similarly to how it's done for `Limb`

Now about the `usize` -> `u32`, I've tried to implement that, and I am reconsidering it. It really feels more natural in many places to have those constants be `usize`, otherwise there's a lot of `as` casts necessary (unless we also have `const LIMBS: u32`). `leading_zeros()` etc can be made to return `u32` more easily, but that would introduce an inconsistency with `BITS`. Perhaps we can leave the types as is after all.