### PR TITLE
Some fixes for modular inversion

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -89,12 +89,12 @@ fn bench_modpow<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
 
     let params = moduli
         .iter()
-        .map(|modulus| DynResidueParams::new(*modulus))
+        .map(|modulus| DynResidueParams::new(modulus))
         .collect::<Vec<_>>();
     let xs_m = xs
         .iter()
         .zip(params.iter())
-        .map(|(x, p)| DynResidue::new(*x, *p))
+        .map(|(x, p)| DynResidue::new(x, *p))
         .collect::<Vec<_>>();
 
     group.bench_function("modpow, 4^4", |b| {

--- a/src/ct_choice.rs
+++ b/src/ct_choice.rs
@@ -1,0 +1,83 @@
+use subtle::Choice;
+
+use crate::Word;
+
+/// A boolean value returned by constant-time `const fn`s.
+// TODO: should be replaced by `subtle::Choice` or `CtOption`
+// when `subtle` starts supporting const fns.
+#[derive(Debug, Copy, Clone)]
+pub struct CtChoice(Word);
+
+impl CtChoice {
+    /// The falsy vaue.
+    pub const FALSE: Self = Self(0);
+
+    /// The truthy vaue.
+    pub const TRUE: Self = Self(Word::MAX);
+
+    /// Returns the truthy value if `value == Word::MAX`, and the falsy value if `value == 0`.
+    /// Panics for other values.
+    pub(crate) const fn from_mask(value: Word) -> Self {
+        debug_assert!(value == Self::FALSE.0 || value == Self::TRUE.0);
+        Self(value)
+    }
+
+    /// Returns the truthy value if `value == 1`, and the falsy value if `value == 0`.
+    /// Panics for other values.
+    pub(crate) const fn from_lsb(value: Word) -> Self {
+        debug_assert!(value == Self::FALSE.0 || value == 1);
+        Self(value.wrapping_neg())
+    }
+
+    pub(crate) const fn not(&self) -> Self {
+        Self(!self.0)
+    }
+
+    pub(crate) const fn and(&self, other: Self) -> Self {
+        Self(self.0 & other.0)
+    }
+
+    pub(crate) const fn or(&self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    /// Return `b` if `self` is truthy, otherwise return `a`.
+    pub(crate) const fn select(&self, a: Word, b: Word) -> Word {
+        a ^ (self.0 & (a ^ b))
+    }
+
+    /// Return `x` if `self` is truthy, otherwise return 0.
+    pub(crate) const fn if_true(&self, x: Word) -> Word {
+        x & self.0
+    }
+
+    pub(crate) const fn is_true_vartime(&self) -> bool {
+        self.0 == CtChoice::TRUE.0
+    }
+}
+
+impl From<CtChoice> for Choice {
+    fn from(choice: CtChoice) -> Self {
+        Choice::from(choice.0 as u8 & 1)
+    }
+}
+
+impl From<CtChoice> for bool {
+    fn from(choice: CtChoice) -> Self {
+        choice.is_true_vartime()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CtChoice;
+    use crate::Word;
+
+    #[test]
+    fn select() {
+        let a: Word = 1;
+        let b: Word = 2;
+        assert_eq!(CtChoice::TRUE.select(a, b), b);
+        assert_eq!(CtChoice::FALSE.select(a, b), a);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ mod wrapping;
 
 pub use crate::{
     checked::Checked,
-    limb::{Limb, WideWord, Word},
+    limb::{CtChoice, Limb, WideWord, Word},
     non_zero::NonZero,
     traits::*,
     uint::div_limb::Reciprocal,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,8 +178,6 @@ pub use crate::{
 };
 pub use subtle;
 
-pub(crate) use limb::{SignedWord, WideSignedWord};
-
 #[cfg(feature = "generic-array")]
 pub use {
     crate::array::{ArrayDecoding, ArrayEncoding, ByteArray},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@ mod nlimbs;
 #[cfg(feature = "generic-array")]
 mod array;
 mod checked;
+mod ct_choice;
 mod limb;
 mod non_zero;
 mod traits;
@@ -169,7 +170,8 @@ mod wrapping;
 
 pub use crate::{
     checked::Checked,
-    limb::{CtChoice, Limb, WideWord, Word},
+    ct_choice::CtChoice,
+    limb::{Limb, WideWord, Word},
     non_zero::NonZero,
     traits::*,
     uint::div_limb::Reciprocal,

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -20,7 +20,7 @@ mod sub;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{Bounded, Zero};
+use crate::{Bounded, CtChoice, Zero};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable};
 
@@ -56,12 +56,6 @@ pub type WideWord = u128;
 
 /// Highest bit in a [`Limb`].
 pub(crate) const HI_BIT: usize = Limb::BITS - 1;
-
-/// A boolean value returned by constant-time `const fn`s.
-/// `Word::MAX` signifies `true`, and `0` signifies `false`.
-// TODO: should be replaced by `subtle::Choice` or `CtOption`
-// when `subtle` starts supporting const fns.
-pub type CtChoice = Word;
 
 /// Big integers are represented as an array of smaller CPU word-size integers
 /// called "limbs".
@@ -100,7 +94,7 @@ impl Limb {
     /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
     pub(crate) const fn ct_select(a: Self, b: Self, c: CtChoice) -> Self {
-        Self(a.0 ^ (c & (a.0 ^ b.0)))
+        Self(c.select(a.0, b.0))
     }
 }
 

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -20,7 +20,7 @@ mod sub;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{Bounded, CtChoice, Zero};
+use crate::{Bounded, Zero};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable};
 
@@ -90,12 +90,6 @@ impl Limb {
     /// Size of the inner integer in bytes.
     #[cfg(target_pointer_width = "64")]
     pub const BYTES: usize = 8;
-
-    /// Return `b` if `c` is truthy, otherwise return `a`.
-    #[inline]
-    pub(crate) const fn ct_select(a: Self, b: Self, c: CtChoice) -> Self {
-        Self(c.select(a.0, b.0))
-    }
 }
 
 impl Bounded for Limb {

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -73,6 +73,12 @@ pub(crate) type WideSignedWord = i128;
 /// Highest bit in a [`Limb`].
 pub(crate) const HI_BIT: usize = Limb::BITS - 1;
 
+/// A boolean value returned by constant-time `const fn`s.
+/// `Word::MAX` signifies `true`, and `0` signifies `false`.
+// TODO: should be replaced by `subtle::Choice` or `CtOption`
+// when `subtle` starts supporting const fns.
+pub type CtChoice = Word;
+
 /// Big integers are represented as an array of smaller CPU word-size integers
 /// called "limbs".
 #[derive(Copy, Clone, Debug, Default, Hash)]
@@ -107,11 +113,9 @@ impl Limb {
     #[cfg(target_pointer_width = "64")]
     pub const BYTES: usize = 8;
 
-    /// Return `a` if `c`==0 or `b` if `c`==`Word::MAX`.
-    ///
-    /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
+    /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
-    pub(crate) const fn ct_select(a: Self, b: Self, c: Word) -> Self {
+    pub(crate) const fn ct_select(a: Self, b: Self, c: CtChoice) -> Self {
         Self(a.0 ^ (c & (a.0 ^ b.0)))
     }
 }

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -38,17 +38,9 @@ compile_error!("this crate builds on 32-bit and 64-bit platforms only");
 #[cfg(target_pointer_width = "32")]
 pub type Word = u32;
 
-/// Signed integer type that corresponds to [`Word`].
-#[cfg(target_pointer_width = "32")]
-pub(crate) type SignedWord = i32;
-
 /// Unsigned wide integer type: double the width of [`Word`].
 #[cfg(target_pointer_width = "32")]
 pub type WideWord = u64;
-
-/// Signed wide integer type: double the width of [`Limb`].
-#[cfg(target_pointer_width = "32")]
-pub(crate) type WideSignedWord = i64;
 
 //
 // 64-bit definitions
@@ -58,17 +50,9 @@ pub(crate) type WideSignedWord = i64;
 #[cfg(target_pointer_width = "64")]
 pub type Word = u64;
 
-/// Signed integer type that corresponds to [`Word`].
-#[cfg(target_pointer_width = "64")]
-pub(crate) type SignedWord = i64;
-
 /// Wide integer type: double the width of [`Word`].
 #[cfg(target_pointer_width = "64")]
 pub type WideWord = u128;
-
-/// Signed wide integer type: double the width of [`SignedWord`].
-#[cfg(target_pointer_width = "64")]
-pub(crate) type WideSignedWord = i128;
 
 /// Highest bit in a [`Limb`].
 pub(crate) const HI_BIT: usize = Limb::BITS - 1;

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -25,6 +25,12 @@ impl Limb {
         self.0 == other.0
     }
 
+    /// Return `b` if `c` is truthy, otherwise return `a`.
+    #[inline]
+    pub(crate) const fn ct_select(a: Self, b: Self, c: CtChoice) -> Self {
+        Self(c.select(a.0, b.0))
+    }
+
     /// Returns the truthy value if `self != 0` and the falsy value otherwise.
     #[inline]
     pub(crate) const fn ct_is_nonzero(&self) -> CtChoice {

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -26,7 +26,7 @@ impl Limb {
 
     /// Returns the truthy value if `self != 0` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn is_nonzero(&self) -> CtChoice {
+    pub(crate) const fn ct_is_nonzero(&self) -> CtChoice {
         let inner = self.0;
         ((inner | inner.wrapping_neg()) >> HI_BIT).wrapping_neg()
     }
@@ -38,7 +38,7 @@ impl Limb {
         let y = rhs.0;
 
         // x ^ y == 0 if and only if x == y
-        !Self(x ^ y).is_nonzero()
+        !Self(x ^ y).ct_is_nonzero()
     }
 
     /// Returns the truthy value if `lhs < rhs` and the falsy value otherwise.

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -1,6 +1,6 @@
 //! Limb comparisons
 
-use super::{Limb, SignedWord, WideSignedWord, Word, HI_BIT};
+use super::{CtChoice, Limb, SignedWord, WideSignedWord, Word, HI_BIT};
 use core::cmp::Ordering;
 use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
@@ -24,11 +24,9 @@ impl Limb {
         self.0 == other.0
     }
 
-    /// Returns all 1's if `a`!=0 or 0 if `a`==0.
-    ///
-    /// Const-friendly: we can't yet use `subtle` in `const fn` contexts.
+    /// Returns the truthy value if `self != 0` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn is_nonzero(self) -> Word {
+    pub(crate) const fn is_nonzero(self) -> CtChoice {
         let inner = self.0 as SignedWord;
         ((inner | inner.saturating_neg()) >> HI_BIT) as Word
     }
@@ -42,9 +40,9 @@ impl Limb {
         (gt as SignedWord) - (lt as SignedWord)
     }
 
-    /// Returns `Word::MAX` if `lhs == rhs` and `0` otherwise.
+    /// Returns the truthy value if `lhs == rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn ct_eq(lhs: Self, rhs: Self) -> Word {
+    pub(crate) const fn ct_eq(lhs: Self, rhs: Self) -> CtChoice {
         let x = lhs.0;
         let y = rhs.0;
 
@@ -60,18 +58,18 @@ impl Limb {
         (d ^ 1).wrapping_neg()
     }
 
-    /// Returns `Word::MAX` if `lhs < rhs` and `0` otherwise.
+    /// Returns the truthy value if `lhs < rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn ct_lt(lhs: Self, rhs: Self) -> Word {
+    pub(crate) const fn ct_lt(lhs: Self, rhs: Self) -> CtChoice {
         let x = lhs.0;
         let y = rhs.0;
         let bit = (((!x) & y) | (((!x) | y) & (x.wrapping_sub(y)))) >> (Limb::BITS - 1);
         bit.wrapping_neg()
     }
 
-    /// Returns `Word::MAX` if `lhs <= rhs` and `0` otherwise.
+    /// Returns the truthy value if `lhs <= rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn ct_le(lhs: Self, rhs: Self) -> Word {
+    pub(crate) const fn ct_le(lhs: Self, rhs: Self) -> CtChoice {
         let x = lhs.0;
         let y = rhs.0;
         let bit = (((!x) | y) & ((x ^ y) | !(y.wrapping_sub(x)))) >> (Limb::BITS - 1);

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -1,6 +1,7 @@
 //! Limb comparisons
 
-use super::{CtChoice, Limb, HI_BIT};
+use super::HI_BIT;
+use crate::{CtChoice, Limb};
 use core::cmp::Ordering;
 use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
@@ -28,7 +29,7 @@ impl Limb {
     #[inline]
     pub(crate) const fn ct_is_nonzero(&self) -> CtChoice {
         let inner = self.0;
-        ((inner | inner.wrapping_neg()) >> HI_BIT).wrapping_neg()
+        CtChoice::from_lsb((inner | inner.wrapping_neg()) >> HI_BIT)
     }
 
     /// Returns the truthy value if `lhs == rhs` and the falsy value otherwise.
@@ -38,7 +39,7 @@ impl Limb {
         let y = rhs.0;
 
         // x ^ y == 0 if and only if x == y
-        !Self(x ^ y).ct_is_nonzero()
+        Self(x ^ y).ct_is_nonzero().not()
     }
 
     /// Returns the truthy value if `lhs < rhs` and the falsy value otherwise.
@@ -47,7 +48,7 @@ impl Limb {
         let x = lhs.0;
         let y = rhs.0;
         let bit = (((!x) & y) | (((!x) | y) & (x.wrapping_sub(y)))) >> (Limb::BITS - 1);
-        bit.wrapping_neg()
+        CtChoice::from_lsb(bit)
     }
 
     /// Returns the truthy value if `lhs <= rhs` and the falsy value otherwise.
@@ -56,7 +57,7 @@ impl Limb {
         let x = lhs.0;
         let y = rhs.0;
         let bit = (((!x) | y) & ((x ^ y) | !(y.wrapping_sub(x)))) >> (Limb::BITS - 1);
-        bit.wrapping_neg()
+        CtChoice::from_lsb(bit)
     }
 }
 

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -1,6 +1,6 @@
 //! [`Uint`] addition operations.
 
-use crate::{Checked, CheckedAdd, Limb, Uint, Word, Wrapping, Zero};
+use crate::{Checked, CheckedAdd, CtChoice, Limb, Uint, Wrapping, Zero};
 use core::ops::{Add, AddAssign};
 use subtle::CtOption;
 
@@ -37,8 +37,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         self.adc(rhs, Limb::ZERO).0
     }
 
-    /// Perform wrapping addition, returning the overflow bit as a `Word` that is either 0...0 or 1...1.
-    pub(crate) const fn conditional_wrapping_add(&self, rhs: &Self, choice: Word) -> (Self, Word) {
+    /// Perform wrapping addition, returning the truthy value as the second element of the tuple
+    /// if an overflow has occurred.
+    pub(crate) const fn conditional_wrapping_add(
+        &self,
+        rhs: &Self,
+        choice: CtChoice,
+    ) -> (Self, CtChoice) {
         let actual_rhs = Uint::ct_select(Uint::ZERO, *rhs, choice);
         let (sum, carry) = self.adc(&actual_rhs, Limb::ZERO);
 

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -44,7 +44,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         rhs: &Self,
         choice: CtChoice,
     ) -> (Self, CtChoice) {
-        let actual_rhs = Uint::ct_select(Uint::ZERO, *rhs, choice);
+        let actual_rhs = Uint::ct_select(&Uint::ZERO, rhs, choice);
         let (sum, carry) = self.adc(&actual_rhs, Limb::ZERO);
 
         debug_assert!(carry.0 == 0 || carry.0 == 1);

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -46,9 +46,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ) -> (Self, CtChoice) {
         let actual_rhs = Uint::ct_select(&Uint::ZERO, rhs, choice);
         let (sum, carry) = self.adc(&actual_rhs, Limb::ZERO);
-
-        debug_assert!(carry.0 == 0 || carry.0 == 1);
-        (sum, carry.0.wrapping_neg())
+        (sum, CtChoice::from_lsb(carry.0))
     }
 }
 

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -42,7 +42,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let actual_rhs = Uint::ct_select(Uint::ZERO, *rhs, choice);
         let (sum, carry) = self.adc(&actual_rhs, Limb::ZERO);
 
-        (sum, carry.0.wrapping_mul(Word::MAX))
+        debug_assert!(carry.0 == 0 || carry.0 == 1);
+        (sum, carry.0.wrapping_neg())
     }
 }
 

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -26,7 +26,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         Limb::ct_select(
             Limb(bits),
             Limb::ZERO,
-            !self.limbs[0].is_nonzero() & !Limb(i as Word).is_nonzero(),
+            !self.limbs[0].ct_is_nonzero() & !Limb(i as Word).ct_is_nonzero(),
         )
         .0 as usize
     }
@@ -43,7 +43,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             let l = limbs[i];
             let z = l.leading_zeros() as Word;
             count += z & mask;
-            mask &= !l.is_nonzero();
+            mask &= !l.ct_is_nonzero();
         }
 
         count as usize
@@ -60,7 +60,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             let l = limbs[i];
             let z = l.trailing_zeros() as Word;
             count += z & mask;
-            mask &= !l.is_nonzero();
+            mask &= !l.ct_is_nonzero();
             i += 1;
         }
 

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -46,8 +46,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         Limb::is_nonzero(Limb(b))
     }
 
+    /// Returns all 1's if `self` is odd or 0 otherwise.
     pub(crate) const fn ct_is_odd(&self) -> Word {
-        (self.limbs[0].0 & 1).wrapping_mul(Word::MAX)
+        (self.limbs[0].0 & 1).wrapping_neg()
     }
 
     /// Returns -1 if self < rhs

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -10,7 +10,7 @@ use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
-    pub(crate) const fn ct_select(a: Uint<LIMBS>, b: Uint<LIMBS>, c: CtChoice) -> Self {
+    pub(crate) const fn ct_select(a: &Self, b: &Self, c: CtChoice) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
 
         let mut i = 0;
@@ -23,7 +23,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     #[inline]
-    pub(crate) const fn ct_swap(a: Uint<LIMBS>, b: Uint<LIMBS>, c: CtChoice) -> (Self, Self) {
+    pub(crate) const fn ct_swap(a: &Self, b: &Self, c: CtChoice) -> (Self, Self) {
         let new_a = Self::ct_select(a, b, c);
         let new_b = Self::ct_select(b, a, c);
 

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -3,7 +3,7 @@
 //! By default these are all constant-time and use the `subtle` crate.
 
 use super::Uint;
-use crate::{CtChoice, Limb, Word};
+use crate::{CtChoice, Limb};
 use core::cmp::Ordering;
 use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
@@ -44,7 +44,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Returns the truthy value if `self` is odd or the falsy value otherwise.
     pub(crate) const fn ct_is_odd(&self) -> CtChoice {
-        (self.limbs[0].0 & 1).wrapping_neg()
+        CtChoice::from_lsb(self.limbs[0].0 & 1)
     }
 
     /// Returns the truthy value if `self == rhs` or the falsy value otherwise.
@@ -59,7 +59,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
 
         // acc == 0 if and only if self == rhs
-        !Limb(acc).ct_is_nonzero()
+        Limb(acc).ct_is_nonzero().not()
     }
 
     /// Returns the truthy value if `self <= rhs` and the falsy value otherwise.
@@ -69,35 +69,35 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // but since we have to use Uint::wrapping_sub(), which calls `sbb()`,
         // there are no savings compared to just calling `sbb()` directly.
         let (_res, borrow) = self.sbb(rhs, Limb::ZERO);
-        borrow.0
+        CtChoice::from_mask(borrow.0)
     }
 
     /// Returns the truthy value if `self <= rhs` and the falsy value otherwise.
     #[inline]
     pub(crate) const fn ct_gt(&self, rhs: &Self) -> CtChoice {
         let (_res, borrow) = rhs.sbb(self, Limb::ZERO);
-        borrow.0
+        CtChoice::from_mask(borrow.0)
     }
 }
 
 impl<const LIMBS: usize> ConstantTimeEq for Uint<LIMBS> {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
-        Choice::from(self.ct_eq(other) as u8 & 1)
+        self.ct_eq(other).into()
     }
 }
 
 impl<const LIMBS: usize> ConstantTimeGreater for Uint<LIMBS> {
     #[inline]
     fn ct_gt(&self, other: &Self) -> Choice {
-        Choice::from(self.ct_gt(other) as u8 & 1)
+        self.ct_gt(other).into()
     }
 }
 
 impl<const LIMBS: usize> ConstantTimeLess for Uint<LIMBS> {
     #[inline]
     fn ct_lt(&self, other: &Self) -> Choice {
-        Choice::from(self.ct_lt(other) as u8 & 1)
+        self.ct_lt(other).into()
     }
 }
 
@@ -108,9 +108,9 @@ impl<const LIMBS: usize> Ord for Uint<LIMBS> {
         let is_lt = self.ct_lt(other);
         let is_eq = self.ct_eq(other);
 
-        if is_lt == Word::MAX {
+        if is_lt.into() {
             Ordering::Less
-        } else if is_eq == Word::MAX {
+        } else if is_eq.into() {
             Ordering::Equal
         } else {
             Ordering::Greater
@@ -126,7 +126,7 @@ impl<const LIMBS: usize> PartialOrd for Uint<LIMBS> {
 
 impl<const LIMBS: usize> PartialEq for Uint<LIMBS> {
     fn eq(&self, other: &Self) -> bool {
-        self.ct_eq(other) == Word::MAX
+        self.ct_eq(other).into()
     }
 }
 

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -39,7 +39,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             b |= self.limbs[i].0;
             i += 1;
         }
-        Limb(b).is_nonzero()
+        Limb(b).ct_is_nonzero()
     }
 
     /// Returns the truthy value if `self` is odd or the falsy value otherwise.
@@ -59,7 +59,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
 
         // acc == 0 if and only if self == rhs
-        !Limb(acc).is_nonzero()
+        !Limb(acc).ct_is_nonzero()
     }
 
     /// Returns the truthy value if `self <= rhs` and the falsy value otherwise.

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -61,9 +61,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         loop {
             let (mut r, borrow) = rem.sbb(&c, Limb::ZERO);
-            rem = Self::ct_select(r, rem, borrow.0);
+            rem = Self::ct_select(&r, &rem, borrow.0);
             r = quo.bitor(&Self::ONE);
-            quo = Self::ct_select(r, quo, borrow.0);
+            quo = Self::ct_select(&r, &quo, borrow.0);
             if bd == 0 {
                 break;
             }
@@ -73,7 +73,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
 
         let is_some = Limb(mb as Word).ct_is_nonzero();
-        quo = Self::ct_select(Self::ZERO, quo, is_some);
+        quo = Self::ct_select(&Self::ZERO, &quo, is_some);
         (quo, rem, is_some)
     }
 
@@ -93,7 +93,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         loop {
             let (r, borrow) = rem.sbb(&c, Limb::ZERO);
-            rem = Self::ct_select(r, rem, borrow.0);
+            rem = Self::ct_select(&r, &rem, borrow.0);
             if bd == 0 {
                 break;
             }
@@ -128,8 +128,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             let (lower_sub, borrow) = lower.sbb(&c.0, Limb::ZERO);
             let (upper_sub, borrow) = upper.sbb(&c.1, borrow);
 
-            lower = Self::ct_select(lower_sub, lower, borrow.0);
-            upper = Self::ct_select(upper_sub, upper, borrow.0);
+            lower = Self::ct_select(&lower_sub, &lower, borrow.0);
+            upper = Self::ct_select(&upper_sub, &upper, borrow.0);
             if bd == 0 {
                 break;
             }

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -146,8 +146,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     pub const fn rem2k(&self, k: usize) -> Self {
         let highest = (LIMBS - 1) as u32;
         let index = k as u32 / (Limb::BITS as u32);
-        let res = Limb::ct_cmp(Limb::from_u32(index), Limb::from_u32(highest)) - 1;
-        let le = Limb::is_nonzero(Limb(res as Word));
+        let le = Limb::ct_le(Limb::from_u32(index), Limb::from_u32(highest));
         let word = Limb::ct_select(Limb::from_u32(highest), Limb::from_u32(index), le).0 as usize;
 
         let base = k % Limb::BITS;

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -113,7 +113,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
-    #[allow(dead_code)]
     pub(crate) const fn ct_rem_wide(lower_upper: (Self, Self), rhs: &Self) -> (Self, Word) {
         let mb = rhs.bits_vartime();
 

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -29,7 +29,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Returns `Word::MAX` as the third element of the tuple if `rhs != 0`, and `0` otherwise.
     #[inline(always)]
     pub(crate) const fn ct_div_rem_limb(&self, rhs: Limb) -> (Self, Limb, Word) {
-        let (reciprocal, is_some) = Reciprocal::new_const(rhs);
+        let (reciprocal, is_some) = Reciprocal::ct_new(rhs);
         let (quo, rem) = div_rem_limb_with_reciprocal(self, &reciprocal);
         (quo, rem, is_some)
     }

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -72,7 +72,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             quo = quo.shl_vartime(1);
         }
 
-        let is_some = Limb(mb as Word).is_nonzero();
+        let is_some = Limb(mb as Word).ct_is_nonzero();
         quo = Self::ct_select(Self::ZERO, quo, is_some);
         (quo, rem, is_some)
     }
@@ -101,7 +101,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             c = c.shr_vartime(1);
         }
 
-        let is_some = Limb(mb as Word).is_nonzero();
+        let is_some = Limb(mb as Word).ct_is_nonzero();
         (rem, is_some)
     }
 
@@ -137,7 +137,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             c = Self::shr_vartime_wide(c, 1);
         }
 
-        let is_some = Limb(mb as Word).is_nonzero();
+        let is_some = Limb(mb as Word).ct_is_nonzero();
         (lower, is_some)
     }
 

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -222,7 +222,7 @@ impl Reciprocal {
     /// A non-const-fn version of `new_const()`, wrapping the result in a `CtOption`.
     pub fn new(divisor: Limb) -> CtOption<Self> {
         let (rec, is_some) = Self::ct_new(divisor);
-        CtOption::new(rec, Choice::from((is_some & 1) as u8))
+        CtOption::new(rec, is_some.into())
     }
 }
 

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -173,7 +173,7 @@ impl Reciprocal {
     /// Note: if the returned flag is `0`, the returned reciprocal object is still self-consistent
     /// and can be passed to functions here without causing them to panic,
     /// but the results are naturally not to be used.
-    pub const fn new_const(divisor: Limb) -> (Self, Word) {
+    pub const fn ct_new(divisor: Limb) -> (Self, Word) {
         // Assuming this is constant-time for primitive types.
         let shift = divisor.0.leading_zeros();
 
@@ -220,7 +220,7 @@ impl Reciprocal {
 
     /// A non-const-fn version of `new_const()`, wrapping the result in a `CtOption`.
     pub fn new(divisor: Limb) -> CtOption<Self> {
-        let (rec, is_some) = Self::new_const(divisor);
+        let (rec, is_some) = Self::ct_new(divisor);
         CtOption::new(rec, Choice::from((is_some & 1) as u8))
     }
 }

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -168,12 +168,12 @@ pub struct Reciprocal {
 impl Reciprocal {
     /// Pre-calculates a reciprocal for a known divisor,
     /// to be used in the single-limb division later.
-    /// Returns the reciprocal, and `1` if `divisor != 0` and `0` otherwise.
+    /// Returns the reciprocal, and `Word::MAX` if `divisor != 0` and `0` otherwise.
     ///
     /// Note: if the returned flag is `0`, the returned reciprocal object is still self-consistent
     /// and can be passed to functions here without causing them to panic,
     /// but the results are naturally not to be used.
-    pub const fn new_const(divisor: Limb) -> (Self, u8) {
+    pub const fn new_const(divisor: Limb) -> (Self, Word) {
         // Assuming this is constant-time for primitive types.
         let shift = divisor.0.leading_zeros();
 
@@ -199,7 +199,7 @@ impl Reciprocal {
                 shift,
                 reciprocal: reciprocal(divisor_normalized),
             },
-            (is_some & 1) as u8,
+            is_some,
         )
     }
 
@@ -221,7 +221,7 @@ impl Reciprocal {
     /// A non-const-fn version of `new_const()`, wrapping the result in a `CtOption`.
     pub fn new(divisor: Limb) -> CtOption<Self> {
         let (rec, is_some) = Self::new_const(divisor);
-        CtOption::new(rec, Choice::from(is_some))
+        CtOption::new(rec, Choice::from((is_some & 1) as u8))
     }
 }
 

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -3,7 +3,7 @@
 //! (DOI: 10.1109/TC.2010.143, <https://gmplib.org/~tege/division-paper.pdf>).
 use subtle::{Choice, ConditionallySelectable, CtOption};
 
-use crate::{Limb, Uint, WideWord, Word};
+use crate::{CtChoice, Limb, Uint, WideWord, Word};
 
 /// Calculates the reciprocal of the given 32-bit divisor with the highmost bit set.
 #[cfg(target_pointer_width = "32")]
@@ -168,12 +168,13 @@ pub struct Reciprocal {
 impl Reciprocal {
     /// Pre-calculates a reciprocal for a known divisor,
     /// to be used in the single-limb division later.
-    /// Returns the reciprocal, and `Word::MAX` if `divisor != 0` and `0` otherwise.
+    /// Returns the reciprocal, and the truthy value if `divisor != 0`
+    /// and the falsy value otherwise.
     ///
-    /// Note: if the returned flag is `0`, the returned reciprocal object is still self-consistent
+    /// Note: if the returned flag is falsy, the returned reciprocal object is still self-consistent
     /// and can be passed to functions here without causing them to panic,
     /// but the results are naturally not to be used.
-    pub const fn ct_new(divisor: Limb) -> (Self, Word) {
+    pub const fn ct_new(divisor: Limb) -> (Self, CtChoice) {
         // Assuming this is constant-time for primitive types.
         let shift = divisor.0.leading_zeros();
 

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -33,7 +33,7 @@ pub const fn reciprocal(d: Word) -> Word {
     // Hence the `ct_select()`.
     let x = v2.wrapping_add(1);
     let (hi, _lo) = mulhilo(x, d);
-    let hi = Limb::ct_select(Limb(d), Limb(hi), Limb(x).is_nonzero()).0;
+    let hi = Limb::ct_select(Limb(d), Limb(hi), Limb(x).ct_is_nonzero()).0;
 
     v2.wrapping_sub(hi).wrapping_sub(d)
 }
@@ -63,7 +63,7 @@ pub const fn reciprocal(d: Word) -> Word {
     // Hence the `ct_select()`.
     let x = v3.wrapping_add(1);
     let (hi, _lo) = mulhilo(x, d);
-    let hi = Limb::ct_select(Limb(d), Limb(hi), Limb(x).is_nonzero()).0;
+    let hi = Limb::ct_select(Limb(d), Limb(hi), Limb(x).ct_is_nonzero()).0;
 
     v3.wrapping_sub(hi).wrapping_sub(d)
 }
@@ -179,7 +179,7 @@ impl Reciprocal {
         let shift = divisor.0.leading_zeros();
 
         #[allow(trivial_numeric_casts)]
-        let is_some = Limb((Word::BITS - shift) as Word).is_nonzero();
+        let is_some = Limb((Word::BITS - shift) as Word).ct_is_nonzero();
 
         // If `divisor = 0`, shifting `divisor` by `leading_zeros == Word::BITS` will cause a panic.
         // Have to substitute a "bogus" shift in that case.

--- a/src/uint/inv_mod.rs
+++ b/src/uint/inv_mod.rs
@@ -1,5 +1,5 @@
 use super::Uint;
-use crate::{Limb, Word};
+use crate::{CtChoice, Limb, Word};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes 1/`self` mod 2^k as specified in Algorithm 4 from
@@ -31,7 +31,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// `bits` and `modulus_bits` are the bounds on the bit size
     /// of `self` and `modulus`, respectively
     /// (the inversion speed will be proportional to `bits + modulus_bits`).
-    /// Returns `(inverse, Limb::MAX)` if an inverse exists, otherwise `(undefined, Limb::ZERO)`.
+    /// The second element of the tuple is the truthy value if an inverse exists,
+    /// otherwise it is a falsy value.
     ///
     /// **Note:** variable time in `bits` and `modulus_bits`.
     ///
@@ -41,7 +42,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         modulus: Uint<LIMBS>,
         bits: usize,
         modulus_bits: usize,
-    ) -> (Self, Word) {
+    ) -> (Self, CtChoice) {
         debug_assert!(modulus.ct_is_odd() == Word::MAX);
 
         let mut a = *self;
@@ -97,7 +98,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
     /// Returns `(inverse, Word::MAX)` if an inverse exists, otherwise `(undefined, Word::ZERO)`.
-    pub const fn inv_odd_mod(&self, modulus: Uint<LIMBS>) -> (Self, Word) {
+    pub const fn inv_odd_mod(&self, modulus: Uint<LIMBS>) -> (Self, CtChoice) {
         self.inv_odd_mod_bounded(modulus, Uint::<LIMBS>::BITS, Uint::<LIMBS>::BITS)
     }
 }

--- a/src/uint/inv_mod.rs
+++ b/src/uint/inv_mod.rs
@@ -93,7 +93,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         debug_assert!(!a.ct_is_nonzero().is_true_vartime());
 
-        (v, b.ct_eq(&Uint::ONE))
+        (v, Uint::ct_eq(&b, &Uint::ONE))
     }
 
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.

--- a/src/uint/inv_mod.rs
+++ b/src/uint/inv_mod.rs
@@ -28,7 +28,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         x
     }
 
-    /// Computes the multiplicative inverse of `self` mod `modulus`. In other words `self^-1 mod modulus`. Returns `(inverse, 1...1)` if an inverse exists, otherwise `(undefined, 0...0)`. The algorithm is the same as in GMP 6.2.1's `mpn_sec_invert`.
+    /// Computes the multiplicative inverse of `self` mod `modulus`.
+    /// In other words `self^-1 mod modulus`. Returns `(inverse, 1...1)` if an inverse exists,
+    /// otherwise `(undefined, 0...0)`.
+    /// The algorithm is the same as in GMP 6.2.1's `mpn_sec_invert`.
     pub const fn inv_odd_mod(self, modulus: Uint<LIMBS>) -> (Self, Word) {
         debug_assert!(modulus.ct_is_odd() == Word::MAX);
 
@@ -83,7 +86,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         (v, b.ct_not_eq(&Uint::ONE) ^ Word::MAX)
     }
 
-    /// Computes the multiplicative inverse of `self` mod `modulus`. In other words `self^-1 mod modulus`. Returns `None` if the inverse does not exist. The algorithm is the same as in GMP 6.2.1's `mpn_sec_invert`.
+    /// Computes the multiplicative inverse of `self` mod `modulus`.
+    /// In other words `self^-1 mod modulus`. Returns `None` if the inverse does not exist.
+    /// The algorithm is the same as in GMP 6.2.1's `mpn_sec_invert`.
     pub fn inv_odd_mod_option(self, modulus: Uint<LIMBS>) -> CtOption<Self> {
         let (inverse, exists) = self.inv_odd_mod(modulus);
         CtOption::new(inverse, Choice::from((exists == Word::MAX) as u8))
@@ -96,41 +101,44 @@ mod tests {
 
     #[test]
     fn inv_mod2k() {
-        let v = U256::from_be_slice(&[
-            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe,
-            0xff, 0xff, 0xfc, 0x2f,
-        ]);
-        let e = U256::from_be_slice(&[
-            0x36, 0x42, 0xe6, 0xfa, 0xea, 0xac, 0x7c, 0x66, 0x63, 0xb9, 0x3d, 0x3d, 0x6a, 0x0d,
-            0x48, 0x9e, 0x43, 0x4d, 0xdc, 0x01, 0x23, 0xdb, 0x5f, 0xa6, 0x27, 0xc7, 0xf6, 0xe2,
-            0x2d, 0xda, 0xca, 0xcf,
-        ]);
+        let v =
+            U256::from_be_hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f");
+        let e =
+            U256::from_be_hex("3642e6faeaac7c6663b93d3d6a0d489e434ddc0123db5fa627c7f6e22ddacacf");
         let a = v.inv_mod2k(256);
         assert_eq!(e, a);
 
-        let v = U256::from_be_slice(&[
-            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-            0xff, 0xfe, 0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b, 0xbf, 0xd2, 0x5e, 0x8c,
-            0xd0, 0x36, 0x41, 0x41,
-        ]);
-        let e = U256::from_be_slice(&[
-            0x26, 0x17, 0x76, 0xf2, 0x9b, 0x6b, 0x10, 0x6c, 0x76, 0x80, 0xcf, 0x3e, 0xd8, 0x30,
-            0x54, 0xa1, 0xaf, 0x5a, 0xe5, 0x37, 0xcb, 0x46, 0x13, 0xdb, 0xb4, 0xf2, 0x00, 0x99,
-            0xaa, 0x77, 0x4e, 0xc1,
-        ]);
+        let v =
+            U256::from_be_hex("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+        let e =
+            U256::from_be_hex("261776f29b6b106c7680cf3ed83054a1af5ae537cb4613dbb4f20099aa774ec1");
         let a = v.inv_mod2k(256);
         assert_eq!(e, a);
     }
 
     #[test]
     fn test_invert() {
-        let a = U1024::from_be_hex("000225E99153B467A5B451979A3F451DAEF3BF8D6C6521D2FA24BBB17F29544E347A412B065B75A351EA9719E2430D2477B11CC9CF9C1AD6EDEE26CB15F463F8BCC72EF87EA30288E95A48AA792226CEC959DCB0672D8F9D80A54CBBEA85CAD8382EC224DEB2F5784E62D0CC2F81C2E6AD14EBABE646D6764B30C32B87688985");
-        let m = U1024::from_be_hex("D509E7854ABDC81921F669F1DC6F61359523F3949803E58ED4EA8BC16483DC6F37BFE27A9AC9EEA2969B357ABC5C0EE214BE16A7D4C58FC620D5B5A20AFF001AD198D3155E5799DC4EA76652D64983A7E130B5EACEBAC768D28D589C36EC749C558D0B64E37CD0775C0D0104AE7D98BA23C815185DD43CD8B16292FD94156767");
+        let a = U1024::from_be_hex(concat![
+            "000225E99153B467A5B451979A3F451DAEF3BF8D6C6521D2FA24BBB17F29544E",
+            "347A412B065B75A351EA9719E2430D2477B11CC9CF9C1AD6EDEE26CB15F463F8",
+            "BCC72EF87EA30288E95A48AA792226CEC959DCB0672D8F9D80A54CBBEA85CAD8",
+            "382EC224DEB2F5784E62D0CC2F81C2E6AD14EBABE646D6764B30C32B87688985"
+        ]);
+        let m = U1024::from_be_hex(concat![
+            "D509E7854ABDC81921F669F1DC6F61359523F3949803E58ED4EA8BC16483DC6F",
+            "37BFE27A9AC9EEA2969B357ABC5C0EE214BE16A7D4C58FC620D5B5A20AFF001A",
+            "D198D3155E5799DC4EA76652D64983A7E130B5EACEBAC768D28D589C36EC749C",
+            "558D0B64E37CD0775C0D0104AE7D98BA23C815185DD43CD8B16292FD94156767"
+        ]);
 
         let res = a.inv_odd_mod_option(m);
 
-        let expected = U1024::from_be_hex("B03623284B0EBABCABD5C5881893320281460C0A8E7BF4BFDCFFCBCCBF436A55D364235C8171E46C7D21AAD0680676E57274A8FDA6D12768EF961CACDD2DAE5788D93DA5EB8EDC391EE3726CDCF4613C539F7D23E8702200CB31B5ED5B06E5CA3E520968399B4017BF98A864FABA2B647EFC4998B56774D4F2CB026BC024A336");
+        let expected = U1024::from_be_hex(concat![
+            "B03623284B0EBABCABD5C5881893320281460C0A8E7BF4BFDCFFCBCCBF436A55",
+            "D364235C8171E46C7D21AAD0680676E57274A8FDA6D12768EF961CACDD2DAE57",
+            "88D93DA5EB8EDC391EE3726CDCF4613C539F7D23E8702200CB31B5ED5B06E5CA",
+            "3E520968399B4017BF98A864FABA2B647EFC4998B56774D4F2CB026BC024A336"
+        ]);
         assert_eq!(res.unwrap(), expected);
     }
 

--- a/src/uint/inv_mod.rs
+++ b/src/uint/inv_mod.rs
@@ -1,5 +1,3 @@
-use subtle::{Choice, CtOption};
-
 use super::Uint;
 use crate::{Limb, Word};
 
@@ -28,22 +26,33 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         x
     }
 
-    /// Computes the multiplicative inverse of `self` mod `modulus`.
-    /// In other words `self^-1 mod modulus`. Returns `(inverse, 1...1)` if an inverse exists,
-    /// otherwise `(undefined, 0...0)`.
+    /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
+    /// In other words `self^-1 mod modulus`.
+    /// `bits` and `modulus_bits` are the bounds on the bit size
+    /// of `self` and `modulus`, respectively
+    /// (the inversion speed will be proportional to `bits + modulus_bits`).
+    /// Returns `(inverse, Limb::MAX)` if an inverse exists, otherwise `(undefined, Limb::ZERO)`.
+    ///
+    /// **Note:** variable time in `bits` and `modulus_bits`.
+    ///
     /// The algorithm is the same as in GMP 6.2.1's `mpn_sec_invert`.
-    pub const fn inv_odd_mod(self, modulus: Uint<LIMBS>) -> (Self, Word) {
+    pub const fn inv_odd_mod_bounded(
+        &self,
+        modulus: Uint<LIMBS>,
+        bits: usize,
+        modulus_bits: usize,
+    ) -> (Self, Word) {
         debug_assert!(modulus.ct_is_odd() == Word::MAX);
 
-        let mut a = self;
+        let mut a = *self;
 
         let mut u = Uint::ONE;
         let mut v = Uint::ZERO;
 
         let mut b = modulus;
 
-        // TODO: This can be lower if `self` is known to be small.
-        let bit_size = 2 * Uint::<LIMBS>::BITS;
+        // `bit_size` can be anything >= `self.bits()` + `modulus.bits()`, setting to the minimum.
+        let bit_size = bits + modulus_bits;
 
         let mut m1hp = modulus;
         let (m1hp_new, carry) = m1hp.shr_1();
@@ -86,18 +95,16 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         (v, b.ct_not_eq(&Uint::ONE) ^ Word::MAX)
     }
 
-    /// Computes the multiplicative inverse of `self` mod `modulus`.
-    /// In other words `self^-1 mod modulus`. Returns `None` if the inverse does not exist.
-    /// The algorithm is the same as in GMP 6.2.1's `mpn_sec_invert`.
-    pub fn inv_odd_mod_option(self, modulus: Uint<LIMBS>) -> CtOption<Self> {
-        let (inverse, exists) = self.inv_odd_mod(modulus);
-        CtOption::new(inverse, Choice::from((exists == Word::MAX) as u8))
+    /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
+    /// Returns `(inverse, Word::MAX)` if an inverse exists, otherwise `(undefined, Word::ZERO)`.
+    pub const fn inv_odd_mod(&self, modulus: Uint<LIMBS>) -> (Self, Word) {
+        self.inv_odd_mod_bounded(modulus, Uint::<LIMBS>::BITS, Uint::<LIMBS>::BITS)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{U1024, U256, U64};
+    use crate::{Word, U1024, U256, U64};
 
     #[test]
     fn inv_mod2k() {
@@ -131,7 +138,7 @@ mod tests {
             "558D0B64E37CD0775C0D0104AE7D98BA23C815185DD43CD8B16292FD94156767"
         ]);
 
-        let res = a.inv_odd_mod_option(m);
+        let (res, is_some) = a.inv_odd_mod(m);
 
         let expected = U1024::from_be_hex(concat![
             "B03623284B0EBABCABD5C5881893320281460C0A8E7BF4BFDCFFCBCCBF436A55",
@@ -139,7 +146,35 @@ mod tests {
             "88D93DA5EB8EDC391EE3726CDCF4613C539F7D23E8702200CB31B5ED5B06E5CA",
             "3E520968399B4017BF98A864FABA2B647EFC4998B56774D4F2CB026BC024A336"
         ]);
-        assert_eq!(res.unwrap(), expected);
+        assert_eq!(is_some, Word::MAX);
+        assert_eq!(res, expected);
+    }
+
+    #[test]
+    fn test_invert_bounded() {
+        let a = U1024::from_be_hex(concat![
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "347A412B065B75A351EA9719E2430D2477B11CC9CF9C1AD6EDEE26CB15F463F8",
+            "BCC72EF87EA30288E95A48AA792226CEC959DCB0672D8F9D80A54CBBEA85CAD8",
+            "382EC224DEB2F5784E62D0CC2F81C2E6AD14EBABE646D6764B30C32B87688985"
+        ]);
+        let m = U1024::from_be_hex(concat![
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "D198D3155E5799DC4EA76652D64983A7E130B5EACEBAC768D28D589C36EC749C",
+            "558D0B64E37CD0775C0D0104AE7D98BA23C815185DD43CD8B16292FD94156767"
+        ]);
+
+        let (res, is_some) = a.inv_odd_mod_bounded(m, 768, 512);
+
+        let expected = U1024::from_be_hex(concat![
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0DCC94E2FE509E6EBBA0825645A38E73EF85D5927C79C1AD8FFE7C8DF9A822FA",
+            "09EB396A21B1EF05CBE51E1A8EF284EF01EBDD36A9A4EA17039D8EEFDD934768"
+        ]);
+        assert_eq!(is_some, Word::MAX);
+        assert_eq!(res, expected);
     }
 
     #[test]
@@ -147,9 +182,10 @@ mod tests {
         let a = U64::from(3u64);
         let m = U64::from(13u64);
 
-        let res = a.inv_odd_mod_option(m);
+        let (res, is_some) = a.inv_odd_mod(m);
 
-        assert_eq!(U64::from(9u64), res.unwrap());
+        assert_eq!(is_some, Word::MAX);
+        assert_eq!(U64::from(9u64), res);
     }
 
     #[test]
@@ -157,8 +193,8 @@ mod tests {
         let a = U64::from(14u64);
         let m = U64::from(49u64);
 
-        let res = a.inv_odd_mod_option(m);
+        let (_res, is_some) = a.inv_odd_mod(m);
 
-        assert!(res.is_none().unwrap_u8() == 1);
+        assert_eq!(is_some, 0);
     }
 }

--- a/src/uint/inv_mod.rs
+++ b/src/uint/inv_mod.rs
@@ -40,7 +40,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mut b = modulus;
 
         // TODO: This can be lower if `self` is known to be small.
-        let bit_size = 2 * LIMBS * 64;
+        let bit_size = 2 * Uint::<LIMBS>::BITS;
 
         let mut m1hp = modulus;
         let (m1hp_new, carry) = m1hp.shr_1();

--- a/src/uint/inv_mod.rs
+++ b/src/uint/inv_mod.rs
@@ -91,9 +91,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             i += 1;
         }
 
-        debug_assert!(a.ct_cmp(&Uint::ZERO) == 0);
+        debug_assert!(a.ct_is_nonzero() == 0);
 
-        (v, b.ct_not_eq(&Uint::ONE) ^ Word::MAX)
+        (v, b.ct_eq(&Uint::ONE))
     }
 
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.

--- a/src/uint/modular.rs
+++ b/src/uint/modular.rs
@@ -64,8 +64,8 @@ mod tests {
         // Divide the value R by R, which should equal 1
         assert_eq!(
             montgomery_reduction::<{ Modulus2::LIMBS }>(
-                (Modulus2::R, Uint::ZERO),
-                Modulus2::MODULUS,
+                &(Modulus2::R, Uint::ZERO),
+                &Modulus2::MODULUS,
                 Modulus2::MOD_NEG_INV
             ),
             Uint::ONE
@@ -77,8 +77,8 @@ mod tests {
         // Divide the value R^2 by R, which should equal R
         assert_eq!(
             montgomery_reduction::<{ Modulus2::LIMBS }>(
-                (Modulus2::R2, Uint::ZERO),
-                Modulus2::MODULUS,
+                &(Modulus2::R2, Uint::ZERO),
+                &Modulus2::MODULUS,
                 Modulus2::MOD_NEG_INV
             ),
             Modulus2::R
@@ -91,8 +91,8 @@ mod tests {
         let (hi, lo) = Modulus2::R.square().split();
         assert_eq!(
             montgomery_reduction::<{ Modulus2::LIMBS }>(
-                (lo, hi),
-                Modulus2::MODULUS,
+                &(lo, hi),
+                &Modulus2::MODULUS,
                 Modulus2::MOD_NEG_INV
             ),
             Modulus2::R
@@ -107,8 +107,8 @@ mod tests {
         let product = x.mul_wide(&Modulus2::R);
         assert_eq!(
             montgomery_reduction::<{ Modulus2::LIMBS }>(
-                product,
-                Modulus2::MODULUS,
+                &product,
+                &Modulus2::MODULUS,
                 Modulus2::MOD_NEG_INV
             ),
             x
@@ -131,8 +131,8 @@ mod tests {
 
         assert_eq!(
             montgomery_reduction::<{ Modulus2::LIMBS }>(
-                product,
-                Modulus2::MODULUS,
+                &product,
+                &Modulus2::MODULUS,
                 Modulus2::MOD_NEG_INV
             ),
             lo
@@ -143,7 +143,7 @@ mod tests {
     fn test_new_retrieve() {
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
-        let x_mod = Residue::<Modulus2, { Modulus2::LIMBS }>::new(x);
+        let x_mod = Residue::<Modulus2, { Modulus2::LIMBS }>::new(&x);
 
         // Confirm that when creating a Modular and retrieving the value, that it equals the original
         assert_eq!(x, x_mod.retrieve());
@@ -154,7 +154,7 @@ mod tests {
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
         assert_eq!(
-            Residue::<Modulus2, { Modulus2::LIMBS }>::new(x),
+            Residue::<Modulus2, { Modulus2::LIMBS }>::new(&x),
             const_residue!(x, Modulus2)
         );
     }

--- a/src/uint/modular/constant_mod.rs
+++ b/src/uint/modular/constant_mod.rs
@@ -41,7 +41,7 @@ pub trait ResidueParams<const LIMBS: usize>: Copy {
     /// R^3, used to perform a multiplicative inverse
     const R3: Uint<LIMBS>;
     /// The lowest limbs of -(MODULUS^-1) mod R
-    // We only need the LSB because during reduction this value is multiplied modulo 2**64.
+    // We only need the LSB because during reduction this value is multiplied modulo 2**Limb::BITS.
     const MOD_NEG_INV: Limb;
 }
 

--- a/src/uint/modular/constant_mod.rs
+++ b/src/uint/modular/constant_mod.rs
@@ -109,7 +109,7 @@ impl<MOD: ResidueParams<LIMBS> + Copy, const LIMBS: usize> ConditionallySelectab
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> ConstantTimeEq for Residue<MOD, LIMBS> {
     fn ct_eq(&self, other: &Self) -> Choice {
-        self.montgomery_form.ct_eq(&other.montgomery_form)
+        ConstantTimeEq::ct_eq(&self.montgomery_form, &other.montgomery_form)
     }
 }
 

--- a/src/uint/modular/constant_mod.rs
+++ b/src/uint/modular/constant_mod.rs
@@ -69,24 +69,22 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     };
 
     /// Instantiates a new `Residue` that represents this `integer` mod `MOD`.
-    pub const fn new(integer: Uint<LIMBS>) -> Self {
-        let mut modular_integer = Residue {
-            montgomery_form: integer,
-            phantom: PhantomData,
-        };
-
+    pub const fn new(integer: &Uint<LIMBS>) -> Self {
         let product = integer.mul_wide(&MOD::R2);
-        modular_integer.montgomery_form =
-            montgomery_reduction::<LIMBS>(product, MOD::MODULUS, MOD::MOD_NEG_INV);
+        let montgomery_form =
+            montgomery_reduction::<LIMBS>(&product, &MOD::MODULUS, MOD::MOD_NEG_INV);
 
-        modular_integer
+        Self {
+            montgomery_form,
+            phantom: PhantomData,
+        }
     }
 
     /// Retrieves the integer currently encoded in this `Residue`, guaranteed to be reduced.
     pub const fn retrieve(&self) -> Uint<LIMBS> {
         montgomery_reduction::<LIMBS>(
-            (self.montgomery_form, Uint::ZERO),
-            MOD::MODULUS,
+            &(self.montgomery_form, Uint::ZERO),
+            &MOD::MODULUS,
             MOD::MOD_NEG_INV,
         )
     }

--- a/src/uint/modular/constant_mod/const_inv.rs
+++ b/src/uint/modular/constant_mod/const_inv.rs
@@ -2,16 +2,16 @@ use core::marker::PhantomData;
 
 use subtle::{Choice, CtOption};
 
-use crate::{modular::inv::inv_montgomery_form, traits::Invert, NonZero, Word};
+use crate::{modular::inv::inv_montgomery_form, traits::Invert, CtChoice, NonZero};
 
 use super::{Residue, ResidueParams};
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// Computes the residue `self^-1` representing the multiplicative inverse of `self`.
     /// I.e. `self * self^-1 = 1`.
-    /// If the number was invertible, the second element of the tuple is `1`,
-    /// otherwise it is `0` (in which case the first element's value is unspecified).
-    pub const fn invert(&self) -> (Self, Word) {
+    /// If the number was invertible, the second element of the tuple is the truthy value,
+    /// otherwise it is the falsy value (in which case the first element's value is unspecified).
+    pub const fn invert(&self) -> (Self, CtChoice) {
         let (montgomery_form, is_some) = inv_montgomery_form(
             self.montgomery_form,
             MOD::MODULUS,

--- a/src/uint/modular/constant_mod/const_inv.rs
+++ b/src/uint/modular/constant_mod/const_inv.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use subtle::{Choice, CtOption};
+use subtle::CtOption;
 
 use crate::{modular::inv::inv_montgomery_form, traits::Invert, CtChoice, NonZero};
 
@@ -32,7 +32,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Invert for Residue<MOD, LIMB
     type Output = CtOption<Self>;
     fn invert(&self) -> Self::Output {
         let (value, is_some) = self.invert();
-        CtOption::new(value, Choice::from((is_some & 1) as u8))
+        CtOption::new(value, is_some.into())
     }
 }
 

--- a/src/uint/modular/constant_mod/const_inv.rs
+++ b/src/uint/modular/constant_mod/const_inv.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 
 use subtle::{Choice, CtOption};
 
-use crate::{modular::inv::inv_montgomery_form, traits::Invert, NonZero};
+use crate::{modular::inv::inv_montgomery_form, traits::Invert, NonZero, Word};
 
 use super::{Residue, ResidueParams};
 
@@ -11,7 +11,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// I.e. `self * self^-1 = 1`.
     /// If the number was invertible, the second element of the tuple is `1`,
     /// otherwise it is `0` (in which case the first element's value is unspecified).
-    pub const fn invert(&self) -> (Self, u8) {
+    pub const fn invert(&self) -> (Self, Word) {
         let (montgomery_form, is_some) = inv_montgomery_form(
             self.montgomery_form,
             MOD::MODULUS,
@@ -24,7 +24,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
             phantom: PhantomData,
         };
 
-        (value, (is_some & 1) as u8)
+        (value, is_some)
     }
 }
 
@@ -32,7 +32,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Invert for Residue<MOD, LIMB
     type Output = CtOption<Self>;
     fn invert(&self) -> Self::Output {
         let (value, is_some) = self.invert();
-        CtOption::new(value, Choice::from(is_some))
+        CtOption::new(value, Choice::from((is_some & 1) as u8))
     }
 }
 

--- a/src/uint/modular/constant_mod/const_inv.rs
+++ b/src/uint/modular/constant_mod/const_inv.rs
@@ -13,8 +13,8 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
     pub const fn invert(&self) -> (Self, CtChoice) {
         let (montgomery_form, is_some) = inv_montgomery_form(
-            self.montgomery_form,
-            MOD::MODULUS,
+            &self.montgomery_form,
+            &MOD::MODULUS,
             &MOD::R3,
             MOD::MOD_NEG_INV,
         );

--- a/src/uint/modular/constant_mod/const_mul.rs
+++ b/src/uint/modular/constant_mod/const_mul.rs
@@ -17,7 +17,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
             montgomery_form: mul_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
-                MOD::MODULUS,
+                &MOD::MODULUS,
                 MOD::MOD_NEG_INV,
             ),
             phantom: PhantomData,
@@ -80,7 +80,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Square for Residue<MOD, LIMB
         Self {
             montgomery_form: square_montgomery_form(
                 &self.montgomery_form,
-                MOD::MODULUS,
+                &MOD::MODULUS,
                 MOD::MOD_NEG_INV,
             ),
             phantom: PhantomData,

--- a/src/uint/modular/constant_mod/const_neg.rs
+++ b/src/uint/modular/constant_mod/const_neg.rs
@@ -12,7 +12,14 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Neg for Residue<MOD, LIMBS> {
     type Output = Self;
     fn neg(self) -> Self {
-        (&self).neg()
+        Residue::neg(&self)
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Neg for &Residue<MOD, LIMBS> {
+    type Output = Residue<MOD, LIMBS>;
+    fn neg(self) -> Residue<MOD, LIMBS> {
+        Residue::neg(self)
     }
 }
 

--- a/src/uint/modular/constant_mod/const_pow.rs
+++ b/src/uint/modular/constant_mod/const_pow.rs
@@ -20,11 +20,11 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     ) -> Residue<MOD, LIMBS> {
         Self {
             montgomery_form: pow_montgomery_form(
-                self.montgomery_form,
+                &self.montgomery_form,
                 exponent,
                 exponent_bits,
-                MOD::MODULUS,
-                MOD::R,
+                &MOD::MODULUS,
+                &MOD::R,
                 MOD::MOD_NEG_INV,
             ),
             phantom: core::marker::PhantomData,

--- a/src/uint/modular/constant_mod/macros.rs
+++ b/src/uint/modular/constant_mod/macros.rs
@@ -27,8 +27,8 @@ macro_rules! impl_modulus {
             );
             const R3: $crate::Uint<{ nlimbs!(<$uint_type>::BITS) }> =
                 $crate::uint::modular::reduction::montgomery_reduction(
-                    Self::R2.square_wide(),
-                    Self::MODULUS,
+                    &Self::R2.square_wide(),
+                    &Self::MODULUS,
                     Self::MOD_NEG_INV,
                 );
         }
@@ -41,7 +41,7 @@ macro_rules! impl_modulus {
 macro_rules! const_residue {
     ($variable:ident, $modulus:ident) => {
         $crate::uint::modular::constant_mod::Residue::<$modulus, { $modulus::LIMBS }>::new(
-            $variable,
+            &$variable,
         )
     };
 }

--- a/src/uint/modular/inv.rs
+++ b/src/uint/modular/inv.rs
@@ -1,14 +1,14 @@
 use crate::{modular::reduction::montgomery_reduction, CtChoice, Limb, Uint};
 
 pub const fn inv_montgomery_form<const LIMBS: usize>(
-    x: Uint<LIMBS>,
-    modulus: Uint<LIMBS>,
+    x: &Uint<LIMBS>,
+    modulus: &Uint<LIMBS>,
     r3: &Uint<LIMBS>,
     mod_neg_inv: Limb,
 ) -> (Uint<LIMBS>, CtChoice) {
     let (inverse, is_some) = x.inv_odd_mod(modulus);
     (
-        montgomery_reduction(inverse.mul_wide(r3), modulus, mod_neg_inv),
+        montgomery_reduction(&inverse.mul_wide(r3), modulus, mod_neg_inv),
         is_some,
     )
 }

--- a/src/uint/modular/inv.rs
+++ b/src/uint/modular/inv.rs
@@ -1,14 +1,14 @@
-use crate::{modular::reduction::montgomery_reduction, Limb, Uint, Word};
+use crate::{modular::reduction::montgomery_reduction, CtChoice, Limb, Uint};
 
 pub const fn inv_montgomery_form<const LIMBS: usize>(
     x: Uint<LIMBS>,
     modulus: Uint<LIMBS>,
     r3: &Uint<LIMBS>,
     mod_neg_inv: Limb,
-) -> (Uint<LIMBS>, Word) {
-    let (inverse, error) = x.inv_odd_mod(modulus);
+) -> (Uint<LIMBS>, CtChoice) {
+    let (inverse, is_some) = x.inv_odd_mod(modulus);
     (
         montgomery_reduction(inverse.mul_wide(r3), modulus, mod_neg_inv),
-        error,
+        is_some,
     )
 }

--- a/src/uint/modular/mul.rs
+++ b/src/uint/modular/mul.rs
@@ -5,18 +5,18 @@ use super::reduction::montgomery_reduction;
 pub(crate) const fn mul_montgomery_form<const LIMBS: usize>(
     a: &Uint<LIMBS>,
     b: &Uint<LIMBS>,
-    modulus: Uint<LIMBS>,
+    modulus: &Uint<LIMBS>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {
     let product = a.mul_wide(b);
-    montgomery_reduction::<LIMBS>(product, modulus, mod_neg_inv)
+    montgomery_reduction::<LIMBS>(&product, modulus, mod_neg_inv)
 }
 
 pub(crate) const fn square_montgomery_form<const LIMBS: usize>(
     a: &Uint<LIMBS>,
-    modulus: Uint<LIMBS>,
+    modulus: &Uint<LIMBS>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {
     let product = a.square_wide();
-    montgomery_reduction::<LIMBS>(product, modulus, mod_neg_inv)
+    montgomery_reduction::<LIMBS>(&product, modulus, mod_neg_inv)
 }

--- a/src/uint/modular/pow.rs
+++ b/src/uint/modular/pow.rs
@@ -7,26 +7,26 @@ use super::mul::{mul_montgomery_form, square_montgomery_form};
 ///
 /// NOTE: this value is leaked in the time pattern.
 pub const fn pow_montgomery_form<const LIMBS: usize>(
-    x: Uint<LIMBS>,
+    x: &Uint<LIMBS>,
     exponent: &Uint<LIMBS>,
     exponent_bits: usize,
-    modulus: Uint<LIMBS>,
-    r: Uint<LIMBS>,
+    modulus: &Uint<LIMBS>,
+    r: &Uint<LIMBS>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {
     if exponent_bits == 0 {
-        return r; // 1 in Montgomery form
+        return *r; // 1 in Montgomery form
     }
 
     const WINDOW: usize = 4;
     const WINDOW_MASK: Word = (1 << WINDOW) - 1;
 
     // powers[i] contains x^i
-    let mut powers = [r; 1 << WINDOW];
-    powers[1] = x;
+    let mut powers = [*r; 1 << WINDOW];
+    powers[1] = *x;
     let mut i = 2;
     while i < powers.len() {
-        powers[i] = mul_montgomery_form(&powers[i - 1], &x, modulus, mod_neg_inv);
+        powers[i] = mul_montgomery_form(&powers[i - 1], x, modulus, mod_neg_inv);
         i += 1;
     }
 
@@ -35,7 +35,7 @@ pub const fn pow_montgomery_form<const LIMBS: usize>(
     let starting_window = starting_bit_in_limb / WINDOW;
     let starting_window_mask = (1 << (starting_bit_in_limb % WINDOW + 1)) - 1;
 
-    let mut z = r; // 1 in Montgomery form
+    let mut z = *r; // 1 in Montgomery form
 
     let mut limb_num = starting_limb + 1;
     while limb_num > 0 {
@@ -67,7 +67,7 @@ pub const fn pow_montgomery_form<const LIMBS: usize>(
             let mut i = 1;
             while i < 1 << WINDOW {
                 let choice = Limb::ct_eq(Limb(i as Word), Limb(idx));
-                power = Uint::<LIMBS>::ct_select(power, powers[i], choice);
+                power = Uint::<LIMBS>::ct_select(&power, &powers[i], choice);
                 i += 1;
             }
 

--- a/src/uint/modular/reduction.rs
+++ b/src/uint/modular/reduction.rs
@@ -1,4 +1,4 @@
-use crate::{Limb, Uint, WideWord, Word};
+use crate::{CtChoice, Limb, Uint, WideWord, Word};
 
 /// Algorithm 14.32 in Handbook of Applied Cryptography (https://cacr.uwaterloo.ca/hac/about/chap14.pdf)
 pub(crate) const fn montgomery_reduction<const LIMBS: usize>(
@@ -49,8 +49,7 @@ pub(crate) const fn montgomery_reduction<const LIMBS: usize>(
 
     // Division is simply taking the upper half of the limbs
     // Final reduction (at this point, the value is at most 2 * modulus)
-    debug_assert!(meta_carry == 0 || meta_carry == 1);
-    let must_reduce = (meta_carry as Word).wrapping_neg() | !Uint::ct_gt(modulus, &upper);
+    let must_reduce = CtChoice::from_lsb(meta_carry as Word).or(Uint::ct_gt(modulus, &upper).not());
     upper = upper.wrapping_sub(&Uint::ct_select(&Uint::ZERO, modulus, must_reduce));
 
     upper

--- a/src/uint/modular/reduction.rs
+++ b/src/uint/modular/reduction.rs
@@ -8,7 +8,7 @@ pub(crate) const fn montgomery_reduction<const LIMBS: usize>(
 ) -> Uint<LIMBS> {
     let (mut lower, mut upper) = lower_upper;
 
-    let mut meta_carry = 0;
+    let mut meta_carry: WideWord = 0;
 
     let mut i = 0;
     while i < LIMBS {
@@ -49,8 +49,9 @@ pub(crate) const fn montgomery_reduction<const LIMBS: usize>(
 
     // Division is simply taking the upper half of the limbs
     // Final reduction (at this point, the value is at most 2 * modulus)
-    let must_reduce = (meta_carry as Word).saturating_mul(Word::MAX)
-        | ((upper.ct_cmp(&modulus) != -1) as Word).saturating_mul(Word::MAX);
+    debug_assert!(meta_carry == 0 || meta_carry == 1);
+    let must_reduce = (meta_carry as Word).wrapping_neg()
+        | ((upper.ct_cmp(&modulus) != -1) as Word).wrapping_neg();
     upper = upper.wrapping_sub(&Uint::ct_select(Uint::ZERO, modulus, must_reduce));
 
     upper

--- a/src/uint/modular/reduction.rs
+++ b/src/uint/modular/reduction.rs
@@ -50,8 +50,7 @@ pub(crate) const fn montgomery_reduction<const LIMBS: usize>(
     // Division is simply taking the upper half of the limbs
     // Final reduction (at this point, the value is at most 2 * modulus)
     debug_assert!(meta_carry == 0 || meta_carry == 1);
-    let must_reduce = (meta_carry as Word).wrapping_neg()
-        | ((upper.ct_cmp(&modulus) != -1) as Word).wrapping_neg();
+    let must_reduce = (meta_carry as Word).wrapping_neg() | !Uint::ct_gt(&modulus, &upper);
     upper = upper.wrapping_sub(&Uint::ct_select(Uint::ZERO, modulus, must_reduce));
 
     upper

--- a/src/uint/modular/reduction.rs
+++ b/src/uint/modular/reduction.rs
@@ -2,11 +2,11 @@ use crate::{Limb, Uint, WideWord, Word};
 
 /// Algorithm 14.32 in Handbook of Applied Cryptography (https://cacr.uwaterloo.ca/hac/about/chap14.pdf)
 pub(crate) const fn montgomery_reduction<const LIMBS: usize>(
-    lower_upper: (Uint<LIMBS>, Uint<LIMBS>),
-    modulus: Uint<LIMBS>,
+    lower_upper: &(Uint<LIMBS>, Uint<LIMBS>),
+    modulus: &Uint<LIMBS>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {
-    let (mut lower, mut upper) = lower_upper;
+    let (mut lower, mut upper) = *lower_upper;
 
     let mut meta_carry: WideWord = 0;
 
@@ -50,8 +50,8 @@ pub(crate) const fn montgomery_reduction<const LIMBS: usize>(
     // Division is simply taking the upper half of the limbs
     // Final reduction (at this point, the value is at most 2 * modulus)
     debug_assert!(meta_carry == 0 || meta_carry == 1);
-    let must_reduce = (meta_carry as Word).wrapping_neg() | !Uint::ct_gt(&modulus, &upper);
-    upper = upper.wrapping_sub(&Uint::ct_select(Uint::ZERO, modulus, must_reduce));
+    let must_reduce = (meta_carry as Word).wrapping_neg() | !Uint::ct_gt(modulus, &upper);
+    upper = upper.wrapping_sub(&Uint::ct_select(&Uint::ZERO, modulus, must_reduce));
 
     upper
 }

--- a/src/uint/modular/runtime_mod.rs
+++ b/src/uint/modular/runtime_mod.rs
@@ -27,7 +27,7 @@ pub struct DynResidueParams<const LIMBS: usize> {
     // R^3, used to compute the multiplicative inverse
     r3: Uint<LIMBS>,
     // The lowest limbs of -(MODULUS^-1) mod R
-    // We only need the LSB because during reduction this value is multiplied modulo 2**64.
+    // We only need the LSB because during reduction this value is multiplied modulo 2**Limb::BITS.
     mod_neg_inv: Limb,
 }
 

--- a/src/uint/modular/runtime_mod.rs
+++ b/src/uint/modular/runtime_mod.rs
@@ -33,15 +33,15 @@ pub struct DynResidueParams<const LIMBS: usize> {
 
 impl<const LIMBS: usize> DynResidueParams<LIMBS> {
     /// Instantiates a new set of `ResidueParams` representing the given `modulus`.
-    pub fn new(modulus: Uint<LIMBS>) -> Self {
-        let r = Uint::MAX.ct_rem(&modulus).0.wrapping_add(&Uint::ONE);
-        let r2 = Uint::ct_rem_wide(r.square_wide(), &modulus).0;
+    pub fn new(modulus: &Uint<LIMBS>) -> Self {
+        let r = Uint::MAX.ct_rem(modulus).0.wrapping_add(&Uint::ONE);
+        let r2 = Uint::ct_rem_wide(r.square_wide(), modulus).0;
         let mod_neg_inv =
             Limb(Word::MIN.wrapping_sub(modulus.inv_mod2k(Word::BITS as usize).limbs[0].0));
-        let r3 = montgomery_reduction(r2.square_wide(), modulus, mod_neg_inv);
+        let r3 = montgomery_reduction(&r2.square_wide(), modulus, mod_neg_inv);
 
         Self {
-            modulus,
+            modulus: *modulus,
             r,
             r2,
             r3,
@@ -59,24 +59,25 @@ pub struct DynResidue<const LIMBS: usize> {
 
 impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// Instantiates a new `Residue` that represents this `integer` mod `MOD`.
-    pub const fn new(integer: Uint<LIMBS>, residue_params: DynResidueParams<LIMBS>) -> Self {
-        let mut modular_integer = Self {
-            montgomery_form: integer,
-            residue_params,
-        };
-
+    pub const fn new(integer: &Uint<LIMBS>, residue_params: DynResidueParams<LIMBS>) -> Self {
         let product = integer.mul_wide(&residue_params.r2);
-        modular_integer.montgomery_form =
-            montgomery_reduction(product, residue_params.modulus, residue_params.mod_neg_inv);
+        let montgomery_form = montgomery_reduction(
+            &product,
+            &residue_params.modulus,
+            residue_params.mod_neg_inv,
+        );
 
-        modular_integer
+        Self {
+            montgomery_form,
+            residue_params,
+        }
     }
 
     /// Retrieves the integer currently encoded in this `Residue`, guaranteed to be reduced.
     pub const fn retrieve(&self) -> Uint<LIMBS> {
         montgomery_reduction(
-            (self.montgomery_form, Uint::ZERO),
-            self.residue_params.modulus,
+            &(self.montgomery_form, Uint::ZERO),
+            &self.residue_params.modulus,
             self.residue_params.mod_neg_inv,
         )
     }

--- a/src/uint/modular/runtime_mod/runtime_add.rs
+++ b/src/uint/modular/runtime_mod/runtime_add.rs
@@ -70,17 +70,17 @@ mod tests {
 
     #[test]
     fn add_overflow() {
-        let params = DynResidueParams::new(U256::from_be_hex(
+        let params = DynResidueParams::new(&U256::from_be_hex(
             "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
         ));
 
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
-        let mut x_mod = DynResidue::new(x, params);
+        let mut x_mod = DynResidue::new(&x, params);
 
         let y =
             U256::from_be_hex("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251");
-        let y_mod = DynResidue::new(y, params);
+        let y_mod = DynResidue::new(&y, params);
 
         x_mod += &y_mod;
 

--- a/src/uint/modular/runtime_mod/runtime_inv.rs
+++ b/src/uint/modular/runtime_mod/runtime_inv.rs
@@ -1,6 +1,6 @@
 use subtle::{Choice, CtOption};
 
-use crate::{modular::inv::inv_montgomery_form, traits::Invert};
+use crate::{modular::inv::inv_montgomery_form, traits::Invert, Word};
 
 use super::DynResidue;
 
@@ -9,7 +9,7 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// I.e. `self * self^-1 = 1`.
     /// If the number was invertible, the second element of the tuple is `1`,
     /// otherwise it is `0` (in which case the first element's value is unspecified).
-    pub const fn invert(&self) -> (Self, u8) {
+    pub const fn invert(&self) -> (Self, Word) {
         let (montgomery_form, is_some) = inv_montgomery_form(
             self.montgomery_form,
             self.residue_params.modulus,
@@ -22,7 +22,7 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
             residue_params: self.residue_params,
         };
 
-        (value, (is_some & 1) as u8)
+        (value, is_some)
     }
 }
 
@@ -30,6 +30,6 @@ impl<const LIMBS: usize> Invert for DynResidue<LIMBS> {
     type Output = CtOption<Self>;
     fn invert(&self) -> Self::Output {
         let (value, is_some) = self.invert();
-        CtOption::new(value, Choice::from(is_some))
+        CtOption::new(value, Choice::from((is_some & 1) as u8))
     }
 }

--- a/src/uint/modular/runtime_mod/runtime_inv.rs
+++ b/src/uint/modular/runtime_mod/runtime_inv.rs
@@ -11,8 +11,8 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
     pub const fn invert(&self) -> (Self, CtChoice) {
         let (montgomery_form, is_some) = inv_montgomery_form(
-            self.montgomery_form,
-            self.residue_params.modulus,
+            &self.montgomery_form,
+            &self.residue_params.modulus,
             &self.residue_params.r3,
             self.residue_params.mod_neg_inv,
         );

--- a/src/uint/modular/runtime_mod/runtime_inv.rs
+++ b/src/uint/modular/runtime_mod/runtime_inv.rs
@@ -1,15 +1,15 @@
 use subtle::{Choice, CtOption};
 
-use crate::{modular::inv::inv_montgomery_form, traits::Invert, Word};
+use crate::{modular::inv::inv_montgomery_form, traits::Invert, CtChoice};
 
 use super::DynResidue;
 
 impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// Computes the residue `self^-1` representing the multiplicative inverse of `self`.
     /// I.e. `self * self^-1 = 1`.
-    /// If the number was invertible, the second element of the tuple is `1`,
-    /// otherwise it is `0` (in which case the first element's value is unspecified).
-    pub const fn invert(&self) -> (Self, Word) {
+    /// If the number was invertible, the second element of the tuple is the truthy value,
+    /// otherwise it is the falsy value (in which case the first element's value is unspecified).
+    pub const fn invert(&self) -> (Self, CtChoice) {
         let (montgomery_form, is_some) = inv_montgomery_form(
             self.montgomery_form,
             self.residue_params.modulus,

--- a/src/uint/modular/runtime_mod/runtime_inv.rs
+++ b/src/uint/modular/runtime_mod/runtime_inv.rs
@@ -1,4 +1,4 @@
-use subtle::{Choice, CtOption};
+use subtle::CtOption;
 
 use crate::{modular::inv::inv_montgomery_form, traits::Invert, CtChoice};
 
@@ -30,6 +30,6 @@ impl<const LIMBS: usize> Invert for DynResidue<LIMBS> {
     type Output = CtOption<Self>;
     fn invert(&self) -> Self::Output {
         let (value, is_some) = self.invert();
-        CtOption::new(value, Choice::from((is_some & 1) as u8))
+        CtOption::new(value, is_some.into())
     }
 }

--- a/src/uint/modular/runtime_mod/runtime_mul.rs
+++ b/src/uint/modular/runtime_mod/runtime_mul.rs
@@ -14,7 +14,7 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
             montgomery_form: mul_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
-                self.residue_params.modulus,
+                &self.residue_params.modulus,
                 self.residue_params.mod_neg_inv,
             ),
             residue_params: self.residue_params,
@@ -70,7 +70,7 @@ impl<const LIMBS: usize> Square for DynResidue<LIMBS> {
         Self {
             montgomery_form: square_montgomery_form(
                 &self.montgomery_form,
-                self.residue_params.modulus,
+                &self.residue_params.modulus,
                 self.residue_params.mod_neg_inv,
             ),
             residue_params: self.residue_params,

--- a/src/uint/modular/runtime_mod/runtime_neg.rs
+++ b/src/uint/modular/runtime_mod/runtime_neg.rs
@@ -12,6 +12,13 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
 impl<const LIMBS: usize> Neg for DynResidue<LIMBS> {
     type Output = Self;
     fn neg(self) -> Self {
-        (&self).neg()
+        DynResidue::neg(&self)
+    }
+}
+
+impl<const LIMBS: usize> Neg for &DynResidue<LIMBS> {
+    type Output = DynResidue<LIMBS>;
+    fn neg(self) -> DynResidue<LIMBS> {
+        DynResidue::neg(self)
     }
 }

--- a/src/uint/modular/runtime_mod/runtime_pow.rs
+++ b/src/uint/modular/runtime_mod/runtime_pow.rs
@@ -16,11 +16,11 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
     pub const fn pow_bounded_exp(&self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
         Self {
             montgomery_form: pow_montgomery_form(
-                self.montgomery_form,
+                &self.montgomery_form,
                 exponent,
                 exponent_bits,
-                self.residue_params.modulus,
-                self.residue_params.r,
+                &self.residue_params.modulus,
+                &self.residue_params.r,
                 self.residue_params.mod_neg_inv,
             ),
             residue_params: self.residue_params,

--- a/src/uint/modular/runtime_mod/runtime_sub.rs
+++ b/src/uint/modular/runtime_mod/runtime_sub.rs
@@ -70,17 +70,17 @@ mod tests {
 
     #[test]
     fn sub_overflow() {
-        let params = DynResidueParams::new(U256::from_be_hex(
+        let params = DynResidueParams::new(&U256::from_be_hex(
             "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
         ));
 
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
-        let mut x_mod = DynResidue::new(x, params);
+        let mut x_mod = DynResidue::new(&x, params);
 
         let y =
             U256::from_be_hex("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251");
-        let y_mod = DynResidue::new(y, params);
+        let y_mod = DynResidue::new(&y, params);
 
         x_mod -= &y_mod;
 

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -20,7 +20,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let (lo, hi) = self.mul_wide(rhs);
 
         // Now use Algorithm 14.47 for the reduction
-        let (lo, carry) = mac_by_limb(lo, hi, c, Limb::ZERO);
+        let (lo, carry) = mac_by_limb(&lo, &hi, c, Limb::ZERO);
 
         let (lo, carry) = {
             let rhs = (carry.0 + 1) as WideWord * c.0 as WideWord;
@@ -38,12 +38,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
 /// Computes `a + (b * c) + carry`, returning the result along with the new carry.
 const fn mac_by_limb<const LIMBS: usize>(
-    mut a: Uint<LIMBS>,
-    b: Uint<LIMBS>,
+    a: &Uint<LIMBS>,
+    b: &Uint<LIMBS>,
     c: Limb,
-    mut carry: Limb,
+    carry: Limb,
 ) -> (Uint<LIMBS>, Limb) {
     let mut i = 0;
+    let mut a = *a;
+    let mut carry = carry;
 
     while i < LIMBS {
         let (n, c) = a.limbs[i].mac(b.limbs[i], c, carry);

--- a/src/uint/neg.rs
+++ b/src/uint/neg.rs
@@ -1,6 +1,6 @@
 use core::ops::Neg;
 
-use crate::{Uint, Word, Wrapping};
+use crate::{CtChoice, Uint, Wrapping};
 
 impl<const LIMBS: usize> Neg for Wrapping<Uint<LIMBS>> {
     type Output = Self;
@@ -13,7 +13,7 @@ impl<const LIMBS: usize> Neg for Wrapping<Uint<LIMBS>> {
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Negates based on `choice` by wrapping the integer.
-    pub(crate) const fn conditional_wrapping_neg(&self, choice: Word) -> Uint<LIMBS> {
+    pub(crate) const fn conditional_wrapping_neg(&self, choice: CtChoice) -> Uint<LIMBS> {
         let (shifted, _) = self.shl_1();
         let negated_self = self.wrapping_sub(&shifted);
 

--- a/src/uint/neg.rs
+++ b/src/uint/neg.rs
@@ -13,10 +13,10 @@ impl<const LIMBS: usize> Neg for Wrapping<Uint<LIMBS>> {
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Negates based on `choice` by wrapping the integer.
-    pub(crate) const fn conditional_wrapping_neg(self, choice: Word) -> Uint<LIMBS> {
+    pub(crate) const fn conditional_wrapping_neg(&self, choice: Word) -> Uint<LIMBS> {
         let (shifted, _) = self.shl_1();
         let negated_self = self.wrapping_sub(&shifted);
 
-        Uint::ct_select(self, negated_self, choice)
+        Uint::ct_select(self, &negated_self, choice)
     }
 }

--- a/src/uint/neg_mod.rs
+++ b/src/uint/neg_mod.rs
@@ -12,7 +12,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         while i < LIMBS {
             // Set ret to 0 if the original value was 0, in which
             // case ret would be p.
-            ret.limbs[i].0 &= z;
+            ret.limbs[i].0 = z.if_true(ret.limbs[i].0);
             i += 1;
         }
         ret

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -45,7 +45,7 @@ impl<const LIMBS: usize> RandomMod for Uint<LIMBS> {
             }
             n.limbs[n_limbs - 1] = n.limbs[n_limbs - 1] & mask;
 
-            if n.ct_lt(modulus).into() {
+            if ConstantTimeLess::ct_lt(&n, modulus).into() {
                 return n;
             }
         }

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -45,7 +45,7 @@ impl<const LIMBS: usize> RandomMod for Uint<LIMBS> {
             }
             n.limbs[n_limbs - 1] = n.limbs[n_limbs - 1] & mask;
 
-            if ConstantTimeLess::ct_lt(&n, modulus).into() {
+            if n.ct_lt(modulus).into() {
                 return n;
             }
         }

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -30,10 +30,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
 
         debug_assert!(carry_bits[LIMBS - 1] == 0 || carry_bits[LIMBS - 1] == 1);
-        (
-            Uint::new(limbs),
-            carry_bits[LIMBS - 1].wrapping_neg(),
-        )
+        (Uint::new(limbs), carry_bits[LIMBS - 1].wrapping_neg())
     }
 
     /// Computes `self << shift` where `0 <= shift < Limb::BITS`,

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -39,7 +39,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     pub(crate) const fn shl_limb(&self, n: usize) -> (Self, Limb) {
         let mut limbs = [Limb::ZERO; LIMBS];
 
-        let nz = Limb(n as Word).is_nonzero();
+        let nz = Limb(n as Word).ct_is_nonzero();
         let lshift = n as Word;
         let rshift = Limb::ct_select(Limb::ZERO, Limb((Limb::BITS - n) as Word), nz).0;
         let carry = Limb::ct_select(

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -29,8 +29,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             i += 1;
         }
 
-        debug_assert!(carry_bits[LIMBS - 1] == 0 || carry_bits[LIMBS - 1] == 1);
-        (Uint::new(limbs), carry_bits[LIMBS - 1].wrapping_neg())
+        (Uint::new(limbs), CtChoice::from_lsb(carry_bits[LIMBS - 1]))
     }
 
     /// Computes `self << shift` where `0 <= shift < Limb::BITS`,
@@ -52,7 +51,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         while i > 0 {
             let mut limb = self.limbs[i].0 << lshift;
             let hi = self.limbs[i - 1].0 >> rshift;
-            limb |= hi & nz;
+            limb |= nz.if_true(hi);
             limbs[i] = Limb(limb);
             i -= 1
         }

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -1,11 +1,11 @@
 //! [`Uint`] bitwise left shift operations.
 
-use crate::{limb::HI_BIT, Limb, Uint, Word};
+use crate::{limb::HI_BIT, CtChoice, Limb, Uint, Word};
 use core::ops::{Shl, ShlAssign};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
-    /// Computes `self << 1` in constant-time, returning the overflowing bit as a `Word` that is either 0...0 or 1...1.
-    pub(crate) const fn shl_1(&self) -> (Self, Word) {
+    /// Computes `self << 1` in constant-time, returning the overflowing bit as a `CtChoice`.
+    pub(crate) const fn shl_1(&self) -> (Self, CtChoice) {
         let mut shifted_bits = [0; LIMBS];
         let mut i = 0;
         while i < LIMBS {

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -29,9 +29,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             i += 1;
         }
 
+        debug_assert!(carry_bits[LIMBS - 1] == 0 || carry_bits[LIMBS - 1] == 1);
         (
             Uint::new(limbs),
-            carry_bits[LIMBS - 1].wrapping_mul(Word::MAX),
+            carry_bits[LIMBS - 1].wrapping_neg(),
         )
     }
 

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -31,7 +31,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         limbs[LIMBS - 1] = Limb(shifted_bits[LIMBS - 1]);
 
         debug_assert!(carry_bits[LIMBS - 1] == 0 || carry_bits[LIMBS - 1] == (1 << HI_BIT));
-        (Uint::new(limbs), (carry_bits[0] >> HI_BIT).wrapping_neg())
+        (
+            Uint::new(limbs),
+            CtChoice::from_lsb(carry_bits[0] >> HI_BIT),
+        )
     }
 
     /// Computes `self >> n`.

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -30,9 +30,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
         limbs[LIMBS - 1] = Limb(shifted_bits[LIMBS - 1]);
 
+        debug_assert!(carry_bits[LIMBS - 1] == 0 || carry_bits[LIMBS - 1] == (1 << HI_BIT));
         (
             Uint::new(limbs),
-            (carry_bits[0] >> HI_BIT).wrapping_mul(Word::MAX),
+            (carry_bits[0] >> HI_BIT).wrapping_neg(),
         )
     }
 

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -31,10 +31,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         limbs[LIMBS - 1] = Limb(shifted_bits[LIMBS - 1]);
 
         debug_assert!(carry_bits[LIMBS - 1] == 0 || carry_bits[LIMBS - 1] == (1 << HI_BIT));
-        (
-            Uint::new(limbs),
-            (carry_bits[0] >> HI_BIT).wrapping_neg(),
-        )
+        (Uint::new(limbs), (carry_bits[0] >> HI_BIT).wrapping_neg())
     }
 
     /// Computes `self >> n`.

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -1,12 +1,12 @@
 //! [`Uint`] bitwise right shift operations.
 
 use super::Uint;
-use crate::{limb::HI_BIT, Limb, Word};
+use crate::{limb::HI_BIT, CtChoice, Limb};
 use core::ops::{Shr, ShrAssign};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self >> 1` in constant-time, returning the overflowing bit as a `Word` that is either 0...0 or 1...1.
-    pub(crate) const fn shr_1(&self) -> (Self, Word) {
+    pub(crate) const fn shr_1(&self) -> (Self, CtChoice) {
         let mut shifted_bits = [0; LIMBS];
         let mut i = 0;
         while i < LIMBS {

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -21,7 +21,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         // If guess increased, the initial guess was low.
         // Repeat until reverse course.
-        while guess.ct_lt(&xn) == Word::MAX {
+        while guess.ct_lt(&xn).is_true_vartime() {
             // Sometimes an increase is too far, especially with large
             // powers, and then takes a long time to walk back.  The upper
             // bound is based on bit size, so saturate on that.
@@ -35,7 +35,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
 
         // Repeat while guess decreases.
-        while guess.ct_gt(&xn) == Word::MAX && xn.ct_is_nonzero() == Word::MAX {
+        while guess.ct_gt(&xn).is_true_vartime() && xn.ct_is_nonzero().is_true_vartime() {
             guess = xn;
             xn = {
                 let q = self.wrapping_div(&guess);

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -21,7 +21,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         // If guess increased, the initial guess was low.
         // Repeat until reverse course.
-        while guess.ct_lt(&xn).is_true_vartime() {
+        while Uint::ct_lt(&guess, &xn).is_true_vartime() {
             // Sometimes an increase is too far, especially with large
             // powers, and then takes a long time to walk back.  The upper
             // bound is based on bit size, so saturate on that.
@@ -35,7 +35,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
 
         // Repeat while guess decreases.
-        while guess.ct_gt(&xn).is_true_vartime() && xn.ct_is_nonzero().is_true_vartime() {
+        while Uint::ct_gt(&guess, &xn).is_true_vartime() && xn.ct_is_nonzero().is_true_vartime() {
             guess = xn;
             xn = {
                 let q = self.wrapping_div(&guess);

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -26,7 +26,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             // powers, and then takes a long time to walk back.  The upper
             // bound is based on bit size, so saturate on that.
             let le = Limb::ct_le(Limb(xn.bits_vartime() as Word), Limb(max_bits as Word));
-            guess = Self::ct_select(cap, xn, le);
+            guess = Self::ct_select(&cap, &xn, le);
             xn = {
                 let q = self.wrapping_div(&guess);
                 let t = guess.wrapping_add(&q);
@@ -44,7 +44,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             };
         }
 
-        Self::ct_select(Self::ZERO, guess, self.ct_is_nonzero())
+        Self::ct_select(&Self::ZERO, &guess, self.ct_is_nonzero())
     }
 
     /// Wrapped sqrt is just normal √(`self`)

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -1,7 +1,7 @@
 //! [`Uint`] addition operations.
 
 use super::Uint;
-use crate::{Checked, CheckedSub, CtChoice, Limb, Word, Wrapping, Zero};
+use crate::{Checked, CheckedSub, CtChoice, Limb, Wrapping, Zero};
 use core::ops::{Sub, SubAssign};
 use subtle::CtOption;
 
@@ -48,9 +48,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ) -> (Self, CtChoice) {
         let actual_rhs = Uint::ct_select(&Uint::ZERO, rhs, choice);
         let (res, borrow) = self.sbb(&actual_rhs, Limb::ZERO);
-
-        debug_assert!(borrow.0 == 0 || borrow.0 == Word::MAX);
-        (res, borrow.0)
+        (res, CtChoice::from_mask(borrow.0))
     }
 }
 

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -46,7 +46,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         rhs: &Self,
         choice: CtChoice,
     ) -> (Self, CtChoice) {
-        let actual_rhs = Uint::ct_select(Uint::ZERO, *rhs, choice);
+        let actual_rhs = Uint::ct_select(&Uint::ZERO, rhs, choice);
         let (res, borrow) = self.sbb(&actual_rhs, Limb::ZERO);
 
         debug_assert!(borrow.0 == 0 || borrow.0 == Word::MAX);

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -44,8 +44,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let actual_rhs = Uint::ct_select(Uint::ZERO, *rhs, choice);
         let (res, borrow) = self.sbb(&actual_rhs, Limb::ZERO);
 
-        // Here we use a saturating multiplication to get the result to 0...0 or 1...1
-        (res, borrow.0.saturating_mul(Word::MAX))
+        debug_assert!(borrow.0 == 0 || borrow.0 == Word::MAX);
+        (res, borrow.0)
     }
 }
 

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -1,7 +1,7 @@
 //! [`Uint`] addition operations.
 
 use super::Uint;
-use crate::{Checked, CheckedSub, Limb, Word, Wrapping, Zero};
+use crate::{Checked, CheckedSub, CtChoice, Limb, Word, Wrapping, Zero};
 use core::ops::{Sub, SubAssign};
 use subtle::CtOption;
 
@@ -39,8 +39,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         self.sbb(rhs, Limb::ZERO).0
     }
 
-    /// Perform wrapping subtraction, returning the underflow bit as a `Word` that is either 0...0 or 1...1.
-    pub(crate) const fn conditional_wrapping_sub(&self, rhs: &Self, choice: Word) -> (Self, Word) {
+    /// Perform wrapping subtraction, returning the truthy value as the second element of the tuple
+    /// if an underflow has occurred.
+    pub(crate) const fn conditional_wrapping_sub(
+        &self,
+        rhs: &Self,
+        choice: CtChoice,
+    ) -> (Self, CtChoice) {
         let actual_rhs = Uint::ct_select(Uint::ZERO, *rhs, choice);
         let (res, borrow) = self.sbb(&actual_rhs, Limb::ZERO);
 

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -258,8 +258,8 @@ proptest! {
 
         let expected = to_uint(a_bi.modpow(&b_bi, &p_bi));
 
-        let params = DynResidueParams::new(P);
-        let a_m = DynResidue::new(a, params);
+        let params = DynResidueParams::new(&P);
+        let a_m = DynResidue::new(&a, params);
         let actual = a_m.pow(&b).retrieve();
 
         assert_eq!(expected, actual);
@@ -276,8 +276,8 @@ proptest! {
 
         let expected = to_uint(a_bi.modpow(&b_bi, &p_bi));
 
-        let params = DynResidueParams::new(P);
-        let a_m = DynResidue::new(a, params);
+        let params = DynResidueParams::new(&P);
+        let a_m = DynResidue::new(&a, params);
         let actual = a_m.pow_bounded_exp(&b, exponent_bits.into()).retrieve();
 
         assert_eq!(expected, actual);


### PR DESCRIPTION
- Break long lines in comments and tests and fix some hardcoded bit sizes
- Fix the hardcoded `Limb` size in `inv_odd_mod()` - was set to 64 (did not cause errors, just made the inversion twice as slow on 32-bit targets)
- Added `inv_odd_mod_bounded()` for cases of argument/modulus known to be small
- Removed `inv_odd_mod_option()` - we do not provide such interface for other constant functions

Additionally:
- Introduced a `CtChoice` newtype for constant-time const fns
- Replaced some multiplications by `Word::MAX` with negations
- Normalized constant-time comparisons API in `Limb` and `Uint`: removed `ct_cmp()` (we never need it in constant-time context, `ct_gt()`/`ct_lt()`/`ct_eq()` are enough), matched const fns with `subtle` trait methods, matched methods between `Limb` and `Uint`
- Removed `SignedWord` and `SignedWideWord`
- `Uint` objects are taken by reference where they were previously taken by value.