### PR TITLE
Improvements to modular arithmetic support

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,8 +1,8 @@
 //! Traits provided by this crate
 
-use crate::{Limb, NonZero};
+use crate::{Limb, NonZero, UInt, Word};
 use core::fmt::Debug;
-use core::ops::{BitAnd, BitOr, BitXor, Div, Not, Rem, Shl, Shr};
+use core::ops::{BitAnd, BitOr, BitXor, Div, Mul, Not, Rem, Shl, Shr};
 use subtle::{
     Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
     CtOption,
@@ -224,4 +224,40 @@ pub trait Encoding: Sized {
 
     /// Encode to little endian bytes.
     fn to_le_bytes(&self) -> Self::Repr;
+}
+
+/// Provides a consistent interface to square a number.
+pub trait Square: Mul<Output = Self> + Copy
+where
+    Self: Sized,
+{
+    /// Computes the same as `self.mul(self)`, but may be more efficient.
+    fn square(self) -> Self {
+        self * self
+    }
+}
+
+/// Provides a consistent interface to exponentiate a number.
+pub trait Pow<const LIMBS: usize>
+where
+    Self: Sized,
+{
+    /// Computes the (reduced) exponentiation of a number.
+    fn pow(self, exponent: &UInt<LIMBS>) -> Self {
+        self.pow_specific(exponent, LIMBS * Word::BITS as usize)
+    }
+
+    /// Computes the (reduced) exponentiation of a number. Here `exponent_bits` represents the
+    /// number of bits to take into account for the exponent. Note that this value is leaked in the
+    /// time pattern.
+    fn pow_specific(self, exponent: &UInt<LIMBS>, exponent_bits: usize) -> Self;
+}
+
+/// Provides a consistent interface to invert an element of an algebraic structure.
+pub trait Inv
+where
+    Self: Sized,
+{
+    /// Computes the (reduced) multiplicative inverse of the element. Returns CtOption, which is `None` if the element was not invertible.
+    fn inv(self) -> CtOption<Self>;
 }

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -48,7 +48,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
-    pub(crate) const fn ct_reduce(&self, rhs: &Self) -> (Self, u8) {
+    pub const fn ct_reduce(&self, rhs: &Self) -> (Self, u8) {
         let mb = rhs.bits_vartime();
         let mut bd = (LIMBS * Limb::BIT_SIZE) - mb;
         let mut rem = *self;
@@ -76,7 +76,7 @@ impl<const LIMBS: usize> UInt<LIMBS> {
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
     #[allow(dead_code)]
-    pub(crate) const fn ct_reduce_wide(lower_upper: (Self, Self), rhs: &Self) -> (Self, u8) {
+    pub const fn ct_reduce_wide(lower_upper: (Self, Self), rhs: &Self) -> (Self, u8) {
         let mb = rhs.bits_vartime();
 
         // The number of bits to consider is two sets of limbs * BIT_SIZE - mb (modulus bitcount)

--- a/src/uint/modular/constant_mod/const_inv.rs
+++ b/src/uint/modular/constant_mod/const_inv.rs
@@ -3,13 +3,13 @@ use core::marker::PhantomData;
 use subtle::{Choice, CtOption};
 
 use crate::{
-    modular::{inv::inv_montgomery_form, InvResidue},
+    modular::{inv::inv_montgomery_form, Inv},
     Word,
 };
 
 use super::{Residue, ResidueParams};
 
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> InvResidue for Residue<MOD, LIMBS> {
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Inv for Residue<MOD, LIMBS> {
     fn inv(self) -> CtOption<Self> {
         let (montgomery_form, error) = inv_montgomery_form(
             self.montgomery_form,
@@ -65,7 +65,7 @@ mod tests {
         let x_mod = const_residue!(x, Modulus);
 
         let inv = x_mod.inv();
-        let res = &x_mod * &inv;
+        let res = x_mod * inv;
 
         assert_eq!(res.retrieve(), U256::ONE);
     }

--- a/src/uint/modular/constant_mod/const_mul.rs
+++ b/src/uint/modular/constant_mod/const_mul.rs
@@ -3,24 +3,28 @@ use core::{
     ops::{Mul, MulAssign},
 };
 
-use crate::modular::{mul::mul_montgomery_form, reduction::montgomery_reduction, MulResidue};
+use crate::modular::mul::mul_montgomery_form;
 
 use super::{Residue, ResidueParams};
 
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> MulResidue for Residue<MOD, LIMBS> {
-    fn mul(&self, rhs: &Self) -> Self {
-        self.mul(rhs)
-    }
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Mul for Residue<MOD, LIMBS> {
+    type Output = Self;
 
-    fn square(&self) -> Self {
-        self.square()
+    fn mul(self, rhs: Self) -> Self {
+        Residue::mul(&self, &rhs)
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> MulAssign<Self> for Residue<MOD, LIMBS> {
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = self.mul(rhs)
     }
 }
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// Computes the (reduced) product between two residues.
     pub const fn mul(&self, rhs: &Self) -> Self {
-        Self {
+        Residue {
             montgomery_form: mul_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
@@ -29,29 +33,5 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
             ),
             phantom: PhantomData,
         }
-    }
-
-    /// Computes the (reduced) square of a residue.
-    pub const fn square(&self) -> Self {
-        let lo_hi = self.montgomery_form.square_wide();
-
-        Self {
-            montgomery_form: montgomery_reduction::<LIMBS>(lo_hi, MOD::MODULUS, MOD::MOD_NEG_INV),
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> MulAssign<&Self> for Residue<MOD, LIMBS> {
-    fn mul_assign(&mut self, rhs: &Self) {
-        *self = self.mul(rhs)
-    }
-}
-
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Mul for &Residue<MOD, LIMBS> {
-    type Output = Residue<MOD, LIMBS>;
-
-    fn mul(self, rhs: Self) -> Self::Output {
-        self.mul(rhs)
     }
 }

--- a/src/uint/modular/constant_mod/const_neg.rs
+++ b/src/uint/modular/constant_mod/const_neg.rs
@@ -1,0 +1,50 @@
+use core::ops::Neg;
+
+use crate::modular::neg::neg_montgomery_form;
+
+use super::{Residue, ResidueParams};
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Neg for Residue<MOD, LIMBS> {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        Residue::neg(&self)
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
+    /// Computes the (reduced) negative of a residue.
+    pub const fn neg(&self) -> Self {
+        Residue {
+            montgomery_form: neg_montgomery_form(&self.montgomery_form, &MOD::MODULUS),
+            phantom: core::marker::PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        const_residue, impl_modulus, modular::constant_mod::ResidueParams, traits::Encoding, U256,
+    };
+
+    impl_modulus!(
+        Modulus,
+        U256,
+        "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"
+    );
+
+    #[test]
+    fn neg() {
+        let x =
+            U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
+        let mut x_mod = const_residue!(x, Modulus);
+
+        x_mod = -x_mod;
+
+        let expected =
+            U256::from_be_hex("bb5309471c93ecbe3d3a768dfb01f6af6ec8cbb28c879b0d17f4e31c5b2f38fb");
+
+        assert_eq!(expected, x_mod.retrieve());
+    }
+}

--- a/src/uint/modular/constant_mod/const_pow.rs
+++ b/src/uint/modular/constant_mod/const_pow.rs
@@ -1,11 +1,11 @@
 use crate::{
-    modular::{pow::pow_montgomery_form, PowResidue},
+    modular::{pow::pow_montgomery_form, Pow},
     UInt, Word,
 };
 
 use super::{Residue, ResidueParams};
 
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> PowResidue<LIMBS> for Residue<MOD, LIMBS> {
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Pow<LIMBS> for Residue<MOD, LIMBS> {
     fn pow_specific(self, exponent: &UInt<LIMBS>, exponent_bits: usize) -> Self {
         self.pow_specific(exponent, exponent_bits)
     }
@@ -13,17 +13,15 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> PowResidue<LIMBS> for Residu
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// Performs modular exponentiation using Montgomery's ladder.
-    pub const fn pow(self, exponent: &UInt<LIMBS>) -> Residue<MOD, LIMBS> {
+    pub const fn pow(self, exponent: &UInt<LIMBS>) -> Self {
         self.pow_specific(exponent, LIMBS * Word::BITS as usize)
     }
 
-    /// Performs modular exponentiation using Montgomery's ladder. `exponent_bits` represents the number of bits to take into account for the exponent. Note that this value is leaked in the time pattern.
-    pub const fn pow_specific(
-        self,
-        exponent: &UInt<LIMBS>,
-        exponent_bits: usize,
-    ) -> Residue<MOD, LIMBS> {
-        Self {
+    /// Performs modular exponentiation using Montgomery's ladder. `exponent_bits` represents the
+    /// number of bits to take into account for the exponent. Note that this value is leaked in the
+    /// time pattern.
+    pub const fn pow_specific(self, exponent: &UInt<LIMBS>, exponent_bits: usize) -> Self {
+        Residue {
             montgomery_form: pow_montgomery_form(
                 self.montgomery_form,
                 exponent,

--- a/src/uint/modular/constant_mod/const_square.rs
+++ b/src/uint/modular/constant_mod/const_square.rs
@@ -1,0 +1,23 @@
+use core::marker::PhantomData;
+
+use crate::modular::{reduction::montgomery_reduction, Square};
+
+use super::{Residue, ResidueParams};
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Square for Residue<MOD, LIMBS> {
+    fn square(self) -> Self {
+        Residue::square(&self)
+    }
+}
+
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
+    /// Computes the (reduced) square of a residue.
+    pub const fn square(&self) -> Self {
+        let lo_hi = self.montgomery_form.square_wide();
+
+        Self {
+            montgomery_form: montgomery_reduction::<LIMBS>(lo_hi, MOD::MODULUS, MOD::MOD_NEG_INV),
+            phantom: PhantomData,
+        }
+    }
+}

--- a/src/uint/modular/constant_mod/const_sub.rs
+++ b/src/uint/modular/constant_mod/const_sub.rs
@@ -1,28 +1,28 @@
-use core::ops::{Add, AddAssign};
+use core::ops::{Sub, SubAssign};
 
-use crate::modular::add::add_montgomery_form;
+use crate::modular::sub::sub_montgomery_form;
 
 use super::{Residue, ResidueParams};
 
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Add for Residue<MOD, LIMBS> {
-    type Output = Self;
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Sub for Residue<MOD, LIMBS> {
+    type Output = Residue<MOD, LIMBS>;
 
-    fn add(self, rhs: Self) -> Self {
-        Residue::add(&self, &rhs)
+    fn sub(self, rhs: Self) -> Self::Output {
+        Residue::sub(&self, &rhs)
     }
 }
 
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> AddAssign<Self> for Residue<MOD, LIMBS> {
-    fn add_assign(&mut self, rhs: Self) {
-        *self = self.add(rhs);
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> SubAssign<Self> for Residue<MOD, LIMBS> {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = self.sub(rhs);
     }
 }
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
-    /// Adds two residues together.
-    pub const fn add(&self, rhs: &Self) -> Self {
+    /// Computes the (reduced) difference between two residues.
+    pub const fn sub(&self, rhs: &Self) -> Self {
         Residue {
-            montgomery_form: add_montgomery_form(
+            montgomery_form: sub_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
                 &MOD::MODULUS,
@@ -45,7 +45,7 @@ mod tests {
     );
 
     #[test]
-    fn add_overflow() {
+    fn sub_underflow() {
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
         let mut x_mod = const_residue!(x, Modulus);
@@ -53,10 +53,10 @@ mod tests {
         let y =
             U256::from_be_hex("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251");
 
-        x_mod += const_residue!(y, Modulus);
+        x_mod -= const_residue!(y, Modulus);
 
         let expected =
-            U256::from_be_hex("1a2472fde50286541d97ca6a3592dd75beb9c9646e40c511b82496cfc3926956");
+            U256::from_be_hex("6f357a71e1d5a03167f34879d469352add829491c6df41ddff65387d7ed56f56");
 
         assert_eq!(expected, x_mod.retrieve());
     }

--- a/src/uint/modular/constant_mod/macros.rs
+++ b/src/uint/modular/constant_mod/macros.rs
@@ -4,13 +4,12 @@
 /// For example, `impl_modulus!(MyModulus, U256, "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001");` implements a 256-bit modulus named `MyModulus`.
 macro_rules! impl_modulus {
     ($name:ident, $uint_type:ty, $value:expr) => {
-        #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+        #[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
         pub struct $name {}
         impl<const DLIMBS: usize> ResidueParams<{ nlimbs!(<$uint_type>::BIT_SIZE) }> for $name
         where
             $crate::UInt<{ nlimbs!(<$uint_type>::BIT_SIZE) }>:
-                $crate::traits::Concat<Output = $crate::UInt<DLIMBS>>,
-            $crate::UInt<DLIMBS>: $crate::traits::Split<Output = $uint_type>,
+                $crate::Concat<Output = $crate::UInt<DLIMBS>>,
         {
             const LIMBS: usize = { nlimbs!(<$uint_type>::BIT_SIZE) };
             const MODULUS: $crate::UInt<{ nlimbs!(<$uint_type>::BIT_SIZE) }> =
@@ -21,12 +20,12 @@ macro_rules! impl_modulus {
                 .wrapping_add(&$crate::UInt::ONE);
             const R2: $crate::UInt<{ nlimbs!(<$uint_type>::BIT_SIZE) }> =
                 $crate::UInt::ct_reduce_wide(Self::R.square_wide(), &Self::MODULUS).0;
-            const MOD_NEG_INV: $crate::Limb = $crate::Limb(
-                $crate::Word::MIN
-                    .wrapping_sub(Self::MODULUS.inv_mod2k($crate::Word::BITS as usize).limbs[0].0),
-            );
+            const MOD_NEG_INV: $crate::Limb =
+                $crate::Limb($crate::Word::MIN.wrapping_sub(
+                    Self::MODULUS.inv_mod2k($crate::Word::BITS as usize).limbs()[0].0,
+                ));
             const R3: $crate::UInt<{ nlimbs!(<$uint_type>::BIT_SIZE) }> =
-                $crate::uint::modular::reduction::montgomery_reduction(
+                $crate::modular::reduction::montgomery_reduction(
                     Self::R2.square_wide(),
                     Self::MODULUS,
                     Self::MOD_NEG_INV,

--- a/src/uint/modular/neg.rs
+++ b/src/uint/modular/neg.rs
@@ -1,0 +1,8 @@
+use crate::UInt;
+
+pub(crate) const fn neg_montgomery_form<const LIMBS: usize>(
+    a: &UInt<LIMBS>,
+    modulus: &UInt<LIMBS>,
+) -> UInt<LIMBS> {
+    a.neg_mod(modulus)
+}

--- a/src/uint/modular/reduction.rs
+++ b/src/uint/modular/reduction.rs
@@ -1,7 +1,7 @@
 use crate::{Limb, UInt, WideWord, Word};
 
 /// Algorithm 14.32 in Handbook of Applied Cryptography (https://cacr.uwaterloo.ca/hac/about/chap14.pdf)
-pub(crate) const fn montgomery_reduction<const LIMBS: usize>(
+pub const fn montgomery_reduction<const LIMBS: usize>(
     lower_upper: (UInt<LIMBS>, UInt<LIMBS>),
     modulus: UInt<LIMBS>,
     mod_neg_inv: Limb,

--- a/src/uint/modular/runtime_mod.rs
+++ b/src/uint/modular/runtime_mod.rs
@@ -1,3 +1,5 @@
+use subtle::{Choice, ConstantTimeEq};
+
 use crate::{Limb, UInt, Word};
 
 use super::{reduction::montgomery_reduction, GenericResidue};
@@ -8,8 +10,14 @@ mod runtime_add;
 mod runtime_inv;
 /// Multiplications between residues with a modulus set at runtime
 mod runtime_mul;
+/// Negation of residues with a modulus set at runtime
+mod runtime_neg;
 /// Exponentiation of residues with a modulus set at runtime
 mod runtime_pow;
+/// Squares of residues with a modulus set at runtime
+mod runtime_square;
+/// Subtractions between residues with a modulus set at runtime
+mod runtime_sub;
 
 /// The parameters to efficiently go to and from the Montgomery form for a modulus provided at runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -75,6 +83,14 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
             self.residue_params.modulus,
             self.residue_params.mod_neg_inv,
         )
+    }
+}
+
+impl<const LIMBS: usize> ConstantTimeEq for DynResidue<LIMBS> {
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> Choice {
+        debug_assert_eq!(self.residue_params, other.residue_params);
+        self.montgomery_form.ct_eq(&other.montgomery_form)
     }
 }
 

--- a/src/uint/modular/runtime_mod/runtime_inv.rs
+++ b/src/uint/modular/runtime_mod/runtime_inv.rs
@@ -1,13 +1,13 @@
 use subtle::{Choice, CtOption};
 
 use crate::{
-    modular::{inv::inv_montgomery_form, InvResidue},
+    modular::{inv::inv_montgomery_form, Inv},
     Word,
 };
 
 use super::DynResidue;
 
-impl<const LIMBS: usize> InvResidue for DynResidue<LIMBS> {
+impl<const LIMBS: usize> Inv for DynResidue<LIMBS> {
     fn inv(self) -> CtOption<Self> {
         let (montgomery_form, error) = inv_montgomery_form(
             self.montgomery_form,
@@ -16,7 +16,7 @@ impl<const LIMBS: usize> InvResidue for DynResidue<LIMBS> {
             self.residue_params.mod_neg_inv,
         );
 
-        let value = Self {
+        let value = DynResidue {
             montgomery_form,
             residue_params: self.residue_params,
         };

--- a/src/uint/modular/runtime_mod/runtime_mul.rs
+++ b/src/uint/modular/runtime_mod/runtime_mul.rs
@@ -1,30 +1,18 @@
 use core::ops::{Mul, MulAssign};
 
-use crate::modular::{
-    mul::{mul_montgomery_form, square_montgomery_form},
-    MulResidue,
-};
+use crate::modular::mul::mul_montgomery_form;
 
 use super::DynResidue;
 
-impl<const LIMBS: usize> MulResidue for DynResidue<LIMBS> {
-    fn mul(&self, rhs: &Self) -> Self {
+impl<const LIMBS: usize> Mul for DynResidue<LIMBS> {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self {
         debug_assert_eq!(self.residue_params, rhs.residue_params);
-        Self {
+        DynResidue {
             montgomery_form: mul_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
-                self.residue_params.modulus,
-                self.residue_params.mod_neg_inv,
-            ),
-            residue_params: self.residue_params,
-        }
-    }
-
-    fn square(&self) -> Self {
-        Self {
-            montgomery_form: square_montgomery_form(
-                &self.montgomery_form,
                 self.residue_params.modulus,
                 self.residue_params.mod_neg_inv,
             ),
@@ -35,21 +23,6 @@ impl<const LIMBS: usize> MulResidue for DynResidue<LIMBS> {
 
 impl<const LIMBS: usize> MulAssign for DynResidue<LIMBS> {
     fn mul_assign(&mut self, rhs: Self) {
-        debug_assert_eq!(self.residue_params, rhs.residue_params);
-        self.montgomery_form = mul_montgomery_form(
-            &self.montgomery_form,
-            &rhs.montgomery_form,
-            self.residue_params.modulus,
-            self.residue_params.mod_neg_inv,
-        );
-    }
-}
-
-impl<const LIMBS: usize> Mul for DynResidue<LIMBS> {
-    type Output = DynResidue<LIMBS>;
-
-    fn mul(mut self, rhs: Self) -> Self::Output {
-        self *= rhs;
-        self
+        *self = *self * rhs;
     }
 }

--- a/src/uint/modular/runtime_mod/runtime_neg.rs
+++ b/src/uint/modular/runtime_mod/runtime_neg.rs
@@ -1,28 +1,20 @@
-use core::ops::{Add, AddAssign};
+use core::ops::Neg;
 
-use crate::modular::add::add_montgomery_form;
+use crate::modular::neg::neg_montgomery_form;
 
 use super::DynResidue;
 
-impl<const LIMBS: usize> Add for DynResidue<LIMBS> {
+impl<const LIMBS: usize> Neg for DynResidue<LIMBS> {
     type Output = Self;
 
-    fn add(self, rhs: Self) -> Self {
-        debug_assert_eq!(self.residue_params, rhs.residue_params);
+    fn neg(self) -> Self {
         DynResidue {
-            montgomery_form: add_montgomery_form(
+            montgomery_form: neg_montgomery_form(
                 &self.montgomery_form,
-                &rhs.montgomery_form,
                 &self.residue_params.modulus,
             ),
             residue_params: self.residue_params,
         }
-    }
-}
-
-impl<const LIMBS: usize> AddAssign for DynResidue<LIMBS> {
-    fn add_assign(&mut self, rhs: Self) {
-        *self = *self + rhs;
     }
 }
 
@@ -34,7 +26,7 @@ mod tests {
     };
 
     #[test]
-    fn add_overflow() {
+    fn neg() {
         let params = DynResidueParams::new(U256::from_be_hex(
             "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
         ));
@@ -43,13 +35,10 @@ mod tests {
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
         let mut x_mod = DynResidue::new(x, params);
 
-        let y =
-            U256::from_be_hex("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251");
-
-        x_mod += DynResidue::new(y, params);
+        x_mod = -x_mod;
 
         let expected =
-            U256::from_be_hex("1a2472fde50286541d97ca6a3592dd75beb9c9646e40c511b82496cfc3926956");
+            U256::from_be_hex("bb5309471c93ecbe3d3a768dfb01f6af6ec8cbb28c879b0d17f4e31c5b2f38fb");
 
         assert_eq!(expected, x_mod.retrieve());
     }

--- a/src/uint/modular/runtime_mod/runtime_pow.rs
+++ b/src/uint/modular/runtime_mod/runtime_pow.rs
@@ -1,20 +1,13 @@
 use crate::{
-    modular::{pow::pow_montgomery_form, PowResidue},
+    modular::{pow::pow_montgomery_form, Pow},
     UInt,
 };
 
 use super::DynResidue;
 
-impl<const LIMBS: usize> PowResidue<LIMBS> for DynResidue<LIMBS> {
+impl<const LIMBS: usize> Pow<LIMBS> for DynResidue<LIMBS> {
     fn pow_specific(self, exponent: &UInt<LIMBS>, exponent_bits: usize) -> Self {
-        self.pow_specific(exponent, exponent_bits)
-    }
-}
-
-impl<const LIMBS: usize> DynResidue<LIMBS> {
-    /// Computes the (reduced) exponentiation of a residue, here `exponent_bits` represents the number of bits to take into account for the exponent. Note that this value is leaked in the time pattern.
-    pub const fn pow_specific(self, exponent: &UInt<LIMBS>, exponent_bits: usize) -> Self {
-        Self {
+        DynResidue {
             montgomery_form: pow_montgomery_form(
                 self.montgomery_form,
                 exponent,

--- a/src/uint/modular/runtime_mod/runtime_square.rs
+++ b/src/uint/modular/runtime_mod/runtime_square.rs
@@ -1,0 +1,16 @@
+use crate::modular::{mul::square_montgomery_form, Square};
+
+use super::DynResidue;
+
+impl<const LIMBS: usize> Square for DynResidue<LIMBS> {
+    fn square(self) -> Self {
+        DynResidue {
+            montgomery_form: square_montgomery_form(
+                &self.montgomery_form,
+                self.residue_params.modulus,
+                self.residue_params.mod_neg_inv,
+            ),
+            residue_params: self.residue_params,
+        }
+    }
+}

--- a/src/uint/modular/runtime_mod/runtime_sub.rs
+++ b/src/uint/modular/runtime_mod/runtime_sub.rs
@@ -1,16 +1,16 @@
-use core::ops::{Add, AddAssign};
+use core::ops::{Sub, SubAssign};
 
-use crate::modular::add::add_montgomery_form;
+use crate::modular::sub::sub_montgomery_form;
 
 use super::DynResidue;
 
-impl<const LIMBS: usize> Add for DynResidue<LIMBS> {
+impl<const LIMBS: usize> Sub for DynResidue<LIMBS> {
     type Output = Self;
 
-    fn add(self, rhs: Self) -> Self {
+    fn sub(self, rhs: Self) -> Self {
         debug_assert_eq!(self.residue_params, rhs.residue_params);
         DynResidue {
-            montgomery_form: add_montgomery_form(
+            montgomery_form: sub_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
                 &self.residue_params.modulus,
@@ -20,9 +20,9 @@ impl<const LIMBS: usize> Add for DynResidue<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> AddAssign for DynResidue<LIMBS> {
-    fn add_assign(&mut self, rhs: Self) {
-        *self = *self + rhs;
+impl<const LIMBS: usize> SubAssign for DynResidue<LIMBS> {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
     }
 }
 

--- a/src/uint/modular/sub.rs
+++ b/src/uint/modular/sub.rs
@@ -1,0 +1,9 @@
+use crate::UInt;
+
+pub(crate) const fn sub_montgomery_form<const LIMBS: usize>(
+    a: &UInt<LIMBS>,
+    b: &UInt<LIMBS>,
+    modulus: &UInt<LIMBS>,
+) -> UInt<LIMBS> {
+    a.sub_mod(b, modulus)
+}

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -1,6 +1,6 @@
 //! Wrapping arithmetic.
 
-use crate::Zero;
+use crate::{Random, Zero};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
@@ -57,6 +57,12 @@ impl<T: ConditionallySelectable> ConditionallySelectable for Wrapping<T> {
 impl<T: ConstantTimeEq> ConstantTimeEq for Wrapping<T> {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
+    }
+}
+
+impl<T: Random> Random for Wrapping<T> {
+    fn random(rng: impl rand_core::CryptoRng + rand_core::RngCore) -> Self {
+        Wrapping(Random::random(rng))
     }
 }
 


### PR DESCRIPTION
- Fix the macro `impl_modulus` so that it's usable from external crates. More specifically:
  - Make `UInt::ct_reduce`, `UInt::ct_reduce_wide` and `montgomery_reduction` public, because they are used in the macro `impl_modulus`. Without this change, the macro is unusable from external crates.
  - Fix qualification of re-exported items.
- Build the `GenericResidue` type around standard Rust traits such as `Add`, `Sub`, and `Mul`, instead of inventing our own traits. This way we can use overloaded operators in code that is generic over any `GenericResidue`.
- For any `GenericResidue`, also require `Sub`, `SubAssign`, `Neg`, and `ConstantTimeEq`.
- For `Residue` (i.e. with compile-time modulus) implement `Zero` and `Random`. (For `DynResidue` we cannot implement these traits, because we'd need to pass the desired modulus.)
- Remove the `Residue` suffix from the traits `SquareResidue`, `PowResidue`, as well as `InvResidue` and move them to `src/traits.rs`, because they are generic, i.e., they can in principle be applied to more than just residues.