### PR TITLE
Use `CryptoRngCore`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ subtle = { version = "2.4", default-features = false }
 # optional dependencies
 der = { version = "0.6", optional = true, default-features = false }
 generic-array = { version = "0.14", optional = true }
-rand_core = { version = "0.6", optional = true }
+rand_core = { version = "0.6.4", optional = true }
 rlp = { version = "0.5", optional = true, default-features = false }
 serdect = { version = "0.1", optional = true, default-features = false }
 zeroize = { version = "1", optional = true,  default-features = false }

--- a/src/limb/rand.rs
+++ b/src/limb/rand.rs
@@ -2,25 +2,25 @@
 
 use super::Limb;
 use crate::{Encoding, NonZero, Random, RandomMod};
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 use subtle::ConstantTimeLess;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 impl Random for Limb {
     #[cfg(target_pointer_width = "32")]
-    fn random(mut rng: impl CryptoRng + RngCore) -> Self {
+    fn random(rng: &mut impl CryptoRngCore) -> Self {
         Self(rng.next_u32())
     }
 
     #[cfg(target_pointer_width = "64")]
-    fn random(mut rng: impl CryptoRng + RngCore) -> Self {
+    fn random(rng: &mut impl CryptoRngCore) -> Self {
         Self(rng.next_u64())
     }
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 impl RandomMod for Limb {
-    fn random_mod(mut rng: impl CryptoRng + RngCore, modulus: &NonZero<Self>) -> Self {
+    fn random_mod(rng: &mut impl CryptoRngCore, modulus: &NonZero<Self>) -> Self {
         let mut bytes = <Self as Encoding>::Repr::default();
 
         let n_bits = modulus.bits();

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -12,10 +12,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use crate::{ArrayEncoding, ByteArray};
 
 #[cfg(feature = "rand_core")]
-use {
-    crate::Random,
-    rand_core::{CryptoRng, RngCore},
-};
+use {crate::Random, rand_core::CryptoRngCore};
 
 #[cfg(feature = "serde")]
 use serdect::serde::{
@@ -126,7 +123,7 @@ where
     T: Random + Zero,
 {
     /// Generate a random `NonZero<T>`.
-    fn random(mut rng: impl CryptoRng + RngCore) -> Self {
+    fn random(mut rng: &mut impl CryptoRngCore) -> Self {
         // Use rejection sampling to eliminate zero values.
         // While this method isn't constant-time, the attacker shouldn't learn
         // anything about unrelated outputs so long as `rng` is a secure `CryptoRng`.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -9,7 +9,7 @@ use subtle::{
 };
 
 #[cfg(feature = "rand_core")]
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 
 /// Integer type.
 pub trait Integer:
@@ -93,7 +93,7 @@ pub trait Zero: ConstantTimeEq + Sized {
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 pub trait Random: Sized {
     /// Generate a cryptographically secure random value.
-    fn random(rng: impl CryptoRng + RngCore) -> Self;
+    fn random(rng: &mut impl CryptoRngCore) -> Self;
 }
 
 /// Modular random number generation support.
@@ -111,7 +111,7 @@ pub trait RandomMod: Sized + Zero {
     /// issue so long as the underlying random number generator is truly a
     /// [`CryptoRng`], where previous outputs are unrelated to subsequent
     /// outputs and do not reveal information about the RNG's internal state.
-    fn random_mod(rng: impl CryptoRng + RngCore, modulus: &NonZero<Self>) -> Self;
+    fn random_mod(rng: &mut impl CryptoRngCore, modulus: &NonZero<Self>) -> Self;
 }
 
 /// Compute `self + rhs mod p`.

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -2,13 +2,13 @@
 
 use super::Uint;
 use crate::{Limb, NonZero, Random, RandomMod};
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 use subtle::ConstantTimeLess;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 impl<const LIMBS: usize> Random for Uint<LIMBS> {
     /// Generate a cryptographically secure random [`Uint`].
-    fn random(mut rng: impl CryptoRng + RngCore) -> Self {
+    fn random(mut rng: &mut impl CryptoRngCore) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
 
         for limb in &mut limbs {
@@ -32,7 +32,7 @@ impl<const LIMBS: usize> RandomMod for Uint<LIMBS> {
     /// issue so long as the underlying random number generator is truly a
     /// [`CryptoRng`], where previous outputs are unrelated to subsequent
     /// outputs and do not reveal information about the RNG's internal state.
-    fn random_mod(mut rng: impl CryptoRng + RngCore, modulus: &NonZero<Self>) -> Self {
+    fn random_mod(mut rng: &mut impl CryptoRngCore, modulus: &NonZero<Self>) -> Self {
         let mut n = Self::ZERO;
 
         let n_bits = modulus.as_ref().bits_vartime();


### PR DESCRIPTION
More succinct marker trait introduced in `rand_core` v0.6.4