### PR TITLE
Use `doc_auto_cfg`

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -12,6 +12,7 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-Dwarnings"
+  RUSTDOCFLAGS: "-Dwarnings"
 
 jobs:
   build:
@@ -143,7 +144,6 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  # just building them to check that they're up to date with the API
   build-benchmarks:
     runs-on: ubuntu-latest
     steps:
@@ -153,3 +153,14 @@ jobs:
           toolchain: 1.61.0
           profile: minimal
       - run: cargo build --all-features --benches
+
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - run: cargo doc --all-features

--- a/src/array.rs
+++ b/src/array.rs
@@ -5,11 +5,9 @@ use core::ops::Add;
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
 /// Alias for a byte array whose size is defined by [`ArrayEncoding::ByteSize`].
-#[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
 pub type ByteArray<T> = GenericArray<u8, <T as ArrayEncoding>::ByteSize>;
 
 /// Support for encoding a big integer as a `GenericArray`.
-#[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
 pub trait ArrayEncoding: Encoding {
     /// Size of a byte array which encodes a big integer.
     type ByteSize: ArrayLength<u8> + Add + Eq + Ord + Unsigned;
@@ -28,7 +26,6 @@ pub trait ArrayEncoding: Encoding {
 }
 
 /// Support for decoding a `GenericArray` as a big integer.
-#[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
 pub trait ArrayDecoding {
     /// Big integer which decodes a `GenericArray`.
     type Output: ArrayEncoding + Integer;

--- a/src/checked.rs
+++ b/src/checked.rs
@@ -61,7 +61,6 @@ impl<T> From<Checked<T>> for Option<T> {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, T: Default + Deserialize<'de>> Deserialize<'de> for Checked<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -74,7 +73,6 @@ impl<'de, T: Default + Deserialize<'de>> Deserialize<'de> for Checked<T> {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, T: Copy + Serialize> Serialize for Checked<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
@@ -118,7 +118,7 @@
 //! ### Random number generation
 //!
 //! When the `rand_core` or `rand` features of this crate are enabled, it's
-//! possible to generate random numbers using any [`CryptoRng`] by using the
+//! possible to generate random numbers using any CSRNG by using the
 //! [`Random`] trait:
 //!
 //! ```
@@ -150,7 +150,6 @@
 //! [`Mul`]: core::ops::Mul
 //! [`Rem`]: core::ops::Rem
 //! [`Sub`]: core::ops::Sub
-//! [`CryptoRng`]: rand_core::CryptoRng
 
 #[cfg(all(feature = "alloc", test))]
 extern crate alloc;

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -130,7 +130,6 @@ impl fmt::UpperHex for Limb {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> Deserialize<'de> for Limb {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -141,7 +140,6 @@ impl<'de> Deserialize<'de> for Limb {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> Serialize for Limb {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -152,5 +150,4 @@ impl<'de> Serialize for Limb {
 }
 
 #[cfg(feature = "zeroize")]
-#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 impl zeroize::DefaultIsZeroes for Limb {}

--- a/src/limb/from.rs
+++ b/src/limb/from.rs
@@ -25,7 +25,6 @@ impl Limb {
     /// Create a [`Limb`] from a `u64` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u64>` when stable
     #[cfg(target_pointer_width = "64")]
-    #[cfg_attr(docsrs, doc(cfg(target_pointer_width = "64")))]
     pub const fn from_u64(n: u64) -> Self {
         Limb(n)
     }
@@ -53,7 +52,6 @@ impl From<u32> for Limb {
 }
 
 #[cfg(target_pointer_width = "64")]
-#[cfg_attr(docsrs, doc(cfg(target_pointer_width = "64")))]
 impl From<u64> for Limb {
     #[inline]
     fn from(n: u64) -> Limb {

--- a/src/limb/rand.rs
+++ b/src/limb/rand.rs
@@ -5,7 +5,6 @@ use crate::{Encoding, NonZero, Random, RandomMod};
 use rand_core::CryptoRngCore;
 use subtle::ConstantTimeLess;
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 impl Random for Limb {
     #[cfg(target_pointer_width = "32")]
     fn random(rng: &mut impl CryptoRngCore) -> Self {
@@ -18,7 +17,6 @@ impl Random for Limb {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 impl RandomMod for Limb {
     fn random_mod(rng: &mut impl CryptoRngCore, modulus: &NonZero<Self>) -> Self {
         let mut bytes = <Self as Encoding>::Repr::default();

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -62,7 +62,6 @@ where
 }
 
 #[cfg(feature = "generic-array")]
-#[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
 impl<T> NonZero<T>
 where
     T: ArrayEncoding + Zero,
@@ -117,7 +116,6 @@ where
 }
 
 #[cfg(feature = "rand_core")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 impl<T> Random for NonZero<T>
 where
     T: Random + Zero,
@@ -126,7 +124,7 @@ where
     fn random(mut rng: &mut impl CryptoRngCore) -> Self {
         // Use rejection sampling to eliminate zero values.
         // While this method isn't constant-time, the attacker shouldn't learn
-        // anything about unrelated outputs so long as `rng` is a secure `CryptoRng`.
+        // anything about unrelated outputs so long as `rng` is a CSRNG.
         loop {
             if let Some(result) = Self::new(T::random(&mut rng)).into() {
                 break result;
@@ -202,7 +200,6 @@ impl NonZero<Limb> {
     /// Create a [`NonZero<Limb>`] from a [`NonZeroU64`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU64>` when stable
     #[cfg(target_pointer_width = "64")]
-    #[cfg_attr(docsrs, doc(cfg(target_pointer_width = "64")))]
     pub const fn from_u64(n: NonZeroU64) -> Self {
         Self(Limb::from_u64(n.get()))
     }
@@ -227,7 +224,6 @@ impl From<NonZeroU32> for NonZero<Limb> {
 }
 
 #[cfg(target_pointer_width = "64")]
-#[cfg_attr(docsrs, doc(cfg(target_pointer_width = "64")))]
 impl From<NonZeroU64> for NonZero<Limb> {
     fn from(integer: NonZeroU64) -> Self {
         Self::from_u64(integer)
@@ -311,7 +307,6 @@ impl<const LIMBS: usize> From<NonZeroU128> for NonZero<Uint<LIMBS>> {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, T: Deserialize<'de> + Zero> Deserialize<'de> for NonZero<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -331,7 +326,6 @@ impl<'de, T: Deserialize<'de> + Zero> Deserialize<'de> for NonZero<T> {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, T: Serialize + Zero> Serialize for NonZero<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -90,7 +90,6 @@ pub trait Zero: ConstantTimeEq + Sized {
 
 /// Random number generation support.
 #[cfg(feature = "rand_core")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 pub trait Random: Sized {
     /// Generate a cryptographically secure random value.
     fn random(rng: &mut impl CryptoRngCore) -> Self;
@@ -98,18 +97,17 @@ pub trait Random: Sized {
 
 /// Modular random number generation support.
 #[cfg(feature = "rand_core")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 pub trait RandomMod: Sized + Zero {
     /// Generate a cryptographically secure random number which is less than
     /// a given `modulus`.
     ///
     /// This function uses rejection sampling, a method which produces an
     /// unbiased distribution of in-range values provided the underlying
-    /// [`CryptoRng`] is unbiased, but runs in variable-time.
+    /// CSRNG is unbiased, but runs in variable-time.
     ///
     /// The variable-time nature of the algorithm should not pose a security
     /// issue so long as the underlying random number generator is truly a
-    /// [`CryptoRng`], where previous outputs are unrelated to subsequent
+    /// CSRNG, where previous outputs are unrelated to subsequent
     /// outputs and do not reveal information about the RNG's internal state.
     fn random_mod(rng: &mut impl CryptoRngCore, modulus: &NonZero<Self>) -> Self;
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -258,7 +258,6 @@ impl<const LIMBS: usize> fmt::UpperHex for Uint<LIMBS> {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, const LIMBS: usize> Deserialize<'de> for Uint<LIMBS>
 where
     Uint<LIMBS>: Encoding,
@@ -275,7 +274,6 @@ where
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, const LIMBS: usize> Serialize for Uint<LIMBS>
 where
     Uint<LIMBS>: Encoding,
@@ -289,7 +287,6 @@ where
 }
 
 #[cfg(feature = "zeroize")]
-#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 impl<const LIMBS: usize> DefaultIsZeroes for Uint<LIMBS> {}
 
 // TODO(tarcieri): use `const_evaluatable_checked` when stable to make generic around bits.

--- a/src/uint/array.rs
+++ b/src/uint/array.rs
@@ -7,7 +7,6 @@ use generic_array::{typenum, GenericArray};
 macro_rules! impl_uint_array_encoding {
     ($(($uint:ident, $bytes:path)),+) => {
         $(
-            #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
             impl ArrayEncoding for super::$uint {
                 type ByteSize = $bytes;
 
@@ -36,7 +35,6 @@ macro_rules! impl_uint_array_encoding {
                 }
             }
 
-            #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
             impl ArrayDecoding for GenericArray<u8, $bytes> {
                 type Output = super::$uint;
 

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -115,7 +115,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Serialize this [`Uint`] as big-endian, writing it into the provided
     /// byte slice.
     #[inline]
-    #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
     pub(crate) fn write_be_bytes(&self, out: &mut [u8]) {
         debug_assert_eq!(out.len(), Limb::BYTES * LIMBS);
 
@@ -133,7 +132,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Serialize this [`Uint`] as little-endian, writing it into the provided
     /// byte slice.
     #[inline]
-    #[cfg_attr(docsrs, doc(cfg(feature = "generic-array")))]
     pub(crate) fn write_le_bytes(&self, out: &mut [u8]) {
         debug_assert_eq!(out.len(), Limb::BYTES * LIMBS);
 

--- a/src/uint/encoding/der.rs
+++ b/src/uint/encoding/der.rs
@@ -6,7 +6,6 @@ use ::der::{
     DecodeValue, EncodeValue, FixedTag, Length, Tag,
 };
 
-#[cfg_attr(docsrs, doc(cfg(feature = "der")))]
 impl<'a, const LIMBS: usize> TryFrom<AnyRef<'a>> for Uint<LIMBS>
 where
     Uint<LIMBS>: ArrayEncoding,
@@ -18,7 +17,6 @@ where
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "der")))]
 impl<'a, const LIMBS: usize> TryFrom<UIntRef<'a>> for Uint<LIMBS>
 where
     Uint<LIMBS>: ArrayEncoding,
@@ -33,7 +31,6 @@ where
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "der")))]
 impl<'a, const LIMBS: usize> DecodeValue<'a> for Uint<LIMBS>
 where
     Uint<LIMBS>: ArrayEncoding,
@@ -43,7 +40,6 @@ where
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "der")))]
 impl<const LIMBS: usize> EncodeValue for Uint<LIMBS>
 where
     Uint<LIMBS>: ArrayEncoding,
@@ -60,7 +56,6 @@ where
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "der")))]
 impl<const LIMBS: usize> FixedTag for Uint<LIMBS>
 where
     Uint<LIMBS>: ArrayEncoding,

--- a/src/uint/encoding/rlp.rs
+++ b/src/uint/encoding/rlp.rs
@@ -3,7 +3,6 @@
 use crate::{Encoding, Uint};
 use rlp::{DecoderError, Rlp, RlpStream};
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rlp")))]
 impl<const LIMBS: usize> rlp::Encodable for Uint<LIMBS>
 where
     Self: Encoding,
@@ -20,7 +19,6 @@ where
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rlp")))]
 impl<const LIMBS: usize> rlp::Decodable for Uint<LIMBS>
 where
     Self: Encoding,

--- a/src/uint/from.rs
+++ b/src/uint/from.rs
@@ -141,7 +141,6 @@ impl<const LIMBS: usize> From<u128> for Uint<LIMBS> {
 }
 
 #[cfg(target_pointer_width = "32")]
-#[cfg_attr(docsrs, doc(cfg(target_pointer_width = "32")))]
 impl From<U64> for u64 {
     fn from(n: U64) -> u64 {
         (n.limbs[0].0 as u64) | ((n.limbs[1].0 as u64) << 32)
@@ -149,7 +148,6 @@ impl From<U64> for u64 {
 }
 
 #[cfg(target_pointer_width = "64")]
-#[cfg_attr(docsrs, doc(cfg(target_pointer_width = "64")))]
 impl From<U64> for u64 {
     fn from(n: U64) -> u64 {
         n.limbs[0].into()

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -5,7 +5,6 @@ use crate::{Limb, NonZero, Random, RandomMod};
 use rand_core::CryptoRngCore;
 use subtle::ConstantTimeLess;
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 impl<const LIMBS: usize> Random for Uint<LIMBS> {
     /// Generate a cryptographically secure random [`Uint`].
     fn random(mut rng: &mut impl CryptoRngCore) -> Self {
@@ -19,18 +18,17 @@ impl<const LIMBS: usize> Random for Uint<LIMBS> {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
 impl<const LIMBS: usize> RandomMod for Uint<LIMBS> {
     /// Generate a cryptographically secure random [`Uint`] which is less than
     /// a given `modulus`.
     ///
     /// This function uses rejection sampling, a method which produces an
     /// unbiased distribution of in-range values provided the underlying
-    /// [`CryptoRng`] is unbiased, but runs in variable-time.
+    /// CSRNG is unbiased, but runs in variable-time.
     ///
     /// The variable-time nature of the algorithm should not pose a security
     /// issue so long as the underlying random number generator is truly a
-    /// [`CryptoRng`], where previous outputs are unrelated to subsequent
+    /// CSRNG, where previous outputs are unrelated to subsequent
     /// outputs and do not reveal information about the RNG's internal state.
     fn random_mod(mut rng: &mut impl CryptoRngCore, modulus: &NonZero<Self>) -> Self {
         let mut n = Self::ZERO;

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -61,7 +61,6 @@ impl<T: ConstantTimeEq> ConstantTimeEq for Wrapping<T> {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, T: Deserialize<'de>> Deserialize<'de> for Wrapping<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -72,7 +71,6 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Wrapping<T> {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, T: Serialize> Serialize for Wrapping<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
Replace manual `cfg(doc(...))` annotations with automatic generation