### PR TITLE
Require some additional traits for `ResidueParams`

### DIFF
--- a/src/uint/modular/constant_mod.rs
+++ b/src/uint/modular/constant_mod.rs
@@ -1,4 +1,4 @@
-use core::marker::PhantomData;
+use core::{fmt::Debug, marker::PhantomData};
 
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
@@ -28,7 +28,9 @@ pub use macros::*;
 /// The parameters to efficiently go to and from the Montgomery form for a given odd modulus. An easy way to generate these parameters is using the `impl_modulus!` macro. These parameters are constant, so they cannot be set at runtime.
 ///
 /// Unfortunately, `LIMBS` must be generic for now until const generics are stabilized.
-pub trait ResidueParams<const LIMBS: usize>: Copy {
+pub trait ResidueParams<const LIMBS: usize>:
+    Copy + Debug + Default + Eq + Send + Sync + 'static
+{
     /// Number of limbs required to encode a residue
     const LIMBS: usize;
 

--- a/src/uint/modular/constant_mod/macros.rs
+++ b/src/uint/modular/constant_mod/macros.rs
@@ -4,7 +4,7 @@
 /// For example, `impl_modulus!(MyModulus, U256, "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001");` implements a 256-bit modulus named `MyModulus`.
 macro_rules! impl_modulus {
     ($name:ident, $uint_type:ty, $value:expr) => {
-        #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+        #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
         pub struct $name {}
         impl<const DLIMBS: usize> ResidueParams<{ nlimbs!(<$uint_type>::BITS) }> for $name
         where


### PR DESCRIPTION
This makes it easier to handle `ResidueParams` and `Residue` in generic code.