### PR TITLE
Make `impl_modulus!` usable from external crates

### DIFF
--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -44,7 +44,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self` / `rhs`, returns the quotient (q), remainder (r)
     /// and the truthy value for is_some or the falsy value for is_none.
     ///
-    /// NOTE: Use only if you need to access const fn. Otherwise use [`div_rem`] because
+    /// NOTE: Use only if you need to access const fn. Otherwise use [`Self::div_rem`] because
     /// the value for is_some needs to be checked before using `q` and `r`.
     ///
     /// This is variable only with respect to `rhs`.
@@ -79,12 +79,12 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self` % `rhs`, returns the remainder and
     /// and the truthy value for is_some or the falsy value for is_none.
     ///
-    /// NOTE: Use only if you need to access const fn. Otherwise use [`rem`].
+    /// NOTE: Use only if you need to access const fn. Otherwise use [`Self::rem`].
     /// This is variable only with respect to `rhs`.
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
-    pub(crate) const fn ct_rem(&self, rhs: &Self) -> (Self, CtChoice) {
+    pub const fn const_rem(&self, rhs: &Self) -> (Self, CtChoice) {
         let mb = rhs.bits_vartime();
         let mut bd = Self::BITS - mb;
         let mut rem = *self;
@@ -111,7 +111,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
-    pub(crate) const fn ct_rem_wide(lower_upper: (Self, Self), rhs: &Self) -> (Self, CtChoice) {
+    pub const fn const_rem_wide(lower_upper: (Self, Self), rhs: &Self) -> (Self, CtChoice) {
         let mb = rhs.bits_vartime();
 
         // The number of bits to consider is two sets of limbs * BITS - mb (modulus bitcount)
@@ -175,7 +175,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes self % rhs, returns the remainder.
     pub fn rem(&self, rhs: &NonZero<Self>) -> Self {
         // Since `rhs` is nonzero, this should always hold.
-        let (r, _c) = self.ct_rem(rhs);
+        let (r, _c) = self.const_rem(rhs);
         r
     }
 
@@ -205,7 +205,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Panics if `rhs == 0`.
     pub const fn wrapping_rem(&self, rhs: &Self) -> Self {
-        let (r, c) = self.ct_rem(rhs);
+        let (r, c) = self.const_rem(rhs);
         assert!(c.is_true_vartime(), "modulo zero");
         r
     }
@@ -663,7 +663,7 @@ mod tests {
 
     #[test]
     fn reduce_one() {
-        let (r, is_some) = U256::from(10u8).ct_rem(&U256::ONE);
+        let (r, is_some) = U256::from(10u8).const_rem(&U256::ONE);
         assert!(is_some.is_true_vartime());
         assert_eq!(r, U256::ZERO);
     }
@@ -671,33 +671,33 @@ mod tests {
     #[test]
     fn reduce_zero() {
         let u = U256::from(10u8);
-        let (r, is_some) = u.ct_rem(&U256::ZERO);
+        let (r, is_some) = u.const_rem(&U256::ZERO);
         assert!(!is_some.is_true_vartime());
         assert_eq!(r, u);
     }
 
     #[test]
     fn reduce_tests() {
-        let (r, is_some) = U256::from(10u8).ct_rem(&U256::from(2u8));
+        let (r, is_some) = U256::from(10u8).const_rem(&U256::from(2u8));
         assert!(is_some.is_true_vartime());
         assert_eq!(r, U256::ZERO);
-        let (r, is_some) = U256::from(10u8).ct_rem(&U256::from(3u8));
+        let (r, is_some) = U256::from(10u8).const_rem(&U256::from(3u8));
         assert!(is_some.is_true_vartime());
         assert_eq!(r, U256::ONE);
-        let (r, is_some) = U256::from(10u8).ct_rem(&U256::from(7u8));
+        let (r, is_some) = U256::from(10u8).const_rem(&U256::from(7u8));
         assert!(is_some.is_true_vartime());
         assert_eq!(r, U256::from(3u8));
     }
 
     #[test]
     fn reduce_tests_wide_zero_padded() {
-        let (r, is_some) = U256::ct_rem_wide((U256::from(10u8), U256::ZERO), &U256::from(2u8));
+        let (r, is_some) = U256::const_rem_wide((U256::from(10u8), U256::ZERO), &U256::from(2u8));
         assert!(is_some.is_true_vartime());
         assert_eq!(r, U256::ZERO);
-        let (r, is_some) = U256::ct_rem_wide((U256::from(10u8), U256::ZERO), &U256::from(3u8));
+        let (r, is_some) = U256::const_rem_wide((U256::from(10u8), U256::ZERO), &U256::from(3u8));
         assert!(is_some.is_true_vartime());
         assert_eq!(r, U256::ONE);
-        let (r, is_some) = U256::ct_rem_wide((U256::from(10u8), U256::ZERO), &U256::from(7u8));
+        let (r, is_some) = U256::const_rem_wide((U256::from(10u8), U256::ZERO), &U256::from(7u8));
         assert!(is_some.is_true_vartime());
         assert_eq!(r, U256::from(3u8));
     }

--- a/src/uint/modular.rs
+++ b/src/uint/modular.rs
@@ -11,6 +11,8 @@ mod mul;
 mod pow;
 mod sub;
 
+pub use reduction::montgomery_reduction;
+
 /// A generalization for numbers kept in optimized representations (e.g. Montgomery)
 /// that can be converted back to the original form.
 pub trait Retrieve {

--- a/src/uint/modular/reduction.rs
+++ b/src/uint/modular/reduction.rs
@@ -1,7 +1,7 @@
 use crate::{CtChoice, Limb, Uint, WideWord, Word};
 
-/// Algorithm 14.32 in Handbook of Applied Cryptography (https://cacr.uwaterloo.ca/hac/about/chap14.pdf)
-pub(crate) const fn montgomery_reduction<const LIMBS: usize>(
+/// Algorithm 14.32 in Handbook of Applied Cryptography <https://cacr.uwaterloo.ca/hac/about/chap14.pdf>
+pub const fn montgomery_reduction<const LIMBS: usize>(
     lower_upper: &(Uint<LIMBS>, Uint<LIMBS>),
     modulus: &Uint<LIMBS>,
     mod_neg_inv: Limb,

--- a/src/uint/modular/runtime_mod.rs
+++ b/src/uint/modular/runtime_mod.rs
@@ -34,8 +34,8 @@ pub struct DynResidueParams<const LIMBS: usize> {
 impl<const LIMBS: usize> DynResidueParams<LIMBS> {
     /// Instantiates a new set of `ResidueParams` representing the given `modulus`.
     pub fn new(modulus: &Uint<LIMBS>) -> Self {
-        let r = Uint::MAX.ct_rem(modulus).0.wrapping_add(&Uint::ONE);
-        let r2 = Uint::ct_rem_wide(r.square_wide(), modulus).0;
+        let r = Uint::MAX.const_rem(modulus).0.wrapping_add(&Uint::ONE);
+        let r2 = Uint::const_rem_wide(r.square_wide(), modulus).0;
         let mod_neg_inv =
             Limb(Word::MIN.wrapping_sub(modulus.inv_mod2k(Word::BITS as usize).limbs[0].0));
         let r3 = montgomery_reduction(&r2.square_wide(), modulus, mod_neg_inv);

--- a/tests/impl_modulus.rs
+++ b/tests/impl_modulus.rs
@@ -1,0 +1,5 @@
+//! Test to ensure that `impl_modulus!` works from outside this crate.
+
+use crypto_bigint::{impl_modulus, U64};
+
+impl_modulus!(TestMod, U64, "30e4b8f030ab42f3");


### PR DESCRIPTION
Previously it was impossible to use `impl_modulus!` in crates that use crypto-bigint, because certain functions were only available within the crypto-bigint crate.