### PR TITLE
crypto-bigint: fix test vectors

### DIFF
--- a/src/limb/mul.rs
+++ b/src/limb/mul.rs
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn mul_wide() {
-        let primes: &[u32] = &[3, 5, 17, 256, 65537];
+        let primes: &[u32] = &[3, 5, 17, 257, 65537];
 
         for &a_int in primes {
             for &b_int in primes {

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -270,7 +270,7 @@ mod tests {
 
     #[test]
     fn mul_wide_lo_only() {
-        let primes: &[u32] = &[3, 5, 17, 256, 65537];
+        let primes: &[u32] = &[3, 5, 17, 257, 65537];
 
         for &a_int in primes {
             for &b_int in primes {


### PR DESCRIPTION
One of the "primes" in a list used in tests was accidentally 256 instead of 257.

This had no actual impact on the test and they continue to pass.