### PR TITLE
Define `U224` and `U544` on 32-bit platforms

### DIFF
--- a/src/uint.rs
+++ b/src/uint.rs
@@ -355,6 +355,12 @@ impl_uint_aliases! {
     (U8192, 8192, "8192-bit")
 }
 
+#[cfg(target_pointer_width = "32")]
+impl_uint_aliases! {
+    (U224, 224, "224-bit"), // For NIST P-224
+    (U544, 544, "544-bit")  // For NIST P-521
+}
+
 // TODO(tarcieri): use `const_evaluatable_checked` when stable to make generic around bits.
 impl_concat! {
     (U64, 64),


### PR DESCRIPTION
These are useful for P-224 and P-521 respectively.

They're gated on the target using 32-bit limbs (since neither is a multiple of 64).

fiat-crypto provides P-224 field arithmetic for 32-bit platforms that uses 7 limbs, for example.