### PR TITLE
Fix #191 by using a module path that is available from outside of the…

### DIFF
--- a/src/uint/modular/constant_mod/macros.rs
+++ b/src/uint/modular/constant_mod/macros.rs
@@ -45,7 +45,7 @@ macro_rules! impl_modulus {
 /// For example, `residue!(U256::from(105u64), MyModulus);` creates a `Residue` for 105 mod `MyModulus`.
 macro_rules! const_residue {
     ($variable:ident, $modulus:ident) => {
-        $crate::uint::modular::constant_mod::Residue::<$modulus, { $modulus::LIMBS }>::new(
+        $crate::modular::constant_mod::Residue::<$modulus, { $modulus::LIMBS }>::new(
             &$variable,
         )
     };

--- a/src/uint/modular/constant_mod/macros.rs
+++ b/src/uint/modular/constant_mod/macros.rs
@@ -45,8 +45,6 @@ macro_rules! impl_modulus {
 /// For example, `residue!(U256::from(105u64), MyModulus);` creates a `Residue` for 105 mod `MyModulus`.
 macro_rules! const_residue {
     ($variable:ident, $modulus:ident) => {
-        $crate::modular::constant_mod::Residue::<$modulus, { $modulus::LIMBS }>::new(
-            &$variable,
-        )
+        $crate::modular::constant_mod::Residue::<$modulus, { $modulus::LIMBS }>::new(&$variable)
     };
 }

--- a/tests/const_residue.rs
+++ b/tests/const_residue.rs
@@ -1,0 +1,10 @@
+//! Test to ensure that `const_residue!` works from outside this crate.
+
+use crypto_bigint::{impl_modulus, const_residue, U64, modular::constant_mod::ResidueParams};
+
+impl_modulus!(TestMod, U64, "30e4b8f030ab42f3");
+
+fn _test_fun() {
+    let base = U64::from(2u64);
+    let _base_mod = const_residue!(base, TestMod);
+}

--- a/tests/const_residue.rs
+++ b/tests/const_residue.rs
@@ -1,6 +1,6 @@
 //! Test to ensure that `const_residue!` works from outside this crate.
 
-use crypto_bigint::{impl_modulus, const_residue, U64, modular::constant_mod::ResidueParams};
+use crypto_bigint::{const_residue, impl_modulus, modular::constant_mod::ResidueParams, U64};
 
 impl_modulus!(TestMod, U64, "30e4b8f030ab42f3");
 


### PR DESCRIPTION
… crate, and add a test to make sure the macro const_residue is possible to use outside of the crate