### PR TITLE
v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.1 (2023-03-13)
+### Changed
+- Improve `Debug` impls on `Limb` and `Uint` ([#195])
+
+### Fixed
+- `const_residue` macro accessibility bug ([#193])
+
+[#193]: https://github.com/RustCrypto/crypto-bigint/pull/193
+[#195]: https://github.com/RustCrypto/crypto-bigint/pull/195
+
 ## 0.5.0 (2023-02-27)
 ### Added
 - `Residue`: modular arithmetic with static compile-time moduli ([#130])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.5.0"
+version = "0.5.1"
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,


### PR DESCRIPTION
### Changed
- Improve `Debug` impls on `Limb` and `Uint` ([#195])

### Fixed
- `const_residue` macro accessibility bug ([#193])

[#193]: https://github.com/RustCrypto/crypto-bigint/pull/193
[#195]: https://github.com/RustCrypto/crypto-bigint/pull/195