### PR TITLE
Expose residue params and modulus in `DynResidue`

### DIFF
--- a/src/uint/modular/runtime_mod.rs
+++ b/src/uint/modular/runtime_mod.rs
@@ -48,6 +48,11 @@ impl<const LIMBS: usize> DynResidueParams<LIMBS> {
             mod_neg_inv,
         }
     }
+
+    /// Returns the modulus which was used to initialize these parameters.
+    pub const fn modulus(&self) -> &Uint<LIMBS> {
+        &self.modulus
+    }
 }
 
 /// A residue represented using `LIMBS` limbs. The odd modulus of this residue is set at runtime.
@@ -96,6 +101,11 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
             montgomery_form: residue_params.r,
             residue_params,
         }
+    }
+
+    /// Returns the parameter struct used to initialize this residue.
+    pub const fn params(&self) -> &DynResidueParams<LIMBS> {
+        &self.residue_params
     }
 }
 


### PR DESCRIPTION
The functionality I would like to have:
- extract `DynResidueParams` from a `DynResidue` object (to be able to, given one residue, initialize another one with the same params);
- extract the modulus from `DynResidueParams` (to be able to implement some modulus-depending algorithms, e.g. square root)

*Edit:* I decided to wait on exposing the Montgomery form for now; I will just retrieve before serializing. Exposing it exposes the specific representation used by the residue, and the API needs some thought, e.g. whether we do a range check when assembling a `DynResidue` from the pre-calculated Montgomery form and params.

Changes:
- Added `DynResidueParams::modulus()`
- Added `DynResidue::params()`
