### PR TITLE
Montgomery multiplication improvements

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -136,6 +136,15 @@ fn bench_montgomery<'a, M: Measurement>(group: &mut BenchmarkGroup<'a, M>) {
                 .for_each(drop)
         })
     });
+
+    group.bench_function("DynResidue creation", |b| {
+        b.iter(|| {
+            moduli
+                .iter()
+                .map(|m| DynResidueParams::new(m))
+                .for_each(drop)
+        })
+    });
 }
 
 fn bench_wrapping_ops(c: &mut Criterion) {

--- a/src/ct_choice.rs
+++ b/src/ct_choice.rs
@@ -37,10 +37,6 @@ impl CtChoice {
         Self(self.0 & other.0)
     }
 
-    pub(crate) const fn or(&self, other: Self) -> Self {
-        Self(self.0 | other.0)
-    }
-
     /// Return `b` if `self` is truthy, otherwise return `a`.
     pub(crate) const fn select(&self, a: Word, b: Word) -> Word {
         a ^ (self.0 & (a ^ b))

--- a/src/uint/add_mod.rs
+++ b/src/uint/add_mod.rs
@@ -16,19 +16,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
         // modulus.
-        let mut i = 0;
-        let mut res = Self::ZERO;
-        let mut carry = Limb::ZERO;
+        let mask = Uint::from_words([borrow.0; LIMBS]);
 
-        while i < LIMBS {
-            let rhs = p.limbs[i].bitand(borrow);
-            let (limb, c) = w.limbs[i].adc(rhs, carry);
-            res.limbs[i] = limb;
-            carry = c;
-            i += 1;
-        }
-
-        res
+        w.wrapping_add(&p.bitand(&mask))
     }
 
     /// Computes `self + rhs mod p` in constant time for the special modulus
@@ -43,8 +33,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // for the overflow. Otherwise, we need to subtract `c` again, which
         // in that case cannot underflow.
         let l = carry.0.wrapping_sub(1) & c.0;
-        let (out, _) = out.sbb(&Uint::from_word(l), Limb::ZERO);
-        out
+        out.wrapping_sub(&Uint::from_word(l))
     }
 }
 

--- a/src/uint/modular/runtime_mod.rs
+++ b/src/uint/modular/runtime_mod.rs
@@ -36,8 +36,13 @@ impl<const LIMBS: usize> DynResidueParams<LIMBS> {
     pub const fn new(modulus: &Uint<LIMBS>) -> Self {
         let r = Uint::MAX.const_rem(modulus).0.wrapping_add(&Uint::ONE);
         let r2 = Uint::const_rem_wide(r.square_wide(), modulus).0;
+
+        // Since we are calculating the inverse modulo (Word::MAX+1),
+        // we can take the modulo right away and calculate the inverse of the first limb only.
+        let modulus_lo = Uint::<1>::from_words([modulus.limbs[0].0]);
         let mod_neg_inv =
-            Limb(Word::MIN.wrapping_sub(modulus.inv_mod2k(Word::BITS as usize).limbs[0].0));
+            Limb(Word::MIN.wrapping_sub(modulus_lo.inv_mod2k(Word::BITS as usize).limbs[0].0));
+
         let r3 = montgomery_reduction(&r2.square_wide(), modulus, mod_neg_inv);
 
         Self {

--- a/src/uint/modular/runtime_mod.rs
+++ b/src/uint/modular/runtime_mod.rs
@@ -33,7 +33,7 @@ pub struct DynResidueParams<const LIMBS: usize> {
 
 impl<const LIMBS: usize> DynResidueParams<LIMBS> {
     /// Instantiates a new set of `ResidueParams` representing the given `modulus`.
-    pub fn new(modulus: &Uint<LIMBS>) -> Self {
+    pub const fn new(modulus: &Uint<LIMBS>) -> Self {
         let r = Uint::MAX.const_rem(modulus).0.wrapping_add(&Uint::ONE);
         let r2 = Uint::const_rem_wide(r.square_wide(), modulus).0;
         let mod_neg_inv =


### PR DESCRIPTION
- Added benchmarks for Montgomery multiplication and DynResidueParams creation
- Replaced the final reduction in `montgomery_reduction()` with `sub_mod_with_hi()`. Speeds it up by ~20% (for `U256`), I guess due to better vectorization?
- Extracted `muladdcarry()` from `montgomery_reduction()`
- Simplified `Uint::sub_mod()`, `sub_mod_special()`, `add_mod()`, `add_mod_special()` by reusing existing methods.
- Made `DynResidueParams::new()` a `const fn`
- Optimized `mod_neg_inv` calculation in `DynResidueParams::new()`, speeds it up by ~10% (for `U256`).

Originally I wanted to implement Montgomery multiplication by simultaneous multiplication + reduction instead of `mul_wide`, but it showed exactly the same performance, with the exception of the last reduction part - that's how I discovered the performance improvement. Still not quite sure what causes it.

(By the way, I measured the performance on arm64 - would be interesting to see the results for x64)