### PR TITLE
Housekeeping fixes

### DIFF
--- a/src/ct_choice.rs
+++ b/src/ct_choice.rs
@@ -25,7 +25,7 @@ impl CtChoice {
     /// Returns the truthy value if `value == 1`, and the falsy value if `value == 0`.
     /// Panics for other values.
     pub(crate) const fn from_lsb(value: Word) -> Self {
-        debug_assert!(value == Self::FALSE.0 || value == 1);
+        debug_assert!(value == 0 || value == 1);
         Self(value.wrapping_neg())
     }
 


### PR DESCRIPTION
Some minor internal things:
- simplify benchmarks by using `iter_batched()` (and regroup them more logically)
- make a debug assert in `CtChoice::from_lsb()` more consistent with the docstring
- move `sub_mod_with_hi()` to `Uint` near `sub_mod()`, since they're very similar