### PR TITLE
Add `div_by_2()` method for integers in Montgomery form

### DIFF
--- a/src/uint/modular.rs
+++ b/src/uint/modular.rs
@@ -6,6 +6,7 @@ pub mod constant_mod;
 pub mod runtime_mod;
 
 mod add;
+mod div_by_2;
 mod inv;
 mod mul;
 mod pow;

--- a/src/uint/modular/constant_mod.rs
+++ b/src/uint/modular/constant_mod.rs
@@ -4,7 +4,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use crate::{Limb, Uint, Zero};
 
-use super::{reduction::montgomery_reduction, Retrieve};
+use super::{div_by_2::div_by_2, reduction::montgomery_reduction, Retrieve};
 
 #[cfg(feature = "rand_core")]
 use crate::{rand_core::CryptoRngCore, NonZero, Random, RandomMod};
@@ -99,6 +99,18 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
             &MOD::MODULUS,
             MOD::MOD_NEG_INV,
         )
+    }
+
+    /// Performs the modular division by 2, that is for given `x` returns `y`
+    /// such that `y * 2 = x mod p`. This means:
+    /// - if `x` is even, returns `x / 2`,
+    /// - if `x` is odd, returns `(x + p) / 2`
+    ///   (since the modulus `p` in Montgomery form is always odd, this divides entirely).
+    pub fn div_by_2(&self) -> Self {
+        Self {
+            montgomery_form: div_by_2(&self.montgomery_form, &MOD::MODULUS),
+            phantom: PhantomData,
+        }
     }
 }
 

--- a/src/uint/modular/div_by_2.rs
+++ b/src/uint/modular/div_by_2.rs
@@ -1,0 +1,32 @@
+use crate::Uint;
+
+pub(crate) fn div_by_2<const LIMBS: usize>(a: &Uint<LIMBS>, modulus: &Uint<LIMBS>) -> Uint<LIMBS> {
+    // We are looking for such `x` that `x * 2 = y mod modulus`,
+    // where the given `a = M(y)` is the Montgomery representation of some `y`.
+    // This means that in Montgomery representation it would still apply:
+    // `M(x) + M(x) = a mod modulus`.
+    // So we can just forget about Montgomery representation, and return whatever is
+    // `a` divided by 2, and this will be the Montgomery representation of `x`.
+    // (Which means that this function works regardless of whether `a`
+    // is in Montgomery representation or not, but the algorithm below
+    // does need `modulus` to be odd)
+
+    // Two possibilities:
+    // - if `a` is even, we can just divide by 2;
+    // - if `a` is odd, we divide `(a + modulus)` by 2.
+    // To stay within the modulus we open the parentheses turning it into `a / 2 + modulus / 2 + 1`
+    // ("+1" because both `a` and `modulus` are odd, we lose 0.5 in each integer division).
+    // This will not overflow, so we can just use wrapping operations.
+
+    let half = a.shr_vartime(1);
+    let half_modulus = modulus.shr_vartime(1);
+
+    let if_even = half;
+    let if_odd = half
+        .wrapping_add(&half_modulus)
+        .wrapping_add(&Uint::<LIMBS>::ONE);
+
+    let is_odd = a.ct_is_odd();
+
+    Uint::<LIMBS>::ct_select(&if_even, &if_odd, is_odd)
+}

--- a/src/uint/modular/runtime_mod.rs
+++ b/src/uint/modular/runtime_mod.rs
@@ -1,6 +1,6 @@
 use crate::{Limb, Uint, Word};
 
-use super::{reduction::montgomery_reduction, Retrieve};
+use super::{div_by_2::div_by_2, reduction::montgomery_reduction, Retrieve};
 
 /// Additions between residues with a modulus set at runtime
 mod runtime_add;
@@ -111,6 +111,18 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// Returns the parameter struct used to initialize this residue.
     pub const fn params(&self) -> &DynResidueParams<LIMBS> {
         &self.residue_params
+    }
+
+    /// Performs the modular division by 2, that is for given `x` returns `y`
+    /// such that `y * 2 = x mod p`. This means:
+    /// - if `x` is even, returns `x / 2`,
+    /// - if `x` is odd, returns `(x + p) / 2`
+    ///   (since the modulus `p` in Montgomery form is always odd, this divides entirely).
+    pub fn div_by_2(&self) -> Self {
+        Self {
+            montgomery_form: div_by_2(&self.montgomery_form, &self.residue_params.modulus),
+            residue_params: self.residue_params,
+        }
     }
 }
 

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -282,4 +282,25 @@ proptest! {
 
         assert_eq!(expected, actual);
     }
+
+    #[test]
+    fn residue_div_by_2(a in uint_mod_p(P)) {
+        let a_bi = to_biguint(&a);
+        let p_bi = to_biguint(&P);
+        let two = BigUint::from(2u32);
+
+        let expected = if a_bi.is_even() {
+            &a_bi / two
+        }
+        else {
+            (&a_bi + &p_bi) / two
+        };
+        let expected = to_uint(expected);
+
+        let params = DynResidueParams::new(&P);
+        let a_m = DynResidue::new(&a, params);
+        let actual = a_m.div_by_2().retrieve();
+
+        assert_eq!(expected, actual);
+    }
 }


### PR DESCRIPTION
For a given `x`, the method finds `y` such that `y + y = x mod p`. 

I understand the method may seem kind of niche. I need it for an efficient way of generating Lucas sequences (see https://doi.org/10.1090/mcom/3616, where Eqs. 16-17 require division by 2). But one can view it as a counterpart of modular square root, just for addition instead of multiplication. 

Technically this can be extended to regular Uints, but then it would have to return a CtOption (to cover the cases with odd `x` and even `p`).