### PR TITLE
Div-by-2 adjustment

### DIFF
--- a/src/uint/modular/div_by_2.rs
+++ b/src/uint/modular/div_by_2.rs
@@ -18,15 +18,13 @@ pub(crate) fn div_by_2<const LIMBS: usize>(a: &Uint<LIMBS>, modulus: &Uint<LIMBS
     // ("+1" because both `a` and `modulus` are odd, we lose 0.5 in each integer division).
     // This will not overflow, so we can just use wrapping operations.
 
-    let half = a.shr_vartime(1);
+    let (half, is_odd) = a.shr_1();
     let half_modulus = modulus.shr_vartime(1);
 
     let if_even = half;
     let if_odd = half
         .wrapping_add(&half_modulus)
         .wrapping_add(&Uint::<LIMBS>::ONE);
-
-    let is_odd = a.ct_is_odd();
 
     Uint::<LIMBS>::ct_select(&if_even, &if_odd, is_odd)
 }

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -5,7 +5,8 @@ use crate::{limb::HI_BIT, CtChoice, Limb};
 use core::ops::{Shr, ShrAssign};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
-    /// Computes `self >> 1` in constant-time, returning the overflowing bit as a `Word` that is either 0...0 or 1...1.
+    /// Computes `self >> 1` in constant-time, returning [`CtChoice::TRUE`] if the overflowing bit
+    /// was set, and [`CtChoice::FALSE`] otherwise.
     pub(crate) const fn shr_1(&self) -> (Self, CtChoice) {
         let mut shifted_bits = [0; LIMBS];
         let mut i = 0;


### PR DESCRIPTION
A minor improvement I missed in the original PR.

- use `shr_1()` instead of calling `is_odd()` separately
- update the docstring of `shr_1()` to reflect that it now returns a `CtChoice`