### PR TITLE
v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.2 (2023-04-26)
+### Added
+- Expose residue params and modulus in `DynResidue` ([#197])
+- Impl `DefaultIsZeroes` for `Residue` ([#210])
+- `div_by_2()` method for integers in Montgomery form ([#211], [#212])
+
+### Changed
+- Montgomery multiplication improvements ([#203])
+
+[#197]: https://github.com/RustCrypto/crypto-bigint/pull/197
+[#203]: https://github.com/RustCrypto/crypto-bigint/pull/203
+[#210]: https://github.com/RustCrypto/crypto-bigint/pull/210
+[#211]: https://github.com/RustCrypto/crypto-bigint/pull/211
+[#212]: https://github.com/RustCrypto/crypto-bigint/pull/212
+
 ## 0.5.1 (2023-03-13)
 ### Changed
 - Improve `Debug` impls on `Limb` and `Uint` ([#195])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.5.1"
+version = "0.5.2"
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,


### PR DESCRIPTION
### Added
- Expose residue params and modulus in `DynResidue` ([#197])
- Impl `DefaultIsZeroes` for `Residue` ([#210])
- `div_by_2()` method for integers in Montgomery form ([#211], [#212])

### Changed
- Montgomery multiplication improvements ([#203])

[#197]: https://github.com/RustCrypto/crypto-bigint/pull/197
[#203]: https://github.com/RustCrypto/crypto-bigint/pull/203
[#210]: https://github.com/RustCrypto/crypto-bigint/pull/210
[#211]: https://github.com/RustCrypto/crypto-bigint/pull/211
[#212]: https://github.com/RustCrypto/crypto-bigint/pull/212