### PR TITLE
Fix serdect usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ rand_chacha = "0.3"
 
 [features]
 default = ["rand"]
-alloc = []
+alloc = ["serdect?/alloc"]
 rand = ["rand_core/std"]
 serde = ["dep:serdect"]
 


### PR DESCRIPTION
If someone tries to use, e.g. `serde_json` as a serialization library with crypto-bigint `UInt`s, currently this fails at runtime:
```
Error("serializer is human readable, which requires the `alloc` crate feature", line: 0, column: 0)
```

This arises from the `serdect` dependency. There's currently no way to pass the `alloc` flag down through crypto-bigint.

The proposed solution here just piggybacks on the crypto-bigint `alloc` flag to also pass it down to `serdect`, but only if that dependency has been realized. Another option would be to always always enable `serdect/alloc` when `serde` is requested:
```toml
alloc = []
serde = ["serdect/alloc"]
```
or offer a new feature altogether to keep all the user's options open:
```toml
alloc = []
serde = ["dep:serdect"]
serde-alloc = ["serde", "serdect/alloc"]
```

I think my changes here make the most sense, but let me know if you prefer one of those other options, or something I haven't thought of.