### PR TITLE
Add cmp_vartime, faster Eq for Uint

### DIFF
--- a/src/ct_choice.rs
+++ b/src/ct_choice.rs
@@ -50,11 +50,15 @@ impl CtChoice {
     pub(crate) const fn is_true_vartime(&self) -> bool {
         self.0 == CtChoice::TRUE.0
     }
+
+    pub(crate) const fn to_u8(self) -> u8 {
+        (self.0 as u8) & 1
+    }
 }
 
 impl From<CtChoice> for Choice {
     fn from(choice: CtChoice) -> Self {
-        Choice::from(choice.0 as u8 & 1)
+        Choice::from(choice.to_u8())
     }
 }
 


### PR DESCRIPTION
This optimizes Eq for Uint to avoid comparing the two values twice. `cmp_vartime` is added for cases where a short-circuiting comparison is sufficient.