### PR TITLE
Make pow work with different sized exponents

### DIFF
--- a/src/uint/modular/constant_mod/const_pow.rs
+++ b/src/uint/modular/constant_mod/const_pow.rs
@@ -4,8 +4,11 @@ use super::{Residue, ResidueParams};
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// Raises to the `exponent` power.
-    pub const fn pow(&self, exponent: &Uint<LIMBS>) -> Residue<MOD, LIMBS> {
-        self.pow_bounded_exp(exponent, Uint::<LIMBS>::BITS)
+    pub const fn pow<const RHS_LIMBS: usize>(
+        &self,
+        exponent: &Uint<RHS_LIMBS>,
+    ) -> Residue<MOD, LIMBS> {
+        self.pow_bounded_exp(exponent, Uint::<RHS_LIMBS>::BITS)
     }
 
     /// Raises to the `exponent` power,
@@ -13,9 +16,9 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// to take into account for the exponent.
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
-    pub const fn pow_bounded_exp(
+    pub const fn pow_bounded_exp<const RHS_LIMBS: usize>(
         &self,
-        exponent: &Uint<LIMBS>,
+        exponent: &Uint<RHS_LIMBS>,
         exponent_bits: usize,
     ) -> Residue<MOD, LIMBS> {
         Self {

--- a/src/uint/modular/pow.rs
+++ b/src/uint/modular/pow.rs
@@ -6,9 +6,9 @@ use super::mul::{mul_montgomery_form, square_montgomery_form};
 /// `exponent_bits` represents the number of bits to take into account for the exponent.
 ///
 /// NOTE: this value is leaked in the time pattern.
-pub const fn pow_montgomery_form<const LIMBS: usize>(
+pub const fn pow_montgomery_form<const LIMBS: usize, const RHS_LIMBS: usize>(
     x: &Uint<LIMBS>,
-    exponent: &Uint<LIMBS>,
+    exponent: &Uint<RHS_LIMBS>,
     exponent_bits: usize,
     modulus: &Uint<LIMBS>,
     r: &Uint<LIMBS>,

--- a/src/uint/modular/runtime_mod/runtime_pow.rs
+++ b/src/uint/modular/runtime_mod/runtime_pow.rs
@@ -4,8 +4,11 @@ use super::DynResidue;
 
 impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// Raises to the `exponent` power.
-    pub const fn pow(&self, exponent: &Uint<LIMBS>) -> DynResidue<LIMBS> {
-        self.pow_bounded_exp(exponent, Uint::<LIMBS>::BITS)
+    pub const fn pow<const RHS_LIMBS: usize>(
+        &self,
+        exponent: &Uint<RHS_LIMBS>,
+    ) -> DynResidue<LIMBS> {
+        self.pow_bounded_exp(exponent, Uint::<RHS_LIMBS>::BITS)
     }
 
     /// Raises to the `exponent` power,
@@ -13,7 +16,11 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// to take into account for the exponent.
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
-    pub const fn pow_bounded_exp(&self, exponent: &Uint<LIMBS>, exponent_bits: usize) -> Self {
+    pub const fn pow_bounded_exp<const RHS_LIMBS: usize>(
+        &self,
+        exponent: &Uint<RHS_LIMBS>,
+        exponent_bits: usize,
+    ) -> Self {
         Self {
             montgomery_form: pow_montgomery_form(
                 &self.montgomery_form,


### PR DESCRIPTION
This is a minimal change that allows working with exponents of a different size than the base for `Residue` and `DynResidue`.

Resolves #234 

Partially replaces the need for #230  