### PR TITLE
Add `TryFrom<&[u8]>` bound to `Encoding::Repr`

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -244,7 +244,12 @@ pub trait Bounded {
 /// Encoding support.
 pub trait Encoding: Sized {
     /// Byte array representation.
-    type Repr: AsRef<[u8]> + AsMut<[u8]> + Copy + Clone + Sized;
+    type Repr: AsRef<[u8]>
+        + AsMut<[u8]>
+        + Copy
+        + Clone
+        + Sized
+        + for<'a> TryFrom<&'a [u8], Error = core::array::TryFromSliceError>;
 
     /// Decode from big endian bytes.
     fn from_be_bytes(bytes: Self::Repr) -> Self;


### PR DESCRIPTION
This helps with deserialization - one doesn't need to create a mutable buffer and use a special purpose `deserialize` mutating its argument (like `serdect` does currently), but instead one can just use a standard `deserialize` with the API compatible with that of `#[serde(with)]` that returns the `Repr` object.