### PR TITLE
Modular inversion improvements

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -153,6 +153,59 @@ fn bench_shifts<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     });
 }
 
+fn bench_inv_mod<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
+    group.bench_function("inv_odd_mod, U256", |b| {
+        b.iter_batched(
+            || {
+                let m = U256::random(&mut OsRng) | U256::ONE;
+                loop {
+                    let x = U256::random(&mut OsRng);
+                    let (_, is_some) = x.inv_odd_mod(&m);
+                    if is_some.into() {
+                        break (x, m);
+                    }
+                }
+            },
+            |(x, m)| x.inv_odd_mod(&m),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("inv_mod, U256, odd modulus", |b| {
+        b.iter_batched(
+            || {
+                let m = U256::random(&mut OsRng) | U256::ONE;
+                loop {
+                    let x = U256::random(&mut OsRng);
+                    let (_, is_some) = x.inv_odd_mod(&m);
+                    if is_some.into() {
+                        break (x, m);
+                    }
+                }
+            },
+            |(x, m)| x.inv_mod(&m),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("inv_mod, U256", |b| {
+        b.iter_batched(
+            || {
+                let m = U256::random(&mut OsRng);
+                loop {
+                    let x = U256::random(&mut OsRng);
+                    let (_, is_some) = x.inv_mod(&m);
+                    if is_some.into() {
+                        break (x, m);
+                    }
+                }
+            },
+            |(x, m)| x.inv_mod(&m),
+            BatchSize::SmallInput,
+        )
+    });
+}
+
 fn bench_wrapping_ops(c: &mut Criterion) {
     let mut group = c.benchmark_group("wrapping ops");
     bench_division(&mut group);
@@ -169,6 +222,7 @@ fn bench_montgomery(c: &mut Criterion) {
 fn bench_modular_ops(c: &mut Criterion) {
     let mut group = c.benchmark_group("modular ops");
     bench_shifts(&mut group);
+    bench_inv_mod(&mut group);
     group.finish();
 }
 

--- a/src/ct_choice.rs
+++ b/src/ct_choice.rs
@@ -50,6 +50,10 @@ impl CtChoice {
         Self(!self.0)
     }
 
+    pub(crate) const fn or(&self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
     pub(crate) const fn and(&self, other: Self) -> Self {
         Self(self.0 & other.0)
     }

--- a/src/ct_choice.rs
+++ b/src/ct_choice.rs
@@ -29,6 +29,17 @@ impl CtChoice {
         Self(value.wrapping_neg())
     }
 
+    /// Returns the truthy value if `value != 0`, and the falsy value otherwise.
+    pub(crate) const fn from_usize_being_nonzero(value: usize) -> Self {
+        const HI_BIT: u32 = usize::BITS - 1;
+        Self::from_lsb(((value | value.wrapping_neg()) >> HI_BIT) as Word)
+    }
+
+    /// Returns the truthy value if `x == y`, and the falsy value otherwise.
+    pub(crate) const fn from_usize_equality(x: usize, y: usize) -> Self {
+        Self::from_usize_being_nonzero(x.wrapping_sub(y)).not()
+    }
+
     /// Returns the truthy value if `x < y`, and the falsy value otherwise.
     pub(crate) const fn from_usize_lt(x: usize, y: usize) -> Self {
         let bit = (((!x) & y) | (((!x) | y) & (x.wrapping_sub(y)))) >> (usize::BITS - 1);

--- a/src/uint/modular/constant_mod/macros.rs
+++ b/src/uint/modular/constant_mod/macros.rs
@@ -32,7 +32,7 @@ macro_rules! impl_modulus {
             const MOD_NEG_INV: $crate::Limb = $crate::Limb(
                 $crate::Word::MIN.wrapping_sub(
                     Self::MODULUS
-                        .inv_mod2k($crate::Word::BITS as usize)
+                        .inv_mod2k_vartime($crate::Word::BITS as usize)
                         .as_limbs()[0]
                         .0,
                 ),

--- a/src/uint/modular/runtime_mod.rs
+++ b/src/uint/modular/runtime_mod.rs
@@ -47,8 +47,9 @@ impl<const LIMBS: usize> DynResidueParams<LIMBS> {
         // Since we are calculating the inverse modulo (Word::MAX+1),
         // we can take the modulo right away and calculate the inverse of the first limb only.
         let modulus_lo = Uint::<1>::from_words([modulus.limbs[0].0]);
-        let mod_neg_inv =
-            Limb(Word::MIN.wrapping_sub(modulus_lo.inv_mod2k(Word::BITS as usize).limbs[0].0));
+        let mod_neg_inv = Limb(
+            Word::MIN.wrapping_sub(modulus_lo.inv_mod2k_vartime(Word::BITS as usize).limbs[0].0),
+        );
 
         let r3 = montgomery_reduction(&r2.square_wide(), modulus, mod_neg_inv);
 

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -213,6 +213,27 @@ proptest! {
     }
 
     #[test]
+    fn inv_mod2k(a in uint(), k in any::<usize>()) {
+        let a = a | U256::ONE; // make odd
+        let k = k % (U256::BITS + 1);
+        let a_bi = to_biguint(&a);
+        let m_bi = BigUint::one() << k;
+
+        let actual = a.inv_mod2k(k);
+        let actual_vartime = a.inv_mod2k_vartime(k);
+        assert_eq!(actual, actual_vartime);
+
+        if k == 0 {
+            assert_eq!(actual, U256::ZERO);
+        }
+        else {
+            let inv_bi = to_biguint(&actual);
+            let res = (inv_bi * a_bi) % m_bi;
+            assert_eq!(res, BigUint::one());
+        }
+    }
+
+    #[test]
     fn wrapping_sqrt(a in uint()) {
         let a_bi = to_biguint(&a);
         let expected = to_uint(a_bi.sqrt());

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -2,7 +2,7 @@
 
 use crypto_bigint::{
     modular::runtime_mod::{DynResidue, DynResidueParams},
-    Encoding, Limb, NonZero, Word, U256,
+    CtChoice, Encoding, Limb, NonZero, Word, U256,
 };
 use num_bigint::BigUint;
 use num_integer::Integer;
@@ -229,6 +229,23 @@ proptest! {
         else {
             let inv_bi = to_biguint(&actual);
             let res = (inv_bi * a_bi) % m_bi;
+            assert_eq!(res, BigUint::one());
+        }
+    }
+
+    #[test]
+    fn inv_mod(a in uint(), b in uint()) {
+        let a_bi = to_biguint(&a);
+        let b_bi = to_biguint(&b);
+
+        let expected_is_some = if a_bi.gcd(&b_bi) == BigUint::one() { CtChoice::TRUE } else { CtChoice::FALSE };
+        let (actual, actual_is_some) = a.inv_mod(&b);
+
+        assert_eq!(bool::from(expected_is_some), bool::from(actual_is_some));
+
+        if actual_is_some.into() {
+            let inv_bi = to_biguint(&actual);
+            let res = (inv_bi * a_bi) % b_bi;
             assert_eq!(res, BigUint::one());
         }
     }

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -204,7 +204,7 @@ proptest! {
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);
 
-        if b_bi.is_zero() {
+        if !b_bi.is_zero() {
             let expected = to_uint(a_bi % b_bi);
             let actual = a.wrapping_rem(&b);
 


### PR DESCRIPTION
- fix a typo in a proptest for `rem()` which rendered it useless
- make `inv_mod2k()` constant-time both in `self` and `k`
- rename the old `inv_mod2k()` to `inv_mod2k_vartime()`
- make the code in `inv_mod2k_vartime()` clearer and fix the attribution
- add a constant-time `inv_mod()` that supports both even and odd moduli (works via RNS and `inv_mod2k()`/`inv_odd_mod()`; another approach is binary GCD (see #227 for more info) which may or may not be faster, but is definitely more complicated)

Note that this PR does not introduce any backwards-incompatible changes (except for the performance regression for the users of `inv_mod2k()`).

Possible additions:
- We can add `inv_mod2k_bounded()`, for the cases where a bound on `k` is known. 
- We can add `inv_mod_vartime()` (that calls `inv_mod2k_vartime()` internally, which would lead to a significant performance gain)

(questions involving breaking changes are moved to #268)