### PR TITLE
Add `const fn` constructors for `NonZero<Uint>` and `NonZero<Limb>`

### DIFF
--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -1,6 +1,6 @@
 //! Wrapper type for non-zero integers.
 
-use crate::{Encoding, Integer, Limb, Uint, Zero};
+use crate::{CtChoice, Encoding, Integer, Limb, Uint, Zero};
 use core::{
     fmt,
     num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8},
@@ -23,6 +23,22 @@ use serdect::serde::{
 /// Wrapper type for non-zero integers.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct NonZero<T: Zero>(T);
+
+impl NonZero<Limb> {
+    /// Creates a new non-zero limb in a const context.
+    /// The second return value is `FALSE` if `n` is zero, `TRUE` otherwise.
+    pub const fn const_new(n: Limb) -> (Self, CtChoice) {
+        (Self(n), n.ct_is_nonzero())
+    }
+}
+
+impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
+    /// Creates a new non-zero integer in a const context.
+    /// The second return value is `FALSE` if `n` is zero, `TRUE` otherwise.
+    pub const fn const_new(n: Uint<LIMBS>) -> (Self, CtChoice) {
+        (Self(n), n.ct_is_nonzero())
+    }
+}
 
 impl<T> NonZero<T>
 where


### PR DESCRIPTION
This will allow us to make a number of methods `const fn` (for example, various division methods) and introduce `NonZero` bounds where they were previously impossible (for example, `inv_mod.rs` methods where moduli are currently just `&Self`). Also it opens up a possibility to initialize a `NonZero` constant of a modulus/divisor known at compile-time, so that it doesn't have to be unwrapped every time on use.