### PR TITLE
Add constant-time `Uint::shr()` and `Uint::shl()`

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,7 +3,7 @@ use criterion::{
 };
 use crypto_bigint::{
     modular::runtime_mod::{DynResidue, DynResidueParams},
-    Limb, NonZero, Random, Reciprocal, U128, U256,
+    Limb, NonZero, Random, Reciprocal, U128, U2048, U256,
 };
 use rand_core::OsRng;
 
@@ -131,6 +131,28 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
     });
 }
 
+fn bench_shifts<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
+    group.bench_function("shl_vartime, small, U2048", |b| {
+        b.iter_batched(|| U2048::ONE, |x| x.shl_vartime(10), BatchSize::SmallInput)
+    });
+
+    group.bench_function("shl_vartime, large, U2048", |b| {
+        b.iter_batched(
+            || U2048::ONE,
+            |x| x.shl_vartime(1024 + 10),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("shl, U2048", |b| {
+        b.iter_batched(|| U2048::ONE, |x| x.shl(1024 + 10), BatchSize::SmallInput)
+    });
+
+    group.bench_function("shr, U2048", |b| {
+        b.iter_batched(|| U2048::ONE, |x| x.shr(1024 + 10), BatchSize::SmallInput)
+    });
+}
+
 fn bench_wrapping_ops(c: &mut Criterion) {
     let mut group = c.benchmark_group("wrapping ops");
     bench_division(&mut group);
@@ -144,5 +166,17 @@ fn bench_montgomery(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_wrapping_ops, bench_montgomery);
+fn bench_modular_ops(c: &mut Criterion) {
+    let mut group = c.benchmark_group("modular ops");
+    bench_shifts(&mut group);
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_wrapping_ops,
+    bench_montgomery,
+    bench_modular_ops
+);
+
 criterion_main!(benches);

--- a/src/ct_choice.rs
+++ b/src/ct_choice.rs
@@ -29,6 +29,12 @@ impl CtChoice {
         Self(value.wrapping_neg())
     }
 
+    /// Returns the truthy value if `x < y`, and the falsy value otherwise.
+    pub(crate) const fn from_usize_lt(x: usize, y: usize) -> Self {
+        let bit = (((!x) & y) | (((!x) | y) & (x.wrapping_sub(y)))) >> (usize::BITS - 1);
+        Self::from_lsb(bit as Word)
+    }
+
     pub(crate) const fn not(&self) -> Self {
         Self(!self.0)
     }

--- a/src/limb/shl.rs
+++ b/src/limb/shl.rs
@@ -5,6 +5,7 @@ use core::ops::{Shl, ShlAssign};
 
 impl Limb {
     /// Computes `self << rhs`.
+    /// Panics if `rhs` overflows `Limb::BITS`.
     #[inline(always)]
     pub const fn shl(self, rhs: Self) -> Self {
         Limb(self.0 << rhs.0)

--- a/src/limb/shr.rs
+++ b/src/limb/shr.rs
@@ -5,6 +5,7 @@ use core::ops::{Shr, ShrAssign};
 
 impl Limb {
     /// Computes `self >> rhs`.
+    /// Panics if `rhs` overflows `Limb::BITS`.
     #[inline(always)]
     pub const fn shr(self, rhs: Self) -> Self {
         Limb(self.0 >> rhs.0)

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -92,6 +92,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Total size of the represented integer in bits.
     pub const BITS: usize = LIMBS * Limb::BITS;
 
+    /// Bit size of `BITS`.
+    // Note: assumes the type of `BITS` is `usize`. Any way to assert that?
+    pub(crate) const LOG2_BITS: usize = (usize::BITS - Self::BITS.leading_zeros()) as usize;
+
     /// Total size of the represented integer in bytes.
     pub const BYTES: usize = LIMBS * Limb::BYTES;
 

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -6,7 +6,7 @@ use crypto_bigint::{
 };
 use num_bigint::BigUint;
 use num_integer::Integer;
-use num_traits::identities::Zero;
+use num_traits::identities::{One, Zero};
 use proptest::prelude::*;
 use std::mem;
 
@@ -55,6 +55,32 @@ proptest! {
 
         let expected = to_uint(a_bi << shift);
         let actual = a.shl_vartime(shift as usize);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn shl(a in uint(), shift in any::<u16>()) {
+        let a_bi = to_biguint(&a);
+
+        // Add a 50% probability of overflow.
+        let shift = (shift as usize) % (U256::BITS * 2);
+
+        let expected = to_uint((a_bi << shift) & ((BigUint::one() << U256::BITS) - BigUint::one()));
+        let actual = a.shl(shift);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn shr(a in uint(), shift in any::<u16>()) {
+        let a_bi = to_biguint(&a);
+
+        // Add a 50% probability of overflow.
+        let shift = (shift as usize) % (U256::BITS * 2);
+
+        let expected = to_uint(a_bi >> shift);
+        let actual = a.shr(shift);
 
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
This overrides the `shr()` implementation in #263 - this one is more efficient (O(LIMBS * log2(BITS)) instead of O(LIMBS^2)). For `U2048` it's ~10x slower than the vartime equivalent.

Question for @tarcieri : what behavior do we want on overflow? `shl()`/`shr()` currently return 0, their vartime equivalents return the original value. I wonder if it would be better to return a pair `(Self, CtChoice)` where the second element indicates the overflow.