### PR TITLE
Fix clippy warnings

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.65.0
+          toolchain: 1.72.0
           components: clippy
       - run: cargo clippy --all --all-features -- -D warnings
 

--- a/src/boxed/uint/add.rs
+++ b/src/boxed/uint/add.rs
@@ -26,6 +26,7 @@ impl CheckedAdd<&BoxedUint> for BoxedUint {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::{BoxedUint, CheckedAdd, Limb};
 

--- a/src/checked.rs
+++ b/src/checked.rs
@@ -83,7 +83,9 @@ impl<T: Copy + Serialize> Serialize for Checked<T> {
 }
 
 #[cfg(all(test, feature = "serde"))]
+#[allow(clippy::unwrap_used)]
 mod tests {
+
     use crate::{Checked, U64};
     use subtle::{Choice, ConstantTimeEq, CtOption};
 

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -1,8 +1,6 @@
 //! Big integers are represented as an array of smaller CPU word-size integers
 //! called "limbs".
 
-#![allow(clippy::derive_hash_xor_eq)]
-
 mod add;
 mod bit_and;
 mod bit_not;
@@ -60,6 +58,8 @@ pub(crate) const HI_BIT: usize = Limb::BITS - 1;
 
 /// Big integers are represented as an array of smaller CPU word-size integers
 /// called "limbs".
+// Our PartialEq impl only differs from the default one by being constant-time, so this is safe
+#[allow(clippy::derived_hash_with_manual_eq)]
 #[derive(Copy, Clone, Default, Hash)]
 #[repr(transparent)]
 pub struct Limb(pub Word);

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -352,6 +352,7 @@ impl<T: Serialize + Zero> Serialize for NonZero<T> {
 }
 
 #[cfg(all(test, feature = "serde"))]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::{NonZero, U64};
     use bincode::ErrorKind;

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1,10 +1,6 @@
 //! Stack-allocated big unsigned integers.
 
-#![allow(
-    clippy::needless_range_loop,
-    clippy::many_single_char_names,
-    clippy::derive_hash_xor_eq
-)]
+#![allow(clippy::needless_range_loop, clippy::many_single_char_names)]
 
 #[macro_use]
 mod macros;
@@ -71,6 +67,8 @@ use zeroize::DefaultIsZeroes;
 ///
 /// [RLP]: https://eth.wiki/fundamentals/rlp
 // TODO(tarcieri): make generic around a specified number of bits.
+// Our PartialEq impl only differs from the default one by being constant-time, so this is safe
+#[allow(clippy::derived_hash_with_manual_eq)]
 #[derive(Copy, Clone, Hash)]
 pub struct Uint<const LIMBS: usize> {
     /// Inner limb array. Stored from least significant to most significant.

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -396,6 +396,7 @@ mod extra_sizes;
 pub use extra_sizes::*;
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::{Encoding, U128};
     use subtle::ConditionallySelectable;

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -730,6 +730,7 @@ mod tests {
         }
     }
 
+    #[allow(clippy::op_ref)]
     #[test]
     fn rem_trait() {
         let a = U256::from(10u64);

--- a/src/uint/encoding/rlp.rs
+++ b/src/uint/encoding/rlp.rs
@@ -44,6 +44,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::U256;
     use hex_literal::hex;

--- a/src/uint/modular/constant_mod/const_inv.rs
+++ b/src/uint/modular/constant_mod/const_inv.rs
@@ -62,7 +62,7 @@ mod tests {
         let x_mod = const_residue!(x, Modulus);
 
         let (inv, _is_some) = x_mod.invert();
-        let res = &x_mod * &inv;
+        let res = x_mod * inv;
 
         assert_eq!(res.retrieve(), U256::ONE);
     }

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -91,6 +91,7 @@ impl<T: Serialize> Serialize for Wrapping<T> {
 }
 
 #[cfg(all(test, feature = "serde"))]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::{Wrapping, U64};
 


### PR DESCRIPTION
Fix a bunch of clippy warnings that are raised with Rust 1.72, but do not appear in CI which uses 1.65 for clippy. Makes it easier to run clippy during development. Clippy bumped to 1.72 in CI.

I decided to go with `#![allow(clippy::unwrap_used)]` for test submodules instead of replacing each `unwrap()` there with `expect()`.
