### PR TITLE
Make `Uint::random_mod()` work identically on 32- and 64-bit targets

### DIFF
--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -1,7 +1,7 @@
 //! Random number generator support
 
 use super::Uint;
-use crate::{Limb, NonZero, Random, RandomMod};
+use crate::{Encoding, Limb, NonZero, Random, RandomMod};
 use rand_core::CryptoRngCore;
 use subtle::ConstantTimeLess;
 
@@ -30,18 +30,29 @@ impl<const LIMBS: usize> RandomMod for Uint<LIMBS> {
     /// issue so long as the underlying random number generator is truly a
     /// CSRNG, where previous outputs are unrelated to subsequent
     /// outputs and do not reveal information about the RNG's internal state.
-    fn random_mod(mut rng: &mut impl CryptoRngCore, modulus: &NonZero<Self>) -> Self {
+    fn random_mod(rng: &mut impl CryptoRngCore, modulus: &NonZero<Self>) -> Self {
         let mut n = Self::ZERO;
 
         let n_bits = modulus.as_ref().bits_vartime();
+        let n_bytes = (n_bits + 7) / 8;
         let n_limbs = (n_bits + Limb::BITS - 1) / Limb::BITS;
-        let mask = Limb::MAX >> (Limb::BITS * n_limbs - n_bits);
+        let hi_bytes = n_bytes - (n_limbs - 1) * Limb::BYTES;
+
+        let mut bytes = Limb::ZERO.to_le_bytes();
 
         loop {
-            for i in 0..n_limbs {
-                n.limbs[i] = Limb::random(&mut rng);
+            for i in 0..n_limbs - 1 {
+                rng.fill_bytes(bytes.as_mut());
+                // Need to deserialize from little-endian to make sure that two 32-bit limbs
+                // deserialized sequentially are equal to one 64-bit limb produced from the same
+                // byte stream.
+                n.limbs[i] = Limb::from_le_bytes(bytes);
             }
-            n.limbs[n_limbs - 1] = n.limbs[n_limbs - 1] & mask;
+
+            // Generate the high limb which may need to only be filled partially.
+            bytes.as_mut().fill(0);
+            rng.fill_bytes(&mut (bytes.as_mut()[0..hi_bytes]));
+            n.limbs[n_limbs - 1] = Limb::from_le_bytes(bytes);
 
             if n.ct_lt(modulus).into() {
                 return n;


### PR DESCRIPTION
The current version of `Uint::random_mod()` produces different results on 32- and 64-bit targets because it exhausts the byte stream differently if the number of bytes in `modulus` is not a multiple of 8 (e.g. if it is 20 bytes, the 32-bit version will read 20 bytes - 5 limbs, but the 64-bit version will read 24 bytes - 3 limbs). This PR makes the behavior identical, so that an RNG with the same seed will produce the same stream of `Uint`s (as long as the RNG itself produces the bytestream consistently, of course). 

I am not sure if that is actually a desired behavior, but I did bump into it when I generated a ZK proof challenge on a 64-bit and 32-bit clients, and expected them to be the same. If it is not a guarantee we want to provide, perhaps an explicit note in the docs will be helpful.

The code in this PR would be much simpler if I could use `Uint::from_le_bytes()`, but then I would have to add an `Encoding` bound. 