### PR TITLE
Update docs for consistency

### DIFF
--- a/src/checked.rs
+++ b/src/checked.rs
@@ -8,7 +8,7 @@ use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// Provides intentionally-checked arithmetic on `T`.
 ///
 /// Internally this leverages the [`CtOption`] type from the [`subtle`] crate
-/// in order to handle overflows in constant time.
+/// in order to handle overflows.
 #[derive(Copy, Clone, Debug)]
 pub struct Checked<T>(pub CtOption<T>);
 

--- a/src/uint/add_mod.rs
+++ b/src/uint/add_mod.rs
@@ -3,7 +3,7 @@
 use crate::{AddMod, Limb, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
-    /// Computes `self + rhs mod p` in constant time.
+    /// Computes `self + rhs mod p`.
     ///
     /// Assumes `self + rhs` as unbounded integer is `< 2p`.
     pub const fn add_mod(&self, rhs: &Uint<LIMBS>, p: &Uint<LIMBS>) -> Uint<LIMBS> {
@@ -21,7 +21,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         w.wrapping_add(&p.bitand(&mask))
     }
 
-    /// Computes `self + rhs mod p` in constant time for the special modulus
+    /// Computes `self + rhs mod p` for the special modulus
     /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
     ///
     /// Assumes `self + rhs` as unbounded integer is `< 2p`.

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -166,6 +166,17 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Computes self / rhs, returns the quotient, remainder.
+    /// ### Usage:
+    /// ```
+    /// use crypto_bigint::{U448, NonZero};
+    /// 
+    /// let a = U448::from(8_u64);
+    /// let b = NonZero::new(U448::from(4_u64)).unwrap();
+    /// let res = a.div_rem(&b);
+    /// 
+    /// assert!(res.0 == U448::from(2_u64));
+    /// assert!(res.1 == U448::ZERO);
+    /// ```
     pub fn div_rem(&self, rhs: &NonZero<Self>) -> (Self, Self) {
         // Since `rhs` is nonzero, this should always hold.
         let (q, r, _c) = self.ct_div_rem(rhs);

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -166,17 +166,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Computes self / rhs, returns the quotient, remainder.
-    /// ### Usage:
-    /// ```
-    /// use crypto_bigint::{U448, NonZero};
-    /// 
-    /// let a = U448::from(8_u64);
-    /// let b = NonZero::new(U448::from(4_u64)).unwrap();
-    /// let res = a.div_rem(&b);
-    /// 
-    /// assert!(res.0 == U448::from(2_u64));
-    /// assert!(res.1 == U448::ZERO);
-    /// ```
     pub fn div_rem(&self, rhs: &NonZero<Self>) -> (Self, Self) {
         // Since `rhs` is nonzero, this should always hold.
         let (q, r, _c) = self.ct_div_rem(rhs);

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -81,7 +81,7 @@ const fn ct_select(a: u32, b: u32, c: u32) -> u32 {
     a ^ (c & (a ^ b))
 }
 
-/// Calculates `dividend / divisor` in constant time, given `dividend` and `divisor`
+/// Calculates `dividend / divisor`, given `dividend` and `divisor`
 /// along with their maximum bitsizes.
 #[inline(always)]
 const fn short_div(dividend: u32, dividend_bits: u32, divisor: u32, divisor_bits: u32) -> u32 {

--- a/src/uint/modular/constant_mod.rs
+++ b/src/uint/modular/constant_mod.rs
@@ -115,7 +115,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     // TODO: remove this method when we can use `generic_const_exprs.` to ensure the modulus is
     // always valid.
     pub fn new_checked(integer: &Uint<LIMBS>) -> CtOption<Self> {
-        // A valid modulus must be odd, which we can check in constant time
+        // A valid modulus must be odd.
         CtOption::new(
             Self::generate_residue(integer),
             MOD::MODULUS.ct_is_odd().into(),

--- a/src/uint/modular/runtime_mod.rs
+++ b/src/uint/modular/runtime_mod.rs
@@ -80,7 +80,7 @@ impl<const LIMBS: usize> DynResidueParams<LIMBS> {
         note = "This functionality will be moved to `new` in a future release."
     )]
     pub fn new_checked(modulus: &Uint<LIMBS>) -> CtOption<Self> {
-        // A valid modulus must be odd, which we check in constant time
+        // A valid modulus must be odd.
         CtOption::new(Self::generate_params(modulus), modulus.ct_is_odd().into())
     }
 

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -3,7 +3,7 @@
 use crate::{Limb, Uint, WideWord, Word};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
-    /// Computes `self * rhs mod p` in constant time for the special modulus
+    /// Computes `self * rhs mod p` for the special modulus
     /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
     /// For the modulus reduction, this function implements Algorithm 14.47 from
     /// the "Handbook of Applied Cryptography", by A. Menezes, P. van Oorschot,

--- a/src/uint/neg_mod.rs
+++ b/src/uint/neg_mod.rs
@@ -3,7 +3,7 @@
 use crate::{Limb, NegMod, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
-    /// Computes `-a mod p` in constant time.
+    /// Computes `-a mod p`.
     /// Assumes `self` is in `[0, p)`.
     pub const fn neg_mod(&self, p: &Self) -> Self {
         let z = self.ct_is_nonzero();
@@ -18,7 +18,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         ret
     }
 
-    /// Computes `-a mod p` in constant time for the special modulus
+    /// Computes `-a mod p` for the special modulus
     /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
     pub const fn neg_mod_special(&self, c: Limb) -> Self {
         Self::ZERO.sub_mod_special(self, c)

--- a/src/uint/sub_mod.rs
+++ b/src/uint/sub_mod.rs
@@ -3,7 +3,7 @@
 use crate::{Limb, SubMod, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
-    /// Computes `self - rhs mod p` in constant time.
+    /// Computes `self - rhs mod p`.
     ///
     /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
     pub const fn sub_mod(&self, rhs: &Uint<LIMBS>, p: &Uint<LIMBS>) -> Uint<LIMBS> {
@@ -34,7 +34,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         out.wrapping_add(&p.bitand(&mask))
     }
 
-    /// Computes `self - rhs mod p` in constant time for the special modulus
+    /// Computes `self - rhs mod p` for the special modulus
     /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
     ///
     /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.


### PR DESCRIPTION
The front of the repo explicitly states under Goals:

"Constant-time by default. Variable-time functions are explicitly marked as such."

Some constant-time functions in the repo are documented that they run in constant-time, while other constant-time functions do not. This inconsistency may lead a newcomer to question if a function is constant-time despite being explicitly chosen as such. This simple PR updates the docs on the functions in question to avoid confusion and remain consistent with the stated goals of the repo.

