### PR TITLE
v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.5 (2023-11-18)
+### Added
+- Multi-exponentiation ([#248])
+- `const_assert_eq!` and `const_assert_ne!` macros ([#293])
+
+[#248]: https://github.com/RustCrypto/crypto-bigint/pull/248
+[#293]: https://github.com/RustCrypto/crypto-bigint/pull/293
+
 ## 0.5.4 (2023-11-12)
 ### Added
 - `trailing_ones[_vartime]()`, `trailing_zeros_vartime()`, `leading_zeros_vartime()` ([#282])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.5.4"
+version = "0.5.5"
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,


### PR DESCRIPTION
### Added
- Multi-exponentiation ([#248])
- `const_assert_eq!` and `const_assert_ne!` macros ([#293])

[#248]: https://github.com/RustCrypto/crypto-bigint/pull/248
[#293]: https://github.com/RustCrypto/crypto-bigint/pull/293