### PR TITLE
Bump version to v0.6.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.6.0-pre"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.6.0-pre"
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,


### PR DESCRIPTION
This version bump does not signify a release, but that we are starting a new round of breaking changes, as proposed in #268.

The first actual prerelease with an associated crate released to crates.io will be versioned v0.6.0-pre.0.