### PR TITLE
crypto-bigint: formatting cleanups

### DIFF
--- a/src/uint/modular.rs
+++ b/src/uint/modular.rs
@@ -1,9 +1,7 @@
-mod reduction;
-
-/// Implements `Residue`s, supporting modular arithmetic with a constant modulus.
 pub mod constant_mod;
-/// Implements `DynResidue`s, supporting modular arithmetic with a modulus set at runtime.
 pub mod runtime_mod;
+
+mod reduction;
 
 mod add;
 mod div_by_2;

--- a/src/uint/modular/constant_mod.rs
+++ b/src/uint/modular/constant_mod.rs
@@ -1,10 +1,16 @@
-use core::{fmt::Debug, marker::PhantomData};
+//! Implements `Residue`s, supporting modular arithmetic with a constant modulus.
 
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
-
-use crate::{Limb, Uint, Zero};
+mod const_add;
+mod const_inv;
+mod const_mul;
+mod const_neg;
+mod const_pow;
+mod const_sub;
 
 use super::{div_by_2::div_by_2, reduction::montgomery_reduction, Retrieve};
+use crate::{Limb, Uint, Zero};
+use core::{fmt::Debug, marker::PhantomData};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "rand_core")]
 use crate::{rand_core::CryptoRngCore, NonZero, Random, RandomMod};
@@ -15,19 +21,6 @@ use {
     serdect::serde::de::Error,
     serdect::serde::{Deserialize, Deserializer, Serialize, Serializer},
 };
-
-/// Additions between residues with a constant modulus
-mod const_add;
-/// Multiplicative inverses of residues with a constant modulus
-mod const_inv;
-/// Multiplications between residues with a constant modulus
-mod const_mul;
-/// Negations of residues with a constant modulus
-mod const_neg;
-/// Exponentiation of residues with a constant modulus
-mod const_pow;
-/// Subtractions between residues with a constant modulus
-mod const_sub;
 
 /// Macros to remove the boilerplate code when dealing with constant moduli.
 #[macro_use]

--- a/src/uint/modular/constant_mod/const_add.rs
+++ b/src/uint/modular/constant_mod/const_add.rs
@@ -1,8 +1,8 @@
-use core::ops::{Add, AddAssign};
-
-use crate::modular::add::add_montgomery_form;
+//! Additions between residues with a constant modulus.
 
 use super::{Residue, ResidueParams};
+use crate::modular::add::add_montgomery_form;
+use core::ops::{Add, AddAssign};
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// Adds `rhs`.

--- a/src/uint/modular/constant_mod/const_inv.rs
+++ b/src/uint/modular/constant_mod/const_inv.rs
@@ -1,10 +1,9 @@
-use core::marker::PhantomData;
-
-use subtle::CtOption;
-
-use crate::{modular::inv::inv_montgomery_form, traits::Invert, CtChoice, NonZero};
+//! Multiplicative inverses of residues with a constant modulus.
 
 use super::{Residue, ResidueParams};
+use crate::{modular::inv::inv_montgomery_form, traits::Invert, CtChoice, NonZero};
+use core::marker::PhantomData;
+use subtle::CtOption;
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// Computes the residue `self^-1` representing the multiplicative inverse of `self`.

--- a/src/uint/modular/constant_mod/const_mul.rs
+++ b/src/uint/modular/constant_mod/const_mul.rs
@@ -1,3 +1,5 @@
+//! Multiplications between residues with a constant modulus.
+
 use core::{
     marker::PhantomData,
     ops::{Mul, MulAssign},

--- a/src/uint/modular/constant_mod/const_neg.rs
+++ b/src/uint/modular/constant_mod/const_neg.rs
@@ -1,6 +1,7 @@
-use core::ops::Neg;
+//! Negations of residues with a constant modulus.
 
 use super::{Residue, ResidueParams};
+use core::ops::Neg;
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// Negates the number.

--- a/src/uint/modular/constant_mod/const_pow.rs
+++ b/src/uint/modular/constant_mod/const_pow.rs
@@ -1,11 +1,13 @@
-use crate::{modular::pow::pow_montgomery_form, MultiExponentiateBoundedExp, PowBoundedExp, Uint};
+//! Exponentiation of residues with a constant modulus.
 
 use super::{Residue, ResidueParams};
-use crate::modular::pow::multi_exponentiate_montgomery_form_array;
+use crate::{
+    modular::pow::{multi_exponentiate_montgomery_form_array, pow_montgomery_form},
+    MultiExponentiateBoundedExp, PowBoundedExp, Uint,
+};
+
 #[cfg(feature = "alloc")]
-use crate::modular::pow::multi_exponentiate_montgomery_form_slice;
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
+use {crate::modular::pow::multi_exponentiate_montgomery_form_slice, alloc::vec::Vec};
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// Raises to the `exponent` power.

--- a/src/uint/modular/constant_mod/const_sub.rs
+++ b/src/uint/modular/constant_mod/const_sub.rs
@@ -1,8 +1,8 @@
-use core::ops::{Sub, SubAssign};
-
-use crate::modular::sub::sub_montgomery_form;
+//! Subtractions between residues with a constant modulus.
 
 use super::{Residue, ResidueParams};
+use crate::modular::sub::sub_montgomery_form;
+use core::ops::{Sub, SubAssign};
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// Subtracts `rhs`.

--- a/src/uint/modular/runtime_mod/runtime_add.rs
+++ b/src/uint/modular/runtime_mod/runtime_add.rs
@@ -1,8 +1,8 @@
-use core::ops::{Add, AddAssign};
-
-use crate::modular::add::add_montgomery_form;
+//! Additions between residues with a modulus set at runtime.
 
 use super::DynResidue;
+use crate::modular::add::add_montgomery_form;
+use core::ops::{Add, AddAssign};
 
 impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// Adds `rhs`.

--- a/src/uint/modular/runtime_mod/runtime_inv.rs
+++ b/src/uint/modular/runtime_mod/runtime_inv.rs
@@ -1,8 +1,8 @@
-use subtle::CtOption;
-
-use crate::{modular::inv::inv_montgomery_form, traits::Invert, CtChoice};
+//! Multiplicative inverses of residues with a modulus set at runtime.
 
 use super::DynResidue;
+use crate::{modular::inv::inv_montgomery_form, traits::Invert, CtChoice};
+use subtle::CtOption;
 
 impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// Computes the residue `self^-1` representing the multiplicative inverse of `self`.

--- a/src/uint/modular/runtime_mod/runtime_mul.rs
+++ b/src/uint/modular/runtime_mod/runtime_mul.rs
@@ -1,11 +1,11 @@
-use core::ops::{Mul, MulAssign};
+//! Multiplications between residues with a modulus set at runtime.
 
+use super::DynResidue;
 use crate::{
     modular::mul::{mul_montgomery_form, square_montgomery_form},
     traits::Square,
 };
-
-use super::DynResidue;
+use core::ops::{Mul, MulAssign};
 
 impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// Multiplies by `rhs`.

--- a/src/uint/modular/runtime_mod/runtime_neg.rs
+++ b/src/uint/modular/runtime_mod/runtime_neg.rs
@@ -1,6 +1,7 @@
-use core::ops::Neg;
+//! Negations of residues with a modulus set at runtime.
 
 use super::DynResidue;
+use core::ops::Neg;
 
 impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// Negates the number.

--- a/src/uint/modular/runtime_mod/runtime_pow.rs
+++ b/src/uint/modular/runtime_mod/runtime_pow.rs
@@ -1,10 +1,13 @@
+//! Exponentiation of residues with a modulus set at runtime.
+
 use super::DynResidue;
-use crate::modular::pow::multi_exponentiate_montgomery_form_array;
+use crate::{
+    modular::pow::{multi_exponentiate_montgomery_form_array, pow_montgomery_form},
+    MultiExponentiateBoundedExp, PowBoundedExp, Uint,
+};
+
 #[cfg(feature = "alloc")]
-use crate::modular::pow::multi_exponentiate_montgomery_form_slice;
-use crate::{modular::pow::pow_montgomery_form, MultiExponentiateBoundedExp, PowBoundedExp, Uint};
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
+use {crate::modular::pow::multi_exponentiate_montgomery_form_slice, alloc::vec::Vec};
 
 impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// Raises to the `exponent` power.

--- a/src/uint/modular/runtime_mod/runtime_sub.rs
+++ b/src/uint/modular/runtime_mod/runtime_sub.rs
@@ -1,8 +1,8 @@
-use core::ops::{Sub, SubAssign};
-
-use crate::modular::sub::sub_montgomery_form;
+//! Subtractions between residues with a modulus set at runtime.
 
 use super::DynResidue;
+use crate::modular::sub::sub_montgomery_form;
+use core::ops::{Sub, SubAssign};
 
 impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// Subtracts `rhs`.


### PR DESCRIPTION
- Moves module-level comments to modules
- Gets rid of newlines between imports that get auto-sorted by rustfmt