### PR TITLE
Fix benchmark build

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -136,6 +136,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.70.0
+      - run: cargo build --benches
       - run: cargo build --all-features --benches
 
   doc:

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,9 +3,12 @@ use criterion::{
 };
 use crypto_bigint::{
     modular::{DynResidue, DynResidueParams},
-    Limb, MultiExponentiate, NonZero, Random, Reciprocal, U128, U2048, U256,
+    Limb, NonZero, Random, Reciprocal, U128, U2048, U256,
 };
 use rand_core::OsRng;
+
+#[cfg(feature = "alloc")]
+use crypto_bigint::MultiExponentiate;
 
 fn bench_division<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("div/rem, U256/U128, full size", |b| {
@@ -102,6 +105,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         )
     });
 
+    #[cfg(feature = "alloc")]
     for i in [1, 2, 3, 4, 10, 100] {
         group.bench_function(
             format!("multi_exponentiate for {i} bases, U256^U256"),


### PR DESCRIPTION
Benchmarks weren't building without the `alloc` feature.

Also adds CI that ensures the benchmarks build with no features.