### PR TITLE
Impl `MulMod` for `Uint`

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -145,16 +145,12 @@ pub trait NegMod {
 }
 
 /// Compute `self * rhs mod p`.
-///
-/// Requires `p_inv = -(p^{-1} mod 2^{BITS}) mod 2^{BITS}` to be provided for efficiency.
 pub trait MulMod<Rhs = Self> {
     /// Output type.
     type Output;
 
     /// Compute `self * rhs mod p`.
-    ///
-    /// Requires `p_inv = -(p^{-1} mod 2^{BITS}) mod 2^{BITS}` to be provided for efficiency.
-    fn mul_mod(&self, rhs: &Rhs, p: &Self, p_inv: Limb) -> Self::Output;
+    fn mul_mod(&self, rhs: &Rhs, p: &Self) -> Self::Output;
 }
 
 /// Checked addition.

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -137,6 +137,24 @@ proptest! {
     }
 
     #[test]
+    fn mul_mod_nist_p256(a in uint_mod_p(P), b in uint_mod_p(P)) {
+        assert!(a < P);
+        assert!(b < P);
+
+        let a_bi = to_biguint(&a);
+        let b_bi = to_biguint(&b);
+        let p_bi = to_biguint(&P);
+
+        let expected = to_uint((a_bi * b_bi) % p_bi);
+        let actual = a.mul_mod(&b, &P);
+
+        assert!(expected < P);
+        assert!(actual < P);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn wrapping_sub(mut a in uint(), mut b in uint()) {
         if b > a {
             mem::swap(&mut a, &mut b);


### PR DESCRIPTION
Uses Montgomery multiplication although it may not be the most efficient approach (e.g. a Barrett reduction might be faster).

This also changes the `MulMod` trait to remove the Montgomery-specific implementation details, allowing a simple `mul_mod(self, rhs, p)`. Optimized Montgomery multiplication is still available via `DynResidue`.

Closes #70