### PR TITLE
Add `Uint::bitand_limb`

### DIFF
--- a/src/boxed/uint/bit_and.rs
+++ b/src/boxed/uint/bit_and.rs
@@ -12,7 +12,8 @@ impl BoxedUint {
         Self::chain(self, rhs, Limb::ZERO, |a, b, z| (a.bitand(b), z)).0
     }
 
-    /// Bitwise `AND` against the given limb.
+    /// Perform bitwise `AND` between `self` and the given [`Limb`], performing the `AND` operation
+    /// on every limb of `self`.
     pub fn bitand_limb(&self, rhs: Limb) -> Self {
         Self {
             limbs: self.limbs.iter().map(|limb| limb.bitand(rhs)).collect(),

--- a/src/uint/add_mod.rs
+++ b/src/uint/add_mod.rs
@@ -11,14 +11,12 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         // Attempt to subtract the modulus, to ensure the result is in the field.
         let (w, borrow) = w.sbb(p, Limb::ZERO);
-        let (_, borrow) = carry.sbb(Limb::ZERO, borrow);
+        let (_, mask) = carry.sbb(Limb::ZERO, borrow);
 
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
         // modulus.
-        let mask = Self::from_words([borrow.0; LIMBS]);
-
-        w.wrapping_add(&p.bitand(&mask))
+        w.wrapping_add(&p.bitand_limb(mask))
     }
 
     /// Computes `self + rhs mod p` for the special modulus

--- a/src/uint/bit_and.rs
+++ b/src/uint/bit_and.rs
@@ -20,6 +20,20 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         Self { limbs }
     }
 
+    /// Perform bitwise `AND` between `self` and the given [`Limb`], performing the `AND` operation
+    /// on every limb of `self`.
+    pub const fn bitand_limb(&self, rhs: Limb) -> Self {
+        let mut limbs = [Limb::ZERO; LIMBS];
+        let mut i = 0;
+
+        while i < LIMBS {
+            limbs[i] = self.limbs[i].bitand(rhs);
+            i += 1;
+        }
+
+        Self { limbs }
+    }
+
     /// Perform wrapping bitwise `AND`.
     ///
     /// There's no way wrapping could ever happen.


### PR DESCRIPTION
Similar to #321, this adds a function which applies a bitwise AND of the given limb to every limb in a `Uint`.

This can be used to replace intermediate array allocations and reduce stack size inside of `Uint::{add_mod, sub_mod}`.