### PR TITLE
Split `Zero` trait into `Zero`+`ZeroConstant`

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -19,7 +19,7 @@ mod sub;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{Bounded, Zero};
+use crate::{Bounded, ZeroConstant};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable};
 
@@ -105,7 +105,7 @@ impl ConditionallySelectable for Limb {
     }
 }
 
-impl Zero for Limb {
+impl ZeroConstant for Limb {
     const ZERO: Self = Self::ZERO;
 }
 

--- a/src/modular/residue.rs
+++ b/src/modular/residue.rs
@@ -8,7 +8,7 @@ mod pow;
 mod sub;
 
 use super::{div_by_2::div_by_2, reduction::montgomery_reduction, Retrieve};
-use crate::{Limb, Uint, Zero};
+use crate::{Limb, Uint, ZeroConstant};
 use core::{fmt::Debug, marker::PhantomData};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
@@ -193,7 +193,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Default for Residue<MOD, LIM
     }
 }
 
-impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Zero for Residue<MOD, LIMBS> {
+impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> ZeroConstant for Residue<MOD, LIMBS> {
     const ZERO: Self = Self::ZERO;
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -80,7 +80,7 @@ pub trait Integer:
 /// Zero values.
 pub trait Zero: ConstantTimeEq + Sized {
     /// The value `0`.
-    const ZERO: Self;
+    fn zero() -> Self;
 
     /// Determine if this value is equal to zero.
     ///
@@ -88,7 +88,21 @@ pub trait Zero: ConstantTimeEq + Sized {
     ///
     /// If zero, returns `Choice(1)`. Otherwise, returns `Choice(0)`.
     fn is_zero(&self) -> Choice {
-        self.ct_eq(&Self::ZERO)
+        self.ct_eq(&Self::zero())
+    }
+}
+
+/// Trait for associating a constant representing zero.
+///
+/// Types which impl this trait automatically receive a blanket impl of [`Zero`].
+pub trait ZeroConstant: Zero {
+    /// The value `0`.
+    const ZERO: Self;
+}
+
+impl<T: ZeroConstant> Zero for T {
+    fn zero() -> T {
+        Self::ZERO
     }
 }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -38,7 +38,7 @@ pub(crate) mod boxed;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{Bounded, Encoding, Integer, Limb, Word, Zero};
+use crate::{Bounded, Encoding, Integer, Limb, Word, ZeroConstant};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable};
 
@@ -224,7 +224,7 @@ impl<const LIMBS: usize> Integer for Uint<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Zero for Uint<LIMBS> {
+impl<const LIMBS: usize> ZeroConstant for Uint<LIMBS> {
     const ZERO: Self = Self::ZERO;
 }
 

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -78,7 +78,6 @@ impl BoxedUint {
     }
 
     /// Is this [`BoxedUint`] equal to zero?
-    // TODO(tarcieri): impl the `Zero` trait
     pub fn is_zero(&self) -> Choice {
         self.limbs
             .iter()
@@ -343,6 +342,16 @@ impl From<Vec<Limb>> for BoxedUint {
 impl<const LIMBS: usize> From<Uint<LIMBS>> for BoxedUint {
     fn from(uint: Uint<LIMBS>) -> BoxedUint {
         Vec::from(uint.to_limbs()).into()
+    }
+}
+
+impl Zero for BoxedUint {
+    fn zero() -> Self {
+        Self::zero()
+    }
+
+    fn is_zero(&self) -> Choice {
+        self.is_zero()
     }
 }
 

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -18,7 +18,9 @@ use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};
 pub struct Wrapping<T>(pub T);
 
 impl<T: Zero> Zero for Wrapping<T> {
-    const ZERO: Self = Self(T::ZERO);
+    fn zero() -> Self {
+        Wrapping(T::zero())
+    }
 }
 
 impl<T: fmt::Display> fmt::Display for Wrapping<T> {


### PR DESCRIPTION
The `BoxedUint` type couldn't impl the old `Zero` trait because it requires the value be bound to a constant instead of computed at runtime.

This commit splits the original trait into two traits, adding a `fn zero()` to `Zero` which can be used for `BoxedUint`.

A blanket impl links the two.

This makes it possible to add a `Zero` trait impl for `BoxedUint`, which is included in this commit.