### PR TITLE
Add `BoxedUint::inv_mod`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,7 +231,7 @@ dependencies = [
  "der",
  "generic-array",
  "hex-literal",
- "num-bigint",
+ "num-bigint-dig",
  "num-integer",
  "num-traits",
  "proptest",
@@ -350,6 +356,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -391,14 +400,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.4"
+name = "num-bigint-dig"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
 dependencies = [
- "autocfg",
+ "byteorder",
+ "lazy_static",
+ "libm",
  "num-integer",
+ "num-iter",
  "num-traits",
+ "rand",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -408,6 +423,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -710,6 +736,18 @@ dependencies = [
  "base16ct",
  "serde",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ zeroize = { version = "1", optional = true,  default-features = false }
 bincode = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
 hex-literal = "0.4"
-num-bigint = "0.4"
+num-bigint = { package = "num-bigint-dig", version = "0.8" }
 num-integer = "0.1"
 num-traits = "0.2"
 proptest = "1"

--- a/src/uint/boxed/bits.rs
+++ b/src/uint/boxed/bits.rs
@@ -29,6 +29,20 @@ impl BoxedUint {
         self.limbs.len() * Limb::BITS
     }
 
+    /// Calculate the number of trailing zeros in the binary representation of this number.
+    pub fn trailing_zeros(&self) -> usize {
+        let mut count: Word = 0;
+        let mut nonzero_limb_not_encountered = Choice::from(1u8);
+
+        for l in &*self.limbs {
+            let z = l.trailing_zeros() as Word;
+            count += Word::conditional_select(&0, &z, nonzero_limb_not_encountered);
+            nonzero_limb_not_encountered &= l.is_zero();
+        }
+
+        count as usize
+    }
+
     /// Sets the bit at `index` to 0 or 1 depending on the value of `bit_value`.
     pub(crate) fn set_bit(&mut self, index: usize, bit_value: Choice) {
         let limb_num = index / Limb::BITS;

--- a/src/uint/boxed/encoding.rs
+++ b/src/uint/boxed/encoding.rs
@@ -24,6 +24,10 @@ impl BoxedUint {
     /// If the length of `bytes` (when interpreted as bits) is larger than `bits_precision`, this
     /// function will return [`DecodeError::InputSize`].
     pub fn from_be_slice(bytes: &[u8], bits_precision: usize) -> Result<Self, DecodeError> {
+        if bytes.is_empty() && bits_precision == 0 {
+            return Ok(Self::zero());
+        }
+
         if bits_precision % Limb::BITS != 0 {
             return Err(DecodeError::Precision);
         }
@@ -50,6 +54,10 @@ impl BoxedUint {
     /// If the length of `bytes` (when interpreted as bits) is larger than `bits_precision`, this
     /// function will return [`DecodeError::InputSize`].
     pub fn from_le_slice(bytes: &[u8], bits_precision: usize) -> Result<Self, DecodeError> {
+        if bytes.is_empty() && bits_precision == 0 {
+            return Ok(Self::zero());
+        }
+
         if bits_precision % Limb::BITS != 0 {
             return Err(DecodeError::Precision);
         }

--- a/src/uint/boxed/mul.rs
+++ b/src/uint/boxed/mul.rs
@@ -27,6 +27,11 @@ impl BoxedUint {
         ret
     }
 
+    /// Perform wrapping multiplication, wrapping to the width of `self`.
+    pub fn wrapping_mul(&self, rhs: &Self) -> Self {
+        self.mul_wide(rhs).shorten(self.bits_precision())
+    }
+
     /// Multiply `self` by itself.
     pub fn square(&self) -> Self {
         // TODO(tarcieri): more optimized implementation

--- a/src/uint/boxed/neg.rs
+++ b/src/uint/boxed/neg.rs
@@ -1,0 +1,53 @@
+//! [`BoxedUint`] negation operations.
+
+use crate::{BoxedUint, Limb, WideWord, Word, Wrapping};
+use core::ops::Neg;
+use subtle::Choice;
+
+impl Neg for Wrapping<BoxedUint> {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self(self.0.wrapping_neg())
+    }
+}
+
+impl BoxedUint {
+    /// Negates based on `choice` by wrapping the integer.
+    pub(crate) fn conditional_wrapping_neg(&self, choice: Choice) -> BoxedUint {
+        Self::conditional_select(self, &self.wrapping_neg(), choice)
+    }
+
+    /// Perform wrapping negation.
+    pub fn wrapping_neg(&self) -> Self {
+        let mut ret = vec![Limb::ZERO; self.nlimbs()];
+        let mut carry = 1;
+
+        for i in 0..self.nlimbs() {
+            let r = (!self.limbs[i].0 as WideWord) + carry;
+            ret[i] = Limb(r as Word);
+            carry = r >> Limb::BITS;
+        }
+
+        ret.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::BoxedUint;
+
+    #[test]
+    fn wrapping_neg() {
+        assert_eq!(BoxedUint::zero().wrapping_neg(), BoxedUint::zero());
+        assert_eq!(BoxedUint::max(64).wrapping_neg(), BoxedUint::one());
+        // assert_eq!(
+        //     BoxedUint::from(13u64).wrapping_neg(),
+        //     BoxedUint::from(13u64).not().saturating_add(&BoxedUint::one())
+        // );
+        // assert_eq!(
+        //     BoxedUint::from(42u64).wrapping_neg(),
+        //     BoxedUint::from(42u64).saturating_sub(&BoxedUint::one()).not()
+        // );
+    }
+}

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -53,7 +53,7 @@ proptest! {
     fn shl_vartime(a in uint(), shift in any::<u8>()) {
         let a_bi = to_biguint(&a);
 
-        let expected = to_uint(a_bi << shift);
+        let expected = to_uint(a_bi << shift.into());
         let actual = a.shl_vartime(shift as usize);
 
         assert_eq!(expected, actual);


### PR DESCRIPTION
Support for computing modular inverses, proptested against the implementation in `num-bigint-dig`, which this commit also switches to (`num-bigint` doesn't provide an implementation we can test against).

Uses the same method as `Uint::inv_mod`, namely an algorithm equivalent to GMP's `mpn_sec_invert`, with code largely duplicated from the `Uint` version.

Notably this version is variable time with respect to the modulus, which might be avoidable with alternative implementations, such as Bernstein-Yang.

It would also be nice to deduplicate the implementation, though reuse between `const fn` use cases and heap-backed use cases is difficult.

This additionally adds the following prerequisites:
- `BoxedUint::{conditional_assign, conditional_swap, is_one}
- `BoxedUint::conditional_wrapping_*` (private)
- `BoxedUint::{trailing_zeros, wrapping_mul, neg}`
- `BoxedUint::{shl, shr}`