### PR TITLE
Assert `Boxed*` size equivalance using `bits_precision`

### DIFF
--- a/src/modular/boxed_residue/mul.rs
+++ b/src/modular/boxed_residue/mul.rs
@@ -95,8 +95,8 @@ pub(super) fn mul_montgomery_form(
     modulus: &BoxedUint,
     mod_neg_inv: Limb,
 ) -> BoxedUint {
-    debug_assert_eq!(a.nlimbs(), modulus.nlimbs());
-    debug_assert_eq!(b.nlimbs(), modulus.nlimbs());
+    debug_assert_eq!(a.bits_precision(), modulus.bits_precision());
+    debug_assert_eq!(b.bits_precision(), modulus.bits_precision());
 
     let mut product = a.mul_wide(b);
     let ret = montgomery_reduction_boxed(&mut product, modulus, mod_neg_inv);

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -196,7 +196,7 @@ impl BoxedUint {
     ///
     /// Panics if `a` and `b` don't have the same precision.
     pub fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        debug_assert_eq!(a.nlimbs(), b.nlimbs());
+        debug_assert_eq!(a.bits_precision(), b.bits_precision());
         let mut limbs = vec![Limb::ZERO; a.nlimbs()].into_boxed_slice();
 
         for i in 0..a.nlimbs() {

--- a/src/uint/boxed/add_mod.rs
+++ b/src/uint/boxed/add_mod.rs
@@ -7,8 +7,8 @@ impl BoxedUint {
     ///
     /// Assumes `self + rhs` as unbounded integer is `< 2p`.
     pub fn add_mod(&self, rhs: &Self, p: &Self) -> Self {
-        debug_assert_eq!(self.nlimbs(), p.nlimbs());
-        debug_assert_eq!(rhs.nlimbs(), p.nlimbs());
+        debug_assert_eq!(self.bits_precision(), p.bits_precision());
+        debug_assert_eq!(rhs.bits_precision(), p.bits_precision());
         debug_assert!(self < p);
         debug_assert!(rhs < p);
 

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -13,7 +13,7 @@ impl BoxedUint {
     /// Panics if `self` and `rhs` have different precisions.
     // TODO(tarcieri): handle different precisions without panicking
     pub fn rem_vartime(&self, rhs: &NonZero<Self>) -> Self {
-        debug_assert_eq!(self.nlimbs(), rhs.nlimbs());
+        debug_assert_eq!(self.bits_precision(), rhs.bits_precision());
         let mb = rhs.bits();
         let mut bd = self.bits_precision() - mb;
         let mut rem = self.clone();

--- a/src/uint/boxed/sub_mod.rs
+++ b/src/uint/boxed/sub_mod.rs
@@ -7,8 +7,8 @@ impl BoxedUint {
     ///
     /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
     pub fn sub_mod(&self, rhs: &Self, p: &Self) -> Self {
-        debug_assert_eq!(self.nlimbs(), p.nlimbs());
-        debug_assert_eq!(rhs.nlimbs(), p.nlimbs());
+        debug_assert_eq!(self.bits_precision(), p.bits_precision());
+        debug_assert_eq!(rhs.bits_precision(), p.bits_precision());
         debug_assert!(self < p);
         debug_assert!(rhs < p);
 
@@ -23,8 +23,8 @@ impl BoxedUint {
     /// Assumes `-(p...) <= (self..., carry) - (rhs...) < (p...)`.
     #[inline(always)]
     pub(crate) fn sub_mod_with_carry(&self, carry: Limb, rhs: &Self, p: &Self) -> Self {
-        debug_assert_eq!(self.nlimbs(), p.nlimbs());
-        debug_assert_eq!(rhs.nlimbs(), p.nlimbs());
+        debug_assert_eq!(self.bits_precision(), p.bits_precision());
+        debug_assert_eq!(rhs.bits_precision(), p.bits_precision());
         debug_assert!(carry.0 <= 1);
 
         let (out, borrow) = self.sbb(rhs, Limb::ZERO);


### PR DESCRIPTION
Several functions on the `Boxed*` types don't yet support implicit widening (#312) and will panic if two or more operands are not the same size (NOTE: we should eventually fix this)

Some of these functions previously had debug asserts that the number of limbs are equal, however that's less helpful information when trying to debug these problems than the precision in bits.

This changes all of the assertions for size equality to use `bits_precision`.