### PR TITLE
Impl `Hash` for `BoxedUint`

### DIFF
--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -36,7 +36,8 @@ use zeroize::Zeroize;
 /// Unlike many other heap-allocated big integer libraries, this type is not
 /// arbitrary precision and will wrap at its fixed-precision rather than
 /// automatically growing.
-#[derive(Clone)]
+#[allow(clippy::derived_hash_with_manual_eq)]
+#[derive(Clone, Hash)]
 pub struct BoxedUint {
     /// Boxed slice containing limbs.
     ///


### PR DESCRIPTION
Uses a derived impl. Ideally this wouldn't be used with secret values, or at least hopefully with a good hashing algorithm (like the default SipHasher, which is a secure PRF)