### PR TITLE
Refactor `Integer` trait; add `Constants`/`LimbsConstant`

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -19,7 +19,7 @@ mod sub;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{Bounded, ZeroConstant};
+use crate::{Bounded, Constants, ZeroConstant};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable};
 
@@ -98,15 +98,20 @@ impl Bounded for Limb {
     const BYTES: usize = Self::BYTES;
 }
 
+impl Constants for Limb {
+    const ONE: Self = Self::ONE;
+    const MAX: Self = Self::MAX;
+}
+
+impl ZeroConstant for Limb {
+    const ZERO: Self = Self::ZERO;
+}
+
 impl ConditionallySelectable for Limb {
     #[inline]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Self(Word::conditional_select(&a.0, &b.0, choice))
     }
-}
-
-impl ZeroConstant for Limb {
-    const ZERO: Self = Self::ZERO;
 }
 
 impl fmt::Debug for Limb {

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -1,6 +1,6 @@
 //! Wrapper type for non-zero integers.
 
-use crate::{CtChoice, Encoding, Integer, Limb, Uint, Zero};
+use crate::{Bounded, Constants, CtChoice, Encoding, Limb, Uint, Zero};
 use core::{
     fmt,
     num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8},
@@ -58,7 +58,18 @@ where
 
 impl<T> NonZero<T>
 where
-    T: Integer,
+    T: Bounded + Zero,
+{
+    /// Total size of the represented integer in bits.
+    pub const BITS: usize = T::BITS;
+
+    /// Total size of the represented integer in bytes.
+    pub const BYTES: usize = T::BYTES;
+}
+
+impl<T> NonZero<T>
+where
+    T: Constants + Zero,
 {
     /// The value `1`.
     pub const ONE: Self = Self(T::ONE);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -11,7 +11,16 @@ use subtle::{
 #[cfg(feature = "rand_core")]
 use rand_core::CryptoRngCore;
 
-/// Integer type.
+/// Integers whose representation takes a bounded amount of space.
+pub trait Bounded {
+    /// Size of this integer in bits.
+    const BITS: usize;
+
+    /// Size of this integer in bytes.
+    const BYTES: usize;
+}
+
+/// Integer trait: represents common functionality of integer types provided by this crate.
 pub trait Integer:
     'static
     + AddMod
@@ -46,19 +55,16 @@ pub trait Integer:
     + Zero
 {
     /// The value `1`.
-    const ONE: Self;
+    fn one() -> Self;
 
-    /// Maximum value this integer can express.
-    const MAX: Self;
+    /// Precision of this integer in bits.
+    fn bits_precision(&self) -> usize;
 
-    /// Total size of the represented integer in bits.
-    const BITS: usize;
+    /// Precision of this integer in bytes.
+    fn bytes_precision(&self) -> usize;
 
-    /// Total size of the represented integer in bytes.
-    const BYTES: usize;
-
-    /// The number of limbs used on this platform.
-    const LIMBS: usize;
+    /// Number of limbs in this integer.
+    fn nlimbs(&self) -> usize;
 
     /// Is this integer value an odd number?
     ///
@@ -104,6 +110,21 @@ impl<T: ZeroConstant> Zero for T {
     fn zero() -> T {
         Self::ZERO
     }
+}
+
+/// Trait for associating constant values with a type.
+pub trait Constants: ZeroConstant {
+    /// The value `1`.
+    const ONE: Self;
+
+    /// Maximum value this integer can express.
+    const MAX: Self;
+}
+
+/// Constant representing the number of limbs used to represent a type.
+pub trait LimbsConstant {
+    /// The number of limbs used on this platform.
+    const LIMBS: usize;
 }
 
 /// Random number generation support.
@@ -244,15 +265,6 @@ pub trait SplitMixed<Hi, Lo> {
     /// Split this number into parts, returning its high and low components
     /// respectively.
     fn split_mixed(&self) -> (Hi, Lo);
-}
-
-/// Integers whose representation takes a bounded amount of space.
-pub trait Bounded {
-    /// Size of this integer in bits.
-    const BITS: usize;
-
-    /// Size of this integer in bytes.
-    const BYTES: usize;
 }
 
 /// Encoding support.

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -38,7 +38,7 @@ pub(crate) mod boxed;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{Bounded, Encoding, Integer, Limb, Word, ZeroConstant};
+use crate::{Bounded, Constants, Encoding, Integer, Limb, LimbsConstant, Word, ZeroConstant};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable};
 
@@ -210,11 +210,21 @@ impl<const LIMBS: usize> Default for Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize> Integer for Uint<LIMBS> {
-    const ONE: Self = Self::ONE;
-    const MAX: Self = Self::MAX;
-    const BITS: usize = Self::BITS;
-    const BYTES: usize = Self::BYTES;
-    const LIMBS: usize = Self::LIMBS;
+    fn one() -> Self {
+        Self::ONE
+    }
+
+    fn bits_precision(&self) -> usize {
+        Self::BITS
+    }
+
+    fn bytes_precision(&self) -> usize {
+        Self::BYTES
+    }
+
+    fn nlimbs(&self) -> usize {
+        Self::LIMBS
+    }
 
     fn is_odd(&self) -> Choice {
         self.limbs
@@ -224,13 +234,22 @@ impl<const LIMBS: usize> Integer for Uint<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> ZeroConstant for Uint<LIMBS> {
-    const ZERO: Self = Self::ZERO;
-}
-
 impl<const LIMBS: usize> Bounded for Uint<LIMBS> {
     const BITS: usize = Self::BITS;
     const BYTES: usize = Self::BYTES;
+}
+
+impl<const LIMBS: usize> Constants for Uint<LIMBS> {
+    const ONE: Self = Self::ONE;
+    const MAX: Self = Self::MAX;
+}
+
+impl<const LIMBS: usize> LimbsConstant for Uint<LIMBS> {
+    const LIMBS: usize = Self::LIMBS;
+}
+
+impl<const LIMBS: usize> ZeroConstant for Uint<LIMBS> {
+    const ZERO: Self = Self::ZERO;
 }
 
 impl<const LIMBS: usize> fmt::Debug for Uint<LIMBS> {

--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -7,7 +7,6 @@ macro_rules! impl_uint_aliases {
             pub type $name = Uint<{nlimbs!($bits)}>;
 
             impl Encoding for $name {
-
                 type Repr = [u8; $bits / 8];
 
                 #[inline]


### PR DESCRIPTION
This commit factors all of the associated constants off of the `Integer` trait into separate traits:

- The existing `Bounded` trait subsumes `BITS`/`BYTES`
- `Constants` provides `ONE` and `MAX`
- `LimbsConstant` provides `LIMBS`

Methods have been added to `Integer` to query what was previously provided by the constants, allowing `BoxedInteger` to potentially impl the trait.

That isn't done yet though, because `BoxedUint` needs more trait impls first to meet the bounds of `Integer`.