### PR TITLE
BoxedUint: add `map_limbs`; rename `fold_limbs`

### DIFF
--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -262,7 +262,7 @@ impl BoxedUint {
     ///
     /// If one of the two values has fewer limbs than the other, pads with
     /// [`Limb::ZERO`] as the value for that limb.
-    fn chain<F>(lhs: &Self, rhs: &Self, mut carry: Limb, f: F) -> (Self, Limb)
+    fn fold_limbs<F>(lhs: &Self, rhs: &Self, mut carry: Limb, f: F) -> (Self, Limb)
     where
         F: Fn(Limb, Limb, Limb) -> (Limb, Limb),
     {
@@ -278,6 +278,24 @@ impl BoxedUint {
         }
 
         (limbs.into(), carry)
+    }
+
+    /// Iterate over the limbs of the inputs, applying the given function, and
+    /// constructing a result from the returned values.
+    fn map_limbs<F>(lhs: &Self, rhs: &Self, f: F) -> Self
+    where
+        F: Fn(Limb, Limb) -> Limb,
+    {
+        let nlimbs = cmp::max(lhs.nlimbs(), rhs.nlimbs());
+        let mut limbs = Vec::with_capacity(nlimbs);
+
+        for i in 0..nlimbs {
+            let &a = lhs.limbs.get(i).unwrap_or(&Limb::ZERO);
+            let &b = rhs.limbs.get(i).unwrap_or(&Limb::ZERO);
+            limbs.push(f(a, b));
+        }
+
+        limbs.into()
     }
 }
 

--- a/src/uint/boxed/add.rs
+++ b/src/uint/boxed/add.rs
@@ -7,7 +7,7 @@ impl BoxedUint {
     /// Computes `a + b + carry`, returning the result along with the new carry.
     #[inline(always)]
     pub fn adc(&self, rhs: &Self, carry: Limb) -> (Self, Limb) {
-        Self::chain(self, rhs, carry, |a, b, c| a.adc(b, c))
+        Self::fold_limbs(self, rhs, carry, |a, b, c| a.adc(b, c))
     }
 
     /// Perform wrapping addition, discarding overflow.

--- a/src/uint/boxed/bit_and.rs
+++ b/src/uint/boxed/bit_and.rs
@@ -9,7 +9,7 @@ impl BoxedUint {
     /// Computes bitwise `a & b`.
     #[inline(always)]
     pub fn bitand(&self, rhs: &Self) -> Self {
-        Self::chain(self, rhs, Limb::ZERO, |a, b, z| (a.bitand(b), z)).0
+        Self::map_limbs(self, rhs, |a, b| a.bitand(b))
     }
 
     /// Perform bitwise `AND` between `self` and the given [`Limb`], performing the `AND` operation

--- a/src/uint/boxed/bit_or.rs
+++ b/src/uint/boxed/bit_or.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] bitwise OR operations.
 
-use crate::{BoxedUint, Limb, Wrapping};
+use crate::{BoxedUint, Wrapping};
 use core::ops::{BitOr, BitOrAssign};
 use subtle::{Choice, CtOption};
 
@@ -8,7 +8,7 @@ impl BoxedUint {
     /// Computes bitwise `a & b`.
     #[inline(always)]
     pub fn bitor(&self, rhs: &Self) -> Self {
-        Self::chain(self, rhs, Limb::ZERO, |a, b, z| (a.bitor(b), z)).0
+        Self::map_limbs(self, rhs, |a, b| a.bitor(b))
     }
 
     /// Perform wrapping bitwise `OR`.

--- a/src/uint/boxed/sub.rs
+++ b/src/uint/boxed/sub.rs
@@ -7,7 +7,7 @@ impl BoxedUint {
     /// Computes `a + b + carry`, returning the result along with the new carry.
     #[inline(always)]
     pub fn sbb(&self, rhs: &Self, borrow: Limb) -> (Self, Limb) {
-        Self::chain(self, rhs, borrow, |a, b, c| a.sbb(b, c))
+        Self::fold_limbs(self, rhs, borrow, |a, b, c| a.sbb(b, c))
     }
 
     /// Perform wrapping subition, discarding overflow.


### PR DESCRIPTION
Splits apart the internal functions for iterating over limbs and handling widening, and applying a given function to the inputs.

`BoxedUint::map_limbs` is useful when there is no carry.

The somewhat ambiguously named `BoxedUint::chain` has also been renamed to `BoxedUint::fold_limbs` which better reflects the combinator being applied.