### PR TITLE
BoxedUint: rename `mul_wide` to `mul`

### DIFF
--- a/src/modular/boxed_residue.rs
+++ b/src/modular/boxed_residue.rs
@@ -105,7 +105,7 @@ impl BoxedResidue {
     pub fn new(integer: &BoxedUint, residue_params: BoxedResidueParams) -> Self {
         debug_assert_eq!(integer.bits_precision(), residue_params.bits_precision());
 
-        let mut product = integer.mul_wide(&residue_params.r2);
+        let mut product = integer.mul(&residue_params.r2);
         let montgomery_form = montgomery_reduction_boxed(
             &mut product,
             &residue_params.modulus,

--- a/src/modular/boxed_residue/inv.rs
+++ b/src/modular/boxed_residue/inv.rs
@@ -13,7 +13,7 @@ impl BoxedResidue {
             .inv_odd_mod(&self.residue_params.modulus);
 
         let montgomery_form = montgomery_reduction_boxed(
-            &mut inverse.mul_wide(&self.residue_params.r3),
+            &mut inverse.mul(&self.residue_params.r3),
             &self.residue_params.modulus,
             self.residue_params.mod_neg_inv,
         );

--- a/src/modular/boxed_residue/mul.rs
+++ b/src/modular/boxed_residue/mul.rs
@@ -98,7 +98,7 @@ pub(super) fn mul_montgomery_form(
     debug_assert_eq!(a.bits_precision(), modulus.bits_precision());
     debug_assert_eq!(b.bits_precision(), modulus.bits_precision());
 
-    let mut product = a.mul_wide(b);
+    let mut product = a.mul(b);
     let ret = montgomery_reduction_boxed(&mut product, modulus, mod_neg_inv);
 
     #[cfg(feature = "zeroize")]

--- a/src/uint/boxed/mul.rs
+++ b/src/uint/boxed/mul.rs
@@ -4,7 +4,9 @@ use crate::{BoxedUint, Limb};
 
 impl BoxedUint {
     /// Multiply `self` by `rhs`.
-    pub fn mul_wide(&self, rhs: &Self) -> Self {
+    ///
+    /// Returns a widened output with a limb count equal to the sums of the input limb counts.
+    pub fn mul(&self, rhs: &Self) -> Self {
         let mut ret = Self {
             limbs: vec![Limb::ZERO; self.nlimbs() + rhs.nlimbs()].into(),
         };
@@ -29,13 +31,13 @@ impl BoxedUint {
 
     /// Perform wrapping multiplication, wrapping to the width of `self`.
     pub fn wrapping_mul(&self, rhs: &Self) -> Self {
-        self.mul_wide(rhs).shorten(self.bits_precision())
+        self.mul(rhs).shorten(self.bits_precision())
     }
 
     /// Multiply `self` by itself.
     pub fn square(&self) -> Self {
         // TODO(tarcieri): more optimized implementation
-        self.mul_wide(self)
+        self.mul(self)
     }
 }
 
@@ -46,18 +48,15 @@ mod tests {
     #[test]
     fn mul_zero_and_one() {
         assert!(bool::from(
-            BoxedUint::zero().mul_wide(&BoxedUint::zero()).is_zero()
+            BoxedUint::zero().mul(&BoxedUint::zero()).is_zero()
         ));
         assert!(bool::from(
-            BoxedUint::zero().mul_wide(&BoxedUint::one()).is_zero()
+            BoxedUint::zero().mul(&BoxedUint::one()).is_zero()
         ));
         assert!(bool::from(
-            BoxedUint::one().mul_wide(&BoxedUint::zero()).is_zero()
+            BoxedUint::one().mul(&BoxedUint::zero()).is_zero()
         ));
-        assert_eq!(
-            BoxedUint::one().mul_wide(&BoxedUint::one()),
-            BoxedUint::one()
-        );
+        assert_eq!(BoxedUint::one().mul(&BoxedUint::one()), BoxedUint::one());
     }
 
     #[test]
@@ -66,7 +65,7 @@ mod tests {
 
         for &a_int in primes {
             for &b_int in primes {
-                let actual = BoxedUint::from(a_int).mul_wide(&BoxedUint::from(b_int));
+                let actual = BoxedUint::from(a_int).mul(&BoxedUint::from(b_int));
                 let expected = BoxedUint::from(a_int as u64 * b_int as u64);
                 assert_eq!(actual, expected);
             }

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -45,7 +45,7 @@ impl BoxedUint {
             return Self::from(reduced as Word);
         }
 
-        let product = self.mul_wide(rhs);
+        let product = self.mul(rhs);
         let (lo_words, hi_words) = product.limbs.split_at(self.nlimbs());
         let lo = BoxedUint::from(lo_words);
         let hi = BoxedUint::from(hi_words);

--- a/tests/boxed_uint_proptests.rs
+++ b/tests/boxed_uint_proptests.rs
@@ -129,7 +129,7 @@ proptest! {
         let b_bi = to_biguint(&b);
 
         let expected = a_bi * b_bi;
-        let actual = a.mul_wide(&b);
+        let actual = a.mul(&b);
 
         prop_assert_eq!(expected, to_biguint(&actual));
     }


### PR DESCRIPTION
This is more consistent with `Uint`, where `mul` returns an output whose limbs are equal to the sum of the input limb counts.

`Uint::mul_wide` returns a tuple of lo and hi components, with `Uint::mul` handling the concatenation.