### PR TITLE
Round up `bits_precision` when creating `BoxedUint`

### DIFF
--- a/src/limb/encoding.rs
+++ b/src/limb/encoding.rs
@@ -38,9 +38,10 @@ impl Limb {
     pub(crate) fn from_be_slice(bytes: &[u8]) -> Self {
         let mut repr = Self::ZERO.to_be_bytes();
         let repr_len = repr.len();
-        if bytes.len() > repr_len {
-            panic!("The given slice is larger than the limb size");
-        }
+        assert!(
+            bytes.len() <= repr_len,
+            "The given slice is larger than the limb size"
+        );
         repr[(repr_len - bytes.len())..].copy_from_slice(bytes);
         Self::from_be_bytes(repr)
     }
@@ -51,9 +52,10 @@ impl Limb {
     pub(crate) fn from_le_slice(bytes: &[u8]) -> Self {
         let mut repr = Self::ZERO.to_le_bytes();
         let repr_len = repr.len();
-        if bytes.len() > repr_len {
-            panic!("The given slice is larger than the limb size");
-        }
+        assert!(
+            bytes.len() <= repr_len,
+            "The given slice is larger than the limb size"
+        );
         repr[..bytes.len()].copy_from_slice(bytes);
         Self::from_le_bytes(repr)
     }

--- a/src/limb/encoding.rs
+++ b/src/limb/encoding.rs
@@ -34,16 +34,28 @@ impl Encoding for Limb {
 impl Limb {
     /// Decode limb from a big endian byte slice.
     ///
-    /// Panics if the slice is not the same size as [`Limb::Repr`].
+    /// Panics if the slice is larger than [`Limb::Repr`].
     pub(crate) fn from_be_slice(bytes: &[u8]) -> Self {
-        Self::from_be_bytes(bytes.try_into().expect("slice not limb-sized"))
+        let mut repr = Self::ZERO.to_be_bytes();
+        let repr_len = repr.len();
+        if bytes.len() > repr_len {
+            panic!("The given slice is larger than the limb size");
+        }
+        repr[(repr_len - bytes.len())..].copy_from_slice(bytes);
+        Self::from_be_bytes(repr)
     }
 
     /// Decode limb from a little endian byte slice.
     ///
     /// Panics if the slice is not the same size as [`Limb::Repr`].
     pub(crate) fn from_le_slice(bytes: &[u8]) -> Self {
-        Self::from_le_bytes(bytes.try_into().expect("slice not limb-sized"))
+        let mut repr = Self::ZERO.to_le_bytes();
+        let repr_len = repr.len();
+        if bytes.len() > repr_len {
+            panic!("The given slice is larger than the limb size");
+        }
+        repr[..bytes.len()].copy_from_slice(bytes);
+        Self::from_le_bytes(repr)
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -59,7 +59,7 @@ macro_rules! const_assert_ne {
 #[macro_export]
 macro_rules! nlimbs {
     ($bits:expr) => {
-        $bits / $crate::Limb::BITS as usize
+        (($bits + $crate::Limb::BITS - 1) / $crate::Limb::BITS) as usize
     };
 }
 

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -50,8 +50,8 @@ pub struct BoxedUint {
 }
 
 impl BoxedUint {
-    fn limbs_for_precision(bits_precision: u32) -> usize {
-        ((bits_precision + Limb::BITS - 1) / Limb::BITS) as usize
+    fn limbs_for_precision(at_least_bits_precision: u32) -> usize {
+        ((at_least_bits_precision + Limb::BITS - 1) / Limb::BITS) as usize
     }
 
     /// Get the value `0` represented as succinctly as possible.
@@ -63,9 +63,9 @@ impl BoxedUint {
 
     /// Get the value `0` with the given number of bits of precision.
     ///
-    /// `bits_precision` is rounded up to a multiple of [`Limb::BITS`].
-    pub fn zero_with_precision(bits_precision: u32) -> Self {
-        vec![Limb::ZERO; Self::limbs_for_precision(bits_precision)].into()
+    /// `at_least_bits_precision` is rounded up to a multiple of [`Limb::BITS`].
+    pub fn zero_with_precision(at_least_bits_precision: u32) -> Self {
+        vec![Limb::ZERO; Self::limbs_for_precision(at_least_bits_precision)].into()
     }
 
     /// Get the value `1`, represented as succinctly as possible.
@@ -77,9 +77,9 @@ impl BoxedUint {
 
     /// Get the value `1` with the given number of bits of precision.
     ///
-    /// `bits_precision` is rounded up to a multiple of [`Limb::BITS`].
-    pub fn one_with_precision(bits_precision: u32) -> Self {
-        let mut ret = Self::zero_with_precision(bits_precision);
+    /// `at_least_bits_precision` is rounded up to a multiple of [`Limb::BITS`].
+    pub fn one_with_precision(at_least_bits_precision: u32) -> Self {
+        let mut ret = Self::zero_with_precision(at_least_bits_precision);
         ret.limbs[0] = Limb::ONE;
         ret
     }
@@ -121,11 +121,12 @@ impl BoxedUint {
         !self.is_odd()
     }
 
-    /// Get the maximum value for a given number of bits of precision.
+    /// Get the maximum value for a `BoxedUint` created with `at_least_bits_precision`
+    /// precision bits requested.
     ///
-    /// `bits_precision` is rounded up to a multiple of [`Limb::BITS`].
-    pub fn max(bits_precision: u32) -> Self {
-        vec![Limb::MAX; Self::limbs_for_precision(bits_precision)].into()
+    /// That is, returns the value `2^self.bits_precision() - 1`.
+    pub fn max(at_least_bits_precision: u32) -> Self {
+        vec![Limb::MAX; Self::limbs_for_precision(at_least_bits_precision)].into()
     }
 
     /// Create a [`BoxedUint`] from an array of [`Word`]s (i.e. word-sized unsigned
@@ -225,21 +226,21 @@ impl BoxedUint {
 
     /// Widen this type's precision to the given number of bits.
     ///
-    /// Panics if `bits_precision` is smaller than the current precision.
-    pub fn widen(&self, bits_precision: u32) -> BoxedUint {
-        assert!(bits_precision >= self.bits_precision());
+    /// Panics if `at_least_bits_precision` is smaller than the current precision.
+    pub fn widen(&self, at_least_bits_precision: u32) -> BoxedUint {
+        assert!(at_least_bits_precision >= self.bits_precision());
 
-        let mut ret = BoxedUint::zero_with_precision(bits_precision);
+        let mut ret = BoxedUint::zero_with_precision(at_least_bits_precision);
         ret.limbs[..self.nlimbs()].copy_from_slice(&self.limbs);
         ret
     }
 
     /// Shortens this type's precision to the given number of bits.
     ///
-    /// Panics if `bits_precision` is larger than the current precision.
-    pub fn shorten(&self, bits_precision: u32) -> BoxedUint {
-        assert!(bits_precision <= self.bits_precision());
-        let mut ret = BoxedUint::zero_with_precision(bits_precision);
+    /// Panics if `at_least_bits_precision` is larger than the current precision.
+    pub fn shorten(&self, at_least_bits_precision: u32) -> BoxedUint {
+        assert!(at_least_bits_precision <= self.bits_precision());
+        let mut ret = BoxedUint::zero_with_precision(at_least_bits_precision);
         let nlimbs = ret.nlimbs();
         ret.limbs.copy_from_slice(&self.limbs[..nlimbs]);
         ret

--- a/src/uint/boxed/encoding.rs
+++ b/src/uint/boxed/encoding.rs
@@ -18,8 +18,11 @@ pub enum DecodeError {
 impl fmt::Display for DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::InputSize => write!(f, "input is not a valid size"),
-            Self::Precision => write!(f, "precision is not a multiple of the word size"),
+            Self::InputSize => write!(f, "input size is too small to fit in the given precision"),
+            Self::Precision => write!(
+                f,
+                "the deserialized number is larger than the given precision"
+            ),
         }
     }
 }

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -87,7 +87,6 @@ mod tests {
         let res = U256::random_mod(&mut rng, &modulus);
 
         // Check that the value is in range
-        assert!(res >= U256::ZERO);
         assert!(res < U256::from(42u8));
 
         // Ensure `random_mod` runs in a reasonable amount of time
@@ -96,7 +95,6 @@ mod tests {
         let res = U256::random_mod(&mut rng, &modulus);
 
         // Check that the value is in range
-        assert!(res >= U256::ZERO);
         assert!(res < U256::from(0x10000000000000001u128));
     }
 }


### PR DESCRIPTION
I understand that this change may be controversial, but let me just put it out there. The reason being, why panic when we don't have to, and also to prevent bugs when something works on a 32 bit but doesn't on a 64 bit target.

- `BoxedUint::zero_with_precision()`, `one_with_precision()`, `max()` round up `bits_precision` to a multiple of `Limb::BITS`. It's a little weird in the case of `max()`, but I am not sure this method should be public in the first place (and perhaps should be renamed). 
- Support arbitrary `bits_precision` in `BoxedUint::random()` (generating a random number in range `[0, 2^bits_precision)`). 
- Fix the tests in `boxed/rand.rs` which didn't actually test `BoxedUint`. 
- Round up `bits_precision` when decoding `BoxedUint` from bytes, to match the constructors' behavior.
- Round up `nlimbs()` in the same way. Fixes #258.

An option here is to keep the given `bits_precision` as a field in the `BoxedUint` without rounding it up. Then we will have to zeroize MSBs in arithmetic operations.