### PR TITLE
Integer: add `bits(_vartime)` and `leading_zeros` methods

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -57,11 +57,23 @@ pub trait Integer:
     /// The value `1`.
     fn one() -> Self;
 
+    /// Calculate the number of bits required to represent a given number.
+    fn bits(&self) -> usize;
+
+    /// Calculate the number of bits required to represent a given number in variable-time with
+    /// respect to `self`.
+    fn bits_vartime(&self) -> usize;
+
     /// Precision of this integer in bits.
     fn bits_precision(&self) -> usize;
 
     /// Precision of this integer in bytes.
     fn bytes_precision(&self) -> usize;
+
+    /// Calculate the number of leading zeros in the binary representation of this number.
+    fn leading_zeros(&self) -> usize  {
+        self.bits_precision() - self.bits()
+    }
 
     /// Number of limbs in this integer.
     fn nlimbs(&self) -> usize;
@@ -92,24 +104,6 @@ pub trait Integer:
 pub trait FixedInteger: Bounded + ConditionallySelectable + Constants + Copy + Integer {
     /// The number of limbs used on this platform.
     const LIMBS: usize;
-}
-
-impl<T: FixedInteger> Integer for T {
-    fn one() -> Self {
-        T::ONE
-    }
-
-    fn bits_precision(&self) -> usize {
-        T::BITS
-    }
-
-    fn bytes_precision(&self) -> usize {
-        T::BYTES
-    }
-
-    fn nlimbs(&self) -> usize {
-        T::LIMBS
-    }
 }
 
 /// Zero values.

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -38,7 +38,7 @@ pub(crate) mod boxed;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{Bounded, Constants, Encoding, FixedInteger, Limb, Word, ZeroConstant};
+use crate::{Bounded, Constants, Encoding, FixedInteger, Integer, Limb, Word, ZeroConstant};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable};
 
@@ -203,6 +203,16 @@ impl<const LIMBS: usize> ConditionallySelectable for Uint<LIMBS> {
     }
 }
 
+impl<const LIMBS: usize> Bounded for Uint<LIMBS> {
+    const BITS: usize = Self::BITS;
+    const BYTES: usize = Self::BYTES;
+}
+
+impl<const LIMBS: usize> Constants for Uint<LIMBS> {
+    const ONE: Self = Self::ONE;
+    const MAX: Self = Self::MAX;
+}
+
 impl<const LIMBS: usize> Default for Uint<LIMBS> {
     fn default() -> Self {
         Self::ZERO
@@ -213,14 +223,30 @@ impl<const LIMBS: usize> FixedInteger for Uint<LIMBS> {
     const LIMBS: usize = LIMBS;
 }
 
-impl<const LIMBS: usize> Bounded for Uint<LIMBS> {
-    const BITS: usize = Self::BITS;
-    const BYTES: usize = Self::BYTES;
-}
+impl<const LIMBS: usize> Integer for Uint<LIMBS> {
+    fn one() -> Self {
+        Self::ONE
+    }
 
-impl<const LIMBS: usize> Constants for Uint<LIMBS> {
-    const ONE: Self = Self::ONE;
-    const MAX: Self = Self::MAX;
+    fn bits(&self) -> usize {
+        self.bits()
+    }
+
+    fn bits_vartime(&self) -> usize {
+        self.bits_vartime()
+    }
+
+    fn bits_precision(&self) -> usize {
+        Self::BITS
+    }
+
+    fn bytes_precision(&self) -> usize {
+        Self::BYTES
+    }
+
+    fn nlimbs(&self) -> usize {
+        Self::LIMBS
+    }
 }
 
 impl<const LIMBS: usize> ZeroConstant for Uint<LIMBS> {

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -408,6 +408,14 @@ impl Integer for BoxedUint {
         Self::one()
     }
 
+    fn bits(&self) -> usize {
+        self.bits()
+    }
+
+    fn bits_vartime(&self) -> usize {
+        self.bits_vartime()
+    }
+
     fn bits_precision(&self) -> usize {
         self.bits_precision()
     }

--- a/src/uint/boxed/bits.rs
+++ b/src/uint/boxed/bits.rs
@@ -24,6 +24,18 @@ impl BoxedUint {
         Limb::BITS * (n as usize) - (leading_zeros as usize)
     }
 
+    /// Calculate the number of bits needed to represent this number in variable-time with respect
+    /// to `self`.
+    pub fn bits_vartime(&self) -> usize {
+        let mut i = self.nlimbs() - 1;
+        while i > 0 && self.limbs[i].0 == 0 {
+            i -= 1;
+        }
+
+        let limb = self.limbs[i];
+        Limb::BITS * (i + 1) - limb.leading_zeros()
+    }
+
     /// Get the precision of this [`BoxedUint`] in bits.
     pub fn bits_precision(&self) -> usize {
         self.limbs.len() * Limb::BITS

--- a/tests/boxed_uint_proptests.rs
+++ b/tests/boxed_uint_proptests.rs
@@ -73,6 +73,13 @@ proptest! {
     }
 
     #[test]
+    fn bits(a in uint()) {
+        let expected = to_biguint(&a).bits();
+        assert_eq!(expected, a.bits());
+        assert_eq!(expected, a.bits_vartime());
+    }
+
+    #[test]
     fn checked_add(a in uint(), b in uint()) {
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -50,6 +50,13 @@ proptest! {
     }
 
     #[test]
+    fn bits(a in uint()) {
+        let expected = to_biguint(&a).bits();
+        assert_eq!(expected, a.bits());
+        assert_eq!(expected, a.bits_vartime());
+    }
+
+    #[test]
     fn shl_vartime(a in uint(), shift in any::<u8>()) {
         let a_bi = to_biguint(&a);
 


### PR DESCRIPTION
Adds the following methods:
- `bits`: count the number of bits required to represent a given number in constant-time
- `bits_vartime`: count the number of bits required to represent a given number in variable-time
- `leading_zeros`: count the number of leading zeros in a number, implemented as a provided method which subtracts `bits` from `bits_precision`.

This also adds `BoxedUint::bits_vartime`, whereas previously it only had a constant-time implementation.