### PR TITLE
Add `CheckedDiv` trait

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -31,6 +31,7 @@ pub trait Integer:
     + for<'a> CheckedAdd<&'a Self, Output = Self>
     + for<'a> CheckedSub<&'a Self, Output = Self>
     + for<'a> CheckedMul<&'a Self, Output = Self>
+    + for<'a> CheckedDiv<&'a Self, Output = Self>
     + Clone
     // + ConditionallySelectable (see dalek-cryptography/subtle#94)
     + ConstantTimeEq
@@ -214,9 +215,19 @@ pub trait CheckedAdd<Rhs = Self>: Sized {
     /// Output type.
     type Output;
 
-    /// Perform checked subtraction, returning a [`CtOption`] which `is_some`
-    /// only if the operation did not overflow.
+    /// Perform checked subtraction, returning a [`CtOption`] which `is_some` only if the operation
+    /// did not overflow.
     fn checked_add(&self, rhs: Rhs) -> CtOption<Self>;
+}
+
+/// Checked division.
+pub trait CheckedDiv<Rhs = Self>: Sized {
+    /// Output type.
+    type Output;
+
+    /// Perform checked division, returning a [`CtOption`] which `is_some` only if the divisor is
+    /// non-zero.
+    fn checked_div(&self, rhs: Rhs) -> CtOption<Self>;
 }
 
 /// Checked multiplication.

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] division operations.
 
-use crate::{BoxedUint, Limb, NonZero, Wrapping};
+use crate::{BoxedUint, CheckedDiv, Limb, NonZero, Wrapping};
 use core::ops::{Div, DivAssign, Rem, RemAssign};
 use subtle::{Choice, ConstantTimeEq, CtOption};
 
@@ -78,6 +78,22 @@ impl BoxedUint {
         }
 
         (quotient, remainder)
+    }
+}
+
+impl CheckedDiv<BoxedUint> for BoxedUint {
+    type Output = Self;
+
+    fn checked_div(&self, rhs: BoxedUint) -> CtOption<Self> {
+        self.checked_div(&rhs)
+    }
+}
+
+impl CheckedDiv<&BoxedUint> for BoxedUint {
+    type Output = Self;
+
+    fn checked_div(&self, rhs: &BoxedUint) -> CtOption<Self> {
+        self.checked_div(rhs)
     }
 }
 

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -1,7 +1,7 @@
 //! [`Uint`] division operations.
 
 use super::div_limb::{div_rem_limb_with_reciprocal, Reciprocal};
-use crate::{CtChoice, Limb, NonZero, Uint, Word, Wrapping};
+use crate::{CheckedDiv, CtChoice, Limb, NonZero, Uint, Word, Wrapping};
 use core::ops::{Div, DivAssign, Rem, RemAssign};
 use subtle::CtOption;
 
@@ -402,6 +402,22 @@ impl<const LIMBS: usize> RemAssign<&NonZero<Limb>> for Wrapping<Uint<LIMBS>> {
 //
 // Division by an Uint
 //
+
+impl<const LIMBS: usize> CheckedDiv<Uint<LIMBS>> for Uint<LIMBS> {
+    type Output = Self;
+
+    fn checked_div(&self, rhs: Uint<LIMBS>) -> CtOption<Self> {
+        self.checked_div(&rhs)
+    }
+}
+
+impl<const LIMBS: usize> CheckedDiv<&Uint<LIMBS>> for Uint<LIMBS> {
+    type Output = Self;
+
+    fn checked_div(&self, rhs: &Uint<LIMBS>) -> CtOption<Self> {
+        self.checked_div(rhs)
+    }
+}
 
 impl<const LIMBS: usize> Div<&NonZero<Uint<LIMBS>>> for &Uint<LIMBS> {
     type Output = Uint<LIMBS>;


### PR DESCRIPTION
Adds a trait for checked division by a `Self` divisor that may be zero.

This provides feature parity with the other `Checked*` traits, which previously only covered addition, subtraction, and multiplication.