### PR TITLE
Make bit ops use `u32` for shifts

### DIFF
--- a/src/ct_choice.rs
+++ b/src/ct_choice.rs
@@ -15,63 +15,132 @@ impl CtChoice {
     /// The truthy value.
     pub const TRUE: Self = Self(Word::MAX);
 
+    #[inline]
+    pub(crate) const fn as_u32_mask(&self) -> u32 {
+        #[allow(trivial_numeric_casts)]
+        (self.0.wrapping_neg() as u32).wrapping_neg()
+    }
+
     /// Returns the truthy value if `value == Word::MAX`, and the falsy value if `value == 0`.
     /// Panics for other values.
-    pub(crate) const fn from_mask(value: Word) -> Self {
+    #[inline]
+    pub(crate) const fn from_word_mask(value: Word) -> Self {
         debug_assert!(value == Self::FALSE.0 || value == Self::TRUE.0);
         Self(value)
     }
 
     /// Returns the truthy value if `value == 1`, and the falsy value if `value == 0`.
     /// Panics for other values.
-    pub(crate) const fn from_lsb(value: Word) -> Self {
+    #[inline]
+    pub(crate) const fn from_word_lsb(value: Word) -> Self {
         debug_assert!(value == 0 || value == 1);
         Self(value.wrapping_neg())
     }
 
+    #[inline]
+    pub(crate) const fn from_u32_lsb(value: u32) -> Self {
+        debug_assert!(value == 0 || value == 1);
+        #[allow(trivial_numeric_casts)]
+        Self((value as Word).wrapping_neg())
+    }
+
     /// Returns the truthy value if `value != 0`, and the falsy value otherwise.
-    pub(crate) const fn from_usize_being_nonzero(value: usize) -> Self {
-        const HI_BIT: u32 = usize::BITS - 1;
-        Self::from_lsb(((value | value.wrapping_neg()) >> HI_BIT) as Word)
+    #[inline]
+    pub(crate) const fn from_u32_nonzero(value: u32) -> Self {
+        Self::from_u32_lsb((value | value.wrapping_neg()) >> (u32::BITS - 1))
+    }
+
+    /// Returns the truthy value if `value != 0`, and the falsy value otherwise.
+    #[inline]
+    pub(crate) const fn from_word_nonzero(value: Word) -> Self {
+        Self::from_word_lsb((value | value.wrapping_neg()) >> (Word::BITS - 1))
     }
 
     /// Returns the truthy value if `x == y`, and the falsy value otherwise.
-    pub(crate) const fn from_usize_equality(x: usize, y: usize) -> Self {
-        Self::from_usize_being_nonzero(x.wrapping_sub(y)).not()
+    #[inline]
+    pub(crate) const fn from_u32_eq(x: u32, y: u32) -> Self {
+        Self::from_u32_nonzero(x ^ y).not()
+    }
+
+    /// Returns the truthy value if `x == y`, and the falsy value otherwise.
+    #[inline]
+    pub(crate) const fn from_word_eq(x: Word, y: Word) -> Self {
+        Self::from_word_nonzero(x ^ y).not()
     }
 
     /// Returns the truthy value if `x < y`, and the falsy value otherwise.
-    pub(crate) const fn from_usize_lt(x: usize, y: usize) -> Self {
-        let bit = (((!x) & y) | (((!x) | y) & (x.wrapping_sub(y)))) >> (usize::BITS - 1);
-        Self::from_lsb(bit as Word)
+    #[inline]
+    pub(crate) const fn from_word_lt(x: Word, y: Word) -> Self {
+        let bit = (((!x) & y) | (((!x) | y) & (x.wrapping_sub(y)))) >> (Word::BITS - 1);
+        Self::from_word_lsb(bit)
     }
 
+    /// Returns the truthy value if `x < y`, and the falsy value otherwise.
+    #[inline]
+    pub(crate) const fn from_u32_lt(x: u32, y: u32) -> Self {
+        let bit = (((!x) & y) | (((!x) | y) & (x.wrapping_sub(y)))) >> (u32::BITS - 1);
+        Self::from_u32_lsb(bit)
+    }
+
+    /// Returns the truthy value if `x <= y` and the falsy value otherwise.
+    #[inline]
+    pub(crate) const fn from_word_le(x: Word, y: Word) -> Self {
+        let bit = (((!x) | y) & ((x ^ y) | !(y.wrapping_sub(x)))) >> (Word::BITS - 1);
+        Self::from_word_lsb(bit)
+    }
+
+    /// Returns the truthy value if `x <= y` and the falsy value otherwise.
+    #[inline]
+    pub(crate) const fn from_u32_le(x: u32, y: u32) -> Self {
+        let bit = (((!x) | y) & ((x ^ y) | !(y.wrapping_sub(x)))) >> (u32::BITS - 1);
+        Self::from_u32_lsb(bit)
+    }
+
+    #[inline]
     pub(crate) const fn not(&self) -> Self {
         Self(!self.0)
     }
 
+    #[inline]
     pub(crate) const fn or(&self, other: Self) -> Self {
         Self(self.0 | other.0)
     }
 
+    #[inline]
     pub(crate) const fn and(&self, other: Self) -> Self {
         Self(self.0 & other.0)
     }
 
     /// Return `b` if `self` is truthy, otherwise return `a`.
-    pub(crate) const fn select(&self, a: Word, b: Word) -> Word {
+    #[inline]
+    pub(crate) const fn select_word(&self, a: Word, b: Word) -> Word {
         a ^ (self.0 & (a ^ b))
     }
 
+    /// Return `b` if `self` is truthy, otherwise return `a`.
+    #[inline]
+    pub(crate) const fn select_u32(&self, a: u32, b: u32) -> u32 {
+        a ^ (self.as_u32_mask() & (a ^ b))
+    }
+
     /// Return `x` if `self` is truthy, otherwise return 0.
-    pub(crate) const fn if_true(&self, x: Word) -> Word {
+    #[inline]
+    pub(crate) const fn if_true_word(&self, x: Word) -> Word {
         x & self.0
     }
 
+    /// Return `x` if `self` is truthy, otherwise return 0.
+    #[inline]
+    pub(crate) const fn if_true_u32(&self, x: u32) -> u32 {
+        x & self.as_u32_mask()
+    }
+
+    #[inline]
     pub(crate) const fn is_true_vartime(&self) -> bool {
         self.0 == CtChoice::TRUE.0
     }
 
+    #[inline]
     pub(crate) const fn to_u8(self) -> u8 {
         (self.0 as u8) & 1
     }
@@ -98,7 +167,7 @@ mod tests {
     fn select() {
         let a: Word = 1;
         let b: Word = 2;
-        assert_eq!(CtChoice::TRUE.select(a, b), b);
-        assert_eq!(CtChoice::FALSE.select(a, b), a);
+        assert_eq!(CtChoice::TRUE.select_word(a, b), b);
+        assert_eq!(CtChoice::FALSE.select_word(a, b), a);
     }
 }

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -54,7 +54,7 @@ pub type Word = u64;
 pub type WideWord = u128;
 
 /// Highest bit in a [`Limb`].
-pub(crate) const HI_BIT: usize = Limb::BITS - 1;
+pub(crate) const HI_BIT: u32 = Limb::BITS - 1;
 
 /// Big integers are represented as an array of smaller CPU word-size integers
 /// called "limbs".
@@ -78,7 +78,7 @@ impl Limb {
 
     /// Size of the inner integer in bits.
     #[cfg(target_pointer_width = "32")]
-    pub const BITS: usize = 32;
+    pub const BITS: u32 = 32;
     /// Size of the inner integer in bytes.
     #[cfg(target_pointer_width = "32")]
     pub const BYTES: usize = 4;
@@ -87,14 +87,14 @@ impl Limb {
 
     /// Size of the inner integer in bits.
     #[cfg(target_pointer_width = "64")]
-    pub const BITS: usize = 64;
+    pub const BITS: u32 = 64;
     /// Size of the inner integer in bytes.
     #[cfg(target_pointer_width = "64")]
     pub const BYTES: usize = 8;
 }
 
 impl Bounded for Limb {
-    const BITS: usize = Self::BITS;
+    const BITS: u32 = Self::BITS;
     const BYTES: usize = Self::BYTES;
 }
 

--- a/src/limb/bits.rs
+++ b/src/limb/bits.rs
@@ -2,22 +2,22 @@ use super::Limb;
 
 impl Limb {
     /// Calculate the number of bits needed to represent this number.
-    pub const fn bits(self) -> usize {
-        Limb::BITS - (self.0.leading_zeros() as usize)
+    pub const fn bits(self) -> u32 {
+        Limb::BITS - self.0.leading_zeros()
     }
 
     /// Calculate the number of leading zeros in the binary representation of this number.
-    pub const fn leading_zeros(self) -> usize {
-        self.0.leading_zeros() as usize
+    pub const fn leading_zeros(self) -> u32 {
+        self.0.leading_zeros()
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number.
-    pub const fn trailing_zeros(self) -> usize {
-        self.0.trailing_zeros() as usize
+    pub const fn trailing_zeros(self) -> u32 {
+        self.0.trailing_zeros()
     }
 
     /// Calculate the number of trailing ones the binary representation of this number.
-    pub const fn trailing_ones(self) -> usize {
-        self.0.trailing_ones() as usize
+    pub const fn trailing_ones(self) -> u32 {
+        self.0.trailing_ones()
     }
 }

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -1,6 +1,5 @@
 //! Limb comparisons
 
-use super::HI_BIT;
 use crate::{CtChoice, Limb};
 use core::cmp::Ordering;
 use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
@@ -28,42 +27,13 @@ impl Limb {
     /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
     pub(crate) const fn ct_select(a: Self, b: Self, c: CtChoice) -> Self {
-        Self(c.select(a.0, b.0))
+        Self(c.select_word(a.0, b.0))
     }
 
     /// Returns the truthy value if `self != 0` and the falsy value otherwise.
     #[inline]
     pub(crate) const fn ct_is_nonzero(&self) -> CtChoice {
-        let inner = self.0;
-        CtChoice::from_lsb((inner | inner.wrapping_neg()) >> HI_BIT)
-    }
-
-    /// Returns the truthy value if `lhs == rhs` and the falsy value otherwise.
-    #[inline]
-    pub(crate) const fn ct_eq(lhs: Self, rhs: Self) -> CtChoice {
-        let x = lhs.0;
-        let y = rhs.0;
-
-        // x ^ y == 0 if and only if x == y
-        Self(x ^ y).ct_is_nonzero().not()
-    }
-
-    /// Returns the truthy value if `lhs < rhs` and the falsy value otherwise.
-    #[inline]
-    pub(crate) const fn ct_lt(lhs: Self, rhs: Self) -> CtChoice {
-        let x = lhs.0;
-        let y = rhs.0;
-        let bit = (((!x) & y) | (((!x) | y) & (x.wrapping_sub(y)))) >> (Limb::BITS - 1);
-        CtChoice::from_lsb(bit)
-    }
-
-    /// Returns the truthy value if `lhs <= rhs` and the falsy value otherwise.
-    #[inline]
-    pub(crate) const fn ct_le(lhs: Self, rhs: Self) -> CtChoice {
-        let x = lhs.0;
-        let y = rhs.0;
-        let bit = (((!x) | y) & ((x ^ y) | !(y.wrapping_sub(x)))) >> (Limb::BITS - 1);
-        CtChoice::from_lsb(bit)
+        CtChoice::from_word_nonzero(self.0)
     }
 }
 

--- a/src/limb/rand.rs
+++ b/src/limb/rand.rs
@@ -21,9 +21,9 @@ impl RandomMod for Limb {
     fn random_mod(rng: &mut impl CryptoRngCore, modulus: &NonZero<Self>) -> Self {
         let mut bytes = <Self as Encoding>::Repr::default();
 
-        let n_bits = modulus.bits();
+        let n_bits = modulus.bits() as usize;
         let n_bytes = (n_bits + 7) / 8;
-        let mask = 0xff >> (8 * n_bytes - n_bits);
+        let mask = 0xffu8 >> (8 * n_bytes - n_bits);
 
         loop {
             rng.fill_bytes(&mut bytes[..n_bytes]);

--- a/src/limb/shl.rs
+++ b/src/limb/shl.rs
@@ -1,46 +1,30 @@
 //! Limb left bitshift
 
-use crate::{Limb, Word};
+use crate::Limb;
 use core::ops::{Shl, ShlAssign};
 
 impl Limb {
-    /// Computes `self << rhs`.
-    /// Panics if `rhs` overflows `Limb::BITS`.
+    /// Computes `self << shift`.
+    /// Panics if `shift` overflows `Limb::BITS`.
     #[inline(always)]
-    pub const fn shl(self, rhs: Self) -> Self {
-        Limb(self.0 << rhs.0)
+    pub const fn shl(self, shift: u32) -> Self {
+        Limb(self.0 << shift)
     }
 }
 
-impl Shl for Limb {
+impl Shl<u32> for Limb {
     type Output = Self;
 
     #[inline(always)]
-    fn shl(self, rhs: Self) -> Self::Output {
-        self.shl(rhs)
+    fn shl(self, shift: u32) -> Self::Output {
+        self.shl(shift)
     }
 }
 
-impl Shl<usize> for Limb {
-    type Output = Self;
-
+impl ShlAssign<u32> for Limb {
     #[inline(always)]
-    fn shl(self, rhs: usize) -> Self::Output {
-        self.shl(Limb(rhs as Word))
-    }
-}
-
-impl ShlAssign for Limb {
-    #[inline(always)]
-    fn shl_assign(&mut self, other: Self) {
-        *self = self.shl(other);
-    }
-}
-
-impl ShlAssign<usize> for Limb {
-    #[inline(always)]
-    fn shl_assign(&mut self, other: usize) {
-        *self = self.shl(Limb(other as Word));
+    fn shl_assign(&mut self, shift: u32) {
+        *self = self.shl(shift);
     }
 }
 

--- a/src/limb/shr.rs
+++ b/src/limb/shr.rs
@@ -1,46 +1,30 @@
 //! Limb right bitshift
 
-use crate::{Limb, Word};
+use crate::Limb;
 use core::ops::{Shr, ShrAssign};
 
 impl Limb {
-    /// Computes `self >> rhs`.
-    /// Panics if `rhs` overflows `Limb::BITS`.
+    /// Computes `self >> shift`.
+    /// Panics if `shift` overflows `Limb::BITS`.
     #[inline(always)]
-    pub const fn shr(self, rhs: Self) -> Self {
-        Limb(self.0 >> rhs.0)
+    pub const fn shr(self, shift: u32) -> Self {
+        Limb(self.0 >> shift)
     }
 }
 
-impl Shr for Limb {
+impl Shr<u32> for Limb {
     type Output = Self;
 
     #[inline(always)]
-    fn shr(self, rhs: Self) -> Self::Output {
-        self.shr(rhs)
+    fn shr(self, shift: u32) -> Self::Output {
+        self.shr(shift)
     }
 }
 
-impl Shr<usize> for Limb {
-    type Output = Self;
-
+impl ShrAssign<u32> for Limb {
     #[inline(always)]
-    fn shr(self, rhs: usize) -> Self::Output {
-        self.shr(Limb(rhs as Word))
-    }
-}
-
-impl ShrAssign for Limb {
-    #[inline(always)]
-    fn shr_assign(&mut self, other: Self) {
-        *self = self.shr(other);
-    }
-}
-
-impl ShrAssign<usize> for Limb {
-    #[inline(always)]
-    fn shr_assign(&mut self, other: usize) {
-        *self = self.shr(Limb(other as Word));
+    fn shr_assign(&mut self, shift: u32) {
+        *self = self.shr(shift);
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -59,7 +59,7 @@ macro_rules! const_assert_ne {
 #[macro_export]
 macro_rules! nlimbs {
     ($bits:expr) => {
-        $bits / $crate::Limb::BITS
+        $bits / $crate::Limb::BITS as usize
     };
 }
 

--- a/src/modular/boxed_residue.rs
+++ b/src/modular/boxed_residue.rs
@@ -67,8 +67,7 @@ impl BoxedResidueParams {
         // we can take the modulo right away and calculate the inverse of the first limb only.
         let modulus_lo = BoxedUint::from(modulus.limbs.get(0).copied().unwrap_or_default());
 
-        let mod_neg_inv =
-            Limb(Word::MIN.wrapping_sub(modulus_lo.inv_mod2k(Word::BITS as usize).limbs[0].0));
+        let mod_neg_inv = Limb(Word::MIN.wrapping_sub(modulus_lo.inv_mod2k(Word::BITS).limbs[0].0));
 
         let r3 = montgomery_reduction_boxed(&mut r2.square(), &modulus, mod_neg_inv);
 
@@ -89,7 +88,7 @@ impl BoxedResidueParams {
     }
 
     /// Bits of precision in the modulus.
-    pub fn bits_precision(&self) -> usize {
+    pub fn bits_precision(&self) -> u32 {
         self.modulus.bits_precision()
     }
 }
@@ -132,7 +131,7 @@ impl BoxedResidue {
     }
 
     /// Bits of precision in the modulus.
-    pub fn bits_precision(&self) -> usize {
+    pub fn bits_precision(&self) -> u32 {
         self.residue_params.bits_precision()
     }
 

--- a/src/modular/boxed_residue/pow.rs
+++ b/src/modular/boxed_residue/pow.rs
@@ -18,7 +18,7 @@ impl BoxedResidue {
     /// to take into account for the exponent.
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
-    pub fn pow_bounded_exp(&self, exponent: &BoxedUint, exponent_bits: usize) -> Self {
+    pub fn pow_bounded_exp(&self, exponent: &BoxedUint, exponent_bits: u32) -> Self {
         Self {
             montgomery_form: pow_montgomery_form(
                 &self.montgomery_form,
@@ -34,7 +34,7 @@ impl BoxedResidue {
 }
 
 impl PowBoundedExp<BoxedUint> for BoxedResidue {
-    fn pow_bounded_exp(&self, exponent: &BoxedUint, exponent_bits: usize) -> Self {
+    fn pow_bounded_exp(&self, exponent: &BoxedUint, exponent_bits: u32) -> Self {
         self.pow_bounded_exp(exponent, exponent_bits)
     }
 }
@@ -46,7 +46,7 @@ impl PowBoundedExp<BoxedUint> for BoxedResidue {
 fn pow_montgomery_form(
     x: &BoxedUint,
     exponent: &BoxedUint,
-    exponent_bits: usize,
+    exponent_bits: u32,
     modulus: &BoxedUint,
     r: &BoxedUint,
     mod_neg_inv: Limb,
@@ -55,7 +55,7 @@ fn pow_montgomery_form(
         return r.clone(); // 1 in Montgomery form
     }
 
-    const WINDOW: usize = 4;
+    const WINDOW: u32 = 4;
     const WINDOW_MASK: Word = (1 << WINDOW) - 1;
 
     // powers[i] contains x^i
@@ -67,7 +67,7 @@ fn pow_montgomery_form(
         i += 1;
     }
 
-    let starting_limb = (exponent_bits - 1) / Limb::BITS;
+    let starting_limb = ((exponent_bits - 1) / Limb::BITS) as usize;
     let starting_bit_in_limb = (exponent_bits - 1) % Limb::BITS;
     let starting_window = starting_bit_in_limb / WINDOW;
     let starting_window_mask = (1 << (starting_bit_in_limb % WINDOW + 1)) - 1;
@@ -103,7 +103,7 @@ fn pow_montgomery_form(
             let mut power = powers[0].clone();
             let mut i = 1;
             while i < 1 << WINDOW {
-                power = BoxedUint::conditional_select(&power, &powers[i], (i as Word).ct_eq(&idx));
+                power = BoxedUint::conditional_select(&power, &powers[i as usize], i.ct_eq(&idx));
                 i += 1;
             }
 

--- a/src/modular/dyn_residue.rs
+++ b/src/modular/dyn_residue.rs
@@ -43,9 +43,8 @@ impl<const LIMBS: usize> DynResidueParams<LIMBS> {
         // Since we are calculating the inverse modulo (Word::MAX+1),
         // we can take the modulo right away and calculate the inverse of the first limb only.
         let modulus_lo = Uint::<1>::from_words([modulus.limbs[0].0]);
-        let mod_neg_inv = Limb(
-            Word::MIN.wrapping_sub(modulus_lo.inv_mod2k_vartime(Word::BITS as usize).limbs[0].0),
-        );
+        let mod_neg_inv =
+            Limb(Word::MIN.wrapping_sub(modulus_lo.inv_mod2k_vartime(Word::BITS).limbs[0].0));
 
         let r3 = montgomery_reduction(&r2.square_wide(), modulus, mod_neg_inv);
 

--- a/src/modular/dyn_residue/pow.rs
+++ b/src/modular/dyn_residue/pow.rs
@@ -26,7 +26,7 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
     pub const fn pow_bounded_exp<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,
-        exponent_bits: usize,
+        exponent_bits: u32,
     ) -> Self {
         Self {
             montgomery_form: pow_montgomery_form(
@@ -45,7 +45,7 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
 impl<const LIMBS: usize, const RHS_LIMBS: usize> PowBoundedExp<Uint<RHS_LIMBS>>
     for DynResidue<LIMBS>
 {
-    fn pow_bounded_exp(&self, exponent: &Uint<RHS_LIMBS>, exponent_bits: usize) -> Self {
+    fn pow_bounded_exp(&self, exponent: &Uint<RHS_LIMBS>, exponent_bits: u32) -> Self {
         self.pow_bounded_exp(exponent, exponent_bits)
     }
 }
@@ -56,7 +56,7 @@ impl<const N: usize, const LIMBS: usize, const RHS_LIMBS: usize>
 {
     fn multi_exponentiate_bounded_exp(
         bases_and_exponents: &[(Self, Uint<RHS_LIMBS>); N],
-        exponent_bits: usize,
+        exponent_bits: u32,
     ) -> Self {
         const_assert_ne!(N, 0, "bases_and_exponents must not be empty");
         let residue_params = bases_and_exponents[0].0.residue_params;
@@ -90,7 +90,7 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize>
 {
     fn multi_exponentiate_bounded_exp(
         bases_and_exponents: &[(Self, Uint<RHS_LIMBS>)],
-        exponent_bits: usize,
+        exponent_bits: u32,
     ) -> Self {
         assert!(
             !bases_and_exponents.is_empty(),

--- a/src/modular/residue/macros.rs
+++ b/src/modular/residue/macros.rs
@@ -39,7 +39,7 @@ macro_rules! impl_modulus {
             const MOD_NEG_INV: $crate::Limb = $crate::Limb(
                 $crate::Word::MIN.wrapping_sub(
                     Self::MODULUS
-                        .inv_mod2k_vartime($crate::Word::BITS as usize)
+                        .inv_mod2k_vartime($crate::Word::BITS)
                         .as_limbs()[0]
                         .0,
                 ),

--- a/src/modular/residue/pow.rs
+++ b/src/modular/residue/pow.rs
@@ -26,7 +26,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     pub const fn pow_bounded_exp<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,
-        exponent_bits: usize,
+        exponent_bits: u32,
     ) -> Residue<MOD, LIMBS> {
         Self {
             montgomery_form: pow_montgomery_form(
@@ -45,7 +45,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize, const RHS_LIMBS: usize>
     PowBoundedExp<Uint<RHS_LIMBS>> for Residue<MOD, LIMBS>
 {
-    fn pow_bounded_exp(&self, exponent: &Uint<RHS_LIMBS>, exponent_bits: usize) -> Self {
+    fn pow_bounded_exp(&self, exponent: &Uint<RHS_LIMBS>, exponent_bits: u32) -> Self {
         self.pow_bounded_exp(exponent, exponent_bits)
     }
 }
@@ -56,7 +56,7 @@ impl<const N: usize, MOD: ResidueParams<LIMBS>, const LIMBS: usize, const RHS_LI
 {
     fn multi_exponentiate_bounded_exp(
         bases_and_exponents: &[(Self, Uint<RHS_LIMBS>); N],
-        exponent_bits: usize,
+        exponent_bits: u32,
     ) -> Self {
         let mut bases_and_exponents_montgomery_form =
             [(Uint::<LIMBS>::ZERO, Uint::<RHS_LIMBS>::ZERO); N];
@@ -88,7 +88,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize, const RHS_LIMBS: usize>
 {
     fn multi_exponentiate_bounded_exp(
         bases_and_exponents: &[(Self, Uint<RHS_LIMBS>)],
-        exponent_bits: usize,
+        exponent_bits: u32,
     ) -> Self {
         let bases_and_exponents: Vec<(Uint<LIMBS>, Uint<RHS_LIMBS>)> = bases_and_exponents
             .iter()

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -61,7 +61,7 @@ where
     T: Bounded + Zero,
 {
     /// Total size of the represented integer in bits.
-    pub const BITS: usize = T::BITS;
+    pub const BITS: u32 = T::BITS;
 
     /// Total size of the represented integer in bytes.
     pub const BYTES: usize = T::BYTES;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -17,7 +17,7 @@ use rand_core::CryptoRngCore;
 /// Integers whose representation takes a bounded amount of space.
 pub trait Bounded {
     /// Size of this integer in bits.
-    const BITS: usize;
+    const BITS: u32;
 
     /// Size of this integer in bytes.
     const BYTES: usize;
@@ -65,10 +65,10 @@ pub trait Integer:
     + for<'a> Rem<&'a NonZero<Self>, Output = Self>
     + Send
     + Sized
-    + Shl<usize, Output = Self>
-    + ShlAssign<usize>
-    + Shr<usize, Output = Self>
-    + ShrAssign<usize>
+    + Shl<u32, Output = Self>
+    + ShlAssign<u32>
+    + Shr<u32, Output = Self>
+    + ShrAssign<u32>
     + SubMod
     + Sync
     + Zero
@@ -77,20 +77,20 @@ pub trait Integer:
     fn one() -> Self;
 
     /// Calculate the number of bits required to represent a given number.
-    fn bits(&self) -> usize;
+    fn bits(&self) -> u32;
 
     /// Calculate the number of bits required to represent a given number in variable-time with
     /// respect to `self`.
-    fn bits_vartime(&self) -> usize;
+    fn bits_vartime(&self) -> u32;
 
     /// Precision of this integer in bits.
-    fn bits_precision(&self) -> usize;
+    fn bits_precision(&self) -> u32;
 
     /// Precision of this integer in bytes.
     fn bytes_precision(&self) -> usize;
 
     /// Calculate the number of leading zeros in the binary representation of this number.
-    fn leading_zeros(&self) -> usize  {
+    fn leading_zeros(&self) -> u32  {
         self.bits_precision() - self.bits()
     }
 
@@ -366,7 +366,7 @@ pub trait PowBoundedExp<Exponent> {
     /// to take into account for the exponent.
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
-    fn pow_bounded_exp(&self, exponent: &Exponent, exponent_bits: usize) -> Self;
+    fn pow_bounded_exp(&self, exponent: &Exponent, exponent_bits: u32) -> Self;
 }
 
 /// Performs modular multi-exponentiation using Montgomery's ladder.
@@ -404,7 +404,7 @@ where
     /// Calculates `x1 ^ k1 * ... * xn ^ kn`.
     fn multi_exponentiate_bounded_exp(
         bases_and_exponents: &BasesAndExponents,
-        exponent_bits: usize,
+        exponent_bits: u32,
     ) -> Self;
 }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -86,11 +86,11 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     };
 
     /// Total size of the represented integer in bits.
-    pub const BITS: usize = LIMBS * Limb::BITS;
+    pub const BITS: u32 = LIMBS as u32 * Limb::BITS;
 
     /// Bit size of `BITS`.
-    // Note: assumes the type of `BITS` is `usize`. Any way to assert that?
-    pub(crate) const LOG2_BITS: usize = (usize::BITS - Self::BITS.leading_zeros()) as usize;
+    // Note: assumes the type of `BITS` is `u32`. Any way to assert that?
+    pub(crate) const LOG2_BITS: u32 = u32::BITS - Self::BITS.leading_zeros();
 
     /// Total size of the represented integer in bytes.
     pub const BYTES: usize = LIMBS * Limb::BYTES;
@@ -204,7 +204,7 @@ impl<const LIMBS: usize> ConditionallySelectable for Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize> Bounded for Uint<LIMBS> {
-    const BITS: usize = Self::BITS;
+    const BITS: u32 = Self::BITS;
     const BYTES: usize = Self::BYTES;
 }
 
@@ -228,15 +228,15 @@ impl<const LIMBS: usize> Integer for Uint<LIMBS> {
         Self::ONE
     }
 
-    fn bits(&self) -> usize {
+    fn bits(&self) -> u32 {
         self.bits()
     }
 
-    fn bits_vartime(&self) -> usize {
+    fn bits_vartime(&self) -> u32 {
         self.bits_vartime()
     }
 
-    fn bits_precision(&self) -> usize {
+    fn bits_precision(&self) -> u32 {
         Self::BITS
     }
 

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -24,7 +24,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Perform saturating addition, returning `MAX` on overflow.
     pub const fn saturating_add(&self, rhs: &Self) -> Self {
         let (res, overflow) = self.adc(rhs, Limb::ZERO);
-        Self::ct_select(&res, &Self::MAX, CtChoice::from_lsb(overflow.0))
+        Self::ct_select(&res, &Self::MAX, CtChoice::from_word_lsb(overflow.0))
     }
 
     /// Perform wrapping addition, discarding overflow.
@@ -41,7 +41,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ) -> (Self, CtChoice) {
         let actual_rhs = Uint::ct_select(&Uint::ZERO, rhs, choice);
         let (sum, carry) = self.adc(&actual_rhs, Limb::ZERO);
-        (sum, CtChoice::from_lsb(carry.0))
+        (sum, CtChoice::from_word_lsb(carry.0))
     }
 }
 

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -1,25 +1,25 @@
-use crate::{CtChoice, Limb, Uint, Word};
+use crate::{CtChoice, Limb, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Get the value of the bit at position `index`, as a truthy or falsy `CtChoice`.
     /// Returns the falsy value for indices out of range.
-    pub const fn bit(&self, index: usize) -> CtChoice {
+    pub const fn bit(&self, index: u32) -> CtChoice {
         let limb_num = index / Limb::BITS;
         let index_in_limb = index % Limb::BITS;
         let index_mask = 1 << index_in_limb;
 
         let limbs = self.as_words();
 
-        let mut result: Word = 0;
+        let mut result = 0;
         let mut i = 0;
         while i < LIMBS {
             let bit = limbs[i] & index_mask;
-            let is_right_limb = CtChoice::from_usize_equality(i, limb_num);
-            result |= is_right_limb.if_true(bit);
+            let is_right_limb = CtChoice::from_u32_eq(i as u32, limb_num);
+            result |= is_right_limb.if_true_word(bit);
             i += 1;
         }
 
-        CtChoice::from_lsb(result >> index_in_limb)
+        CtChoice::from_word_lsb(result >> index_in_limb)
     }
 
     /// Returns `true` if the bit at position `index` is set, `false` otherwise.
@@ -27,54 +27,54 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// # Remarks
     /// This operation is variable time with respect to `index` only.
     #[inline(always)]
-    pub const fn bit_vartime(&self, index: usize) -> bool {
+    pub const fn bit_vartime(&self, index: u32) -> bool {
         if index >= Self::BITS {
             false
         } else {
-            (self.limbs[index / Limb::BITS].0 >> (index % Limb::BITS)) & 1 == 1
+            (self.limbs[(index / Limb::BITS) as usize].0 >> (index % Limb::BITS)) & 1 == 1
         }
     }
 
     /// Calculate the number of bits needed to represent this number.
     #[inline]
-    pub const fn bits(&self) -> usize {
+    pub const fn bits(&self) -> u32 {
         Self::BITS - self.leading_zeros()
     }
 
     /// Calculate the number of bits needed to represent this number in variable-time with respect
     /// to `self`.
-    pub const fn bits_vartime(&self) -> usize {
+    pub const fn bits_vartime(&self) -> u32 {
         let mut i = LIMBS - 1;
         while i > 0 && self.limbs[i].0 == 0 {
             i -= 1;
         }
 
         let limb = self.limbs[i];
-        Limb::BITS * (i + 1) - limb.leading_zeros()
+        Limb::BITS * (i as u32 + 1) - limb.leading_zeros()
     }
 
     /// Calculate the number of leading zeros in the binary representation of this number.
-    pub const fn leading_zeros(&self) -> usize {
+    pub const fn leading_zeros(&self) -> u32 {
         let limbs = self.as_limbs();
 
-        let mut count: Word = 0;
+        let mut count = 0;
         let mut i = LIMBS;
         let mut nonzero_limb_not_encountered = CtChoice::TRUE;
         while i > 0 {
             i -= 1;
             let l = limbs[i];
-            let z = l.leading_zeros() as Word;
-            count += nonzero_limb_not_encountered.if_true(z);
+            let z = l.leading_zeros();
+            count += nonzero_limb_not_encountered.if_true_u32(z);
             nonzero_limb_not_encountered =
-                nonzero_limb_not_encountered.and(l.ct_is_nonzero().not());
+                nonzero_limb_not_encountered.and(CtChoice::from_word_nonzero(l.0).not());
         }
 
-        count as usize
+        count
     }
 
     /// Calculate the number of leading zeros in the binary representation of this number in
     /// variable-time with respect to `self`.
-    pub const fn leading_zeros_vartime(&self) -> usize {
+    pub const fn leading_zeros_vartime(&self) -> u32 {
         let limbs = self.as_limbs();
 
         let mut count = 0;
@@ -93,27 +93,27 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number.
-    pub const fn trailing_zeros(&self) -> usize {
+    pub const fn trailing_zeros(&self) -> u32 {
         let limbs = self.as_limbs();
 
-        let mut count: Word = 0;
+        let mut count = 0;
         let mut i = 0;
         let mut nonzero_limb_not_encountered = CtChoice::TRUE;
         while i < LIMBS {
             let l = limbs[i];
-            let z = l.trailing_zeros() as Word;
-            count += nonzero_limb_not_encountered.if_true(z);
+            let z = l.trailing_zeros();
+            count += nonzero_limb_not_encountered.if_true_u32(z);
             nonzero_limb_not_encountered =
-                nonzero_limb_not_encountered.and(l.ct_is_nonzero().not());
+                nonzero_limb_not_encountered.and(CtChoice::from_word_nonzero(l.0).not());
             i += 1;
         }
 
-        count as usize
+        count
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number in
     /// variable-time with respect to `self`.
-    pub const fn trailing_zeros_vartime(&self) -> usize {
+    pub const fn trailing_zeros_vartime(&self) -> u32 {
         let limbs = self.as_limbs();
 
         let mut count = 0;
@@ -132,27 +132,27 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Calculate the number of trailing ones in the binary representation of this number.
-    pub const fn trailing_ones(&self) -> usize {
+    pub const fn trailing_ones(&self) -> u32 {
         let limbs = self.as_limbs();
 
-        let mut count: Word = 0;
+        let mut count = 0;
         let mut i = 0;
         let mut nonmax_limb_not_encountered = CtChoice::TRUE;
         while i < LIMBS {
             let l = limbs[i];
-            let z = l.trailing_ones() as Word;
-            count += nonmax_limb_not_encountered.if_true(z);
+            let z = l.trailing_ones();
+            count += nonmax_limb_not_encountered.if_true_u32(z);
             nonmax_limb_not_encountered =
-                nonmax_limb_not_encountered.and(Limb::ct_eq(l, Limb::MAX));
+                nonmax_limb_not_encountered.and(CtChoice::from_word_eq(l.0, Limb::MAX.0));
             i += 1;
         }
 
-        count as usize
+        count
     }
 
     /// Calculate the number of trailing ones in the binary representation of this number,
     /// variable time in `self`.
-    pub const fn trailing_ones_vartime(&self) -> usize {
+    pub const fn trailing_ones_vartime(&self) -> u32 {
         let limbs = self.as_limbs();
 
         let mut count = 0;
@@ -171,7 +171,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Sets the bit at `index` to 0 or 1 depending on the value of `bit_value`.
-    pub(crate) const fn set_bit(self, index: usize, bit_value: CtChoice) -> Self {
+    pub(crate) const fn set_bit(self, index: u32, bit_value: CtChoice) -> Self {
         let mut result = self;
         let limb_num = index / Limb::BITS;
         let index_in_limb = index % Limb::BITS;
@@ -179,10 +179,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         let mut i = 0;
         while i < LIMBS {
-            let is_right_limb = CtChoice::from_usize_equality(i, limb_num);
+            let is_right_limb = CtChoice::from_u32_eq(i as u32, limb_num);
             let old_limb = result.limbs[i].0;
-            let new_limb = bit_value.select(old_limb & !index_mask, old_limb | index_mask);
-            result.limbs[i] = Limb(is_right_limb.select(old_limb, new_limb));
+            let new_limb = bit_value.select_word(old_limb & !index_mask, old_limb | index_mask);
+            result.limbs[i] = Limb(is_right_limb.select_word(old_limb, new_limb));
             i += 1;
         }
         result
@@ -193,7 +193,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 mod tests {
     use crate::{CtChoice, U256};
 
-    fn uint_with_bits_at(positions: &[usize]) -> U256 {
+    fn uint_with_bits_at(positions: &[u32]) -> U256 {
         let mut result = U256::ZERO;
         for pos in positions {
             result |= U256::ONE << *pos;

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -60,14 +60,14 @@ impl BoxedUint {
     /// Get the value `0` with the given number of bits of precision.
     ///
     /// Panics if the precision is not a multiple of [`Limb::BITS`].
-    pub fn zero_with_precision(bits_precision: usize) -> Self {
+    pub fn zero_with_precision(bits_precision: u32) -> Self {
         assert_eq!(
             bits_precision % Limb::BITS,
             0,
             "precision is not a multiple of limb size"
         );
 
-        vec![Limb::ZERO; bits_precision / Limb::BITS].into()
+        vec![Limb::ZERO; (bits_precision / Limb::BITS) as usize].into()
     }
 
     /// Get the value `1`, represented as succinctly as possible.
@@ -81,7 +81,7 @@ impl BoxedUint {
     ///
     /// Panics if the precision is not at least [`Limb::BITS`] or if it is not
     /// a multiple thereof.
-    pub fn one_with_precision(bits_precision: usize) -> Self {
+    pub fn one_with_precision(bits_precision: u32) -> Self {
         assert!(bits_precision >= Limb::BITS, "precision too small");
         let mut ret = Self::zero_with_precision(bits_precision);
         ret.limbs[0] = Limb::ONE;
@@ -128,14 +128,14 @@ impl BoxedUint {
     /// Get the maximum value for a given number of bits of precision.
     ///
     /// Panics if the precision is not a multiple of [`Limb::BITS`].
-    pub fn max(bits_precision: usize) -> Self {
+    pub fn max(bits_precision: u32) -> Self {
         assert_eq!(
             bits_precision % Limb::BITS,
             0,
             "precision is not a multiple of limb size"
         );
 
-        vec![Limb::MAX; bits_precision / Limb::BITS].into()
+        vec![Limb::MAX; (bits_precision / Limb::BITS) as usize].into()
     }
 
     /// Create a [`BoxedUint`] from an array of [`Word`]s (i.e. word-sized unsigned
@@ -237,7 +237,7 @@ impl BoxedUint {
     ///
     /// Panics if `bits_precision` is not a multiple of `Limb::BITS` or smaller than the current
     /// precision.
-    pub fn widen(&self, bits_precision: usize) -> BoxedUint {
+    pub fn widen(&self, bits_precision: u32) -> BoxedUint {
         assert!(bits_precision % Limb::BITS == 0);
         assert!(bits_precision >= self.bits_precision());
 
@@ -250,7 +250,7 @@ impl BoxedUint {
     ///
     /// Panics if `bits_precision` is not a multiple of `Limb::BITS` or smaller than the current
     /// precision.
-    pub fn shorten(&self, bits_precision: usize) -> BoxedUint {
+    pub fn shorten(&self, bits_precision: u32) -> BoxedUint {
         assert!(bits_precision % Limb::BITS == 0);
         assert!(bits_precision <= self.bits_precision());
         let mut ret = BoxedUint::zero_with_precision(bits_precision);
@@ -306,7 +306,7 @@ impl NonZero<BoxedUint> {
     /// Widen this type's precision to the given number of bits.
     ///
     /// See [`BoxedUint::widen`] for more information, including panic conditions.
-    pub fn widen(&self, bits_precision: usize) -> Self {
+    pub fn widen(&self, bits_precision: u32) -> Self {
         NonZero(self.0.widen(bits_precision))
     }
 }
@@ -408,15 +408,15 @@ impl Integer for BoxedUint {
         Self::one()
     }
 
-    fn bits(&self) -> usize {
+    fn bits(&self) -> u32 {
         self.bits()
     }
 
-    fn bits_vartime(&self) -> usize {
+    fn bits_vartime(&self) -> u32 {
         self.bits_vartime()
     }
 
-    fn bits_precision(&self) -> usize {
+    fn bits_precision(&self) -> u32 {
         self.bits_precision()
     }
 

--- a/src/uint/boxed/bits.rs
+++ b/src/uint/boxed/bits.rs
@@ -1,6 +1,6 @@
 //! Bit manipulation functions.
 
-use crate::{BoxedUint, Limb, Word, Zero};
+use crate::{BoxedUint, Limb, Zero};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 impl BoxedUint {
@@ -8,7 +8,7 @@ impl BoxedUint {
     /// set bit.
     ///
     /// Use [`BoxedUint::bits_precision`] to get the total capacity of this integer.
-    pub fn bits(&self) -> usize {
+    pub fn bits(&self) -> u32 {
         // Use `u32` because `subtle` can't select on `usize` and it matches what `core` uses for
         // the return value of `leading_zeros`
         let mut leading_zeros = 0u32;
@@ -18,52 +18,52 @@ impl BoxedUint {
             n.conditional_assign(&(n + 1), !limb.is_zero() | !n.ct_eq(&0));
 
             // Set `leading_zeros` for the first nonzero limb we encounter
-            leading_zeros.conditional_assign(&(limb.leading_zeros() as u32), n.ct_eq(&1));
+            leading_zeros.conditional_assign(&limb.leading_zeros(), n.ct_eq(&1));
         }
 
-        Limb::BITS * (n as usize) - (leading_zeros as usize)
+        Limb::BITS * n - leading_zeros
     }
 
     /// Calculate the number of bits needed to represent this number in variable-time with respect
     /// to `self`.
-    pub fn bits_vartime(&self) -> usize {
+    pub fn bits_vartime(&self) -> u32 {
         let mut i = self.nlimbs() - 1;
         while i > 0 && self.limbs[i].0 == 0 {
             i -= 1;
         }
 
         let limb = self.limbs[i];
-        Limb::BITS * (i + 1) - limb.leading_zeros()
+        Limb::BITS * (i as u32 + 1) - limb.leading_zeros()
     }
 
     /// Get the precision of this [`BoxedUint`] in bits.
-    pub fn bits_precision(&self) -> usize {
-        self.limbs.len() * Limb::BITS
+    pub fn bits_precision(&self) -> u32 {
+        self.limbs.len() as u32 * Limb::BITS
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number.
-    pub fn trailing_zeros(&self) -> usize {
-        let mut count: Word = 0;
+    pub fn trailing_zeros(&self) -> u32 {
+        let mut count = 0;
         let mut nonzero_limb_not_encountered = Choice::from(1u8);
 
         for l in &*self.limbs {
-            let z = l.trailing_zeros() as Word;
-            count += Word::conditional_select(&0, &z, nonzero_limb_not_encountered);
+            let z = l.trailing_zeros();
+            count += u32::conditional_select(&0, &z, nonzero_limb_not_encountered);
             nonzero_limb_not_encountered &= l.is_zero();
         }
 
-        count as usize
+        count
     }
 
     /// Sets the bit at `index` to 0 or 1 depending on the value of `bit_value`.
-    pub(crate) fn set_bit(&mut self, index: usize, bit_value: Choice) {
-        let limb_num = index / Limb::BITS;
+    pub(crate) fn set_bit(&mut self, index: u32, bit_value: Choice) {
+        let limb_num = (index / Limb::BITS) as usize;
         let index_in_limb = index % Limb::BITS;
         let index_mask = 1 << index_in_limb;
 
         for i in 0..self.nlimbs() {
             let limb = &mut self.limbs[i];
-            let is_right_limb = (i as Word).ct_eq(&(limb_num as Word));
+            let is_right_limb = i.ct_eq(&limb_num);
             let old_limb = *limb;
             let new_limb = Limb::conditional_select(
                 &Limb(old_limb.0 & !index_mask),
@@ -81,7 +81,7 @@ mod tests {
     use hex_literal::hex;
     use subtle::Choice;
 
-    fn uint_with_bits_at(positions: &[usize]) -> BoxedUint {
+    fn uint_with_bits_at(positions: &[u32]) -> BoxedUint {
         let mut result = BoxedUint::zero_with_precision(256);
         for &pos in positions {
             result |= BoxedUint::one_with_precision(256).shl_vartime(pos);

--- a/src/uint/boxed/cmp.rs
+++ b/src/uint/boxed/cmp.rs
@@ -30,7 +30,7 @@ impl ConstantTimeGreater for BoxedUint {
     #[inline]
     fn ct_gt(&self, other: &Self) -> Choice {
         let (_, borrow) = other.sbb(self, Limb::ZERO);
-        CtChoice::from_mask(borrow.0).into()
+        CtChoice::from_word_mask(borrow.0).into()
     }
 }
 
@@ -38,7 +38,7 @@ impl ConstantTimeLess for BoxedUint {
     #[inline]
     fn ct_lt(&self, other: &Self) -> Choice {
         let (_, borrow) = self.sbb(other, Limb::ZERO);
-        CtChoice::from_mask(borrow.0).into()
+        CtChoice::from_word_mask(borrow.0).into()
     }
 }
 

--- a/src/uint/boxed/encoding.rs
+++ b/src/uint/boxed/encoding.rs
@@ -36,7 +36,7 @@ impl BoxedUint {
     ///
     /// If the length of `bytes` (when interpreted as bits) is larger than `bits_precision`, this
     /// function will return [`DecodeError::InputSize`].
-    pub fn from_be_slice(bytes: &[u8], bits_precision: usize) -> Result<Self, DecodeError> {
+    pub fn from_be_slice(bytes: &[u8], bits_precision: u32) -> Result<Self, DecodeError> {
         if bytes.is_empty() && bits_precision == 0 {
             return Ok(Self::zero());
         }
@@ -45,7 +45,7 @@ impl BoxedUint {
             return Err(DecodeError::Precision);
         }
 
-        if bytes.len() % Limb::BYTES != 0 || bytes.len() * 8 > bits_precision {
+        if bytes.len() % Limb::BYTES != 0 || bytes.len() * 8 > bits_precision as usize {
             return Err(DecodeError::InputSize);
         }
 
@@ -66,7 +66,7 @@ impl BoxedUint {
     ///
     /// If the length of `bytes` (when interpreted as bits) is larger than `bits_precision`, this
     /// function will return [`DecodeError::InputSize`].
-    pub fn from_le_slice(bytes: &[u8], bits_precision: usize) -> Result<Self, DecodeError> {
+    pub fn from_le_slice(bytes: &[u8], bits_precision: u32) -> Result<Self, DecodeError> {
         if bytes.is_empty() && bits_precision == 0 {
             return Ok(Self::zero());
         }
@@ -75,7 +75,7 @@ impl BoxedUint {
             return Err(DecodeError::Precision);
         }
 
-        if bytes.len() % Limb::BYTES != 0 || bytes.len() * 8 > bits_precision {
+        if bytes.len() % Limb::BYTES != 0 || bytes.len() * 8 > bits_precision as usize {
             return Err(DecodeError::InputSize);
         }
 

--- a/src/uint/boxed/rand.rs
+++ b/src/uint/boxed/rand.rs
@@ -6,7 +6,7 @@ use rand_core::CryptoRngCore;
 
 impl BoxedUint {
     /// Generate a cryptographically secure random [`BoxedUint`].
-    pub fn random(mut rng: &mut impl CryptoRngCore, bits_precision: usize) -> Self {
+    pub fn random(mut rng: &mut impl CryptoRngCore, bits_precision: u32) -> Self {
         let mut ret = BoxedUint::zero_with_precision(bits_precision);
 
         for limb in &mut *ret.limbs {

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -44,7 +44,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Returns the truthy value if `self` is odd or the falsy value otherwise.
     pub(crate) const fn ct_is_odd(&self) -> CtChoice {
-        CtChoice::from_lsb(self.limbs[0].0 & 1)
+        CtChoice::from_word_lsb(self.limbs[0].0 & 1)
     }
 
     /// Returns the truthy value if `self == rhs` or the falsy value otherwise.
@@ -69,14 +69,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // but since we have to use Uint::wrapping_sub(), which calls `sbb()`,
         // there are no savings compared to just calling `sbb()` directly.
         let (_res, borrow) = lhs.sbb(rhs, Limb::ZERO);
-        CtChoice::from_mask(borrow.0)
+        CtChoice::from_word_mask(borrow.0)
     }
 
     /// Returns the truthy value if `self >= rhs` and the falsy value otherwise.
     #[inline]
     pub(crate) const fn ct_gt(lhs: &Self, rhs: &Self) -> CtChoice {
         let (_res, borrow) = rhs.sbb(lhs, Limb::ZERO);
-        CtChoice::from_mask(borrow.0)
+        CtChoice::from_word_mask(borrow.0)
     }
 
     /// Returns the ordering between `self` and `rhs` as an i8.

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -184,15 +184,12 @@ impl Reciprocal {
         // If `divisor = 0`, shifting `divisor` by `leading_zeros == Word::BITS` will cause a panic.
         // Have to substitute a "bogus" shift in that case.
         #[allow(trivial_numeric_casts)]
-        let shift_limb = Limb::ct_select(Limb::ZERO, Limb(shift as Word), is_some);
+        let shift = is_some.select(0, shift as Word) as u32;
 
         // Need to provide bogus normalized divisor and reciprocal too,
         // so that we don't get a panic in low-level functions.
-        let divisor_normalized = divisor.shl(shift_limb);
+        let divisor_normalized = divisor.shl(shift);
         let divisor_normalized = Limb::ct_select(Limb::MAX, divisor_normalized, is_some).0;
-
-        #[allow(trivial_numeric_casts)]
-        let shift = shift_limb.0 as u32;
 
         (
             Self {

--- a/src/uint/from.rs
+++ b/src/uint/from.rs
@@ -56,7 +56,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     // TODO(tarcieri): replace with `const impl From<u128>` when stable
     pub const fn from_u128(n: u128) -> Self {
         assert!(
-            LIMBS >= (128 / Limb::BITS),
+            LIMBS >= 16 / Limb::BYTES,
             "number of limbs must be greater than zero"
         );
 
@@ -127,7 +127,7 @@ impl<const LIMBS: usize> From<u32> for Uint<LIMBS> {
 impl<const LIMBS: usize> From<u64> for Uint<LIMBS> {
     fn from(n: u64) -> Self {
         // TODO(tarcieri): const where clause when possible
-        debug_assert!(LIMBS >= (64 / Limb::BITS), "not enough limbs");
+        debug_assert!(LIMBS >= 8 / Limb::BYTES, "not enough limbs");
         Self::from_u64(n)
     }
 }
@@ -135,7 +135,7 @@ impl<const LIMBS: usize> From<u64> for Uint<LIMBS> {
 impl<const LIMBS: usize> From<u128> for Uint<LIMBS> {
     fn from(n: u128) -> Self {
         // TODO(tarcieri): const where clause when possible
-        debug_assert!(LIMBS >= (128 / Limb::BITS), "not enough limbs");
+        debug_assert!(LIMBS >= 16 / Limb::BYTES, "not enough limbs");
         Self::from_u128(n)
     }
 }

--- a/src/uint/neg_mod.rs
+++ b/src/uint/neg_mod.rs
@@ -12,7 +12,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         while i < LIMBS {
             // Set ret to 0 if the original value was 0, in which
             // case ret would be p.
-            ret.limbs[i].0 = z.if_true(ret.limbs[i].0);
+            ret.limbs[i].0 = z.if_true_word(ret.limbs[i].0);
             i += 1;
         }
         ret

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -43,12 +43,12 @@ pub(super) fn random_mod_core<T>(
     rng: &mut impl CryptoRngCore,
     n: &mut T,
     modulus: &NonZero<T>,
-    n_bits: usize,
+    n_bits: u32,
 ) where
     T: AsMut<[Limb]> + ConstantTimeLess + Zero,
 {
-    let n_bytes = (n_bits + 7) / 8;
-    let n_limbs = (n_bits + Limb::BITS - 1) / Limb::BITS;
+    let n_bytes = ((n_bits + 7) / 8) as usize;
+    let n_limbs = ((n_bits + Limb::BITS - 1) / Limb::BITS) as usize;
     let hi_bytes = n_bytes - (n_limbs - 1) * Limb::BYTES;
 
     let mut bytes = Limb::ZERO.to_le_bytes();

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -1,7 +1,7 @@
 //! [`Uint`] square root operations.
 
 use super::Uint;
-use crate::{Limb, Word};
+use crate::CtChoice;
 use subtle::{ConstantTimeEq, CtOption};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
@@ -34,7 +34,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             // Sometimes an increase is too far, especially with large
             // powers, and then takes a long time to walk back.  The upper
             // bound is based on bit size, so saturate on that.
-            let le = Limb::ct_le(Limb(xn.bits_vartime() as Word), Limb(max_bits as Word));
+            let le = CtChoice::from_u32_le(xn.bits_vartime(), max_bits);
             guess = Self::ct_select(&cap, &xn, le);
             xn = {
                 let q = self.wrapping_div(&guess);

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -25,7 +25,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Perform saturating subtraction, returning `ZERO` on underflow.
     pub const fn saturating_sub(&self, rhs: &Self) -> Self {
         let (res, underflow) = self.sbb(rhs, Limb::ZERO);
-        Self::ct_select(&res, &Self::ZERO, CtChoice::from_mask(underflow.0))
+        Self::ct_select(&res, &Self::ZERO, CtChoice::from_word_mask(underflow.0))
     }
 
     /// Perform wrapping subtraction, discarding underflow and wrapping around
@@ -43,7 +43,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ) -> (Self, CtChoice) {
         let actual_rhs = Uint::ct_select(&Uint::ZERO, rhs, choice);
         let (res, borrow) = self.sbb(&actual_rhs, Limb::ZERO);
-        (res, CtChoice::from_mask(borrow.0))
+        (res, CtChoice::from_word_mask(borrow.0))
     }
 }
 

--- a/tests/boxed_residue_proptests.rs
+++ b/tests/boxed_residue_proptests.rs
@@ -38,7 +38,7 @@ prop_compose! {
         let extra = bytes.len() % Limb::BYTES;
         let bytes_precision = bytes.len() - extra;
         bytes.truncate(bytes_precision);
-        BoxedUint::from_be_slice(&bytes, bytes_precision * 8).unwrap()
+        BoxedUint::from_be_slice(&bytes, bytes_precision as u32 * 8).unwrap()
     }
 }
 prop_compose! {

--- a/tests/boxed_uint_proptests.rs
+++ b/tests/boxed_uint_proptests.rs
@@ -16,7 +16,7 @@ fn to_uint(big_uint: BigUint) -> BoxedUint {
     let pad_count = Limb::BYTES - (bytes.len() % Limb::BYTES);
     let mut padded_bytes = vec![0u8; pad_count];
     padded_bytes.extend_from_slice(&bytes);
-    BoxedUint::from_be_slice(&padded_bytes, padded_bytes.len() * 8).unwrap()
+    BoxedUint::from_be_slice(&padded_bytes, padded_bytes.len() as u32 * 8).unwrap()
 }
 
 fn reduce(x: &BoxedUint, n: &BoxedUint) -> BoxedUint {
@@ -40,7 +40,7 @@ prop_compose! {
         let extra = bytes.len() % Limb::BYTES;
         let bytes_precision = bytes.len() - extra;
         bytes.truncate(bytes_precision);
-        BoxedUint::from_be_slice(&bytes, bytes_precision * 8).unwrap()
+        BoxedUint::from_be_slice(&bytes, bytes_precision as u32 * 8).unwrap()
     }
 }
 prop_compose! {
@@ -74,7 +74,7 @@ proptest! {
 
     #[test]
     fn bits(a in uint()) {
-        let expected = to_biguint(&a).bits();
+        let expected = to_biguint(&a).bits() as u32;
         assert_eq!(expected, a.bits());
         assert_eq!(expected, a.bits_vartime());
     }

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -51,7 +51,7 @@ proptest! {
 
     #[test]
     fn bits(a in uint()) {
-        let expected = to_biguint(&a).bits();
+        let expected = to_biguint(&a).bits() as u32;
         assert_eq!(expected, a.bits());
         assert_eq!(expected, a.bits_vartime());
     }
@@ -61,7 +61,7 @@ proptest! {
         let a_bi = to_biguint(&a);
 
         let expected = to_uint(a_bi << shift.into());
-        let actual = a.shl_vartime(shift as usize);
+        let actual = a.shl_vartime(shift.into());
 
         assert_eq!(expected, actual);
     }
@@ -71,9 +71,9 @@ proptest! {
         let a_bi = to_biguint(&a);
 
         // Add a 50% probability of overflow.
-        let shift = (shift as usize) % (U256::BITS * 2);
+        let shift = u32::from(shift) % (U256::BITS * 2);
 
-        let expected = to_uint((a_bi << shift) & ((BigUint::one() << U256::BITS) - BigUint::one()));
+        let expected = to_uint((a_bi << shift as usize) & ((BigUint::one() << U256::BITS as usize) - BigUint::one()));
         let actual = a.shl(shift);
 
         assert_eq!(expected, actual);
@@ -84,9 +84,9 @@ proptest! {
         let a_bi = to_biguint(&a);
 
         // Add a 50% probability of overflow.
-        let shift = (shift as usize) % (U256::BITS * 2);
+        let shift = u32::from(shift) % (U256::BITS * 2);
 
-        let expected = to_uint(a_bi >> shift);
+        let expected = to_uint(a_bi >> shift as usize);
         let actual = a.shr(shift);
 
         assert_eq!(expected, actual);
@@ -238,11 +238,11 @@ proptest! {
     }
 
     #[test]
-    fn inv_mod2k(a in uint(), k in any::<usize>()) {
+    fn inv_mod2k(a in uint(), k in any::<u32>()) {
         let a = a | U256::ONE; // make odd
         let k = k % (U256::BITS + 1);
         let a_bi = to_biguint(&a);
-        let m_bi = BigUint::one() << k;
+        let m_bi = BigUint::one() << k as usize;
 
         let actual = a.inv_mod2k(k);
         let actual_vartime = a.inv_mod2k_vartime(k);


### PR DESCRIPTION
A part of #268:
- make all shift arguments in various bit shifts use `u32`
- the corresponding constants (e.g. `BITS`) and methods (e.g. `bit_precision()`) return `u32`. Note that the methods and constants that are used for indexing (`LIMBS` and `BYTES`) are still `usize`.
- added some methods to `CtChoice` (working on `u32` arguments) and normalized their names.

Notes:
- I also added `inline` to all the `CtChoice` methods which bumped performance quite a bit in my tests (tens of percents in various benchmarks). 
- I tried using `u8` and `u32` in `CtChoice`, but it seems to marginally decrease performance, so `Word` stays for now.
