### PR TITLE
Constant-time square root and division

### DIFF
--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -47,11 +47,47 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// NOTE: Use only if you need to access const fn. Otherwise use [`Self::div_rem`] because
     /// the value for is_some needs to be checked before using `q` and `r`.
     ///
+    /// This function is constant-time with respect to both `self` and `rhs`.
+    pub(crate) const fn const_div_rem(&self, rhs: &Self) -> (Self, Self, CtChoice) {
+        let mb = rhs.bits();
+        let mut rem = *self;
+        let mut quo = Self::ZERO;
+        let mut c = rhs.shl(Self::BITS - mb);
+
+        let mut i = Self::BITS;
+        let mut done = CtChoice::FALSE;
+        loop {
+            let (mut r, borrow) = rem.sbb(&c, Limb::ZERO);
+            rem = Self::ct_select(&r, &rem, CtChoice::from_mask(borrow.0).or(done));
+            r = quo.bitor(&Self::ONE);
+            quo = Self::ct_select(&r, &quo, CtChoice::from_mask(borrow.0).or(done));
+            if i == 0 {
+                break;
+            }
+            i -= 1;
+            // when `i < mb`, the computation is actually done, so we ensure `quo` and `rem`
+            // aren't modified further (but do the remaining iterations anyway to be constant-time)
+            done = Limb::ct_lt(Limb(i as Word), Limb(mb as Word));
+            c = c.shr_vartime(1);
+            quo = Self::ct_select(&quo.shl_vartime(1), &quo, done);
+        }
+
+        let is_some = Limb(mb as Word).ct_is_nonzero();
+        quo = Self::ct_select(&Self::ZERO, &quo, is_some);
+        (quo, rem, is_some)
+    }
+
+    /// Computes `self` / `rhs`, returns the quotient (q), remainder (r)
+    /// and the truthy value for is_some or the falsy value for is_none.
+    ///
+    /// NOTE: Use only if you need to access const fn. Otherwise use [`Self::div_rem`] because
+    /// the value for is_some needs to be checked before using `q` and `r`.
+    ///
     /// This is variable only with respect to `rhs`.
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
-    pub(crate) const fn ct_div_rem(&self, rhs: &Self) -> (Self, Self, CtChoice) {
+    pub(crate) const fn const_div_rem_vartime(&self, rhs: &Self) -> (Self, Self, CtChoice) {
         let mb = rhs.bits_vartime();
         let mut bd = Self::BITS - mb;
         let mut rem = *self;
@@ -169,7 +205,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes self / rhs, returns the quotient, remainder.
     pub fn div_rem(&self, rhs: &NonZero<Self>) -> (Self, Self) {
         // Since `rhs` is nonzero, this should always hold.
-        let (q, r, _c) = self.ct_div_rem(rhs);
+        let (q, r, _c) = self.const_div_rem(rhs);
+        (q, r)
+    }
+
+    /// Computes self / rhs, returns the quotient, remainder. Constant-time only for fixed `rhs`.
+    pub fn div_rem_vartime(&self, rhs: &NonZero<Self>) -> (Self, Self) {
+        // Since `rhs` is nonzero, this should always hold.
+        let (q, r, _c) = self.const_div_rem_vartime(rhs);
         (q, r)
     }
 
@@ -186,7 +229,18 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Panics if `rhs == 0`.
     pub const fn wrapping_div(&self, rhs: &Self) -> Self {
-        let (q, _, c) = self.ct_div_rem(rhs);
+        let (q, _, c) = self.const_div_rem(rhs);
+        assert!(c.is_true_vartime(), "divide by zero");
+        q
+    }
+
+    /// Wrapped division is just normal division i.e. `self` / `rhs`
+    /// There’s no way wrapping could ever happen.
+    /// This function exists, so that all operations are accounted for in the wrapping operations.
+    ///
+    /// Panics if `rhs == 0`. Constant-time only for fixed `rhs`.
+    pub const fn wrapping_div_vartime(&self, rhs: &Self) -> Self {
+        let (q, _, c) = self.const_div_rem_vartime(rhs);
         assert!(c.is_true_vartime(), "divide by zero");
         q
     }
@@ -625,7 +679,11 @@ mod tests {
         ] {
             let lhs = U256::from(*n);
             let rhs = U256::from(*d);
-            let (q, r, is_some) = lhs.ct_div_rem(&rhs);
+            let (q, r, is_some) = lhs.const_div_rem(&rhs);
+            assert!(is_some.is_true_vartime());
+            assert_eq!(U256::from(*e), q);
+            assert_eq!(U256::from(*ee), r);
+            let (q, r, is_some) = lhs.const_div_rem_vartime(&rhs);
             assert!(is_some.is_true_vartime());
             assert_eq!(U256::from(*e), q);
             assert_eq!(U256::from(*ee), r);
@@ -641,7 +699,10 @@ mod tests {
             let den = U256::random(&mut rng).shr_vartime(128);
             let n = num.checked_mul(&den);
             if n.is_some().into() {
-                let (q, _, is_some) = n.unwrap().ct_div_rem(&den);
+                let (q, _, is_some) = n.unwrap().const_div_rem(&den);
+                assert!(is_some.is_true_vartime());
+                assert_eq!(q, num);
+                let (q, _, is_some) = n.unwrap().const_div_rem_vartime(&den);
                 assert!(is_some.is_true_vartime());
                 assert_eq!(q, num);
             }
@@ -663,7 +724,11 @@ mod tests {
 
     #[test]
     fn div_zero() {
-        let (q, r, is_some) = U256::ONE.ct_div_rem(&U256::ZERO);
+        let (q, r, is_some) = U256::ONE.const_div_rem(&U256::ZERO);
+        assert!(!is_some.is_true_vartime());
+        assert_eq!(q, U256::ZERO);
+        assert_eq!(r, U256::ONE);
+        let (q, r, is_some) = U256::ONE.const_div_rem_vartime(&U256::ZERO);
         assert!(!is_some.is_true_vartime());
         assert_eq!(q, U256::ZERO);
         assert_eq!(r, U256::ONE);
@@ -671,7 +736,11 @@ mod tests {
 
     #[test]
     fn div_one() {
-        let (q, r, is_some) = U256::from(10u8).ct_div_rem(&U256::ONE);
+        let (q, r, is_some) = U256::from(10u8).const_div_rem(&U256::ONE);
+        assert!(is_some.is_true_vartime());
+        assert_eq!(q, U256::from(10u8));
+        assert_eq!(r, U256::ZERO);
+        let (q, r, is_some) = U256::from(10u8).const_div_rem_vartime(&U256::ONE);
         assert!(is_some.is_true_vartime());
         assert_eq!(q, U256::from(10u8));
         assert_eq!(r, U256::ZERO);

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -109,13 +109,24 @@ mod tests {
 
     #[test]
     fn edge() {
+        assert_eq!(U256::ZERO.sqrt(), U256::ZERO);
+        assert_eq!(U256::ONE.sqrt(), U256::ONE);
+        let mut half = U256::ZERO;
+        for i in 0..half.limbs.len() / 2 {
+            half.limbs[i] = Limb::MAX;
+        }
+        assert_eq!(U256::MAX.sqrt(), half);
+    }
+
+    #[test]
+    fn edge_vartime() {
         assert_eq!(U256::ZERO.sqrt_vartime(), U256::ZERO);
         assert_eq!(U256::ONE.sqrt_vartime(), U256::ONE);
         let mut half = U256::ZERO;
         for i in 0..half.limbs.len() / 2 {
             half.limbs[i] = Limb::MAX;
         }
-        assert_eq!(U256::MAX.sqrt_vartime(), half,);
+        assert_eq!(U256::MAX.sqrt_vartime(), half);
     }
 
     #[test]
@@ -137,13 +148,28 @@ mod tests {
         for (a, e) in &tests {
             let l = U256::from(*a);
             let r = U256::from(*e);
+            assert_eq!(l.sqrt(), r);
             assert_eq!(l.sqrt_vartime(), r);
+            assert_eq!(l.checked_sqrt().is_some().unwrap_u8(), 1u8);
             assert_eq!(l.checked_sqrt_vartime().is_some().unwrap_u8(), 1u8);
         }
     }
 
     #[test]
     fn nonsquares() {
+        assert_eq!(U256::from(2u8).sqrt(), U256::from(1u8));
+        assert_eq!(U256::from(2u8).checked_sqrt().is_some().unwrap_u8(), 0);
+        assert_eq!(U256::from(3u8).sqrt(), U256::from(1u8));
+        assert_eq!(U256::from(3u8).checked_sqrt().is_some().unwrap_u8(), 0);
+        assert_eq!(U256::from(5u8).sqrt(), U256::from(2u8));
+        assert_eq!(U256::from(6u8).sqrt(), U256::from(2u8));
+        assert_eq!(U256::from(7u8).sqrt(), U256::from(2u8));
+        assert_eq!(U256::from(8u8).sqrt(), U256::from(2u8));
+        assert_eq!(U256::from(10u8).sqrt(), U256::from(3u8));
+    }
+
+    #[test]
+    fn nonsquares_vartime() {
         assert_eq!(U256::from(2u8).sqrt_vartime(), U256::from(1u8));
         assert_eq!(
             U256::from(2u8).checked_sqrt_vartime().is_some().unwrap_u8(),
@@ -169,7 +195,9 @@ mod tests {
             let t = rng.next_u32() as u64;
             let s = U256::from(t);
             let s2 = s.checked_mul(&s).unwrap();
+            assert_eq!(s2.sqrt(), s);
             assert_eq!(s2.sqrt_vartime(), s);
+            assert_eq!(s2.checked_sqrt().is_some().unwrap_u8(), 1);
             assert_eq!(s2.checked_sqrt_vartime().is_some().unwrap_u8(), 1);
         }
 
@@ -177,6 +205,7 @@ mod tests {
             let s = U256::random(&mut rng);
             let mut s2 = U512::ZERO;
             s2.limbs[..s.limbs.len()].copy_from_slice(&s.limbs);
+            assert_eq!(s.square().sqrt(), s2);
             assert_eq!(s.square().sqrt_vartime(), s2);
         }
     }

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -1,7 +1,6 @@
 //! [`Uint`] square root operations.
 
 use super::Uint;
-use crate::CtChoice;
 use subtle::{ConstantTimeEq, CtOption};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
@@ -21,6 +20,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         // Repeat enough times to guarantee result has stabilized.
         // See Hast, "Note on computation of integer square roots" for a proof of this bound.
+        // https://github.com/RustCrypto/crypto-bigint/files/12600669/ct_sqrt.pdf
         let mut i = 0;
         while i < usize::BITS - Self::BITS.leading_zeros() {
             guess = xn;

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -279,9 +279,10 @@ proptest! {
     fn wrapping_sqrt(a in uint()) {
         let a_bi = to_biguint(&a);
         let expected = to_uint(a_bi.sqrt());
-        let actual = a.wrapping_sqrt_vartime();
-
-        assert_eq!(expected, actual);
+        let actual_ct = a.wrapping_sqrt();
+        assert_eq!(expected, actual_ct);
+        let actual_vartime = a.wrapping_sqrt_vartime();
+        assert_eq!(expected, actual_vartime);
     }
 
     #[test]

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -195,8 +195,9 @@ proptest! {
         if !b_bi.is_zero() {
             let expected = to_uint(a_bi / b_bi);
             let actual = a.wrapping_div(&b);
-
             assert_eq!(expected, actual);
+            let actual_vartime = a.wrapping_div_vartime(&b);
+            assert_eq!(expected, actual_vartime);
         }
     }
 


### PR DESCRIPTION
This is the implementation from #277, rebased and with most of the review comments addressed.

The ones I didn't address are:

- [still a bit confused about constant-time division, left comments](https://github.com/RustCrypto/crypto-bigint/pull/277/files/6e6c5442bde4f1f3e1860bc2a9e4fc2f425325ab#diff-62d1bf839c2bbb8be6ed2db8a80b297aabc227fcb68d58f9e6d1521a04a7fa0e)
- [mismatch between paper and implementation?](https://github.com/RustCrypto/crypto-bigint/pull/277#discussion_r1351040253)
- [testing improvement suggestion](https://github.com/RustCrypto/crypto-bigint/pull/277#pullrequestreview-1666138090)

This was already getting a bit hard to rebase, so if we can get it over the finish line before it becomes too stale that seems good.