### PR TITLE
Reorganize bit shift operations

### DIFF
--- a/src/modular/div_by_2.rs
+++ b/src/modular/div_by_2.rs
@@ -18,7 +18,7 @@ pub(crate) fn div_by_2<const LIMBS: usize>(a: &Uint<LIMBS>, modulus: &Uint<LIMBS
     // ("+1" because both `a` and `modulus` are odd, we lose 0.5 in each integer division).
     // This will not overflow, so we can just use wrapping operations.
 
-    let (half, is_odd) = a.shr_1();
+    let (half, is_odd) = a.shr1();
     let half_modulus = modulus.shr_vartime(1);
 
     let if_even = half;

--- a/src/uint/boxed/inv_mod.rs
+++ b/src/uint/boxed/inv_mod.rs
@@ -101,7 +101,7 @@ impl BoxedUint {
         let bit_size = bits + modulus_bits;
 
         let mut m1hp = modulus.clone();
-        let (m1hp_new, carry) = m1hp.shr_1();
+        let (m1hp_new, carry) = m1hp.shr1();
         debug_assert!(bool::from(carry));
         m1hp = m1hp_new.wrapping_add(&Self::one_with_precision(bits_precision));
 
@@ -124,9 +124,9 @@ impl BoxedUint {
             let (new_u, cyy) = new_u.conditional_wrapping_add(modulus, cy);
             debug_assert!(bool::from(cy.ct_eq(&cyy)));
 
-            let (new_a, overflow) = a.shr_1();
+            let (new_a, overflow) = a.shr1();
             debug_assert!(!bool::from(overflow));
-            let (new_u, cy) = new_u.shr_1();
+            let (new_u, cy) = new_u.shr1();
             let (new_u, cy) = new_u.conditional_wrapping_add(&m1hp, cy);
             debug_assert!(!bool::from(cy));
 

--- a/src/uint/inv_mod.rs
+++ b/src/uint/inv_mod.rs
@@ -96,7 +96,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let bit_size = bits + modulus_bits;
 
         let mut m1hp = *modulus;
-        let (m1hp_new, carry) = m1hp.shr_1();
+        let (m1hp_new, carry) = m1hp.shr1();
         debug_assert!(carry.is_true_vartime());
         m1hp = m1hp_new.wrapping_add(&Uint::ONE);
 
@@ -118,9 +118,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             let (new_u, cyy) = new_u.conditional_wrapping_add(modulus, cy);
             debug_assert!(cy.is_true_vartime() == cyy.is_true_vartime());
 
-            let (new_a, overflow) = a.shr_1();
+            let (new_a, overflow) = a.shr1();
             debug_assert!(!overflow.is_true_vartime());
-            let (new_u, cy) = new_u.shr_1();
+            let (new_u, cy) = new_u.shr1();
             let (new_u, cy) = new_u.conditional_wrapping_add(&m1hp, cy);
             debug_assert!(!cy.is_true_vartime());
 


### PR DESCRIPTION
- Places `shl`/`shr` ahead of `shl_vartime`/`shr_vartime`
- Removes variable-time comments about trait impls that call the constant-time bit shift functions
- Renames internal `sh*_1` functions to `sh*1`.