### PR TITLE
Reorganize benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,5 +52,9 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [[bench]]
-name = "bench"
+name = "dyn_residue"
+harness = false
+
+[[bench]]
+name = "uint"
 harness = false

--- a/benches/dyn_residue.rs
+++ b/benches/dyn_residue.rs
@@ -1,0 +1,109 @@
+use criterion::{
+    criterion_group, criterion_main, measurement::Measurement, BatchSize, BenchmarkGroup, Criterion,
+};
+use crypto_bigint::{
+    modular::{DynResidue, DynResidueParams},
+    Random, U256,
+};
+use rand_core::OsRng;
+
+#[cfg(feature = "alloc")]
+use crypto_bigint::MultiExponentiate;
+
+fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
+    let params = DynResidueParams::new(&(U256::random(&mut OsRng) | U256::ONE)).unwrap();
+    group.bench_function("multiplication, U256*U256", |b| {
+        b.iter_batched(
+            || {
+                let x = DynResidue::new(&U256::random(&mut OsRng), params);
+                let y = DynResidue::new(&U256::random(&mut OsRng), params);
+                (x, y)
+            },
+            |(x, y)| x * y,
+            BatchSize::SmallInput,
+        )
+    });
+
+    let m = U256::random(&mut OsRng) | U256::ONE;
+    let params = DynResidueParams::new(&m).unwrap();
+    group.bench_function("modpow, U256^U256", |b| {
+        b.iter_batched(
+            || {
+                let x = U256::random(&mut OsRng);
+                let x_m = DynResidue::new(&x, params);
+                let p = U256::random(&mut OsRng) | (U256::ONE << (U256::BITS - 1));
+                (x_m, p)
+            },
+            |(x, p)| x.pow(&p),
+            BatchSize::SmallInput,
+        )
+    });
+
+    #[cfg(feature = "alloc")]
+    for i in [1, 2, 3, 4, 10, 100] {
+        group.bench_function(
+            format!("multi_exponentiate for {i} bases, U256^U256"),
+            |b| {
+                b.iter_batched(
+                    || {
+                        let bases_and_exponents: Vec<(DynResidue<{ U256::LIMBS }>, U256)> = (1..=i)
+                            .map(|_| {
+                                let x = U256::random(&mut OsRng);
+                                let x_m = DynResidue::new(&x, params);
+                                let p = U256::random(&mut OsRng) | (U256::ONE << (U256::BITS - 1));
+                                (x_m, p)
+                            })
+                            .collect();
+
+                        bases_and_exponents
+                    },
+                    |bases_and_exponents| {
+                        DynResidue::<{ U256::LIMBS }>::multi_exponentiate(
+                            bases_and_exponents.as_slice(),
+                        )
+                    },
+                    BatchSize::SmallInput,
+                )
+            },
+        );
+    }
+}
+
+fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
+    group.bench_function("DynResidueParams creation", |b| {
+        b.iter_batched(
+            || U256::random(&mut OsRng) | U256::ONE,
+            |modulus| DynResidueParams::new(&modulus),
+            BatchSize::SmallInput,
+        )
+    });
+
+    let params = DynResidueParams::new(&(U256::random(&mut OsRng) | U256::ONE)).unwrap();
+    group.bench_function("DynResidue creation", |b| {
+        b.iter_batched(
+            || U256::random(&mut OsRng),
+            |x| DynResidue::new(&x, params),
+            BatchSize::SmallInput,
+        )
+    });
+
+    let params = DynResidueParams::new(&(U256::random(&mut OsRng) | U256::ONE)).unwrap();
+    group.bench_function("DynResidue retrieve", |b| {
+        b.iter_batched(
+            || DynResidue::new(&U256::random(&mut OsRng), params),
+            |x| x.retrieve(),
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+fn bench_montgomery(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Montgomery arithmetic");
+    bench_montgomery_conversion(&mut group);
+    bench_montgomery_ops(&mut group);
+    group.finish();
+}
+
+criterion_group!(benches, bench_montgomery);
+
+criterion_main!(benches);

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -1,14 +1,8 @@
 use criterion::{
     criterion_group, criterion_main, measurement::Measurement, BatchSize, BenchmarkGroup, Criterion,
 };
-use crypto_bigint::{
-    modular::{DynResidue, DynResidueParams},
-    Limb, NonZero, Random, Reciprocal, U128, U2048, U256,
-};
+use crypto_bigint::{Limb, NonZero, Random, Reciprocal, U128, U2048, U256};
 use rand_core::OsRng;
-
-#[cfg(feature = "alloc")]
-use crypto_bigint::MultiExponentiate;
 
 fn bench_division<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("div/rem, U256/U128, full size", |b| {
@@ -71,93 +65,6 @@ fn bench_division<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                 (x, r)
             },
             |(x, r)| x.div_rem_limb_with_reciprocal(&r),
-            BatchSize::SmallInput,
-        )
-    });
-}
-
-fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let params = DynResidueParams::new(&(U256::random(&mut OsRng) | U256::ONE)).unwrap();
-    group.bench_function("multiplication, U256*U256", |b| {
-        b.iter_batched(
-            || {
-                let x = DynResidue::new(&U256::random(&mut OsRng), params);
-                let y = DynResidue::new(&U256::random(&mut OsRng), params);
-                (x, y)
-            },
-            |(x, y)| x * y,
-            BatchSize::SmallInput,
-        )
-    });
-
-    let m = U256::random(&mut OsRng) | U256::ONE;
-    let params = DynResidueParams::new(&m).unwrap();
-    group.bench_function("modpow, U256^U256", |b| {
-        b.iter_batched(
-            || {
-                let x = U256::random(&mut OsRng);
-                let x_m = DynResidue::new(&x, params);
-                let p = U256::random(&mut OsRng) | (U256::ONE << (U256::BITS - 1));
-                (x_m, p)
-            },
-            |(x, p)| x.pow(&p),
-            BatchSize::SmallInput,
-        )
-    });
-
-    #[cfg(feature = "alloc")]
-    for i in [1, 2, 3, 4, 10, 100] {
-        group.bench_function(
-            format!("multi_exponentiate for {i} bases, U256^U256"),
-            |b| {
-                b.iter_batched(
-                    || {
-                        let bases_and_exponents: Vec<(DynResidue<{ U256::LIMBS }>, U256)> = (1..=i)
-                            .map(|_| {
-                                let x = U256::random(&mut OsRng);
-                                let x_m = DynResidue::new(&x, params);
-                                let p = U256::random(&mut OsRng) | (U256::ONE << (U256::BITS - 1));
-                                (x_m, p)
-                            })
-                            .collect();
-
-                        bases_and_exponents
-                    },
-                    |bases_and_exponents| {
-                        DynResidue::<{ U256::LIMBS }>::multi_exponentiate(
-                            bases_and_exponents.as_slice(),
-                        )
-                    },
-                    BatchSize::SmallInput,
-                )
-            },
-        );
-    }
-}
-
-fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    group.bench_function("DynResidueParams creation", |b| {
-        b.iter_batched(
-            || U256::random(&mut OsRng) | U256::ONE,
-            |modulus| DynResidueParams::new(&modulus),
-            BatchSize::SmallInput,
-        )
-    });
-
-    let params = DynResidueParams::new(&(U256::random(&mut OsRng) | U256::ONE)).unwrap();
-    group.bench_function("DynResidue creation", |b| {
-        b.iter_batched(
-            || U256::random(&mut OsRng),
-            |x| DynResidue::new(&x, params),
-            BatchSize::SmallInput,
-        )
-    });
-
-    let params = DynResidueParams::new(&(U256::random(&mut OsRng) | U256::ONE)).unwrap();
-    group.bench_function("DynResidue retrieve", |b| {
-        b.iter_batched(
-            || DynResidue::new(&U256::random(&mut OsRng), params),
-            |x| x.retrieve(),
             BatchSize::SmallInput,
         )
     });
@@ -244,13 +151,6 @@ fn bench_wrapping_ops(c: &mut Criterion) {
     group.finish();
 }
 
-fn bench_montgomery(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Montgomery arithmetic");
-    bench_montgomery_conversion(&mut group);
-    bench_montgomery_ops(&mut group);
-    group.finish();
-}
-
 fn bench_modular_ops(c: &mut Criterion) {
     let mut group = c.benchmark_group("modular ops");
     bench_shifts(&mut group);
@@ -258,11 +158,6 @@ fn bench_modular_ops(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(
-    benches,
-    bench_wrapping_ops,
-    bench_montgomery,
-    bench_modular_ops
-);
+criterion_group!(benches, bench_wrapping_ops, bench_modular_ops);
 
 criterion_main!(benches);


### PR DESCRIPTION
Splits apart the `Uint` and `DynResidue` benchmarks, in preparation for adding benchmarks for `BoxedUint` and `BoxedResidue`.