### PR TITLE
Revert "BoxedUint: improve efficiency of `square` (#382)"

### DIFF
--- a/src/uint/boxed/mul.rs
+++ b/src/uint/boxed/mul.rs
@@ -1,9 +1,6 @@
 //! [`BoxedUint`] multiplication operations.
 
-use crate::{
-    uint::mul::{diagonal_mul_limbs, half_mul_limbs, mul_limbs},
-    BoxedUint, CheckedMul, Limb, WideningMul, Wrapping, Zero,
-};
+use crate::{uint::mul::mul_limbs, BoxedUint, CheckedMul, Limb, WideningMul, Wrapping, Zero};
 use core::ops::{Mul, MulAssign};
 use subtle::{Choice, CtOption};
 
@@ -12,9 +9,9 @@ impl BoxedUint {
     ///
     /// Returns a widened output with a limb count equal to the sums of the input limb counts.
     pub fn mul(&self, rhs: &Self) -> Self {
-        let mut out = vec![Limb::ZERO; self.nlimbs() + rhs.nlimbs()];
-        mul_limbs(&self.limbs, &rhs.limbs, &mut out);
-        out.into()
+        let mut limbs = vec![Limb::ZERO; self.nlimbs() + rhs.nlimbs()];
+        mul_limbs(&self.limbs, &rhs.limbs, &mut limbs);
+        limbs.into()
     }
 
     /// Perform wrapping multiplication, wrapping to the width of `self`.
@@ -24,11 +21,8 @@ impl BoxedUint {
 
     /// Multiply `self` by itself.
     pub fn square(&self) -> Self {
-        let mut out = Self::from(vec![Limb::ZERO; self.nlimbs() * 2]);
-        half_mul_limbs(&self.limbs, &mut out.limbs);
-        out <<= 1;
-        diagonal_mul_limbs(&self.limbs, &mut out.limbs);
-        out
+        // TODO(tarcieri): more optimized implementation (shared with `Uint`?)
+        self.mul(self)
     }
 }
 

--- a/tests/boxed_uint_proptests.rs
+++ b/tests/boxed_uint_proptests.rs
@@ -147,21 +147,13 @@ proptest! {
     }
 
     #[test]
-    fn mul(a in uint(), b in uint()) {
+    fn mul_wide(a in uint(), b in uint()) {
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);
 
         let expected = a_bi * b_bi;
         let actual = a.mul(&b);
 
-        prop_assert_eq!(expected, to_biguint(&actual));
-    }
-
-    #[test]
-    fn square(n in uint()) {
-        let n_bi = to_biguint(&n);
-        let expected = &n_bi * &n_bi;
-        let actual = n.square();
         prop_assert_eq!(expected, to_biguint(&actual));
     }
 


### PR DESCRIPTION
This reverts commit cd9cdcecf9cd27fae48843905581b053c31952e0.

Benchmarks reveal this caused a performance regression to modpow. Reverting it yields the following improvement:

```
Montgomery arithmetic/modpow, BoxedUint^BoxedUint
                        time:   [76.362 µs 76.381 µs 76.403 µs]
                        change: [-72.846% -72.795% -72.747%] (p = 0.00 < 0.05)
                        Performance has improved.
```