### PR TITLE
Uint: bit shift improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //!     U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
 //!
 //! // Compute `MODULUS` shifted right by 1 at compile time
-//! pub const MODULUS_SHR1: U256 = MODULUS.shr_vartime(1);
+//! pub const MODULUS_SHR1: U256 = MODULUS.shr(1);
 //! ```
 //!
 //! Note that large constant computations may accidentally trigger a the `const_eval_limit` of the compiler.

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -53,9 +53,6 @@ pub type Word = u64;
 #[cfg(target_pointer_width = "64")]
 pub type WideWord = u128;
 
-/// Highest bit in a [`Limb`].
-pub(crate) const HI_BIT: u32 = Limb::BITS - 1;
-
 /// Big integers are represented as an array of smaller CPU word-size integers
 /// called "limbs".
 // Our PartialEq impl only differs from the default one by being constant-time, so this is safe
@@ -73,6 +70,9 @@ impl Limb {
 
     /// Maximum value this [`Limb`] can express.
     pub const MAX: Self = Limb(Word::MAX);
+
+    /// Highest bit in a [`Limb`].
+    pub(crate) const HI_BIT: u32 = Limb::BITS - 1;
 
     // 32-bit
 

--- a/src/modular/div_by_2.rs
+++ b/src/modular/div_by_2.rs
@@ -18,8 +18,8 @@ pub(crate) fn div_by_2<const LIMBS: usize>(a: &Uint<LIMBS>, modulus: &Uint<LIMBS
     // ("+1" because both `a` and `modulus` are odd, we lose 0.5 in each integer division).
     // This will not overflow, so we can just use wrapping operations.
 
-    let (half, is_odd) = a.shr1();
-    let half_modulus = modulus.shr_vartime(1);
+    let (half, is_odd) = a.shr1_with_overflow();
+    let half_modulus = modulus.shr1();
 
     let if_even = half;
     let if_odd = half

--- a/src/uint/boxed/shr.rs
+++ b/src/uint/boxed/shr.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] bitwise right shift operations.
 
-use crate::{limb::HI_BIT, BoxedUint, Limb};
+use crate::{BoxedUint, Limb};
 use core::ops::{Shr, ShrAssign};
 use subtle::{Choice, ConstantTimeLess};
 
@@ -77,7 +77,7 @@ impl BoxedUint {
 
         let mut carry_bits = vec![0; nlimbs];
         for i in 0..nlimbs {
-            carry_bits[i] = self.limbs[i].0 << HI_BIT;
+            carry_bits[i] = self.limbs[i].0 << Limb::HI_BIT;
         }
 
         let mut limbs = vec![Limb(0); nlimbs];
@@ -86,8 +86,11 @@ impl BoxedUint {
         }
         limbs[nlimbs - 1] = Limb(shifted_bits[nlimbs - 1]);
 
-        debug_assert!(carry_bits[nlimbs - 1] == 0 || carry_bits[nlimbs - 1] == (1 << HI_BIT));
-        (limbs.into(), Choice::from((carry_bits[0] >> HI_BIT) as u8))
+        debug_assert!(carry_bits[nlimbs - 1] == 0 || carry_bits[nlimbs - 1] == (1 << Limb::HI_BIT));
+        (
+            limbs.into(),
+            Choice::from((carry_bits[0] >> Limb::HI_BIT) as u8),
+        )
     }
 }
 

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -69,8 +69,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             // when `i < mb`, the computation is actually done, so we ensure `quo` and `rem`
             // aren't modified further (but do the remaining iterations anyway to be constant-time)
             done = CtChoice::from_word_lt(i as Word, mb as Word);
-            c = c.shr_vartime(1);
-            quo = Self::ct_select(&quo.shl_vartime(1), &quo, done);
+            c = c.shr1();
+            quo = Self::ct_select(&quo.shl1(), &quo, done);
         }
 
         let is_some = Limb(mb as Word).ct_is_nonzero();
@@ -104,8 +104,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
                 break;
             }
             bd -= 1;
-            c = c.shr_vartime(1);
-            quo = quo.shl_vartime(1);
+            c = c.shr1();
+            quo = quo.shl1();
         }
 
         let is_some = CtChoice::from_u32_nonzero(mb);
@@ -113,8 +113,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         (quo, rem, is_some)
     }
 
-    /// Computes `self` % `rhs`, returns the remainder and
-    /// and the truthy value for is_some or the falsy value for is_none.
+    /// Computes `self` % `rhs`, returns the remainder and and the truthy value for is_some or the
+    /// falsy value for is_none.
     ///
     /// NOTE: Use only if you need to access const fn. Otherwise use [`Self::rem`].
     /// This is variable only with respect to `rhs`.
@@ -134,7 +134,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
                 break;
             }
             bd -= 1;
-            c = c.shr_vartime(1);
+            c = c.shr1();
         }
 
         let is_some = CtChoice::from_u32_nonzero(mb);
@@ -654,7 +654,7 @@ impl<const LIMBS: usize> RemAssign<&NonZero<Uint<LIMBS>>> for Wrapping<Uint<LIMB
 
 #[cfg(test)]
 mod tests {
-    use crate::{limb::HI_BIT, Limb, NonZero, Uint, Word, U256};
+    use crate::{Limb, NonZero, Uint, Word, U256};
 
     #[cfg(feature = "rand")]
     use {
@@ -717,8 +717,8 @@ mod tests {
         b.limbs[b.limbs.len() - 1] = Limb(Word::MAX);
         let q = a.wrapping_div(&b);
         assert_eq!(q, Uint::ZERO);
-        a.limbs[a.limbs.len() - 1] = Limb(1 << (HI_BIT - 7));
-        b.limbs[b.limbs.len() - 1] = Limb(0x82 << (HI_BIT - 7));
+        a.limbs[a.limbs.len() - 1] = Limb(1 << (Limb::HI_BIT - 7));
+        b.limbs[b.limbs.len() - 1] = Limb(0x82 << (Limb::HI_BIT - 7));
         let q = a.wrapping_div(&b);
         assert_eq!(q, Uint::ZERO);
     }
@@ -795,8 +795,8 @@ mod tests {
         b.limbs[b.limbs.len() - 1] = Limb(Word::MAX);
         let r = a.wrapping_rem(&b);
         assert_eq!(r, Uint::ZERO);
-        a.limbs[a.limbs.len() - 1] = Limb(1 << (HI_BIT - 7));
-        b.limbs[b.limbs.len() - 1] = Limb(0x82 << (HI_BIT - 7));
+        a.limbs[a.limbs.len() - 1] = Limb(1 << (Limb::HI_BIT - 7));
+        b.limbs[b.limbs.len() - 1] = Limb(0x82 << (Limb::HI_BIT - 7));
         let r = a.wrapping_rem(&b);
         assert_eq!(r, a);
     }

--- a/src/uint/inv_mod.rs
+++ b/src/uint/inv_mod.rs
@@ -23,7 +23,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             let x_i = b.limbs[0].0 & 1;
             let x_i_choice = CtChoice::from_word_lsb(x_i);
             // b_{i+1} = (b_i - a * X_i) / 2
-            b = Self::ct_select(&b, &b.wrapping_sub(self), x_i_choice).shr_vartime(1);
+            b = Self::ct_select(&b, &b.wrapping_sub(self), x_i_choice).shr1();
             // Store the X_i bit in the result (x = x | (1 << X_i))
             x = x.bitor(&Uint::from_word(x_i).shl_vartime(i));
 
@@ -53,7 +53,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             let x_i = b.limbs[0].0 & 1;
             let x_i_choice = CtChoice::from_word_lsb(x_i);
             // b_{i+1} = (b_i - a * X_i) / 2
-            b = Self::ct_select(&b, &b.wrapping_sub(self), x_i_choice).shr_vartime(1);
+            b = Self::ct_select(&b, &b.wrapping_sub(self), x_i_choice).shr1();
 
             // Store the X_i bit in the result (x = x | (1 << X_i))
             // Don't change the result in dummy iterations.
@@ -96,7 +96,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let bit_size = bits + modulus_bits;
 
         let mut m1hp = *modulus;
-        let (m1hp_new, carry) = m1hp.shr1();
+        let (m1hp_new, carry) = m1hp.shr1_with_overflow();
         debug_assert!(carry.is_true_vartime());
         m1hp = m1hp_new.wrapping_add(&Uint::ONE);
 
@@ -118,9 +118,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             let (new_u, cyy) = new_u.conditional_wrapping_add(modulus, cy);
             debug_assert!(cy.is_true_vartime() == cyy.is_true_vartime());
 
-            let (new_a, overflow) = a.shr1();
+            let (new_a, overflow) = a.shr1_with_overflow();
             debug_assert!(!overflow.is_true_vartime());
-            let (new_u, cy) = new_u.shr1();
+            let (new_u, cy) = new_u.shr1_with_overflow();
             let (new_u, cy) = new_u.conditional_wrapping_add(&m1hp, cy);
             debug_assert!(!cy.is_true_vartime());
 

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -90,6 +90,12 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         (Uint::<LIMBS>::new(limbs), Limb(carry))
     }
+
+    /// Computes `self >> 1` in constant-time.
+    pub(crate) const fn shl1(&self) -> Self {
+        // TODO(tarcieri): optimized implementation
+        self.shl_vartime(1)
+    }
 }
 
 impl<const LIMBS: usize> Shl<u32> for Uint<LIMBS> {

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -32,7 +32,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             // A protection in case `self == 0`, which will make `x == 0`
             let q = Self::ct_select(&Self::ZERO, &q, is_some);
 
-            x = x.wrapping_add(&q).shr_vartime(1);
+            x = x.wrapping_add(&q).shr1();
             i += 1;
         }
 
@@ -56,7 +56,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             // Calculate `x_{i+1} = floor((x_i + self / x_i) / 2)`
             let q = self.wrapping_div_vartime(&x);
             let t = x.wrapping_add(&q);
-            let next_x = t.shr_vartime(1);
+            let next_x = t.shr1();
 
             // If `next_x` is the same as `x` or greater, we reached convergence
             // (`x` is guaranteed to either go down or oscillate between


### PR DESCRIPTION
- Add `shl1` and `shr1` methods
- Change function for returning overflow bit to `shr1_with_overflow`
- Move `HI_BIT` to an inherent constant of `Limb`