### PR TITLE
`BoxedUint`: bit shift improvements

### DIFF
--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -34,7 +34,7 @@ impl BoxedUint {
                 break rem;
             }
             bd -= 1;
-            c = c.shr_vartime(1);
+            c.shr1_assign();
         }
     }
 
@@ -73,7 +73,7 @@ impl BoxedUint {
                 break;
             }
             bd -= 1;
-            c = c.shr(1);
+            c.shr1_assign();
             quotient = quotient.shl(1);
         }
 

--- a/src/uint/boxed/inv_mod.rs
+++ b/src/uint/boxed/inv_mod.rs
@@ -56,7 +56,7 @@ impl BoxedUint {
             let x_i = b.limbs[0].0 & 1;
             let x_i_choice = Choice::from(x_i as u8);
             // b_{i+1} = (b_i - a * X_i) / 2
-            b = Self::conditional_select(&b, &b.wrapping_sub(self), x_i_choice).shr_vartime(1);
+            b = Self::conditional_select(&b, &b.wrapping_sub(self), x_i_choice).shr1();
 
             // Store the X_i bit in the result (x = x | (1 << X_i))
             // Don't change the result in dummy iterations.
@@ -101,7 +101,7 @@ impl BoxedUint {
         let bit_size = bits + modulus_bits;
 
         let mut m1hp = modulus.clone();
-        let (m1hp_new, carry) = m1hp.shr1();
+        let (m1hp_new, carry) = m1hp.shr1_with_overflow();
         debug_assert!(bool::from(carry));
         m1hp = m1hp_new.wrapping_add(&Self::one_with_precision(bits_precision));
 
@@ -124,9 +124,9 @@ impl BoxedUint {
             let (new_u, cyy) = new_u.conditional_wrapping_add(modulus, cy);
             debug_assert!(bool::from(cy.ct_eq(&cyy)));
 
-            let (new_a, overflow) = a.shr1();
+            let (new_a, overflow) = a.shr1_with_overflow();
             debug_assert!(!bool::from(overflow));
-            let (new_u, cy) = new_u.shr1();
+            let (new_u, cy) = new_u.shr1_with_overflow();
             let (new_u, cy) = new_u.conditional_wrapping_add(&m1hp, cy);
             debug_assert!(!bool::from(cy));
 


### PR DESCRIPTION
Analogous changes to #388 for `BoxedUint`, which eliminates some allocations by using in-place operations instead.