### PR TITLE
BoxedResidue: (almost) in-place Montgomery reductions

### DIFF
--- a/benches/boxed_residue.rs
+++ b/benches/boxed_residue.rs
@@ -18,10 +18,8 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("multiplication, BoxedUint*BoxedUint", |b| {
         b.iter_batched(
             || {
-                let x =
-                    BoxedResidue::new(&BoxedUint::random(&mut OsRng, UINT_BITS), params.clone());
-                let y =
-                    BoxedResidue::new(&BoxedUint::random(&mut OsRng, UINT_BITS), params.clone());
+                let x = BoxedResidue::new(BoxedUint::random(&mut OsRng, UINT_BITS), params.clone());
+                let y = BoxedResidue::new(BoxedUint::random(&mut OsRng, UINT_BITS), params.clone());
                 (x, y)
             },
             |(x, y)| x * y,
@@ -35,7 +33,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 let x = BoxedUint::random(&mut OsRng, UINT_BITS);
-                let x_m = BoxedResidue::new(&x, params.clone());
+                let x_m = BoxedResidue::new(x, params.clone());
                 let p = BoxedUint::random(&mut OsRng, UINT_BITS)
                     | (BoxedUint::one_with_precision(UINT_BITS) << (UINT_BITS - 1));
                 (x_m, p)
@@ -62,7 +60,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
     group.bench_function("BoxedResidue creation", |b| {
         b.iter_batched(
             || BoxedUint::random(&mut OsRng, UINT_BITS),
-            |x| BoxedResidue::new(&x, params.clone()),
+            |x| BoxedResidue::new(x, params.clone()),
             BatchSize::SmallInput,
         )
     });
@@ -73,7 +71,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
     .unwrap();
     group.bench_function("BoxedResidue retrieve", |b| {
         b.iter_batched(
-            || BoxedResidue::new(&BoxedUint::random(&mut OsRng, UINT_BITS), params.clone()),
+            || BoxedResidue::new(BoxedUint::random(&mut OsRng, UINT_BITS), params.clone()),
             |x| x.retrieve(),
             BatchSize::SmallInput,
         )

--- a/src/modular/boxed_residue/add.rs
+++ b/src/modular/boxed_residue/add.rs
@@ -86,14 +86,14 @@ mod tests {
             256,
         )
         .unwrap();
-        let mut x_mod = BoxedResidue::new(&x, params.clone());
+        let mut x_mod = BoxedResidue::new(x, params.clone());
 
         let y = BoxedUint::from_be_slice(
             &hex!("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251"),
             256,
         )
         .unwrap();
-        let y_mod = BoxedResidue::new(&y, params.clone());
+        let y_mod = BoxedResidue::new(y, params.clone());
 
         x_mod += &y_mod;
 

--- a/src/modular/boxed_residue/inv.rs
+++ b/src/modular/boxed_residue/inv.rs
@@ -1,25 +1,28 @@
 //! Multiplicative inverses of boxed residue.
 
 use super::BoxedResidue;
-use crate::{modular::reduction::montgomery_reduction_boxed, traits::Invert};
+use crate::{modular::reduction::montgomery_reduction_boxed_mut, traits::Invert};
 use subtle::CtOption;
 
 impl BoxedResidue {
     /// Computes the residue `self^-1` representing the multiplicative inverse of `self`.
     /// I.e. `self * self^-1 = 1`.
     pub fn invert(&self) -> CtOption<Self> {
-        let (inverse, is_some) = self
+        let (mut inverse, is_some) = self
             .montgomery_form
             .inv_odd_mod(&self.residue_params.modulus);
 
-        let montgomery_form = montgomery_reduction_boxed(
-            &mut inverse.mul(&self.residue_params.r3),
+        let mut product = inverse.mul(&self.residue_params.r3);
+
+        montgomery_reduction_boxed_mut(
+            &mut product,
             &self.residue_params.modulus,
             self.residue_params.mod_neg_inv,
+            &mut inverse,
         );
 
         let value = Self {
-            montgomery_form,
+            montgomery_form: inverse,
             residue_params: self.residue_params.clone(),
         };
 

--- a/src/modular/boxed_residue/sub.rs
+++ b/src/modular/boxed_residue/sub.rs
@@ -87,14 +87,14 @@ mod tests {
             256,
         )
         .unwrap();
-        let mut x_mod = BoxedResidue::new(&x, params.clone());
+        let mut x_mod = BoxedResidue::new(x, params.clone());
 
         let y = BoxedUint::from_be_slice(
             &hex!("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251"),
             256,
         )
         .unwrap();
-        let y_mod = BoxedResidue::new(&y, params);
+        let y_mod = BoxedResidue::new(y, params);
 
         x_mod -= &y_mod;
 

--- a/src/uint/boxed/add.rs
+++ b/src/uint/boxed/add.rs
@@ -12,6 +12,22 @@ impl BoxedUint {
         Self::fold_limbs(self, rhs, carry, |a, b, c| a.adc(b, c))
     }
 
+    /// Computes `a + b + carry` in-place, returning the new carry.
+    ///
+    /// Panics if `rhs` has a larger precision than `self`.
+    #[inline(always)]
+    pub fn adc_assign(&mut self, rhs: &Self, mut carry: Limb) -> Limb {
+        debug_assert!(self.bits_precision() <= rhs.bits_precision());
+
+        for i in 0..self.nlimbs() {
+            let (limb, b) = self.limbs[i].adc(*rhs.limbs.get(i).unwrap_or(&Limb::ZERO), carry);
+            self.limbs[i] = limb;
+            carry = b;
+        }
+
+        carry
+    }
+
     /// Perform wrapping addition, discarding overflow.
     pub fn wrapping_add(&self, rhs: &Self) -> Self {
         self.adc(rhs, Limb::ZERO).0

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -19,8 +19,8 @@ impl BoxedUint {
         // It's worth potentially exploring other approaches to improve efficiency.
         match Option::<BoxedResidueParams>::from(BoxedResidueParams::new(p.clone())) {
             Some(params) => {
-                let lhs = BoxedResidue::new(self, params.clone());
-                let rhs = BoxedResidue::new(rhs, params);
+                let lhs = BoxedResidue::new(self.clone(), params.clone());
+                let rhs = BoxedResidue::new(rhs.clone(), params);
                 let ret = lhs * rhs;
                 ret.retrieve()
             }

--- a/src/uint/boxed/sub_mod.rs
+++ b/src/uint/boxed/sub_mod.rs
@@ -32,26 +32,6 @@ impl BoxedUint {
         let l = borrow.0 & c.0;
         out.wrapping_sub(&Self::from(l))
     }
-
-    /// Returns `(self..., carry) - (rhs...) mod (p...)`, where `carry <= 1`.
-    /// Assumes `-(p...) <= (self..., carry) - (rhs...) < (p...)`.
-    #[inline(always)]
-    pub(crate) fn sub_mod_with_carry(&self, carry: Limb, rhs: &Self, p: &Self) -> Self {
-        debug_assert_eq!(self.bits_precision(), p.bits_precision());
-        debug_assert_eq!(rhs.bits_precision(), p.bits_precision());
-        debug_assert!(carry.0 <= 1);
-
-        let (out, borrow) = self.sbb(rhs, Limb::ZERO);
-
-        // The new `borrow = Word::MAX` iff `carry == 0` and `borrow == Word::MAX`.
-        let borrow = (!carry.0.wrapping_neg()) & borrow.0;
-
-        // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
-        // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the modulus.
-        let mask = Self::from_words(vec![borrow; p.nlimbs()]);
-
-        out.wrapping_add(&p.bitand(&mask))
-    }
 }
 
 impl SubMod for BoxedUint {

--- a/tests/boxed_residue_proptests.rs
+++ b/tests/boxed_residue_proptests.rs
@@ -29,7 +29,7 @@ fn reduce(n: &BoxedUint, p: BoxedResidueParams) -> BoxedResidue {
     };
 
     let n_reduced = n.rem_vartime(&modulus).widen(p.bits_precision());
-    BoxedResidue::new(&n_reduced, p)
+    BoxedResidue::new(n_reduced, p)
 }
 
 prop_compose! {


### PR DESCRIPTION
Eliminates several allocations by performing most operations of a Montgomery reduction in-place.

Only conditionally adding the modulus presently incurs an allocation.

### Benchmarks

```
Montgomery arithmetic/BoxedResidue creation
                        time:   [135.30 ns 135.50 ns 135.76 ns]
                        change: [-36.403% -36.104% -35.794%] (p = 0.00 < 0.05)
                        Performance has improved.

Montgomery arithmetic/BoxedResidue retrieve
                        time:   [203.59 ns 204.01 ns 204.45 ns]
                        change: [-17.533% -16.947% -16.403%] (p = 0.00 < 0.05)
                        Performance has improved.

Montgomery arithmetic/multiplication, BoxedUint*BoxedUint
                        time:   [223.19 ns 223.76 ns 224.40 ns]
                        change: [-19.576% -19.107% -18.645%] (p = 0.00 < 0.05)
                        Performance has improved.

Montgomery arithmetic/modpow, BoxedUint^BoxedUint
                        time:   [58.927 µs 59.009 µs 59.103 µs]
                        change: [-18.486% -18.227% -17.952%] (p = 0.00 < 0.05)
                        Performance has improved.
```