### PR TITLE
BoxedUint: implement in-place conditional addition/subtraction

### DIFF
--- a/src/modular/reduction.rs
+++ b/src/modular/reduction.rs
@@ -1,7 +1,9 @@
+//! Modular reduction implementation.
+
 use crate::{Limb, Uint, WideWord, Word};
 
 #[cfg(feature = "alloc")]
-use crate::BoxedUint;
+use {crate::BoxedUint, subtle::Choice};
 
 /// Returns `(hi, lo)` such that `hi * R + lo = x * y + z + w`.
 #[inline(always)]
@@ -94,8 +96,7 @@ pub(crate) fn montgomery_reduction_boxed_mut(
 
     // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
     // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the modulus.
-    // TODO(tarcieri): eliminate bitand_limb allocation (with conditional adc_assign?)
-    out.adc_assign(&modulus.bitand_limb(borrow), Limb::ZERO);
+    out.conditional_adc_assign(modulus, Choice::from((borrow.0 & 1) as u8));
 }
 
 /// Algorithm 14.32 in Handbook of Applied Cryptography <https://cacr.uwaterloo.ca/hac/about/chap14.pdf>

--- a/src/uint/boxed/inv_mod.rs
+++ b/src/uint/boxed/inv_mod.rs
@@ -111,23 +111,23 @@ impl BoxedUint {
             let self_odd = a.is_odd();
 
             // Set `self -= b` if `self` is odd.
-            let (new_a, swap) = a.conditional_wrapping_sub(&b, self_odd);
+            let swap = a.conditional_sbb_assign(&b, self_odd);
             // Set `b += self` if `swap` is true.
-            b = Self::conditional_select(&b, &b.wrapping_add(&new_a), swap);
+            b = Self::conditional_select(&b, &b.wrapping_add(&a), swap);
             // Negate `self` if `swap` is true.
-            a = new_a.conditional_wrapping_neg(swap);
+            a = a.conditional_wrapping_neg(swap);
 
             let mut new_u = u.clone();
             let mut new_v = v.clone();
             Self::conditional_swap(&mut new_u, &mut new_v, swap);
-            let (new_u, cy) = new_u.conditional_wrapping_sub(&new_v, self_odd);
-            let (new_u, cyy) = new_u.conditional_wrapping_add(modulus, cy);
+            let cy = new_u.conditional_sbb_assign(&new_v, self_odd);
+            let cyy = new_u.conditional_adc_assign(modulus, cy);
             debug_assert!(bool::from(cy.ct_eq(&cyy)));
 
             let (new_a, overflow) = a.shr1_with_overflow();
             debug_assert!(!bool::from(overflow));
-            let (new_u, cy) = new_u.shr1_with_overflow();
-            let (new_u, cy) = new_u.conditional_wrapping_add(&m1hp, cy);
+            let (mut new_u, cy) = new_u.shr1_with_overflow();
+            let cy = new_u.conditional_adc_assign(&m1hp, cy);
             debug_assert!(!bool::from(cy));
 
             a = new_a;


### PR DESCRIPTION
Adds internal `conditional_adc_assign` and `conditional_sbb_assign` methods on `BoxedUint` which conditionally perform in-place addition/subtraction with carry.

This eliminates the last allocations in Montgomery reduction as well as a number of them in modular inversions.

### Benchmarks

```
Montgomery arithmetic/BoxedResidueParams creation
                        time:   [17.432 µs 17.453 µs 17.475 µs]
                        change: [-5.8279% -5.5913% -5.3509%] (p = 0.00 < 0.05)
                        Performance has improved.

Montgomery arithmetic/BoxedResidue creation
                        time:   [113.13 ns 113.75 ns 114.46 ns]
                        change: [-16.909% -16.489% -16.042%] (p = 0.00 < 0.05)
                        Performance has improved.

Montgomery arithmetic/BoxedResidue retrieve
                        time:   [167.52 ns 168.03 ns 168.56 ns]
                        change: [-18.571% -17.870% -17.225%] (p = 0.00 < 0.05)
                        Performance has improved.

Montgomery arithmetic/multiplication, BoxedUint*BoxedUint
                        time:   [185.41 ns 186.34 ns 187.23 ns]
                        change: [-18.862% -18.195% -17.606%] (p = 0.00 < 0.05)
                        Performance has improved.

Montgomery arithmetic/modpow, BoxedUint^BoxedUint
                        time:   [48.787 µs 48.858 µs 48.937 µs]
                        change: [-17.467% -17.232% -16.971%] (p = 0.00 < 0.05)
                        Performance has improved.
```