### PR TITLE
BoxedResidue: use conditional assignment in `pow`

### DIFF
--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -210,7 +210,11 @@ impl BoxedUint {
     /// This function should execute in constant time.
     #[inline]
     pub fn conditional_assign(&mut self, other: &Self, choice: Choice) {
-        *self = Self::conditional_select(self, other, choice);
+        debug_assert_eq!(self.bits_precision(), other.bits_precision());
+
+        for i in 0..self.nlimbs() {
+            self.limbs[i] = Limb::conditional_select(&self.limbs[i], &other.limbs[i], choice);
+        }
     }
 
     /// Conditionally swap `self` and `other` if `choice == 1`; otherwise,


### PR DESCRIPTION
Changes `BoxedUint::conditional_assign` to actually be an in-place operation rather than allocating, and uses it to impl `BoxedResidue::pow`.

This leads to a fairly significant performance increase.

### Benchmarks

```
Montgomery arithmetic/modpow, BoxedUint^BoxedUint
                        time:   [27.769 µs 27.798 µs 27.830 µs]
                        change: [-39.063% -38.898% -38.724%] (p = 0.00 < 0.05)
                        Performance has improved.
```