### PR TITLE
Bring the overflow behavior in bit shifts in sync with `std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,11 @@ harness = false
 required-features = ["alloc"]
 
 [[bench]]
+name = "boxed_uint"
+harness = false
+required-features = ["alloc"]
+
+[[bench]]
 name = "dyn_residue"
 harness = false
 

--- a/benches/boxed_uint.rs
+++ b/benches/boxed_uint.rs
@@ -1,0 +1,48 @@
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use crypto_bigint::BoxedUint;
+use rand_core::OsRng;
+
+/// Size of `BoxedUint` to use in benchmark.
+const UINT_BITS: u32 = 4096;
+
+fn bench_shifts(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bit shifts");
+
+    group.bench_function("shl_vartime", |b| {
+        b.iter_batched(
+            || BoxedUint::random(&mut OsRng, UINT_BITS),
+            |x| black_box(x.shl_vartime(UINT_BITS / 2 + 10)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("shl", |b| {
+        b.iter_batched(
+            || BoxedUint::random(&mut OsRng, UINT_BITS),
+            |x| x.shl(UINT_BITS / 2 + 10),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("shr_vartime", |b| {
+        b.iter_batched(
+            || BoxedUint::random(&mut OsRng, UINT_BITS),
+            |x| black_box(x.shr_vartime(UINT_BITS / 2 + 10)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("shr", |b| {
+        b.iter_batched(
+            || BoxedUint::random(&mut OsRng, UINT_BITS),
+            |x| x.shr(UINT_BITS / 2 + 10),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_shifts);
+
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //!     U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
 //!
 //! // Compute `MODULUS` shifted right by 1 at compile time
-//! pub const MODULUS_SHR1: U256 = MODULUS.shr(1);
+//! pub const MODULUS_SHR1: U256 = MODULUS.shr(1).0;
 //! ```
 //!
 //! Note that large constant computations may accidentally trigger a the `const_eval_limit` of the compiler.

--- a/src/limb/bit_not.rs
+++ b/src/limb/bit_not.rs
@@ -5,6 +5,7 @@ use core::ops::Not;
 
 impl Limb {
     /// Calculates `!a`.
+    #[inline(always)]
     pub const fn not(self) -> Self {
         Limb(!self.0)
     }

--- a/src/limb/bit_or.rs
+++ b/src/limb/bit_or.rs
@@ -5,6 +5,7 @@ use core::ops::{BitOr, BitOrAssign};
 
 impl Limb {
     /// Calculates `a | b`.
+    #[inline(always)]
     pub const fn bitor(self, rhs: Self) -> Self {
         Limb(self.0 | rhs.0)
     }

--- a/src/limb/bit_xor.rs
+++ b/src/limb/bit_xor.rs
@@ -5,6 +5,7 @@ use core::ops::BitXor;
 
 impl Limb {
     /// Calculates `a ^ b`.
+    #[inline(always)]
     pub const fn bitxor(self, rhs: Self) -> Self {
         Limb(self.0 ^ rhs.0)
     }

--- a/src/limb/bits.rs
+++ b/src/limb/bits.rs
@@ -2,21 +2,25 @@ use super::Limb;
 
 impl Limb {
     /// Calculate the number of bits needed to represent this number.
+    #[inline(always)]
     pub const fn bits(self) -> u32 {
         Limb::BITS - self.0.leading_zeros()
     }
 
     /// Calculate the number of leading zeros in the binary representation of this number.
+    #[inline(always)]
     pub const fn leading_zeros(self) -> u32 {
         self.0.leading_zeros()
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number.
+    #[inline(always)]
     pub const fn trailing_zeros(self) -> u32 {
         self.0.trailing_zeros()
     }
 
     /// Calculate the number of trailing ones the binary representation of this number.
+    #[inline(always)]
     pub const fn trailing_ones(self) -> u32 {
         self.0.trailing_ones()
     }

--- a/src/limb/mul.rs
+++ b/src/limb/mul.rs
@@ -17,7 +17,7 @@ impl Limb {
     }
 
     /// Perform saturating multiplication.
-    #[inline]
+    #[inline(always)]
     pub const fn saturating_mul(&self, rhs: Self) -> Self {
         Limb(self.0.saturating_mul(rhs.0))
     }

--- a/src/limb/shl.rs
+++ b/src/limb/shl.rs
@@ -10,6 +10,12 @@ impl Limb {
     pub const fn shl(self, shift: u32) -> Self {
         Limb(self.0 << shift)
     }
+
+    /// Computes `self << 1` and return the result and the carry (0 or 1).
+    #[inline(always)]
+    pub(crate) const fn shl1(self) -> (Self, Self) {
+        (Self(self.0 << 1), Self(self.0 >> Self::HI_BIT))
+    }
 }
 
 impl Shl<u32> for Limb {

--- a/src/limb/shr.rs
+++ b/src/limb/shr.rs
@@ -10,6 +10,12 @@ impl Limb {
     pub const fn shr(self, shift: u32) -> Self {
         Limb(self.0 >> shift)
     }
+
+    /// Computes `self >> 1` and return the result and the carry (0 or `1 << HI_BIT`).
+    #[inline(always)]
+    pub(crate) const fn shr1(self) -> (Self, Self) {
+        (Self(self.0 >> 1), Self(self.0 << Self::HI_BIT))
+    }
 }
 
 impl Shr<u32> for Limb {

--- a/src/modular/div_by_2.rs
+++ b/src/modular/div_by_2.rs
@@ -18,7 +18,7 @@ pub(crate) fn div_by_2<const LIMBS: usize>(a: &Uint<LIMBS>, modulus: &Uint<LIMBS
     // ("+1" because both `a` and `modulus` are odd, we lose 0.5 in each integer division).
     // This will not overflow, so we can just use wrapping operations.
 
-    let (half, is_odd) = a.shr1_with_overflow();
+    let (half, is_odd) = a.shr1_with_carry();
     let half_modulus = modulus.shr1();
 
     let if_even = half;

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -27,7 +27,7 @@ mod rand;
 use crate::{Integer, Limb, NonZero, Uint, Word, Zero, U128, U64};
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::{fmt, mem};
-use subtle::{Choice, ConstantTimeEq};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -257,6 +257,15 @@ impl BoxedUint {
     /// Set the value of `self` to zero in-place.
     pub(crate) fn set_to_zero(&mut self) {
         self.limbs.as_mut().fill(Limb::ZERO)
+    }
+
+    /// Set the value of `self` to zero in-place if `choice` is truthy.
+    pub(crate) fn conditional_set_to_zero(&mut self, choice: Choice) {
+        let nlimbs = self.nlimbs();
+        let limbs = self.limbs.as_mut();
+        for i in 0..nlimbs {
+            limbs[i] = Limb::conditional_select(&limbs[i], &Limb::ZERO, choice);
+        }
     }
 }
 

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -253,6 +253,11 @@ impl BoxedUint {
 
         limbs.into()
     }
+
+    /// Set the value of `self` to zero in-place.
+    pub(crate) fn set_to_zero(&mut self) {
+        self.limbs.as_mut().fill(Limb::ZERO)
+    }
 }
 
 impl NonZero<BoxedUint> {

--- a/src/uint/boxed/bits.rs
+++ b/src/uint/boxed/bits.rs
@@ -84,7 +84,7 @@ mod tests {
     fn uint_with_bits_at(positions: &[u32]) -> BoxedUint {
         let mut result = BoxedUint::zero_with_precision(256);
         for &pos in positions {
-            result |= BoxedUint::one_with_precision(256).shl_vartime(pos);
+            result |= BoxedUint::one_with_precision(256).shl_vartime(pos).unwrap();
         }
         result
     }

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -37,7 +37,8 @@ impl BoxedUint {
         let mb = rhs.bits();
         let mut bd = self.bits_precision() - mb;
         let mut rem = self.clone();
-        let mut c = rhs.shl_vartime(bd);
+        // Will not overflow since `bd < bits_precision`
+        let mut c = rhs.shl_vartime(bd).expect("shift within range");
 
         loop {
             let (r, borrow) = rem.sbb(&c, Limb::ZERO);
@@ -77,7 +78,7 @@ impl BoxedUint {
         let bits_precision = self.bits_precision();
         let mut rem = self.clone();
         let mut quo = Self::zero_with_precision(bits_precision);
-        let mut c = rhs.shl(bits_precision - mb);
+        let (mut c, _overflow) = rhs.shl(bits_precision - mb);
         let mut i = bits_precision;
         let mut done = Choice::from(0u8);
 
@@ -110,7 +111,8 @@ impl BoxedUint {
         let mut bd = self.bits_precision() - mb;
         let mut remainder = self.clone();
         let mut quotient = Self::zero_with_precision(self.bits_precision());
-        let mut c = rhs.shl_vartime(bd);
+        // Will not overflow since `bd < bits_precision`
+        let mut c = rhs.shl_vartime(bd).expect("shift within range");
 
         loop {
             let (mut r, borrow) = remainder.sbb(&c, Limb::ZERO);

--- a/src/uint/boxed/inv_mod.rs
+++ b/src/uint/boxed/inv_mod.rs
@@ -11,7 +11,7 @@ impl BoxedUint {
 
         // Decompose `modulus = s * 2^k` where `s` is odd
         let k = modulus.trailing_zeros();
-        let s = modulus.shr(k);
+        let s = modulus >> k;
 
         // Decompose `self` into RNS with moduli `2^k` and `s` and calculate the inverses.
         // Using the fact that `(z^{-1} mod (m1 * m2)) mod m1 == z^{-1} mod m1`
@@ -26,7 +26,7 @@ impl BoxedUint {
         let (m_odd_inv, _is_some) = s.inv_mod2k(k); // `s` is odd, so this always exists
 
         // This part is mod 2^k
-        let mask = Self::one().shl(k).wrapping_sub(&Self::one());
+        let mask = (Self::one() << k).wrapping_sub(&Self::one());
         let t = (b.wrapping_sub(&a).wrapping_mul(&m_odd_inv)).bitand(&mask);
 
         // Will not overflow since `a <= s - 1`, `t <= 2^k - 1`,

--- a/src/uint/boxed/inv_mod.rs
+++ b/src/uint/boxed/inv_mod.rs
@@ -126,9 +126,9 @@ impl BoxedUint {
             let cyy = new_u.conditional_adc_assign(modulus, cy);
             debug_assert!(bool::from(cy.ct_eq(&cyy)));
 
-            let (new_a, overflow) = a.shr1_with_overflow();
-            debug_assert!(bool::from(!modulus_is_odd | !overflow));
-            let (mut new_u, cy) = new_u.shr1_with_overflow();
+            let (new_a, carry) = a.shr1_with_carry();
+            debug_assert!(bool::from(!modulus_is_odd | !carry));
+            let (mut new_u, cy) = new_u.shr1_with_carry();
             let cy = new_u.conditional_adc_assign(&m1hp, cy);
             debug_assert!(bool::from(!modulus_is_odd | !cy));
 

--- a/src/uint/boxed/shl.rs
+++ b/src/uint/boxed/shl.rs
@@ -6,7 +6,7 @@ use subtle::{Choice, ConstantTimeLess};
 
 impl BoxedUint {
     /// Computes `self << shift`.
-    /// Returns `None` if `shift >= Self::BITS`.
+    /// Returns `None` if `shift >= self.bits_precision()`.
     pub fn shl(&self, shift: u32) -> (Self, Choice) {
         // `floor(log2(bits_precision - 1))` is the number of bits in the representation of `shift`
         // (which lies in range `0 <= shift < bits_precision`).
@@ -37,7 +37,7 @@ impl BoxedUint {
     }
 
     /// Computes `self << shift` and writes the result into `dest`.
-    /// Returns `None` if `shift >= Self::BITS`.
+    /// Returns `None` if `shift >= self.bits_precision()`.
     ///
     /// WARNING: for performance reasons, `dest` is assumed to be pre-zeroized.
     ///
@@ -75,7 +75,7 @@ impl BoxedUint {
     }
 
     /// Computes `self << shift`.
-    /// Returns `None` if `shift >= Self::BITS`.
+    /// Returns `None` if `shift >= self.bits_precision()`.
     ///
     /// NOTE: this operation is variable time with respect to `shift` *ONLY*.
     ///
@@ -87,14 +87,14 @@ impl BoxedUint {
         success.map(|_| result)
     }
 
-    /// Computes `self >> 1` in constant-time.
+    /// Computes `self << 1` in constant-time.
     pub(crate) fn shl1(&self) -> Self {
         let mut ret = self.clone();
         ret.shl1_assign();
         ret
     }
 
-    /// Computes `self >> 1` in-place in constant-time.
+    /// Computes `self << 1` in-place in constant-time.
     pub(crate) fn shl1_assign(&mut self) {
         let mut carry = self.limbs[0].0 >> Limb::HI_BIT;
         self.limbs[0].shl_assign(1);

--- a/src/uint/boxed/shl.rs
+++ b/src/uint/boxed/shl.rs
@@ -6,7 +6,9 @@ use subtle::{Choice, ConstantTimeLess};
 
 impl BoxedUint {
     /// Computes `self << shift`.
-    /// Returns `None` if `shift >= self.bits_precision()`.
+    ///
+    /// Returns a zero and a falsy `Choice` if `shift >= self.bits_precision()`,
+    /// or the result and a truthy `Choice` otherwise.
     pub fn shl(&self, shift: u32) -> (Self, Choice) {
         // `floor(log2(bits_precision - 1))` is the number of bits in the representation of `shift`
         // (which lies in range `0 <= shift < bits_precision`).

--- a/src/uint/boxed/shl.rs
+++ b/src/uint/boxed/shl.rs
@@ -26,14 +26,9 @@ impl BoxedUint {
             result.conditional_assign(&temp, bit);
         }
 
-        (
-            Self::conditional_select(
-                &result,
-                &Self::zero_with_precision(self.bits_precision()),
-                overflow,
-            ),
-            overflow,
-        )
+        result.conditional_set_to_zero(overflow);
+
+        (result, overflow)
     }
 
     /// Computes `self << shift` and writes the result into `dest`.

--- a/src/uint/boxed/shl.rs
+++ b/src/uint/boxed/shl.rs
@@ -7,8 +7,8 @@ use subtle::{Choice, ConstantTimeLess};
 impl BoxedUint {
     /// Computes `self << shift`.
     ///
-    /// Returns a zero and a falsy `Choice` if `shift >= self.bits_precision()`,
-    /// or the result and a truthy `Choice` otherwise.
+    /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
+    /// or the result and a falsy `Choice` otherwise.
     pub fn shl(&self, shift: u32) -> (Self, Choice) {
         // `floor(log2(bits_precision - 1))` is the number of bits in the representation of `shift`
         // (which lies in range `0 <= shift < bits_precision`).

--- a/src/uint/boxed/shr.rs
+++ b/src/uint/boxed/shr.rs
@@ -26,14 +26,9 @@ impl BoxedUint {
             result.conditional_assign(&temp, bit);
         }
 
-        (
-            Self::conditional_select(
-                &result,
-                &Self::zero_with_precision(self.bits_precision()),
-                overflow,
-            ),
-            overflow,
-        )
+        result.conditional_set_to_zero(overflow);
+
+        (result, overflow)
     }
 
     /// Computes `self >> shift`.

--- a/src/uint/boxed/shr.rs
+++ b/src/uint/boxed/shr.rs
@@ -7,8 +7,8 @@ use subtle::{Choice, ConstantTimeLess};
 impl BoxedUint {
     /// Computes `self >> shift`.
     ///
-    /// Returns a zero and a falsy `Choice` if `shift >= self.bits_precision()`,
-    /// or the result and a truthy `Choice` otherwise.
+    /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
+    /// or the result and a falsy `Choice` otherwise.
     pub fn shr(&self, shift: u32) -> (Self, Choice) {
         // `floor(log2(bits_precision - 1))` is the number of bits in the representation of `shift`
         // (which lies in range `0 <= shift < bits_precision`).

--- a/src/uint/boxed/shr.rs
+++ b/src/uint/boxed/shr.rs
@@ -6,7 +6,7 @@ use subtle::{Choice, ConstantTimeLess};
 
 impl BoxedUint {
     /// Computes `self >> shift`.
-    /// Returns `None` if `shift >= Self::BITS`.
+    /// Returns `None` if `shift >= self.bits_precision()`.
     pub fn shr(&self, shift: u32) -> (Self, Choice) {
         // `floor(log2(bits_precision - 1))` is the number of bits in the representation of `shift`
         // (which lies in range `0 <= shift < bits_precision`).
@@ -37,7 +37,7 @@ impl BoxedUint {
     }
 
     /// Computes `self >> shift`.
-    /// Returns `None` if `shift >= Self::BITS`.
+    /// Returns `None` if `shift >= self.bits_precision()`.
     ///
     /// WARNING: for performance reasons, `dest` is assumed to be pre-zeroized.
     ///
@@ -73,7 +73,7 @@ impl BoxedUint {
     }
 
     /// Computes `self >> shift`.
-    /// Returns `None` if `shift >= Self::BITS`.
+    /// Returns `None` if `shift >= self.bits_precision()`.
     ///
     /// NOTE: this operation is variable time with respect to `shift` *ONLY*.
     ///

--- a/src/uint/boxed/shr.rs
+++ b/src/uint/boxed/shr.rs
@@ -6,7 +6,9 @@ use subtle::{Choice, ConstantTimeLess};
 
 impl BoxedUint {
     /// Computes `self >> shift`.
-    /// Returns `None` if `shift >= self.bits_precision()`.
+    ///
+    /// Returns a zero and a falsy `Choice` if `shift >= self.bits_precision()`,
+    /// or the result and a truthy `Choice` otherwise.
     pub fn shr(&self, shift: u32) -> (Self, Choice) {
         // `floor(log2(bits_precision - 1))` is the number of bits in the representation of `shift`
         // (which lies in range `0 <= shift < bits_precision`).

--- a/src/uint/boxed/shr.rs
+++ b/src/uint/boxed/shr.rs
@@ -85,9 +85,9 @@ impl BoxedUint {
         success.map(|_| result)
     }
 
-    /// Computes `self >> 1` in constant-time, returning a true [`Choice`] if the overflowing bit
-    /// was set, and a false [`Choice::FALSE`] otherwise.
-    pub(crate) fn shr1_with_overflow(&self) -> (Self, Choice) {
+    /// Computes `self >> 1` in constant-time, returning a true [`Choice`]
+    /// if the least significant bit was set, and a false [`Choice::FALSE`] otherwise.
+    pub(crate) fn shr1_with_carry(&self) -> (Self, Choice) {
         let carry = self.limbs[0].0 & 1;
         (self.shr1(), Choice::from(carry as u8))
     }

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -53,7 +53,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mb = rhs.bits();
         let mut rem = *self;
         let mut quo = Self::ZERO;
-        let mut c = rhs.shl(Self::BITS - mb);
+        // If there is overflow, it means `mb == 0`, so `rhs == 0`.
+        let (mut c, overflow) = rhs.shl(Self::BITS - mb);
+        let is_some = overflow.not();
 
         let mut i = Self::BITS;
         let mut done = CtChoice::FALSE;
@@ -73,7 +75,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             quo = Self::ct_select(&quo.shl1(), &quo, done);
         }
 
-        let is_some = Limb(mb as Word).ct_is_nonzero();
         quo = Self::ct_select(&Self::ZERO, &quo, is_some);
         (quo, rem, is_some)
     }
@@ -93,7 +94,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mut bd = Self::BITS - mb;
         let mut rem = *self;
         let mut quo = Self::ZERO;
-        let mut c = rhs.shl_vartime(bd);
+        let (mut c, overflow) = rhs.shl_vartime(bd);
+        let is_some = overflow.not();
 
         loop {
             let (mut r, borrow) = rem.sbb(&c, Limb::ZERO);
@@ -108,7 +110,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             quo = quo.shl1();
         }
 
-        let is_some = CtChoice::from_u32_nonzero(mb);
         quo = Self::ct_select(&Self::ZERO, &quo, is_some);
         (quo, rem, is_some)
     }
@@ -125,7 +126,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mb = rhs.bits_vartime();
         let mut bd = Self::BITS - mb;
         let mut rem = *self;
-        let mut c = rhs.shl_vartime(bd);
+        let (mut c, overflow) = rhs.shl_vartime(bd);
+        let is_some = overflow.not();
 
         loop {
             let (r, borrow) = rem.sbb(&c, Limb::ZERO);
@@ -137,7 +139,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             c = c.shr1();
         }
 
-        let is_some = CtChoice::from_u32_nonzero(mb);
         (rem, is_some)
     }
 
@@ -158,7 +159,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let (mut lower, mut upper) = lower_upper;
 
         // Factor of the modulus, split into two halves
-        let mut c = Self::shl_vartime_wide((*rhs, Uint::ZERO), bd);
+        let (mut c, _overflow) = Self::shl_vartime_wide((*rhs, Uint::ZERO), bd);
 
         loop {
             let (lower_sub, borrow) = lower.sbb(&c.0, Limb::ZERO);
@@ -170,7 +171,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
                 break;
             }
             bd -= 1;
-            c = Self::shr_vartime_wide(c, 1);
+            let (new_c, _overflow) = Self::shr_vartime_wide(c, 1);
+            c = new_c;
         }
 
         let is_some = CtChoice::from_u32_nonzero(mb);
@@ -696,8 +698,8 @@ mod tests {
     fn div() {
         let mut rng = ChaChaRng::from_seed([7u8; 32]);
         for _ in 0..25 {
-            let num = U256::random(&mut rng).shr_vartime(128);
-            let den = U256::random(&mut rng).shr_vartime(128);
+            let (num, _) = U256::random(&mut rng).shr_vartime(128);
+            let (den, _) = U256::random(&mut rng).shr_vartime(128);
             let n = num.checked_mul(&den);
             if n.is_some().into() {
                 let (q, _, is_some) = n.unwrap().const_div_rem(&den);
@@ -808,7 +810,7 @@ mod tests {
         for _ in 0..25 {
             let num = U256::random(&mut rng);
             let k = rng.next_u32() % 256;
-            let den = U256::ONE.shl_vartime(k);
+            let (den, _) = U256::ONE.shl_vartime(k);
 
             let a = num.rem2k(k);
             let e = num.wrapping_rem(&den);

--- a/src/uint/inv_mod.rs
+++ b/src/uint/inv_mod.rs
@@ -128,9 +128,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             let (new_u, cyy) = new_u.conditional_wrapping_add(modulus, cy);
             debug_assert!(cy.is_true_vartime() == cyy.is_true_vartime());
 
-            let (new_a, overflow) = a.shr1_with_overflow();
-            debug_assert!(modulus_is_odd.not().or(overflow.not()).is_true_vartime());
-            let (new_u, cy) = new_u.shr1_with_overflow();
+            let (new_a, carry) = a.shr1_with_carry();
+            debug_assert!(modulus_is_odd.not().or(carry.not()).is_true_vartime());
+            let (new_u, cy) = new_u.shr1_with_carry();
             let (new_u, cy) = new_u.conditional_wrapping_add(&m1hp, cy);
             debug_assert!(modulus_is_odd.not().or(cy.not()).is_true_vartime());
 

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -135,7 +135,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         // Double the current result, this accounts for the other half of the multiplication grid.
         // TODO: The top word is empty so we can also use a special purpose shl.
-        (lo, hi) = Self::shl_vartime_wide((lo, hi), 1);
+        (lo, hi) = Self::shl_vartime_wide((lo, hi), 1).0;
 
         // Handle the diagonal of the multiplication grid, which finishes the multiplication grid.
         let mut carry = Limb::ZERO;

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -118,10 +118,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         (Uint::<LIMBS>::new(limbs), Limb(carry))
     }
 
-    /// Computes `self << 1` in constant-time, returning [`CtChoice::TRUE`] if the overflowing bit
-    /// was set, and [`CtChoice::FALSE`] otherwise.
+    /// Computes `self << 1` in constant-time, returning [`CtChoice::TRUE`]
+    /// if the most significant bit was set, and [`CtChoice::FALSE`] otherwise.
     #[inline(always)]
-    pub(crate) const fn shl1_with_overflow(&self) -> (Self, CtChoice) {
+    pub(crate) const fn shl1_with_carry(&self) -> (Self, CtChoice) {
         let mut ret = Self::ZERO;
         let mut i = 0;
         let mut carry = Limb::ZERO;
@@ -138,7 +138,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self << 1` in constant-time.
     pub(crate) const fn shl1(&self) -> Self {
         // TODO(tarcieri): optimized implementation
-        self.shl1_with_overflow().0
+        self.shl1_with_carry().0
     }
 }
 

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -43,10 +43,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let shift_num = (shift / Limb::BITS) as usize;
         let rem = shift % Limb::BITS;
 
-        let mut i = LIMBS;
-        while i > shift_num {
-            i -= 1;
+        let mut i = shift_num;
+        while i < LIMBS {
             limbs[i] = self.limbs[i - shift_num];
+            i += 1;
         }
 
         if rem == 0 {
@@ -55,6 +55,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         let mut carry = Limb::ZERO;
 
+        let mut i = shift_num;
         while i < LIMBS {
             let shifted = limbs[i].shl(rem);
             let new_carry = limbs[i].shr(Limb::BITS - rem);
@@ -104,15 +105,15 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let rshift = nz.if_true_u32(Limb::BITS - shift);
         let carry = nz.if_true_word(self.limbs[LIMBS - 1].0.wrapping_shr(Word::BITS - shift));
 
-        let mut i = LIMBS - 1;
-        while i > 0 {
+        limbs[0] = Limb(self.limbs[0].0 << lshift);
+        let mut i = 1;
+        while i < LIMBS {
             let mut limb = self.limbs[i].0 << lshift;
             let hi = self.limbs[i - 1].0 >> rshift;
             limb |= nz.if_true_word(hi);
             limbs[i] = Limb(limb);
-            i -= 1
+            i += 1
         }
-        limbs[0] = Limb(self.limbs[0].0 << lshift);
 
         (Uint::<LIMBS>::new(limbs), Limb(carry))
     }

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -195,19 +195,4 @@ mod tests {
             ((U128::ZERO, U128::ZERO), CtChoice::TRUE)
         );
     }
-
-    /*
-    #[test]
-    fn shr_limb() {
-        let x = U128::from_be_hex("00112233445566778899aabbccddeeff");
-        assert_eq!(x.shr_limb(0), (x, Limb::ZERO));
-        assert_eq!(
-            x.shr_limb(8),
-            (
-                U128::from_be_hex("0000112233445566778899aabbccddee"),
-                Limb(0xff << (Limb::BITS - 8))
-            )
-        );
-    }
-    */
 }

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -93,10 +93,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
     }
 
-    /// Computes `self >> 1` in constant-time, returning [`CtChoice::TRUE`] if the overflowing bit
-    /// was set, and [`CtChoice::FALSE`] otherwise.
+    /// Computes `self >> 1` in constant-time, returning [`CtChoice::TRUE`]
+    /// if the least significant bit was set, and [`CtChoice::FALSE`] otherwise.
     #[inline(always)]
-    pub(crate) const fn shr1_with_overflow(&self) -> (Self, CtChoice) {
+    pub(crate) const fn shr1_with_carry(&self) -> (Self, CtChoice) {
         let mut ret = Self::ZERO;
         let mut i = LIMBS;
         let mut carry = Limb::ZERO;
@@ -113,7 +113,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self >> 1` in constant-time.
     pub(crate) const fn shr1(&self) -> Self {
         // TODO(tarcieri): optimized implementation
-        self.shr1_with_overflow().0
+        self.shr1_with_carry().0
     }
 }
 

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -15,7 +15,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // https://github.com/RustCrypto/crypto-bigint/files/12600669/ct_sqrt.pdf
 
         // The initial guess: `x_0 = 2^ceil(b/2)`, where `2^(b-1) <= self < b`.
-        let mut x = Self::ONE.shl((self.bits() + 1) >> 1); // ≥ √(`self`)
+        // Will not overflow since `b <= BITS`.
+        let (mut x, _overflow) = Self::ONE.shl((self.bits() + 1) >> 1); // ≥ √(`self`)
 
         // Repeat enough times to guarantee result has stabilized.
         let mut i = 0;
@@ -49,7 +50,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.13
 
         // The initial guess: `x_0 = 2^ceil(b/2)`, where `2^(b-1) <= self < b`.
-        let mut x = Self::ONE.shl((self.bits() + 1) >> 1); // ≥ √(`self`)
+        // Will not overflow since `b <= BITS`.
+        let (mut x, _overflow) = Self::ONE.shl((self.bits() + 1) >> 1); // ≥ √(`self`)
 
         // Stop right away if `x` is zero to avoid divizion by zero.
         while !x.cmp_vartime(&Self::ZERO).is_eq() {

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -60,11 +60,17 @@ proptest! {
     fn shl_vartime(a in uint(), shift in any::<u8>()) {
         let a_bi = to_biguint(&a);
 
-        let expected = to_uint(a_bi << shift.into());
+        // Add a 50% probability of overflow.
+        let shift = u32::from(shift) % (U256::BITS * 2);
+
+        let expected = to_uint((a_bi << shift as usize) & ((BigUint::one() << U256::BITS as usize) - BigUint::one()));
         let (actual, overflow) = a.shl_vartime(shift.into());
 
         assert_eq!(expected, actual);
-        assert_eq!(overflow, CtChoice::FALSE);
+        if shift >= U256::BITS {
+            assert_eq!(actual, U256::ZERO);
+            assert_eq!(overflow, CtChoice::TRUE);
+        }
     }
 
     #[test]
@@ -76,6 +82,23 @@ proptest! {
 
         let expected = to_uint((a_bi << shift as usize) & ((BigUint::one() << U256::BITS as usize) - BigUint::one()));
         let (actual, overflow) = a.shl(shift);
+
+        assert_eq!(expected, actual);
+        if shift >= U256::BITS {
+            assert_eq!(actual, U256::ZERO);
+            assert_eq!(overflow, CtChoice::TRUE);
+        }
+    }
+
+    #[test]
+    fn shr_vartime(a in uint(), shift in any::<u16>()) {
+        let a_bi = to_biguint(&a);
+
+        // Add a 50% probability of overflow.
+        let shift = u32::from(shift) % (U256::BITS * 2);
+
+        let expected = to_uint(a_bi >> shift as usize);
+        let (actual, overflow) = a.shr_vartime(shift);
 
         assert_eq!(expected, actual);
         if shift >= U256::BITS {

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -61,9 +61,10 @@ proptest! {
         let a_bi = to_biguint(&a);
 
         let expected = to_uint(a_bi << shift.into());
-        let actual = a.shl_vartime(shift.into());
+        let (actual, overflow) = a.shl_vartime(shift.into());
 
         assert_eq!(expected, actual);
+        assert_eq!(overflow, CtChoice::FALSE);
     }
 
     #[test]
@@ -74,9 +75,13 @@ proptest! {
         let shift = u32::from(shift) % (U256::BITS * 2);
 
         let expected = to_uint((a_bi << shift as usize) & ((BigUint::one() << U256::BITS as usize) - BigUint::one()));
-        let actual = a.shl(shift);
+        let (actual, overflow) = a.shl(shift);
 
         assert_eq!(expected, actual);
+        if shift >= U256::BITS {
+            assert_eq!(actual, U256::ZERO);
+            assert_eq!(overflow, CtChoice::TRUE);
+        }
     }
 
     #[test]
@@ -87,9 +92,13 @@ proptest! {
         let shift = u32::from(shift) % (U256::BITS * 2);
 
         let expected = to_uint(a_bi >> shift as usize);
-        let actual = a.shr(shift);
+        let (actual, overflow) = a.shr(shift);
 
         assert_eq!(expected, actual);
+        if shift >= U256::BITS {
+            assert_eq!(actual, U256::ZERO);
+            assert_eq!(overflow, CtChoice::TRUE);
+        }
     }
 
     #[test]


### PR DESCRIPTION
A part of #268 
Fixes #121

- `const fn` bit shifts for `Uint` return the overflow status as `CtChoice` (and set the result to zero in that case, which is documented, so it's a part of the API now). `Option` would be better for the vartime shifts, but its methods are not `const` yet in stable.
- `shl/shr` for `BoxedUint` return `(Self, Choice)` (not `CtOption` since most of its methods need the type to be `ConditionallySelectable`, which `BoxedUint` isn't). The vartime equivalents return `Option<Self>`.
- operator impls panic on overflow (which is the default behavior for built-in integers)
- made the implementations in `uint/shl.rs` and `shr.rs` more uniform and improved vartime shift performance (before it was calling a constant-time shift-by-no-more-than-limb which added some overhead)  
- improved constant-time shift performance for `BoxedUint` by reducing the amount of allocations
- added an optimized `BoxedUint::shl1()` implementation
- added some inlines for `Limb` methods which improved shift performance noticeably
- added more benchmarks for shifts and simplify benchmark hierarchy a little (create test group directly in the respective function)
- fixed an inefficiency in `Uint` shifts: we need to iterate to log2(BITS-1), not log2(BITS), because that's the maximum size of the shift.
- Renamed `sh(r/l)1_with_overflow()` to `sh(r/l)1_with_carry` to avoid confusion - in the context of shifts we call the shift being too large an overflow.