### PR TITLE
`BoxedResidue::pow` using "almost Montgomery multiplication"

### DIFF
--- a/src/modular/boxed_residue/mul.rs
+++ b/src/modular/boxed_residue/mul.rs
@@ -196,6 +196,11 @@ pub(crate) fn montgomery_mul(z: &mut [Word], x: &[Word], y: &[Word], m: &[Word],
     let mut c: Word = 0;
     let n = m.len();
 
+    let pre_cond = z.len() > n && z[n..].len() == n && x.len() == n && y.len() == n && m.len() == n;
+    if !pre_cond {
+        panic!("invalid inputs");
+    }
+
     for i in 0..n {
         let c2 = add_mul_vvw(&mut z[i..n + i], x, y[i]);
         let t = z[i].wrapping_mul(k);

--- a/src/modular/boxed_residue/pow.rs
+++ b/src/modular/boxed_residue/pow.rs
@@ -66,7 +66,7 @@ fn pow_montgomery_form(
     powers.push(x.clone());
 
     for i in 2..(1 << WINDOW) {
-        powers.push(multiplier.mul_amm(&powers[i - 1], x));
+        powers.push(multiplier.mul(&powers[i - 1], x));
     }
 
     let starting_limb = ((exponent_bits - 1) / Limb::BITS) as usize;
@@ -95,7 +95,7 @@ fn pow_montgomery_form(
                 idx &= starting_window_mask;
             } else {
                 for _ in 1..=WINDOW {
-                    multiplier.square_amm_assign(&mut z);
+                    multiplier.square_assign(&mut z);
                 }
             }
 
@@ -105,7 +105,7 @@ fn pow_montgomery_form(
                 power.conditional_assign(&powers[i as usize], i.ct_eq(&idx));
             }
 
-            multiplier.mul_amm_assign(&mut z, &power);
+            multiplier.mul_assign(&mut z, &power);
         }
     }
 

--- a/src/modular/reduction.rs
+++ b/src/modular/reduction.rs
@@ -15,7 +15,7 @@ const fn muladdcarry(x: Word, y: Word, z: Word, w: Word) -> (Word, Word) {
     ((res >> Word::BITS) as Word, res as Word)
 }
 
-/// Impl the core Montgomery reduction algorithm.
+/// Implement the Montgomery reduction algorithm.
 ///
 /// This is implemented as a macro to abstract over `const fn` and boxed use cases, since the latter
 /// needs mutable references and thus the unstable `const_mut_refs` feature (rust-lang/rust#57349).
@@ -74,7 +74,6 @@ pub const fn montgomery_reduction<const LIMBS: usize>(
 ///
 /// This version writes the result into the provided [`BoxedUint`].
 #[cfg(feature = "alloc")]
-#[inline]
 pub(crate) fn montgomery_reduction_boxed_mut(
     x: &mut BoxedUint,
     modulus: &BoxedUint,


### PR DESCRIPTION
Implements `BoxedResidue::pow` using the "almost Montgomery multiplication" method used by `num-bigint` as originally added in rust-num/num-bigint@f523b9c359b0b4e8718176aba693c6e061cd0353