### PR TITLE
Use `black_box` on benchmarks; 4096-bit BoxedResidue

### DIFF
--- a/benches/boxed_residue.rs
+++ b/benches/boxed_residue.rs
@@ -1,5 +1,6 @@
 use criterion::{
-    criterion_group, criterion_main, measurement::Measurement, BatchSize, BenchmarkGroup, Criterion,
+    black_box, criterion_group, criterion_main, measurement::Measurement, BatchSize,
+    BenchmarkGroup, Criterion,
 };
 use crypto_bigint::{
     modular::{BoxedResidue, BoxedResidueParams},
@@ -8,7 +9,7 @@ use crypto_bigint::{
 use rand_core::OsRng;
 
 /// Size of `BoxedUint` to use in benchmark.
-const UINT_BITS: u32 = 256;
+const UINT_BITS: u32 = 4096;
 
 fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let params = BoxedResidueParams::new(
@@ -22,7 +23,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                 let y = BoxedResidue::new(BoxedUint::random(&mut OsRng, UINT_BITS), params.clone());
                 (x, y)
             },
-            |(x, y)| x * y,
+            |(x, y)| black_box(x * y),
             BatchSize::SmallInput,
         )
     });
@@ -38,7 +39,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                     | (BoxedUint::one_with_precision(UINT_BITS) << (UINT_BITS - 1));
                 (x_m, p)
             },
-            |(x, p)| x.pow(&p),
+            |(x, p)| black_box(x.pow(&p)),
             BatchSize::SmallInput,
         )
     });
@@ -60,7 +61,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
     group.bench_function("BoxedResidue creation", |b| {
         b.iter_batched(
             || BoxedUint::random(&mut OsRng, UINT_BITS),
-            |x| BoxedResidue::new(x, params.clone()),
+            |x| black_box(BoxedResidue::new(x, params.clone())),
             BatchSize::SmallInput,
         )
     });
@@ -72,7 +73,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
     group.bench_function("BoxedResidue retrieve", |b| {
         b.iter_batched(
             || BoxedResidue::new(BoxedUint::random(&mut OsRng, UINT_BITS), params.clone()),
-            |x| x.retrieve(),
+            |x| black_box(x.retrieve()),
             BatchSize::SmallInput,
         )
     });

--- a/benches/dyn_residue.rs
+++ b/benches/dyn_residue.rs
@@ -1,5 +1,6 @@
 use criterion::{
-    criterion_group, criterion_main, measurement::Measurement, BatchSize, BenchmarkGroup, Criterion,
+    black_box, criterion_group, criterion_main, measurement::Measurement, BatchSize,
+    BenchmarkGroup, Criterion,
 };
 use crypto_bigint::{
     modular::{DynResidue, DynResidueParams},
@@ -19,7 +20,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                 let y = DynResidue::new(&U256::random(&mut OsRng), params);
                 (x, y)
             },
-            |(x, y)| x * y,
+            |(x, y)| black_box(x * y),
             BatchSize::SmallInput,
         )
     });
@@ -34,7 +35,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                 let p = U256::random(&mut OsRng) | (U256::ONE << (U256::BITS - 1));
                 (x_m, p)
             },
-            |(x, p)| x.pow(&p),
+            |(x, p)| black_box(x.pow(&p)),
             BatchSize::SmallInput,
         )
     });
@@ -58,9 +59,9 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                         bases_and_exponents
                     },
                     |bases_and_exponents| {
-                        DynResidue::<{ U256::LIMBS }>::multi_exponentiate(
+                        black_box(DynResidue::<{ U256::LIMBS }>::multi_exponentiate(
                             bases_and_exponents.as_slice(),
-                        )
+                        ))
                     },
                     BatchSize::SmallInput,
                 )
@@ -73,7 +74,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
     group.bench_function("DynResidueParams creation", |b| {
         b.iter_batched(
             || U256::random(&mut OsRng) | U256::ONE,
-            |modulus| DynResidueParams::new(&modulus),
+            |modulus| black_box(DynResidueParams::new(&modulus)),
             BatchSize::SmallInput,
         )
     });
@@ -82,7 +83,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
     group.bench_function("DynResidue creation", |b| {
         b.iter_batched(
             || U256::random(&mut OsRng),
-            |x| DynResidue::new(&x, params),
+            |x| black_box(DynResidue::new(&x, params)),
             BatchSize::SmallInput,
         )
     });
@@ -91,7 +92,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
     group.bench_function("DynResidue retrieve", |b| {
         b.iter_batched(
             || DynResidue::new(&U256::random(&mut OsRng), params),
-            |x| x.retrieve(),
+            |x| black_box(x.retrieve()),
             BatchSize::SmallInput,
         )
     });

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -1,5 +1,6 @@
 use criterion::{
-    criterion_group, criterion_main, measurement::Measurement, BatchSize, BenchmarkGroup, Criterion,
+    black_box, criterion_group, criterion_main, measurement::Measurement, BatchSize,
+    BenchmarkGroup, Criterion,
 };
 use crypto_bigint::{Limb, NonZero, Random, Reciprocal, U128, U2048, U256};
 use rand_core::OsRng;
@@ -13,7 +14,7 @@ fn bench_division<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                 let y: U256 = (y_half, U128::ZERO).into();
                 (x, NonZero::new(y).unwrap())
             },
-            |(x, y)| x.div_rem(&y),
+            |(x, y)| black_box(x.div_rem(&y)),
             BatchSize::SmallInput,
         )
     });
@@ -26,7 +27,7 @@ fn bench_division<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                 let y: U256 = (y_half, U128::ZERO).into();
                 (x, NonZero::new(y).unwrap())
             },
-            |(x, y)| x.rem(&y),
+            |(x, y)| black_box(x.rem(&y)),
             BatchSize::SmallInput,
         )
     });
@@ -39,7 +40,7 @@ fn bench_division<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                 let y = U256::from_word(y_small.0);
                 (x, NonZero::new(y).unwrap())
             },
-            |(x, y)| x.div_rem(&y),
+            |(x, y)| black_box(x.div_rem(&y)),
             BatchSize::SmallInput,
         )
     });
@@ -51,7 +52,7 @@ fn bench_division<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                 let y = Limb::random(&mut OsRng);
                 (x, NonZero::new(y).unwrap())
             },
-            |(x, y)| x.div_rem_limb(y),
+            |(x, y)| black_box(x.div_rem_limb(y)),
             BatchSize::SmallInput,
         )
     });
@@ -64,7 +65,7 @@ fn bench_division<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                 let r = Reciprocal::new(y);
                 (x, r)
             },
-            |(x, r)| x.div_rem_limb_with_reciprocal(&r),
+            |(x, r)| black_box(x.div_rem_limb_with_reciprocal(&r)),
             BatchSize::SmallInput,
         )
     });
@@ -78,7 +79,7 @@ fn bench_shifts<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("shl_vartime, large, U2048", |b| {
         b.iter_batched(
             || U2048::ONE,
-            |x| x.shl_vartime(1024 + 10),
+            |x| black_box(x.shl_vartime(1024 + 10)),
             BatchSize::SmallInput,
         )
     });
@@ -105,7 +106,7 @@ fn bench_inv_mod<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                     }
                 }
             },
-            |(x, m)| x.inv_odd_mod(&m),
+            |(x, m)| black_box(x.inv_odd_mod(&m)),
             BatchSize::SmallInput,
         )
     });
@@ -122,7 +123,7 @@ fn bench_inv_mod<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                     }
                 }
             },
-            |(x, m)| x.inv_mod(&m),
+            |(x, m)| black_box(x.inv_mod(&m)),
             BatchSize::SmallInput,
         )
     });
@@ -133,13 +134,13 @@ fn bench_inv_mod<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                 let m = U256::random(&mut OsRng);
                 loop {
                     let x = U256::random(&mut OsRng);
-                    let (_, is_some) = x.inv_mod(&m);
+                    let (_, is_some) = black_box(x.inv_mod(&m));
                     if is_some.into() {
                         break (x, m);
                     }
                 }
             },
-            |(x, m)| x.inv_mod(&m),
+            |(x, m)| black_box(x.inv_mod(&m)),
             BatchSize::SmallInput,
         )
     });


### PR DESCRIPTION
This avoids the compiler potentially optimizing away part or all of an operation inside of a benchmark.

Using a larger `BoxedResidue` is both more indicative of real-world usages as well as reduces noise in the benchmark.