### PR TITLE
Add `BoxedResidueParams::new_vartime`

### DIFF
--- a/benches/boxed_residue.rs
+++ b/benches/boxed_residue.rs
@@ -73,17 +73,25 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                 );
                 (x_m, p)
             },
-            |(x, p)| x.modpow(&p, &modulus),
+            |(x, p)| black_box(x.modpow(&p, &modulus)),
             BatchSize::SmallInput,
         )
     });
 }
 
 fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    group.bench_function("BoxedResidueParams creation", |b| {
+    group.bench_function("BoxedResidueParams::new", |b| {
         b.iter_batched(
             || BoxedUint::random(&mut OsRng, UINT_BITS) | BoxedUint::one_with_precision(UINT_BITS),
-            |modulus| BoxedResidueParams::new(modulus),
+            |modulus| black_box(BoxedResidueParams::new(modulus)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("BoxedResidueParams::new_vartime", |b| {
+        b.iter_batched(
+            || BoxedUint::random(&mut OsRng, UINT_BITS) | BoxedUint::one_with_precision(UINT_BITS),
+            |modulus| black_box(BoxedResidueParams::new_vartime(modulus)),
             BatchSize::SmallInput,
         )
     });
@@ -92,7 +100,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
         BoxedUint::random(&mut OsRng, UINT_BITS) | BoxedUint::one_with_precision(UINT_BITS),
     )
     .unwrap();
-    group.bench_function("BoxedResidue creation", |b| {
+    group.bench_function("BoxedResidue::new", |b| {
         b.iter_batched(
             || BoxedUint::random(&mut OsRng, UINT_BITS),
             |x| black_box(BoxedResidue::new(x, params.clone())),
@@ -104,7 +112,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
         BoxedUint::random(&mut OsRng, UINT_BITS) | BoxedUint::one_with_precision(UINT_BITS),
     )
     .unwrap();
-    group.bench_function("BoxedResidue retrieve", |b| {
+    group.bench_function("BoxedResidue::retrieve", |b| {
         b.iter_batched(
             || BoxedResidue::new(BoxedUint::random(&mut OsRng, UINT_BITS), params.clone()),
             |x| black_box(x.retrieve()),

--- a/tests/boxed_residue_proptests.rs
+++ b/tests/boxed_residue_proptests.rs
@@ -60,6 +60,17 @@ prop_compose! {
 
 proptest! {
     #[test]
+    fn new(mut n in uint()) {
+        if n.is_even().into() {
+            n = n.wrapping_add(&BoxedUint::one());
+        }
+
+        let params1 = BoxedResidueParams::new(n.clone()).unwrap();
+        let params2 = BoxedResidueParams::new_vartime(n).unwrap();
+        prop_assert_eq!(params1, params2);
+    }
+
+    #[test]
     fn inv(x in uint(), n in modulus()) {
         let x = reduce(&x, n.clone());
         let actual = Option::<BoxedResidue>::from(x.invert()).map(|a| a.retrieve());


### PR DESCRIPTION
Adds a variable-time constructor usable when the modulus is non-secret, such as is the case with RSA, providing a ~6X performance improvement.

### Benchmarks

```
Montgomery arithmetic/BoxedResidueParams::new
                        time:   [8.3193 ms 8.3255 ms 8.3326 ms]
```

```
Montgomery arithmetic/BoxedResidueParams::new_vartime
                        time:   [1.3982 ms 1.4002 ms 1.4022 ms]
```