### PR TITLE
Implement `Zeroize` for `NonZero` wrapper

### DIFF
--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -367,6 +367,13 @@ impl<T: Serialize + Zero> Serialize for NonZero<T> {
     }
 }
 
+#[cfg(feature = "zeroize")]
+impl<T: zeroize::Zeroize + Zero> zeroize::Zeroize for NonZero<T> {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
 #[cfg(all(test, feature = "serde"))]
 #[allow(clippy::unwrap_used)]
 mod tests {


### PR DESCRIPTION
When attempting to port over `dsa` to `crypto-bigint`, I noticed that the `NonZero` wrapper has no implementation for the `Zeroize` trait.  

That made it a bit annoying to implement the internals that expect the private factor `x` to be wrapped into a `Zeroizing` wrapper.