### PR TITLE
Limb: optimize constant-time comparisons

### DIFF
--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -44,19 +44,26 @@ impl ConstantTimeEq for Limb {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
     }
+
+    #[inline]
+    fn ct_ne(&self, other: &Self) -> Choice {
+        self.0.ct_ne(&other.0)
+    }
 }
 
 impl ConstantTimeGreater for Limb {
     #[inline]
     fn ct_gt(&self, other: &Self) -> Choice {
-        self.0.ct_gt(&other.0)
+        let borrow = other.sbb(*self, Limb::ZERO).1;
+        Choice::from(borrow.0 as u8 & 1)
     }
 }
 
 impl ConstantTimeLess for Limb {
     #[inline]
     fn ct_lt(&self, other: &Self) -> Choice {
-        self.0.ct_lt(&other.0)
+        let borrow = self.sbb(*other, Limb::ZERO).1;
+        Choice::from(borrow.0 as u8 & 1)
     }
 }
 


### PR DESCRIPTION
Optimizes `ConstantTimeGreater`/`ConstantTimeLess` impls by using borrowing subtraction and checking whether a borrow occurred.

### Benchmarks

```
ops/ct_lt               time:   [900.95 ps 909.83 ps 922.37 ps]
                        change: [-76.095% -75.752% -75.373%] (p = 0.00 < 0.05)
                        Performance has improved.
```

```
ops/ct_gt               time:   [902.46 ps 938.83 ps 1.0134 ns]
                        change: [-55.763% -53.637% -50.192%] (p = 0.00 < 0.05)
                        Performance has improved.
```