### PR TITLE
Make `inv_mod2k(_vartime)` return a `CtChoice`

### DIFF
--- a/src/ct_choice.rs
+++ b/src/ct_choice.rs
@@ -158,6 +158,12 @@ impl From<CtChoice> for bool {
     }
 }
 
+impl PartialEq for CtChoice {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::CtChoice;

--- a/src/modular/boxed_residue.rs
+++ b/src/modular/boxed_residue.rs
@@ -103,12 +103,9 @@ impl BoxedResidueParams {
 
     /// Common functionality of `new` and `new_vartime`.
     fn new_inner(modulus: BoxedUint, r: BoxedUint, r2: BoxedUint) -> CtOption<Self> {
-        let is_odd = modulus.is_odd();
-
-        // Since we are calculating the inverse modulo (Word::MAX+1),
-        // we can take the modulo right away and calculate the inverse of the first limb only.
-        let modulus_lo = BoxedUint::from(modulus.limbs.get(0).copied().unwrap_or_default());
-        let mod_neg_inv = Limb(Word::MIN.wrapping_sub(modulus_lo.inv_mod2k(Word::BITS).limbs[0].0));
+        // If the inverse exists, it means the modulus is odd.
+        let (inv_mod_limb, modulus_is_odd) = modulus.inv_mod2k(Word::BITS);
+        let mod_neg_inv = Limb(Word::MIN.wrapping_sub(inv_mod_limb.limbs[0].0));
         let r3 = montgomery_reduction_boxed(&mut r2.square(), &modulus, mod_neg_inv);
 
         let params = Self {
@@ -119,7 +116,7 @@ impl BoxedResidueParams {
             mod_neg_inv,
         };
 
-        CtOption::new(params, is_odd)
+        CtOption::new(params, modulus_is_odd)
     }
 
     /// Modulus value.

--- a/src/modular/residue/macros.rs
+++ b/src/modular/residue/macros.rs
@@ -40,6 +40,7 @@ macro_rules! impl_modulus {
                 $crate::Word::MIN.wrapping_sub(
                     Self::MODULUS
                         .inv_mod2k_vartime($crate::Word::BITS)
+                        .0
                         .as_limbs()[0]
                         .0,
                 ),

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -245,9 +245,11 @@ proptest! {
         let a_bi = to_biguint(&a);
         let m_bi = BigUint::one() << k as usize;
 
-        let actual = a.inv_mod2k(k);
-        let actual_vartime = a.inv_mod2k_vartime(k);
+        let (actual, is_some) = a.inv_mod2k(k);
+        let (actual_vartime, is_some_vartime) = a.inv_mod2k_vartime(k);
         assert_eq!(actual, actual_vartime);
+        assert_eq!(is_some, CtChoice::TRUE);
+        assert_eq!(is_some_vartime, CtChoice::TRUE);
 
         if k == 0 {
             assert_eq!(actual, U256::ZERO);


### PR DESCRIPTION
- `inv_mod2k(_vartime)` return a tuple with the second parameter indicating whether the inverse exists
- In `inv_mod2k(_vartime)` docstrings, removed the note about `self` having to be less than `2^k` - the algorithm works just fine even if it's not
- Simplified the usage of `inv_mod2k` in the creation of `DynResidueParams`
- `inv_odd_mod()` now also returns a falsy `CtChoice` in case of an even modulus