### PR TITLE
Normalize the usage of prefixes for method names

### DIFF
--- a/src/ct_choice.rs
+++ b/src/ct_choice.rs
@@ -6,9 +6,9 @@ use crate::Word;
 // TODO: should be replaced by `subtle::Choice` or `CtOption`
 // when `subtle` starts supporting const fns.
 #[derive(Debug, Copy, Clone)]
-pub struct CtChoice(Word);
+pub struct ConstChoice(Word);
 
-impl CtChoice {
+impl ConstChoice {
     /// The falsy value.
     pub const FALSE: Self = Self(0);
 
@@ -137,7 +137,7 @@ impl CtChoice {
 
     #[inline]
     pub(crate) const fn is_true_vartime(&self) -> bool {
-        self.0 == CtChoice::TRUE.0
+        self.0 == ConstChoice::TRUE.0
     }
 
     #[inline]
@@ -146,19 +146,19 @@ impl CtChoice {
     }
 }
 
-impl From<CtChoice> for Choice {
-    fn from(choice: CtChoice) -> Self {
+impl From<ConstChoice> for Choice {
+    fn from(choice: ConstChoice) -> Self {
         Choice::from(choice.to_u8())
     }
 }
 
-impl From<CtChoice> for bool {
-    fn from(choice: CtChoice) -> Self {
+impl From<ConstChoice> for bool {
+    fn from(choice: ConstChoice) -> Self {
         choice.is_true_vartime()
     }
 }
 
-impl PartialEq for CtChoice {
+impl PartialEq for ConstChoice {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }
@@ -166,14 +166,14 @@ impl PartialEq for CtChoice {
 
 #[cfg(test)]
 mod tests {
-    use super::CtChoice;
+    use super::ConstChoice;
     use crate::Word;
 
     #[test]
     fn select() {
         let a: Word = 1;
         let b: Word = 2;
-        assert_eq!(CtChoice::TRUE.select_word(a, b), b);
-        assert_eq!(CtChoice::FALSE.select_word(a, b), a);
+        assert_eq!(ConstChoice::TRUE.select_word(a, b), b);
+        assert_eq!(ConstChoice::FALSE.select_word(a, b), a);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ mod wrapping;
 
 pub use crate::{
     checked::Checked,
-    ct_choice::CtChoice,
+    ct_choice::ConstChoice,
     limb::{Limb, WideWord, Word},
     non_zero::NonZero,
     traits::*,

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -1,6 +1,6 @@
 //! Limb comparisons
 
-use crate::{CtChoice, Limb};
+use crate::{ConstChoice, Limb};
 use core::cmp::Ordering;
 use subtle::{
     Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
@@ -28,14 +28,14 @@ impl Limb {
 
     /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
-    pub(crate) const fn select(a: Self, b: Self, c: CtChoice) -> Self {
+    pub(crate) const fn select(a: Self, b: Self, c: ConstChoice) -> Self {
         Self(c.select_word(a.0, b.0))
     }
 
     /// Returns the truthy value if `self != 0` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn is_nonzero(&self) -> CtChoice {
-        CtChoice::from_word_nonzero(self.0)
+    pub(crate) const fn is_nonzero(&self) -> ConstChoice {
+        ConstChoice::from_word_nonzero(self.0)
     }
 }
 

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -28,13 +28,13 @@ impl Limb {
 
     /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
-    pub(crate) const fn ct_select(a: Self, b: Self, c: CtChoice) -> Self {
+    pub(crate) const fn select(a: Self, b: Self, c: CtChoice) -> Self {
         Self(c.select_word(a.0, b.0))
     }
 
     /// Returns the truthy value if `self != 0` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn ct_is_nonzero(&self) -> CtChoice {
+    pub(crate) const fn is_nonzero(&self) -> CtChoice {
         CtChoice::from_word_nonzero(self.0)
     }
 }

--- a/src/modular/div_by_2.rs
+++ b/src/modular/div_by_2.rs
@@ -26,5 +26,5 @@ pub(crate) fn div_by_2<const LIMBS: usize>(a: &Uint<LIMBS>, modulus: &Uint<LIMBS
         .wrapping_add(&half_modulus)
         .wrapping_add(&Uint::<LIMBS>::ONE);
 
-    Uint::<LIMBS>::ct_select(&if_even, &if_odd, is_odd)
+    Uint::<LIMBS>::select(&if_even, &if_odd, is_odd)
 }

--- a/src/modular/dyn_residue/inv.rs
+++ b/src/modular/dyn_residue/inv.rs
@@ -1,7 +1,7 @@
 //! Multiplicative inverses of residues with a modulus set at runtime.
 
 use super::DynResidue;
-use crate::{modular::inv::inv_montgomery_form, traits::Invert, CtChoice};
+use crate::{modular::inv::inv_montgomery_form, traits::Invert, ConstChoice};
 use subtle::CtOption;
 
 impl<const LIMBS: usize> DynResidue<LIMBS> {
@@ -9,7 +9,7 @@ impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// I.e. `self * self^-1 = 1`.
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
-    pub const fn invert(&self) -> (Self, CtChoice) {
+    pub const fn invert(&self) -> (Self, ConstChoice) {
         let (montgomery_form, is_some) = inv_montgomery_form(
             &self.montgomery_form,
             &self.residue_params.modulus,

--- a/src/modular/inv.rs
+++ b/src/modular/inv.rs
@@ -1,11 +1,11 @@
-use crate::{modular::reduction::montgomery_reduction, CtChoice, Limb, Uint};
+use crate::{modular::reduction::montgomery_reduction, ConstChoice, Limb, Uint};
 
 pub const fn inv_montgomery_form<const LIMBS: usize>(
     x: &Uint<LIMBS>,
     modulus: &Uint<LIMBS>,
     r3: &Uint<LIMBS>,
     mod_neg_inv: Limb,
-) -> (Uint<LIMBS>, CtChoice) {
+) -> (Uint<LIMBS>, ConstChoice) {
     let (inverse, is_some) = x.inv_odd_mod(modulus);
     (
         montgomery_reduction(&inverse.mul_wide(r3), modulus, mod_neg_inv),

--- a/src/modular/pow.rs
+++ b/src/modular/pow.rs
@@ -1,4 +1,4 @@
-use crate::{CtChoice, Limb, Uint, Word};
+use crate::{ConstChoice, Limb, Uint, Word};
 
 use super::mul::{mul_montgomery_form, square_montgomery_form};
 
@@ -163,7 +163,7 @@ const fn multi_exponentiate_montgomery_form_internal<const LIMBS: usize, const R
                 let mut power = powers[0];
                 let mut j = 1;
                 while j < 1 << WINDOW {
-                    let choice = CtChoice::from_word_eq(j, idx);
+                    let choice = ConstChoice::from_word_eq(j, idx);
                     power = Uint::<LIMBS>::select(&power, &powers[j as usize], choice);
                     j += 1;
                 }

--- a/src/modular/pow.rs
+++ b/src/modular/pow.rs
@@ -164,7 +164,7 @@ const fn multi_exponentiate_montgomery_form_internal<const LIMBS: usize, const R
                 let mut j = 1;
                 while j < 1 << WINDOW {
                     let choice = CtChoice::from_word_eq(j, idx);
-                    power = Uint::<LIMBS>::ct_select(&power, &powers[j as usize], choice);
+                    power = Uint::<LIMBS>::select(&power, &powers[j as usize], choice);
                     j += 1;
                 }
 

--- a/src/modular/residue.rs
+++ b/src/modular/residue.rs
@@ -204,7 +204,7 @@ where
         D: Deserializer<'de>,
     {
         Uint::<LIMBS>::deserialize(deserializer).and_then(|montgomery_form| {
-            if Uint::ct_lt(&montgomery_form, &MOD::MODULUS).into() {
+            if montgomery_form < MOD::MODULUS.0 {
                 Ok(Self {
                     montgomery_form,
                     phantom: PhantomData,

--- a/src/modular/residue/inv.rs
+++ b/src/modular/residue/inv.rs
@@ -1,7 +1,7 @@
 //! Multiplicative inverses of residues with a constant modulus.
 
 use super::{Residue, ResidueParams};
-use crate::{modular::inv::inv_montgomery_form, traits::Invert, CtChoice, NonZero};
+use crate::{modular::inv::inv_montgomery_form, traits::Invert, ConstChoice, NonZero};
 use core::marker::PhantomData;
 use subtle::CtOption;
 
@@ -10,7 +10,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// I.e. `self * self^-1 = 1`.
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
-    pub const fn invert(&self) -> (Self, CtChoice) {
+    pub const fn invert(&self) -> (Self, ConstChoice) {
         let (montgomery_form, is_some) = inv_montgomery_form(
             &self.montgomery_form,
             &MOD::MODULUS.0,

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -28,7 +28,7 @@ impl NonZero<Limb> {
     /// Creates a new non-zero limb in a const context.
     /// The second return value is `FALSE` if `n` is zero, `TRUE` otherwise.
     pub const fn const_new(n: Limb) -> (Self, CtChoice) {
-        (Self(n), n.ct_is_nonzero())
+        (Self(n), n.is_nonzero())
     }
 }
 
@@ -36,7 +36,7 @@ impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
     /// Creates a new non-zero integer in a const context.
     /// The second return value is `FALSE` if `n` is zero, `TRUE` otherwise.
     pub const fn const_new(n: Uint<LIMBS>) -> (Self, CtChoice) {
-        (Self(n), n.ct_is_nonzero())
+        (Self(n), n.is_nonzero())
     }
 }
 

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -1,6 +1,6 @@
 //! Wrapper type for non-zero integers.
 
-use crate::{Bounded, Constants, CtChoice, Encoding, Limb, Uint, Zero};
+use crate::{Bounded, ConstChoice, Constants, Encoding, Limb, Uint, Zero};
 use core::{
     fmt,
     num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8},
@@ -27,7 +27,7 @@ pub struct NonZero<T: Zero>(pub(crate) T);
 impl NonZero<Limb> {
     /// Creates a new non-zero limb in a const context.
     /// The second return value is `FALSE` if `n` is zero, `TRUE` otherwise.
-    pub const fn const_new(n: Limb) -> (Self, CtChoice) {
+    pub const fn const_new(n: Limb) -> (Self, ConstChoice) {
         (Self(n), n.is_nonzero())
     }
 }
@@ -35,7 +35,7 @@ impl NonZero<Limb> {
 impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
     /// Creates a new non-zero integer in a const context.
     /// The second return value is `FALSE` if `n` is zero, `TRUE` otherwise.
-    pub const fn const_new(n: Uint<LIMBS>) -> (Self, CtChoice) {
+    pub const fn const_new(n: Uint<LIMBS>) -> (Self, ConstChoice) {
         (Self(n), n.is_nonzero())
     }
 }

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -1,6 +1,6 @@
 //! [`Uint`] addition operations.
 
-use crate::{Checked, CheckedAdd, CtChoice, Limb, Uint, Wrapping, Zero};
+use crate::{Checked, CheckedAdd, ConstChoice, Limb, Uint, Wrapping, Zero};
 use core::ops::{Add, AddAssign};
 use subtle::CtOption;
 
@@ -24,7 +24,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Perform saturating addition, returning `MAX` on overflow.
     pub const fn saturating_add(&self, rhs: &Self) -> Self {
         let (res, overflow) = self.adc(rhs, Limb::ZERO);
-        Self::select(&res, &Self::MAX, CtChoice::from_word_lsb(overflow.0))
+        Self::select(&res, &Self::MAX, ConstChoice::from_word_lsb(overflow.0))
     }
 
     /// Perform wrapping addition, discarding overflow.
@@ -37,11 +37,11 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     pub(crate) const fn conditional_wrapping_add(
         &self,
         rhs: &Self,
-        choice: CtChoice,
-    ) -> (Self, CtChoice) {
+        choice: ConstChoice,
+    ) -> (Self, ConstChoice) {
         let actual_rhs = Uint::select(&Uint::ZERO, rhs, choice);
         let (sum, carry) = self.adc(&actual_rhs, Limb::ZERO);
-        (sum, CtChoice::from_word_lsb(carry.0))
+        (sum, ConstChoice::from_word_lsb(carry.0))
     }
 }
 

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -24,7 +24,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Perform saturating addition, returning `MAX` on overflow.
     pub const fn saturating_add(&self, rhs: &Self) -> Self {
         let (res, overflow) = self.adc(rhs, Limb::ZERO);
-        Self::ct_select(&res, &Self::MAX, CtChoice::from_word_lsb(overflow.0))
+        Self::select(&res, &Self::MAX, CtChoice::from_word_lsb(overflow.0))
     }
 
     /// Perform wrapping addition, discarding overflow.
@@ -39,7 +39,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         rhs: &Self,
         choice: CtChoice,
     ) -> (Self, CtChoice) {
-        let actual_rhs = Uint::ct_select(&Uint::ZERO, rhs, choice);
+        let actual_rhs = Uint::select(&Uint::ZERO, rhs, choice);
         let (sum, carry) = self.adc(&actual_rhs, Limb::ZERO);
         (sum, CtChoice::from_word_lsb(carry.0))
     }

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -1,9 +1,9 @@
-use crate::{CtChoice, Limb, Uint};
+use crate::{ConstChoice, Limb, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
-    /// Get the value of the bit at position `index`, as a truthy or falsy `CtChoice`.
+    /// Get the value of the bit at position `index`, as a truthy or falsy `ConstChoice`.
     /// Returns the falsy value for indices out of range.
-    pub const fn bit(&self, index: u32) -> CtChoice {
+    pub const fn bit(&self, index: u32) -> ConstChoice {
         let limb_num = index / Limb::BITS;
         let index_in_limb = index % Limb::BITS;
         let index_mask = 1 << index_in_limb;
@@ -14,12 +14,12 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mut i = 0;
         while i < LIMBS {
             let bit = limbs[i] & index_mask;
-            let is_right_limb = CtChoice::from_u32_eq(i as u32, limb_num);
+            let is_right_limb = ConstChoice::from_u32_eq(i as u32, limb_num);
             result |= is_right_limb.if_true_word(bit);
             i += 1;
         }
 
-        CtChoice::from_word_lsb(result >> index_in_limb)
+        ConstChoice::from_word_lsb(result >> index_in_limb)
     }
 
     /// Returns `true` if the bit at position `index` is set, `false` otherwise.
@@ -59,14 +59,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         let mut count = 0;
         let mut i = LIMBS;
-        let mut nonzero_limb_not_encountered = CtChoice::TRUE;
+        let mut nonzero_limb_not_encountered = ConstChoice::TRUE;
         while i > 0 {
             i -= 1;
             let l = limbs[i];
             let z = l.leading_zeros();
             count += nonzero_limb_not_encountered.if_true_u32(z);
             nonzero_limb_not_encountered =
-                nonzero_limb_not_encountered.and(CtChoice::from_word_nonzero(l.0).not());
+                nonzero_limb_not_encountered.and(ConstChoice::from_word_nonzero(l.0).not());
         }
 
         count
@@ -98,13 +98,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         let mut count = 0;
         let mut i = 0;
-        let mut nonzero_limb_not_encountered = CtChoice::TRUE;
+        let mut nonzero_limb_not_encountered = ConstChoice::TRUE;
         while i < LIMBS {
             let l = limbs[i];
             let z = l.trailing_zeros();
             count += nonzero_limb_not_encountered.if_true_u32(z);
             nonzero_limb_not_encountered =
-                nonzero_limb_not_encountered.and(CtChoice::from_word_nonzero(l.0).not());
+                nonzero_limb_not_encountered.and(ConstChoice::from_word_nonzero(l.0).not());
             i += 1;
         }
 
@@ -137,13 +137,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         let mut count = 0;
         let mut i = 0;
-        let mut nonmax_limb_not_encountered = CtChoice::TRUE;
+        let mut nonmax_limb_not_encountered = ConstChoice::TRUE;
         while i < LIMBS {
             let l = limbs[i];
             let z = l.trailing_ones();
             count += nonmax_limb_not_encountered.if_true_u32(z);
             nonmax_limb_not_encountered =
-                nonmax_limb_not_encountered.and(CtChoice::from_word_eq(l.0, Limb::MAX.0));
+                nonmax_limb_not_encountered.and(ConstChoice::from_word_eq(l.0, Limb::MAX.0));
             i += 1;
         }
 
@@ -171,7 +171,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Sets the bit at `index` to 0 or 1 depending on the value of `bit_value`.
-    pub(crate) const fn set_bit(self, index: u32, bit_value: CtChoice) -> Self {
+    pub(crate) const fn set_bit(self, index: u32, bit_value: ConstChoice) -> Self {
         let mut result = self;
         let limb_num = index / Limb::BITS;
         let index_in_limb = index % Limb::BITS;
@@ -179,7 +179,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         let mut i = 0;
         while i < LIMBS {
-            let is_right_limb = CtChoice::from_u32_eq(i as u32, limb_num);
+            let is_right_limb = ConstChoice::from_u32_eq(i as u32, limb_num);
             let old_limb = result.limbs[i].0;
             let new_limb = bit_value.select_word(old_limb & !index_mask, old_limb | index_mask);
             result.limbs[i] = Limb(is_right_limb.select_word(old_limb, new_limb));
@@ -191,7 +191,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{CtChoice, U256};
+    use crate::{ConstChoice, U256};
 
     fn uint_with_bits_at(positions: &[u32]) -> U256 {
         let mut result = U256::ZERO;
@@ -337,25 +337,25 @@ mod tests {
     fn set_bit() {
         let u = uint_with_bits_at(&[16, 79, 150]);
         assert_eq!(
-            u.set_bit(127, CtChoice::TRUE),
+            u.set_bit(127, ConstChoice::TRUE),
             uint_with_bits_at(&[16, 79, 127, 150])
         );
 
         let u = uint_with_bits_at(&[16, 79, 150]);
         assert_eq!(
-            u.set_bit(150, CtChoice::TRUE),
+            u.set_bit(150, ConstChoice::TRUE),
             uint_with_bits_at(&[16, 79, 150])
         );
 
         let u = uint_with_bits_at(&[16, 79, 150]);
         assert_eq!(
-            u.set_bit(127, CtChoice::FALSE),
+            u.set_bit(127, ConstChoice::FALSE),
             uint_with_bits_at(&[16, 79, 150])
         );
 
         let u = uint_with_bits_at(&[16, 79, 150]);
         assert_eq!(
-            u.set_bit(150, CtChoice::FALSE),
+            u.set_bit(150, ConstChoice::FALSE),
             uint_with_bits_at(&[16, 79])
         );
     }

--- a/src/uint/boxed/cmp.rs
+++ b/src/uint/boxed/cmp.rs
@@ -5,7 +5,7 @@
 pub(super) use core::cmp::{max, Ordering};
 
 use super::BoxedUint;
-use crate::{CtChoice, Limb};
+use crate::{ConstChoice, Limb};
 use subtle::{
     Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
 };
@@ -30,7 +30,7 @@ impl ConstantTimeGreater for BoxedUint {
     #[inline]
     fn ct_gt(&self, other: &Self) -> Choice {
         let (_, borrow) = other.sbb(self, Limb::ZERO);
-        CtChoice::from_word_mask(borrow.0).into()
+        ConstChoice::from_word_mask(borrow.0).into()
     }
 }
 
@@ -38,7 +38,7 @@ impl ConstantTimeLess for BoxedUint {
     #[inline]
     fn ct_lt(&self, other: &Self) -> Choice {
         let (_, borrow) = self.sbb(other, Limb::ZERO);
-        CtChoice::from_word_mask(borrow.0).into()
+        ConstChoice::from_word_mask(borrow.0).into()
     }
 }
 

--- a/src/uint/boxed/inv_mod.rs
+++ b/src/uint/boxed/inv_mod.rs
@@ -38,8 +38,8 @@ impl BoxedUint {
     /// Computes 1/`self` mod `2^k`.
     ///
     /// If the inverse does not exist (`k > 0` and `self` is even),
-    /// returns `CtChoice::FALSE` as the second element of the tuple,
-    /// otherwise returns `CtChoice::TRUE`.
+    /// returns `ConstChoice::FALSE` as the second element of the tuple,
+    /// otherwise returns `ConstChoice::TRUE`.
     pub(crate) fn inv_mod2k(&self, k: u32) -> (Self, Choice) {
         let mut x = Self::zero_with_precision(self.bits_precision()); // keeps `x` during iterations
         let mut b = Self::one_with_precision(self.bits_precision()); // keeps `b_i` during iterations

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -3,14 +3,14 @@
 //! By default these are all constant-time and use the `subtle` crate.
 
 use super::Uint;
-use crate::{CtChoice, Limb};
+use crate::{ConstChoice, Limb};
 use core::cmp::Ordering;
 use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
-    pub(crate) const fn select(a: &Self, b: &Self, c: CtChoice) -> Self {
+    pub(crate) const fn select(a: &Self, b: &Self, c: ConstChoice) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
 
         let mut i = 0;
@@ -23,7 +23,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     #[inline]
-    pub(crate) const fn swap(a: &Self, b: &Self, c: CtChoice) -> (Self, Self) {
+    pub(crate) const fn swap(a: &Self, b: &Self, c: ConstChoice) -> (Self, Self) {
         let new_a = Self::select(a, b, c);
         let new_b = Self::select(b, a, c);
 
@@ -32,7 +32,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Returns the truthy value if `self`!=0 or the falsy value otherwise.
     #[inline]
-    pub(crate) const fn is_nonzero(&self) -> CtChoice {
+    pub(crate) const fn is_nonzero(&self) -> ConstChoice {
         let mut b = 0;
         let mut i = 0;
         while i < LIMBS {
@@ -43,13 +43,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Returns the truthy value if `self` is odd or the falsy value otherwise.
-    pub(crate) const fn is_odd(&self) -> CtChoice {
-        CtChoice::from_word_lsb(self.limbs[0].0 & 1)
+    pub(crate) const fn is_odd(&self) -> ConstChoice {
+        ConstChoice::from_word_lsb(self.limbs[0].0 & 1)
     }
 
     /// Returns the truthy value if `self == rhs` or the falsy value otherwise.
     #[inline]
-    pub(crate) const fn eq(lhs: &Self, rhs: &Self) -> CtChoice {
+    pub(crate) const fn eq(lhs: &Self, rhs: &Self) -> ConstChoice {
         let mut acc = 0;
         let mut i = 0;
 
@@ -64,19 +64,19 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Returns the truthy value if `self <= rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn lt(lhs: &Self, rhs: &Self) -> CtChoice {
+    pub(crate) const fn lt(lhs: &Self, rhs: &Self) -> ConstChoice {
         // We could use the same approach as in Limb::ct_lt(),
         // but since we have to use Uint::wrapping_sub(), which calls `sbb()`,
         // there are no savings compared to just calling `sbb()` directly.
         let (_res, borrow) = lhs.sbb(rhs, Limb::ZERO);
-        CtChoice::from_word_mask(borrow.0)
+        ConstChoice::from_word_mask(borrow.0)
     }
 
     /// Returns the truthy value if `self >= rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn gt(lhs: &Self, rhs: &Self) -> CtChoice {
+    pub(crate) const fn gt(lhs: &Self, rhs: &Self) -> ConstChoice {
         let (_res, borrow) = rhs.sbb(lhs, Limb::ZERO);
-        CtChoice::from_word_mask(borrow.0)
+        ConstChoice::from_word_mask(borrow.0)
     }
 
     /// Returns the ordering between `self` and `rhs` as an i8.

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -10,12 +10,12 @@ use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
-    pub(crate) const fn ct_select(a: &Self, b: &Self, c: CtChoice) -> Self {
+    pub(crate) const fn select(a: &Self, b: &Self, c: CtChoice) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
 
         let mut i = 0;
         while i < LIMBS {
-            limbs[i] = Limb::ct_select(a.limbs[i], b.limbs[i], c);
+            limbs[i] = Limb::select(a.limbs[i], b.limbs[i], c);
             i += 1;
         }
 
@@ -23,33 +23,33 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     #[inline]
-    pub(crate) const fn ct_swap(a: &Self, b: &Self, c: CtChoice) -> (Self, Self) {
-        let new_a = Self::ct_select(a, b, c);
-        let new_b = Self::ct_select(b, a, c);
+    pub(crate) const fn swap(a: &Self, b: &Self, c: CtChoice) -> (Self, Self) {
+        let new_a = Self::select(a, b, c);
+        let new_b = Self::select(b, a, c);
 
         (new_a, new_b)
     }
 
     /// Returns the truthy value if `self`!=0 or the falsy value otherwise.
     #[inline]
-    pub(crate) const fn ct_is_nonzero(&self) -> CtChoice {
+    pub(crate) const fn is_nonzero(&self) -> CtChoice {
         let mut b = 0;
         let mut i = 0;
         while i < LIMBS {
             b |= self.limbs[i].0;
             i += 1;
         }
-        Limb(b).ct_is_nonzero()
+        Limb(b).is_nonzero()
     }
 
     /// Returns the truthy value if `self` is odd or the falsy value otherwise.
-    pub(crate) const fn ct_is_odd(&self) -> CtChoice {
+    pub(crate) const fn is_odd(&self) -> CtChoice {
         CtChoice::from_word_lsb(self.limbs[0].0 & 1)
     }
 
     /// Returns the truthy value if `self == rhs` or the falsy value otherwise.
     #[inline]
-    pub(crate) const fn ct_eq(lhs: &Self, rhs: &Self) -> CtChoice {
+    pub(crate) const fn eq(lhs: &Self, rhs: &Self) -> CtChoice {
         let mut acc = 0;
         let mut i = 0;
 
@@ -59,12 +59,12 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
 
         // acc == 0 if and only if self == rhs
-        Limb(acc).ct_is_nonzero().not()
+        Limb(acc).is_nonzero().not()
     }
 
     /// Returns the truthy value if `self <= rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn ct_lt(lhs: &Self, rhs: &Self) -> CtChoice {
+    pub(crate) const fn lt(lhs: &Self, rhs: &Self) -> CtChoice {
         // We could use the same approach as in Limb::ct_lt(),
         // but since we have to use Uint::wrapping_sub(), which calls `sbb()`,
         // there are no savings compared to just calling `sbb()` directly.
@@ -74,7 +74,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Returns the truthy value if `self >= rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn ct_gt(lhs: &Self, rhs: &Self) -> CtChoice {
+    pub(crate) const fn gt(lhs: &Self, rhs: &Self) -> CtChoice {
         let (_res, borrow) = rhs.sbb(lhs, Limb::ZERO);
         CtChoice::from_word_mask(borrow.0)
     }
@@ -85,7 +85,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///   0 is Equal
     ///   1 is Greater
     #[inline]
-    pub(crate) const fn ct_cmp(lhs: &Self, rhs: &Self) -> i8 {
+    pub(crate) const fn cmp(lhs: &Self, rhs: &Self) -> i8 {
         let mut i = 0;
         let mut borrow = Limb::ZERO;
         let mut diff = Limb::ZERO;
@@ -97,7 +97,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             i += 1;
         }
         let sgn = ((borrow.0 & 2) as i8) - 1;
-        (diff.ct_is_nonzero().to_u8() as i8) * sgn
+        (diff.is_nonzero().to_u8() as i8) * sgn
     }
 
     /// Returns the Ordering between `self` and `rhs` in variable time.
@@ -123,21 +123,21 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 impl<const LIMBS: usize> ConstantTimeEq for Uint<LIMBS> {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
-        Uint::ct_eq(self, other).into()
+        Uint::eq(self, other).into()
     }
 }
 
 impl<const LIMBS: usize> ConstantTimeGreater for Uint<LIMBS> {
     #[inline]
     fn ct_gt(&self, other: &Self) -> Choice {
-        Uint::ct_gt(self, other).into()
+        Uint::gt(self, other).into()
     }
 }
 
 impl<const LIMBS: usize> ConstantTimeLess for Uint<LIMBS> {
     #[inline]
     fn ct_lt(&self, other: &Self) -> Choice {
-        Uint::ct_lt(self, other).into()
+        Uint::lt(self, other).into()
     }
 }
 
@@ -145,7 +145,7 @@ impl<const LIMBS: usize> Eq for Uint<LIMBS> {}
 
 impl<const LIMBS: usize> Ord for Uint<LIMBS> {
     fn cmp(&self, other: &Self) -> Ordering {
-        let c = Self::ct_cmp(self, other);
+        let c = Self::cmp(self, other);
         match c {
             -1 => Ordering::Less,
             0 => Ordering::Equal,
@@ -181,9 +181,15 @@ mod tests {
 
     #[test]
     fn is_odd() {
+        // inherent methods
         assert!(!bool::from(U128::ZERO.is_odd()));
         assert!(bool::from(U128::ONE.is_odd()));
         assert!(bool::from(U128::MAX.is_odd()));
+
+        // `Integer` methods
+        assert!(!bool::from(<U128 as Integer>::is_odd(&U128::ZERO)));
+        assert!(bool::from(<U128 as Integer>::is_odd(&U128::ONE)));
+        assert!(bool::from(<U128 as Integer>::is_odd(&U128::MAX)));
     }
 
     #[test]

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -34,9 +34,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mut done = CtChoice::FALSE;
         loop {
             let (mut r, borrow) = rem.sbb(&c, Limb::ZERO);
-            rem = Self::ct_select(&r, &rem, CtChoice::from_word_mask(borrow.0).or(done));
+            rem = Self::select(&r, &rem, CtChoice::from_word_mask(borrow.0).or(done));
             r = quo.bitor(&Self::ONE);
-            quo = Self::ct_select(&r, &quo, CtChoice::from_word_mask(borrow.0).or(done));
+            quo = Self::select(&r, &quo, CtChoice::from_word_mask(borrow.0).or(done));
             if i == 0 {
                 break;
             }
@@ -45,7 +45,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             // aren't modified further (but do the remaining iterations anyway to be constant-time)
             done = CtChoice::from_word_lt(i as Word, mb as Word);
             c = c.shr1();
-            quo = Self::ct_select(&quo.shl1(), &quo, done);
+            quo = Self::select(&quo.shl1(), &quo, done);
         }
 
         (quo, rem)
@@ -68,9 +68,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         loop {
             let (mut r, borrow) = rem.sbb(&c, Limb::ZERO);
-            rem = Self::ct_select(&r, &rem, CtChoice::from_word_mask(borrow.0));
+            rem = Self::select(&r, &rem, CtChoice::from_word_mask(borrow.0));
             r = quo.bitor(&Self::ONE);
-            quo = Self::ct_select(&r, &quo, CtChoice::from_word_mask(borrow.0));
+            quo = Self::select(&r, &quo, CtChoice::from_word_mask(borrow.0));
             if bd == 0 {
                 break;
             }
@@ -96,7 +96,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         loop {
             let (r, borrow) = rem.sbb(&c, Limb::ZERO);
-            rem = Self::ct_select(&r, &rem, CtChoice::from_word_mask(borrow.0));
+            rem = Self::select(&r, &rem, CtChoice::from_word_mask(borrow.0));
             if bd == 0 {
                 break;
             }
@@ -129,8 +129,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             let (lower_sub, borrow) = lower.sbb(&c.0, Limb::ZERO);
             let (upper_sub, borrow) = upper.sbb(&c.1, borrow);
 
-            lower = Self::ct_select(&lower_sub, &lower, CtChoice::from_word_mask(borrow.0));
-            upper = Self::ct_select(&upper_sub, &upper, CtChoice::from_word_mask(borrow.0));
+            lower = Self::select(&lower_sub, &lower, CtChoice::from_word_mask(borrow.0));
+            upper = Self::select(&upper_sub, &upper, CtChoice::from_word_mask(borrow.0));
             if bd == 0 {
                 break;
             }
@@ -156,7 +156,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         let outmask = Limb(out.limbs[limb_num].0 & mask);
 
-        out.limbs[limb_num] = Limb::ct_select(out.limbs[limb_num], outmask, le);
+        out.limbs[limb_num] = Limb::select(out.limbs[limb_num], outmask, le);
 
         // TODO: this is not constant-time.
         let mut i = limb_num + 1;

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -3,7 +3,7 @@
 //! (DOI: 10.1109/TC.2010.143, <https://gmplib.org/~tege/division-paper.pdf>).
 use subtle::{Choice, ConditionallySelectable};
 
-use crate::{CtChoice, Limb, NonZero, Uint, WideWord, Word};
+use crate::{ConstChoice, Limb, NonZero, Uint, WideWord, Word};
 
 /// Calculates the reciprocal of the given 32-bit divisor with the highmost bit set.
 #[cfg(target_pointer_width = "32")]
@@ -33,7 +33,7 @@ pub const fn reciprocal(d: Word) -> Word {
     // Hence the `ct_select()`.
     let x = v2.wrapping_add(1);
     let (hi, _lo) = mulhilo(x, d);
-    let hi = CtChoice::from_u32_nonzero(x).select_word(d, hi);
+    let hi = ConstChoice::from_u32_nonzero(x).select_word(d, hi);
 
     v2.wrapping_sub(hi).wrapping_sub(d)
 }
@@ -63,7 +63,7 @@ pub const fn reciprocal(d: Word) -> Word {
     // Hence the `ct_select()`.
     let x = v3.wrapping_add(1);
     let (hi, _lo) = mulhilo(x, d);
-    let hi = CtChoice::from_word_nonzero(x).select_word(d, hi);
+    let hi = ConstChoice::from_word_nonzero(x).select_word(d, hi);
 
     v3.wrapping_sub(hi).wrapping_sub(d)
 }
@@ -142,7 +142,7 @@ const fn div2by1(u1: Word, u0: Word, reciprocal: &Reciprocal) -> (Word, Word) {
     let q1 = q1.wrapping_add(1);
     let r = u0.wrapping_sub(q1.wrapping_mul(d));
 
-    let r_gt_q0 = CtChoice::from_word_lt(q0, r);
+    let r_gt_q0 = ConstChoice::from_word_lt(q0, r);
     let q1 = r_gt_q0.select_word(q1, q1.wrapping_sub(1));
     let r = r_gt_q0.select_word(r, r.wrapping_add(d));
 
@@ -150,7 +150,7 @@ const fn div2by1(u1: Word, u0: Word, reciprocal: &Reciprocal) -> (Word, Word) {
     // But since we calculate both results either way, we have to wrap.
     // Added an assert to still check the lack of overflow in debug mode.
     debug_assert!(r < d || q1 < Word::MAX);
-    let r_ge_d = CtChoice::from_word_le(d, r);
+    let r_ge_d = ConstChoice::from_word_le(d, r);
     let q1 = r_ge_d.select_word(q1, q1.wrapping_add(1));
     let r = r_ge_d.select_word(r, r.wrapping_sub(d));
 

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -70,14 +70,14 @@ pub const fn reciprocal(d: Word) -> Word {
 
 /// Returns `u32::MAX` if `a < b` and `0` otherwise.
 #[inline]
-const fn ct_lt(a: u32, b: u32) -> u32 {
+const fn lt(a: u32, b: u32) -> u32 {
     let bit = (((!a) & b) | (((!a) | b) & (a.wrapping_sub(b)))) >> (u32::BITS - 1);
     bit.wrapping_neg()
 }
 
 /// Returns `a` if `c == 0` and `b` if `c == u32::MAX`.
 #[inline(always)]
-const fn ct_select(a: u32, b: u32, c: u32) -> u32 {
+const fn select(a: u32, b: u32, c: u32) -> u32 {
     a ^ (c & (a ^ b))
 }
 
@@ -101,8 +101,8 @@ const fn short_div(dividend: u32, dividend_bits: u32, divisor: u32, divisor_bits
 
     while i > 0 {
         i -= 1;
-        let bit = ct_lt(dividend, divisor);
-        dividend = ct_select(dividend.wrapping_sub(divisor), dividend, bit);
+        let bit = lt(dividend, divisor);
+        dividend = select(dividend.wrapping_sub(divisor), dividend, bit);
         divisor >>= 1;
         let inv_bit = !bit;
         quotient |= (inv_bit >> (u32::BITS - 1)) << i;

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -76,7 +76,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Perform saturating multiplication, returning `MAX` on overflow.
     pub const fn saturating_mul<const HLIMBS: usize>(&self, rhs: &Uint<HLIMBS>) -> Self {
         let (res, overflow) = self.mul_wide(rhs);
-        Self::ct_select(&res, &Self::MAX, overflow.ct_is_nonzero())
+        Self::select(&res, &Self::MAX, overflow.is_nonzero())
     }
 
     /// Perform wrapping multiplication, discarding overflow.

--- a/src/uint/neg.rs
+++ b/src/uint/neg.rs
@@ -13,7 +13,7 @@ impl<const LIMBS: usize> Neg for Wrapping<Uint<LIMBS>> {
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Negates based on `choice` by wrapping the integer.
     pub(crate) const fn conditional_wrapping_neg(&self, choice: CtChoice) -> Uint<LIMBS> {
-        Uint::ct_select(self, &self.wrapping_neg(), choice)
+        Uint::select(self, &self.wrapping_neg(), choice)
     }
 
     /// Perform wrapping negation.

--- a/src/uint/neg.rs
+++ b/src/uint/neg.rs
@@ -1,6 +1,6 @@
 use core::ops::Neg;
 
-use crate::{CtChoice, Limb, Uint, WideWord, Word, Wrapping};
+use crate::{ConstChoice, Limb, Uint, WideWord, Word, Wrapping};
 
 impl<const LIMBS: usize> Neg for Wrapping<Uint<LIMBS>> {
     type Output = Self;
@@ -12,7 +12,7 @@ impl<const LIMBS: usize> Neg for Wrapping<Uint<LIMBS>> {
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Negates based on `choice` by wrapping the integer.
-    pub(crate) const fn conditional_wrapping_neg(&self, choice: CtChoice) -> Uint<LIMBS> {
+    pub(crate) const fn conditional_wrapping_neg(&self, choice: ConstChoice) -> Uint<LIMBS> {
         Uint::select(self, &self.wrapping_neg(), choice)
     }
 

--- a/src/uint/neg_mod.rs
+++ b/src/uint/neg_mod.rs
@@ -6,7 +6,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `-a mod p`.
     /// Assumes `self` is in `[0, p)`.
     pub const fn neg_mod(&self, p: &Self) -> Self {
-        let z = self.ct_is_nonzero();
+        let z = self.is_nonzero();
         let mut ret = p.sbb(self, Limb::ZERO).0;
         let mut i = 0;
         while i < LIMBS {

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -17,11 +17,11 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mut i = 0;
         while i < shift_bits {
             let bit = CtChoice::from_u32_lsb((shift >> i) & 1);
-            result = Uint::ct_select(&result, &result.shl_vartime(1 << i).0, bit);
+            result = Uint::select(&result, &result.shl_vartime(1 << i).0, bit);
             i += 1;
         }
 
-        (Uint::ct_select(&result, &Self::ZERO, overflow), overflow)
+        (Uint::select(&result, &Self::ZERO, overflow), overflow)
     }
 
     /// Computes `self << shift`.

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -17,11 +17,11 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mut i = 0;
         while i < shift_bits {
             let bit = CtChoice::from_u32_lsb((shift >> i) & 1);
-            result = Uint::ct_select(&result, &result.shr_vartime(1 << i).0, bit);
+            result = Uint::select(&result, &result.shr_vartime(1 << i).0, bit);
             i += 1;
         }
 
-        (Uint::ct_select(&result, &Self::ZERO, overflow), overflow)
+        (Uint::select(&result, &Self::ZERO, overflow), overflow)
     }
 
     /// Computes `self >> shift`.

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -33,7 +33,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             let (q, _) = self.div_rem(&nz_x);
 
             // A protection in case `self == 0`, which will make `x == 0`
-            let q = Self::ct_select(&Self::ZERO, &q, is_some);
+            let q = Self::select(&Self::ZERO, &q, is_some);
 
             x = x.wrapping_add(&q).shr1();
             i += 1;
@@ -42,7 +42,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // At this point `x_prev == x_{n}` and `x == x_{n+1}`
         // where `n == i - 1 == LOG2_BITS + 1 == floor(log2(BITS)) + 1`.
         // Thus, according to Hast, `sqrt(self) = min(x_n, x_{n+1})`.
-        Self::ct_select(&x_prev, &x, Uint::ct_gt(&x_prev, &x))
+        Self::select(&x_prev, &x, Uint::gt(&x_prev, &x))
     }
 
     /// Computes √(`self`)
@@ -72,7 +72,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             x = next_x;
         }
 
-        if self.ct_is_nonzero().is_true_vartime() {
+        if self.is_nonzero().is_true_vartime() {
             x
         } else {
             Self::ZERO

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -25,7 +25,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Perform saturating subtraction, returning `ZERO` on underflow.
     pub const fn saturating_sub(&self, rhs: &Self) -> Self {
         let (res, underflow) = self.sbb(rhs, Limb::ZERO);
-        Self::ct_select(&res, &Self::ZERO, CtChoice::from_word_mask(underflow.0))
+        Self::select(&res, &Self::ZERO, CtChoice::from_word_mask(underflow.0))
     }
 
     /// Perform wrapping subtraction, discarding underflow and wrapping around
@@ -41,7 +41,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         rhs: &Self,
         choice: CtChoice,
     ) -> (Self, CtChoice) {
-        let actual_rhs = Uint::ct_select(&Uint::ZERO, rhs, choice);
+        let actual_rhs = Uint::select(&Uint::ZERO, rhs, choice);
         let (res, borrow) = self.sbb(&actual_rhs, Limb::ZERO);
         (res, CtChoice::from_word_mask(borrow.0))
     }

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -1,7 +1,7 @@
 //! [`Uint`] addition operations.
 
 use super::Uint;
-use crate::{Checked, CheckedSub, CtChoice, Limb, Wrapping, Zero};
+use crate::{Checked, CheckedSub, ConstChoice, Limb, Wrapping, Zero};
 use core::ops::{Sub, SubAssign};
 use subtle::CtOption;
 
@@ -25,7 +25,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Perform saturating subtraction, returning `ZERO` on underflow.
     pub const fn saturating_sub(&self, rhs: &Self) -> Self {
         let (res, underflow) = self.sbb(rhs, Limb::ZERO);
-        Self::select(&res, &Self::ZERO, CtChoice::from_word_mask(underflow.0))
+        Self::select(&res, &Self::ZERO, ConstChoice::from_word_mask(underflow.0))
     }
 
     /// Perform wrapping subtraction, discarding underflow and wrapping around
@@ -39,11 +39,11 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     pub(crate) const fn conditional_wrapping_sub(
         &self,
         rhs: &Self,
-        choice: CtChoice,
-    ) -> (Self, CtChoice) {
+        choice: ConstChoice,
+    ) -> (Self, ConstChoice) {
         let actual_rhs = Uint::select(&Uint::ZERO, rhs, choice);
         let (res, borrow) = self.sbb(&actual_rhs, Limb::ZERO);
-        (res, CtChoice::from_word_mask(borrow.0))
+        (res, ConstChoice::from_word_mask(borrow.0))
     }
 }
 

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -2,7 +2,7 @@
 
 use crypto_bigint::{
     modular::{DynResidue, DynResidueParams},
-    CtChoice, Encoding, Limb, NonZero, Word, U256,
+    ConstChoice, Encoding, Limb, NonZero, Word, U256,
 };
 use num_bigint::BigUint;
 use num_integer::Integer;
@@ -69,7 +69,7 @@ proptest! {
         assert_eq!(expected, actual);
         if shift >= U256::BITS {
             assert_eq!(actual, U256::ZERO);
-            assert_eq!(overflow, CtChoice::TRUE);
+            assert_eq!(overflow, ConstChoice::TRUE);
         }
     }
 
@@ -86,7 +86,7 @@ proptest! {
         assert_eq!(expected, actual);
         if shift >= U256::BITS {
             assert_eq!(actual, U256::ZERO);
-            assert_eq!(overflow, CtChoice::TRUE);
+            assert_eq!(overflow, ConstChoice::TRUE);
         }
     }
 
@@ -103,7 +103,7 @@ proptest! {
         assert_eq!(expected, actual);
         if shift >= U256::BITS {
             assert_eq!(actual, U256::ZERO);
-            assert_eq!(overflow, CtChoice::TRUE);
+            assert_eq!(overflow, ConstChoice::TRUE);
         }
     }
 
@@ -120,7 +120,7 @@ proptest! {
         assert_eq!(expected, actual);
         if shift >= U256::BITS {
             assert_eq!(actual, U256::ZERO);
-            assert_eq!(overflow, CtChoice::TRUE);
+            assert_eq!(overflow, ConstChoice::TRUE);
         }
     }
 
@@ -281,8 +281,8 @@ proptest! {
         let (actual, is_some) = a.inv_mod2k(k);
         let (actual_vartime, is_some_vartime) = a.inv_mod2k_vartime(k);
         assert_eq!(actual, actual_vartime);
-        assert_eq!(is_some, CtChoice::TRUE);
-        assert_eq!(is_some_vartime, CtChoice::TRUE);
+        assert_eq!(is_some, ConstChoice::TRUE);
+        assert_eq!(is_some_vartime, ConstChoice::TRUE);
 
         if k == 0 {
             assert_eq!(actual, U256::ZERO);
@@ -299,7 +299,7 @@ proptest! {
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);
 
-        let expected_is_some = if a_bi.gcd(&b_bi) == BigUint::one() { CtChoice::TRUE } else { CtChoice::FALSE };
+        let expected_is_some = if a_bi.gcd(&b_bi) == BigUint::one() { ConstChoice::TRUE } else { ConstChoice::FALSE };
         let (actual, actual_is_some) = a.inv_mod(&b);
 
         assert_eq!(bool::from(expected_is_some), bool::from(actual_is_some));


### PR DESCRIPTION
- Don't use "ct_" prefixes for constant-time methods - it is the default
- Renamed `CtChoice` to `ConstChoice` (to distinguish it from `subtle::Choice`)