### PR TITLE
Make division methods take `NonZero`-wrapped divisors

### DIFF
--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -60,8 +60,11 @@ fn bench_division(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let x = U256::random(&mut OsRng);
-                let y = Limb::random(&mut OsRng);
-                let r = Reciprocal::new(y);
+                let mut y = Limb::random(&mut OsRng);
+                if y == Limb::ZERO {
+                    y = Limb::ONE;
+                }
+                let r = Reciprocal::new(NonZero::new(y).unwrap());
                 (x, r)
             },
             |(x, r)| black_box(x.div_rem_limb_with_reciprocal(&r)),

--- a/src/modular/dyn_residue.rs
+++ b/src/modular/dyn_residue.rs
@@ -78,7 +78,7 @@ impl<const LIMBS: usize> DynResidueParams<LIMBS> {
         P: ResidueParams<LIMBS>,
     {
         Self {
-            modulus: P::MODULUS,
+            modulus: P::MODULUS.0,
             r: P::R,
             r2: P::R2,
             r3: P::R3,

--- a/src/modular/residue.rs
+++ b/src/modular/residue.rs
@@ -10,7 +10,7 @@ mod sub;
 use super::{div_by_2::div_by_2, reduction::montgomery_reduction, Retrieve};
 use crate::{Limb, NonZero, Uint, ZeroConstant};
 use core::{fmt::Debug, marker::PhantomData};
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 #[cfg(feature = "rand_core")]
 use crate::{rand_core::CryptoRngCore, Random, RandomMod};
@@ -38,9 +38,7 @@ pub trait ResidueParams<const LIMBS: usize>:
     const LIMBS: usize;
 
     /// The constant modulus
-    const MODULUS: Uint<LIMBS>;
-    /// The constant modulus pre-wrapped in NonZero
-    const MODULUS_NZ: NonZero<Uint<LIMBS>>;
+    const MODULUS: NonZero<Uint<LIMBS>>;
     /// Parameter used in Montgomery reduction
     const R: Uint<LIMBS>;
     /// R^2, used to move into Montgomery form
@@ -88,7 +86,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     const fn generate_residue(integer: &Uint<LIMBS>) -> Self {
         let product = integer.mul_wide(&MOD::R2);
         let montgomery_form =
-            montgomery_reduction::<LIMBS>(&product, &MOD::MODULUS, MOD::MOD_NEG_INV);
+            montgomery_reduction::<LIMBS>(&product, &MOD::MODULUS.0, MOD::MOD_NEG_INV);
 
         Self {
             montgomery_form,
@@ -97,37 +95,15 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     }
 
     /// Instantiates a new [`Residue`] that represents this `integer` mod `MOD`.
-    ///
-    /// If the modulus represented by `MOD` is not odd, this function will panic; use
-    /// [`new_checked`][`Residue::new_checked`] if you want to be able to detect an invalid modulus.
     pub const fn new(integer: &Uint<LIMBS>) -> Self {
-        // A valid modulus must be odd
-        if MOD::MODULUS.ct_is_odd().to_u8() == 0 {
-            panic!("modulus must be odd");
-        }
-
         Self::generate_residue(integer)
-    }
-
-    /// Instantiates a new `Residue` that represents this `integer` mod `MOD` if the modulus is odd.
-    ///
-    /// Returns a [`CtOption`] that is `None` if the provided modulus is not odd; this is a safer
-    /// version of [`new`][`Residue::new`], which can panic.
-    // TODO: remove this method when we can use `generic_const_exprs.` to ensure the modulus is
-    // always valid.
-    pub fn new_checked(integer: &Uint<LIMBS>) -> CtOption<Self> {
-        // A valid modulus must be odd.
-        CtOption::new(
-            Self::generate_residue(integer),
-            MOD::MODULUS.ct_is_odd().into(),
-        )
     }
 
     /// Retrieves the integer currently encoded in this [`Residue`], guaranteed to be reduced.
     pub const fn retrieve(&self) -> Uint<LIMBS> {
         montgomery_reduction::<LIMBS>(
             &(self.montgomery_form, Uint::ZERO),
-            &MOD::MODULUS,
+            &MOD::MODULUS.0,
             MOD::MOD_NEG_INV,
         )
     }
@@ -206,7 +182,7 @@ where
 {
     #[inline]
     fn random(rng: &mut impl CryptoRngCore) -> Self {
-        Self::new(&Uint::random_mod(rng, &NonZero::from_uint(MOD::MODULUS)))
+        Self::new(&Uint::random_mod(rng, &MOD::MODULUS))
     }
 }
 

--- a/src/modular/residue.rs
+++ b/src/modular/residue.rs
@@ -8,12 +8,12 @@ mod pow;
 mod sub;
 
 use super::{div_by_2::div_by_2, reduction::montgomery_reduction, Retrieve};
-use crate::{Limb, Uint, ZeroConstant};
+use crate::{Limb, NonZero, Uint, ZeroConstant};
 use core::{fmt::Debug, marker::PhantomData};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "rand_core")]
-use crate::{rand_core::CryptoRngCore, NonZero, Random, RandomMod};
+use crate::{rand_core::CryptoRngCore, Random, RandomMod};
 
 #[cfg(feature = "serde")]
 use {
@@ -39,6 +39,8 @@ pub trait ResidueParams<const LIMBS: usize>:
 
     /// The constant modulus
     const MODULUS: Uint<LIMBS>;
+    /// The constant modulus pre-wrapped in NonZero
+    const MODULUS_NZ: NonZero<Uint<LIMBS>>;
     /// Parameter used in Montgomery reduction
     const R: Uint<LIMBS>;
     /// R^2, used to move into Montgomery form

--- a/src/modular/residue/add.rs
+++ b/src/modular/residue/add.rs
@@ -11,7 +11,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
             montgomery_form: add_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
-                &MOD::MODULUS,
+                &MOD::MODULUS.0,
             ),
             phantom: core::marker::PhantomData,
         }

--- a/src/modular/residue/inv.rs
+++ b/src/modular/residue/inv.rs
@@ -13,7 +13,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     pub const fn invert(&self) -> (Self, CtChoice) {
         let (montgomery_form, is_some) = inv_montgomery_form(
             &self.montgomery_form,
-            &MOD::MODULUS,
+            &MOD::MODULUS.0,
             &MOD::R3,
             MOD::MOD_NEG_INV,
         );

--- a/src/modular/residue/macros.rs
+++ b/src/modular/residue/macros.rs
@@ -30,12 +30,15 @@ macro_rules! impl_modulus {
 
                 res
             };
+
+            // Can unwrap `NonZero::const_new()` here since `MODULUS` was asserted to be non-zero.
+            const MODULUS_NZ: $crate::NonZero<$uint_type> =
+                $crate::NonZero::<$uint_type>::const_new(Self::MODULUS).0;
+
             const R: $uint_type = $crate::Uint::MAX
-                .const_rem(&Self::MODULUS)
-                .0
+                .rem(&Self::MODULUS_NZ)
                 .wrapping_add(&$crate::Uint::ONE);
-            const R2: $uint_type =
-                $crate::Uint::const_rem_wide(Self::R.square_wide(), &Self::MODULUS).0;
+            const R2: $uint_type = $crate::Uint::rem_wide(Self::R.square_wide(), &Self::MODULUS_NZ);
             const MOD_NEG_INV: $crate::Limb = $crate::Limb(
                 $crate::Word::MIN.wrapping_sub(
                     Self::MODULUS

--- a/src/modular/residue/mul.rs
+++ b/src/modular/residue/mul.rs
@@ -19,7 +19,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
             montgomery_form: mul_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
-                &MOD::MODULUS,
+                &MOD::MODULUS.0,
                 MOD::MOD_NEG_INV,
             ),
             phantom: PhantomData,
@@ -31,7 +31,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
         Self {
             montgomery_form: square_montgomery_form(
                 &self.montgomery_form,
-                &MOD::MODULUS,
+                &MOD::MODULUS.0,
                 MOD::MOD_NEG_INV,
             ),
             phantom: PhantomData,

--- a/src/modular/residue/pow.rs
+++ b/src/modular/residue/pow.rs
@@ -33,7 +33,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
                 &self.montgomery_form,
                 exponent,
                 exponent_bits,
-                &MOD::MODULUS,
+                &MOD::MODULUS.0,
                 &MOD::R,
                 MOD::MOD_NEG_INV,
             ),

--- a/src/modular/residue/sub.rs
+++ b/src/modular/residue/sub.rs
@@ -11,7 +11,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
             montgomery_form: sub_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
-                &MOD::MODULUS,
+                &MOD::MODULUS.0,
             ),
             phantom: core::marker::PhantomData,
         }

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -50,6 +50,11 @@ where
         CtOption::new(Self(n), !is_zero)
     }
 
+    /// Provides access to the contents of `NonZero` in a `const` context.
+    pub const fn as_ref(&self) -> &T {
+        &self.0
+    }
+
     /// Returns the inner value.
     pub fn get(self) -> T {
         self.0

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -169,26 +169,20 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Wrapped division is just normal division i.e. `self` / `rhs`
+    ///
     /// There’s no way wrapping could ever happen.
     /// This function exists, so that all operations are accounted for in the wrapping operations.
-    ///
-    /// Panics if `rhs == 0`.
-    pub const fn wrapping_div(&self, rhs: &Self) -> Self {
-        let (nz_rhs, c) = NonZero::<Self>::const_new(*rhs);
-        assert!(c.is_true_vartime(), "divide by zero");
-        let (q, _) = self.div_rem(&nz_rhs);
+    pub const fn wrapping_div(&self, rhs: &NonZero<Self>) -> Self {
+        let (q, _) = self.div_rem(rhs);
         q
     }
 
     /// Wrapped division is just normal division i.e. `self` / `rhs`
+    ///
     /// There’s no way wrapping could ever happen.
     /// This function exists, so that all operations are accounted for in the wrapping operations.
-    ///
-    /// Panics if `rhs == 0`. Constant-time only for fixed `rhs`.
-    pub const fn wrapping_div_vartime(&self, rhs: &Self) -> Self {
-        let (nz_rhs, c) = NonZero::<Self>::const_new(*rhs);
-        assert!(c.is_true_vartime(), "divide by zero");
-        let (q, _) = self.div_rem_vartime(&nz_rhs);
+    pub const fn wrapping_div_vartime(&self, rhs: &NonZero<Self>) -> Self {
+        let (q, _) = self.div_rem_vartime(rhs);
         q
     }
 
@@ -657,24 +651,12 @@ mod tests {
         let mut a = U256::ZERO;
         let mut b = U256::ZERO;
         b.limbs[b.limbs.len() - 1] = Limb(Word::MAX);
-        let q = a.wrapping_div(&b);
+        let q = a.wrapping_div(&NonZero::new(b).unwrap());
         assert_eq!(q, Uint::ZERO);
         a.limbs[a.limbs.len() - 1] = Limb(1 << (Limb::HI_BIT - 7));
         b.limbs[b.limbs.len() - 1] = Limb(0x82 << (Limb::HI_BIT - 7));
-        let q = a.wrapping_div(&b);
+        let q = a.wrapping_div(&NonZero::new(b).unwrap());
         assert_eq!(q, Uint::ZERO);
-    }
-
-    #[test]
-    #[should_panic(expected = "divide by zero")]
-    fn div_zero() {
-        U256::ONE.wrapping_div(&U256::ZERO);
-    }
-
-    #[test]
-    #[should_panic(expected = "divide by zero")]
-    fn div_zero_vartime() {
-        U256::ONE.wrapping_div_vartime(&U256::ZERO);
     }
 
     #[test]

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -19,21 +19,16 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         div_rem_limb_with_reciprocal(self, &Reciprocal::new(rhs))
     }
 
-    /// Computes `self` / `rhs`, returns the quotient (q), remainder (r)
-    /// and the truthy value for is_some or the falsy value for is_none.
-    ///
-    /// NOTE: Use only if you need to access const fn. Otherwise use [`Self::div_rem`] because
-    /// the value for is_some needs to be checked before using `q` and `r`.
+    /// Computes `self` / `rhs`, returns the quotient (q) and the remainder (r)
     ///
     /// This function is constant-time with respect to both `self` and `rhs`.
     #[allow(trivial_numeric_casts)]
-    pub(crate) const fn const_div_rem(&self, rhs: &Self) -> (Self, Self, CtChoice) {
-        let mb = rhs.bits();
+    pub const fn div_rem(&self, rhs: &NonZero<Self>) -> (Self, Self) {
+        let mb = rhs.0.bits();
         let mut rem = *self;
         let mut quo = Self::ZERO;
         // If there is overflow, it means `mb == 0`, so `rhs == 0`.
-        let (mut c, overflow) = rhs.shl(Self::BITS - mb);
-        let is_some = overflow.not();
+        let (mut c, _overflow) = rhs.0.shl(Self::BITS - mb);
 
         let mut i = Self::BITS;
         let mut done = CtChoice::FALSE;
@@ -53,27 +48,23 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             quo = Self::ct_select(&quo.shl1(), &quo, done);
         }
 
-        quo = Self::ct_select(&Self::ZERO, &quo, is_some);
-        (quo, rem, is_some)
+        (quo, rem)
     }
 
-    /// Computes `self` / `rhs`, returns the quotient (q), remainder (r)
-    /// and the truthy value for is_some or the falsy value for is_none.
-    ///
-    /// NOTE: Use only if you need to access const fn. Otherwise use [`Self::div_rem`] because
-    /// the value for is_some needs to be checked before using `q` and `r`.
+    /// Computes `self` / `rhs`, returns the quotient (q) and the remainder (r)
     ///
     /// This is variable only with respect to `rhs`.
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
-    pub(crate) const fn const_div_rem_vartime(&self, rhs: &Self) -> (Self, Self, CtChoice) {
-        let mb = rhs.bits_vartime();
+    #[allow(trivial_numeric_casts)]
+    pub const fn div_rem_vartime(&self, rhs: &NonZero<Self>) -> (Self, Self) {
+        let mb = rhs.0.bits_vartime();
         let mut bd = Self::BITS - mb;
         let mut rem = *self;
         let mut quo = Self::ZERO;
-        let (mut c, overflow) = rhs.shl_vartime(bd);
-        let is_some = overflow.not();
+        // If there is overflow, it means `mb == 0`, so `rhs == 0`.
+        let (mut c, _overflow) = rhs.0.shl_vartime(bd);
 
         loop {
             let (mut r, borrow) = rem.sbb(&c, Limb::ZERO);
@@ -88,8 +79,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             quo = quo.shl1();
         }
 
-        quo = Self::ct_select(&Self::ZERO, &quo, is_some);
-        (quo, rem, is_some)
+        (quo, rem)
     }
 
     /// Computes `self` % `rhs`, returns the remainder and and the truthy value for is_some or the
@@ -183,20 +173,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         out
     }
 
-    /// Computes self / rhs, returns the quotient, remainder.
-    pub fn div_rem(&self, rhs: &NonZero<Self>) -> (Self, Self) {
-        // Since `rhs` is nonzero, this should always hold.
-        let (q, r, _c) = self.const_div_rem(rhs);
-        (q, r)
-    }
-
-    /// Computes self / rhs, returns the quotient, remainder. Constant-time only for fixed `rhs`.
-    pub fn div_rem_vartime(&self, rhs: &NonZero<Self>) -> (Self, Self) {
-        // Since `rhs` is nonzero, this should always hold.
-        let (q, r, _c) = self.const_div_rem_vartime(rhs);
-        (q, r)
-    }
-
     /// Computes self % rhs, returns the remainder.
     pub fn rem(&self, rhs: &NonZero<Self>) -> Self {
         // Since `rhs` is nonzero, this should always hold.
@@ -210,8 +186,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Panics if `rhs == 0`.
     pub const fn wrapping_div(&self, rhs: &Self) -> Self {
-        let (q, _, c) = self.const_div_rem(rhs);
+        let (nz_rhs, c) = NonZero::<Self>::const_new(*rhs);
         assert!(c.is_true_vartime(), "divide by zero");
+        let (q, _) = self.div_rem(&nz_rhs);
         q
     }
 
@@ -221,8 +198,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Panics if `rhs == 0`. Constant-time only for fixed `rhs`.
     pub const fn wrapping_div_vartime(&self, rhs: &Self) -> Self {
-        let (q, _, c) = self.const_div_rem_vartime(rhs);
+        let (nz_rhs, c) = NonZero::<Self>::const_new(*rhs);
         assert!(c.is_true_vartime(), "divide by zero");
+        let (q, _) = self.div_rem_vartime(&nz_rhs);
         q
     }
 
@@ -659,13 +637,11 @@ mod tests {
             (1u64, 13u64, 0u64, 1u64),
         ] {
             let lhs = U256::from(*n);
-            let rhs = U256::from(*d);
-            let (q, r, is_some) = lhs.const_div_rem(&rhs);
-            assert!(is_some.is_true_vartime());
+            let rhs = NonZero::new(U256::from(*d)).unwrap();
+            let (q, r) = lhs.div_rem(&rhs);
             assert_eq!(U256::from(*e), q);
             assert_eq!(U256::from(*ee), r);
-            let (q, r, is_some) = lhs.const_div_rem_vartime(&rhs);
-            assert!(is_some.is_true_vartime());
+            let (q, r) = lhs.div_rem_vartime(&rhs);
             assert_eq!(U256::from(*e), q);
             assert_eq!(U256::from(*ee), r);
         }
@@ -677,14 +653,12 @@ mod tests {
         let mut rng = ChaChaRng::from_seed([7u8; 32]);
         for _ in 0..25 {
             let (num, _) = U256::random(&mut rng).shr_vartime(128);
-            let (den, _) = U256::random(&mut rng).shr_vartime(128);
-            let n = num.checked_mul(&den);
+            let den = NonZero::new(U256::random(&mut rng).shr_vartime(128).0).unwrap();
+            let n = num.checked_mul(den.as_ref());
             if n.is_some().into() {
-                let (q, _, is_some) = n.unwrap().const_div_rem(&den);
-                assert!(is_some.is_true_vartime());
+                let (q, _) = n.unwrap().div_rem(&den);
                 assert_eq!(q, num);
-                let (q, _, is_some) = n.unwrap().const_div_rem_vartime(&den);
-                assert!(is_some.is_true_vartime());
+                let (q, _) = n.unwrap().div_rem_vartime(&den);
                 assert_eq!(q, num);
             }
         }
@@ -704,25 +678,23 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "divide by zero")]
     fn div_zero() {
-        let (q, r, is_some) = U256::ONE.const_div_rem(&U256::ZERO);
-        assert!(!is_some.is_true_vartime());
-        assert_eq!(q, U256::ZERO);
-        assert_eq!(r, U256::ONE);
-        let (q, r, is_some) = U256::ONE.const_div_rem_vartime(&U256::ZERO);
-        assert!(!is_some.is_true_vartime());
-        assert_eq!(q, U256::ZERO);
-        assert_eq!(r, U256::ONE);
+        U256::ONE.wrapping_div(&U256::ZERO);
+    }
+
+    #[test]
+    #[should_panic(expected = "divide by zero")]
+    fn div_zero_vartime() {
+        U256::ONE.wrapping_div_vartime(&U256::ZERO);
     }
 
     #[test]
     fn div_one() {
-        let (q, r, is_some) = U256::from(10u8).const_div_rem(&U256::ONE);
-        assert!(is_some.is_true_vartime());
+        let (q, r) = U256::from(10u8).div_rem(&NonZero::new(U256::ONE).unwrap());
         assert_eq!(q, U256::from(10u8));
         assert_eq!(r, U256::ZERO);
-        let (q, r, is_some) = U256::from(10u8).const_div_rem_vartime(&U256::ONE);
-        assert!(is_some.is_true_vartime());
+        let (q, r) = U256::from(10u8).div_rem_vartime(&NonZero::new(U256::ONE).unwrap());
         assert_eq!(q, U256::from(10u8));
         assert_eq!(r, U256::ZERO);
     }

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -17,7 +17,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // Barrett reduction instead.
         //
         // It's worth potentially exploring other approaches to improve efficiency.
-        match DynResidueParams::new(p).into() {
+        match DynResidueParams::new(p) {
             Some(params) => {
                 let lhs = DynResidue::new(self, params);
                 let rhs = DynResidue::new(rhs, params);

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -17,7 +17,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // Barrett reduction instead.
         //
         // It's worth potentially exploring other approaches to improve efficiency.
-        match DynResidueParams::new(p) {
+        match DynResidueParams::new(p).into() {
             Some(params) => {
                 let lhs = DynResidue::new(self, params);
                 let rhs = DynResidue::new(rhs, params);

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -58,7 +58,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // Stop right away if `x` is zero to avoid divizion by zero.
         while !x.cmp_vartime(&Self::ZERO).is_eq() {
             // Calculate `x_{i+1} = floor((x_i + self / x_i) / 2)`
-            let q = self.wrapping_div_vartime(&x);
+            let q = self.wrapping_div_vartime(&NonZero::<Self>::const_new(x).0);
             let t = x.wrapping_add(&q);
             let next_x = t.shr1();
 

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -1,7 +1,8 @@
 //! [`Uint`] square root operations.
 
-use super::Uint;
 use subtle::{ConstantTimeEq, CtOption};
+
+use crate::{NonZero, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes √(`self`) in constant time.
@@ -28,7 +29,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
             // Calculate `x_{i+1} = floor((x_i + self / x_i) / 2)`
 
-            let (q, _, is_some) = self.const_div_rem(&x);
+            let (nz_x, is_some) = NonZero::<Self>::const_new(x);
+            let (q, _) = self.div_rem(&nz_x);
 
             // A protection in case `self == 0`, which will make `x == 0`
             let q = Self::ct_select(&Self::ZERO, &q, is_some);

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -226,9 +226,10 @@ proptest! {
 
         if !b_bi.is_zero() {
             let expected = to_uint(a_bi / b_bi);
-            let actual = a.wrapping_div(&b);
+            let b_nz = NonZero::new(b).unwrap();
+            let actual = a.wrapping_div(&b_nz);
             assert_eq!(expected, actual);
-            let actual_vartime = a.wrapping_div_vartime(&b);
+            let actual_vartime = a.wrapping_div_vartime(&b_nz);
             assert_eq!(expected, actual_vartime);
         }
     }


### PR DESCRIPTION
This simplifies the API allowing us to avoid returning `CtChoice` results, and making some methods redundant. Also that's what `BoxedUint` is already doing.

- Simplify `Reciprocal` API by taking a `NonZero<Limb>` in `Reciprocal::new()` which is now `const`.
- `Reciprocal::ct_new()` is removed. 
- `Uint::div_rem_limb()` and `Uint::div_rem_limb_with_reciprocal()` take a `NonZero<Limb>` and are now `const`.
- `Uint::ct_div_rem_limb()` and `Uint::ct_div_rem_limb_with_reciprocal()` are removed.
- `Uint::div_rem()` and `Uint::div_rem_vartime()` are now `const`.
- `Uint::const_div_rem()` and `Uint::const_div_rem_vartime()` are removed.
- Make `Uint::rem()` and `rem_wide()` take `NonZero` rhs and make them const.
- Make `Uint::wrapping_div(_vartime)` take `NonZero` rhs
- Wrap `ResidueParams::MODULUS` in `NonZero`.
- `Residue::new_checked()` removed since `ResidueParams` has already done that check in compile time.
- Added a `const fn` `NonZero::as_ref()` to get access to the inner value in a const context.
