### PR TITLE
BoxedUint: optimize `shl_assign`

### DIFF
--- a/src/uint/boxed/shl.rs
+++ b/src/uint/boxed/shl.rs
@@ -10,27 +10,37 @@ impl BoxedUint {
     /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
     /// or the result and a falsy `Choice` otherwise.
     pub fn shl(&self, shift: u32) -> (Self, Choice) {
+        let mut result = self.clone();
+        let overflow = result.shl_assign_with_carry(shift);
+        (result, overflow)
+    }
+
+    /// Computes `self <<= shift`.
+    ///
+    /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
+    /// or the result and a falsy `Choice` otherwise.
+    fn shl_assign_with_carry(&mut self, shift: u32) -> Choice {
         // `floor(log2(bits_precision - 1))` is the number of bits in the representation of `shift`
         // (which lies in range `0 <= shift < bits_precision`).
         let shift_bits = u32::BITS - (self.bits_precision() - 1).leading_zeros();
         let overflow = !shift.ct_lt(&self.bits_precision());
         let shift = shift % self.bits_precision();
-        let mut result = self.clone();
         let mut temp = self.clone();
 
         for i in 0..shift_bits {
             let bit = Choice::from(((shift >> i) & 1) as u8);
             temp.set_zero();
             // Will not overflow by construction
-            result
-                .shl_vartime_into(&mut temp, 1 << i)
+            self.shl_vartime_into(&mut temp, 1 << i)
                 .expect("shift within range");
-            result.conditional_assign(&temp, bit);
+            self.conditional_assign(&temp, bit);
         }
 
-        result.conditional_set_zero(overflow);
+        #[cfg(feature = "zeroize")]
+        zeroize::Zeroize::zeroize(&mut temp);
 
-        (result, overflow)
+        self.conditional_set_zero(overflow);
+        overflow
     }
 
     /// Computes `self << shift` and writes the result into `dest`.
@@ -124,8 +134,8 @@ impl Shl<u32> for &BoxedUint {
 
 impl ShlAssign<u32> for BoxedUint {
     fn shl_assign(&mut self, shift: u32) {
-        // TODO(tarcieri): in-place implementation that avoids clone
-        *self = self.clone().shl(shift)
+        let overflow = self.shl_assign_with_carry(shift);
+        assert!(!bool::from(overflow), "attempt to shift left with overflow");
     }
 }
 

--- a/src/uint/boxed/shl.rs
+++ b/src/uint/boxed/shl.rs
@@ -11,15 +11,15 @@ impl BoxedUint {
     /// or the result and a falsy `Choice` otherwise.
     pub fn shl(&self, shift: u32) -> (Self, Choice) {
         let mut result = self.clone();
-        let overflow = result.shl_assign_with_carry(shift);
+        let overflow = result.overflowing_shl_assign(shift);
         (result, overflow)
     }
 
     /// Computes `self <<= shift`.
     ///
     /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
-    /// or the result and a falsy `Choice` otherwise.
-    fn shl_assign_with_carry(&mut self, shift: u32) -> Choice {
+    /// or a falsy `Choice` otherwise.
+    fn overflowing_shl_assign(&mut self, shift: u32) -> Choice {
         // `floor(log2(bits_precision - 1))` is the number of bits in the representation of `shift`
         // (which lies in range `0 <= shift < bits_precision`).
         let shift_bits = u32::BITS - (self.bits_precision() - 1).leading_zeros();
@@ -134,7 +134,7 @@ impl Shl<u32> for &BoxedUint {
 
 impl ShlAssign<u32> for BoxedUint {
     fn shl_assign(&mut self, shift: u32) {
-        let overflow = self.shl_assign_with_carry(shift);
+        let overflow = self.overflowing_shl_assign(shift);
         assert!(!bool::from(overflow), "attempt to shift left with overflow");
     }
 }


### PR DESCRIPTION
Allows `shl_assign` to operate in-place on `self` (although it still requires a temporary buffer)