### PR TITLE
`BoxedUint`: use `Integer::{is_even, is_odd}`

### DIFF
--- a/src/modular/boxed_residue.rs
+++ b/src/modular/boxed_residue.rs
@@ -12,7 +12,7 @@ use super::{
     reduction::{montgomery_reduction_boxed, montgomery_reduction_boxed_mut},
     Retrieve,
 };
-use crate::{BoxedUint, Limb, NonZero, Word};
+use crate::{BoxedUint, Integer, Limb, NonZero, Word};
 use subtle::CtOption;
 
 #[cfg(feature = "std")]

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -98,29 +98,6 @@ impl BoxedUint {
         iter.fold(choice, |acc, limb| acc & limb.is_zero())
     }
 
-    /// Is this integer value an odd number?
-    ///
-    /// # Returns
-    ///
-    /// If odd, returns `Choice(1)`. Otherwise, returns `Choice(0)`.
-    // TODO(tarcieri): impl the `Integer` trait
-    pub fn is_odd(&self) -> Choice {
-        self.limbs
-            .first()
-            .map(|limb| limb.is_odd())
-            .unwrap_or_else(|| Choice::from(0))
-    }
-
-    /// Is this integer value an even number?
-    ///
-    /// # Returns
-    ///
-    /// If even, returns `Choice(1)`. Otherwise, returns `Choice(0)`.
-    // TODO(tarcieri): impl the `Integer` trait
-    pub fn is_even(&self) -> Choice {
-        !self.is_odd()
-    }
-
     /// Get the maximum value for a `BoxedUint` created with `at_least_bits_precision`
     /// precision bits requested.
     ///
@@ -414,10 +391,6 @@ impl Integer for BoxedUint {
 
     fn nlimbs(&self) -> usize {
         self.nlimbs()
-    }
-
-    fn is_odd(&self) -> Choice {
-        self.is_odd()
     }
 }
 

--- a/src/uint/boxed/inv_mod.rs
+++ b/src/uint/boxed/inv_mod.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] modular inverse (i.e. reciprocal) operations.
 
-use crate::BoxedUint;
+use crate::{BoxedUint, Integer};
 use subtle::{Choice, ConstantTimeEq, ConstantTimeLess, CtOption};
 
 impl BoxedUint {

--- a/tests/boxed_residue_proptests.rs
+++ b/tests/boxed_residue_proptests.rs
@@ -4,7 +4,7 @@
 
 use crypto_bigint::{
     modular::{BoxedResidue, BoxedResidueParams},
-    BoxedUint, Limb, NonZero,
+    BoxedUint, Integer, Limb, NonZero,
 };
 use num_bigint::{BigUint, ModInverse};
 use proptest::prelude::*;

--- a/tests/boxed_uint_proptests.rs
+++ b/tests/boxed_uint_proptests.rs
@@ -3,7 +3,7 @@
 #![cfg(feature = "alloc")]
 
 use core::cmp::Ordering;
-use crypto_bigint::{BoxedUint, CheckedAdd, Limb, NonZero};
+use crypto_bigint::{BoxedUint, CheckedAdd, Integer, Limb, NonZero};
 use num_bigint::{BigUint, ModInverse};
 use num_traits::identities::One;
 use proptest::prelude::*;


### PR DESCRIPTION
Avoid redefining these methods by using the provided impls on the trait