### PR TITLE
Impl `Wrapping*` traits from `num-traits`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ subtle = { version = "2.5", default-features = false }
 # optional dependencies
 der = { version = "0.7", optional = true, default-features = false }
 generic-array = { version = "0.14", optional = true }
+num-traits = { version = "0.2", default-features = false }
 rand_core = { version = "0.6.4", optional = true }
 rlp = { version = "0.5", optional = true, default-features = false }
 serdect = { version = "0.2", optional = true, default-features = false }
@@ -33,7 +34,6 @@ criterion = { version = "0.5", features = ["html_reports"] }
 hex-literal = "0.4"
 num-bigint = { package = "num-bigint-dig", version = "0.8" }
 num-integer = "0.1"
-num-traits = "0.2"
 proptest = "1"
 rand_core = { version = "0.6", features = ["std"] }
 rand_chacha = "0.3"

--- a/src/modular.rs
+++ b/src/modular.rs
@@ -135,7 +135,7 @@ mod tests {
         // Reducing xR should return x
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
-        let product = x.widening_mul_split(&Modulus2::R);
+        let product = x.split_mul(&Modulus2::R);
         assert_eq!(
             montgomery_reduction::<{ Modulus2::LIMBS }>(
                 &product,
@@ -151,10 +151,10 @@ mod tests {
         // Reducing xR^2 should return xR
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
-        let product = x.widening_mul_split(&Modulus2::R2);
+        let product = x.split_mul(&Modulus2::R2);
 
         // Computing xR mod modulus without Montgomery reduction
-        let (lo, hi) = x.widening_mul_split(&Modulus2::R);
+        let (lo, hi) = x.split_mul(&Modulus2::R);
         let c = hi.concat(&lo);
         let red = c.rem(&NonZero::new(U256::ZERO.concat(&Modulus2::MODULUS)).unwrap());
         let (hi, lo) = red.split();

--- a/src/modular.rs
+++ b/src/modular.rs
@@ -135,7 +135,7 @@ mod tests {
         // Reducing xR should return x
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
-        let product = x.mul_wide(&Modulus2::R);
+        let product = x.widening_mul_split(&Modulus2::R);
         assert_eq!(
             montgomery_reduction::<{ Modulus2::LIMBS }>(
                 &product,
@@ -151,10 +151,10 @@ mod tests {
         // Reducing xR^2 should return xR
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
-        let product = x.mul_wide(&Modulus2::R2);
+        let product = x.widening_mul_split(&Modulus2::R2);
 
         // Computing xR mod modulus without Montgomery reduction
-        let (lo, hi) = x.mul_wide(&Modulus2::R);
+        let (lo, hi) = x.widening_mul_split(&Modulus2::R);
         let c = hi.concat(&lo);
         let red = c.rem(&NonZero::new(U256::ZERO.concat(&Modulus2::MODULUS)).unwrap());
         let (hi, lo) = red.split();

--- a/src/modular/dyn_residue.rs
+++ b/src/modular/dyn_residue.rs
@@ -119,7 +119,7 @@ pub struct DynResidue<const LIMBS: usize> {
 impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// Instantiates a new `Residue` that represents this `integer` mod `MOD`.
     pub const fn new(integer: &Uint<LIMBS>, residue_params: DynResidueParams<LIMBS>) -> Self {
-        let product = integer.widening_mul_split(&residue_params.r2);
+        let product = integer.split_mul(&residue_params.r2);
         let montgomery_form = montgomery_reduction(
             &product,
             &residue_params.modulus,

--- a/src/modular/dyn_residue.rs
+++ b/src/modular/dyn_residue.rs
@@ -119,7 +119,7 @@ pub struct DynResidue<const LIMBS: usize> {
 impl<const LIMBS: usize> DynResidue<LIMBS> {
     /// Instantiates a new `Residue` that represents this `integer` mod `MOD`.
     pub const fn new(integer: &Uint<LIMBS>, residue_params: DynResidueParams<LIMBS>) -> Self {
-        let product = integer.mul_wide(&residue_params.r2);
+        let product = integer.widening_mul_split(&residue_params.r2);
         let montgomery_form = montgomery_reduction(
             &product,
             &residue_params.modulus,

--- a/src/modular/inv.rs
+++ b/src/modular/inv.rs
@@ -8,7 +8,7 @@ pub const fn inv_montgomery_form<const LIMBS: usize>(
 ) -> (Uint<LIMBS>, ConstChoice) {
     let (inverse, is_some) = x.inv_odd_mod(modulus);
     (
-        montgomery_reduction(&inverse.mul_wide(r3), modulus, mod_neg_inv),
+        montgomery_reduction(&inverse.widening_mul_split(r3), modulus, mod_neg_inv),
         is_some,
     )
 }

--- a/src/modular/inv.rs
+++ b/src/modular/inv.rs
@@ -8,7 +8,7 @@ pub const fn inv_montgomery_form<const LIMBS: usize>(
 ) -> (Uint<LIMBS>, ConstChoice) {
     let (inverse, is_some) = x.inv_odd_mod(modulus);
     (
-        montgomery_reduction(&inverse.widening_mul_split(r3), modulus, mod_neg_inv),
+        montgomery_reduction(&inverse.split_mul(r3), modulus, mod_neg_inv),
         is_some,
     )
 }

--- a/src/modular/mul.rs
+++ b/src/modular/mul.rs
@@ -8,7 +8,7 @@ pub(crate) const fn mul_montgomery_form<const LIMBS: usize>(
     modulus: &Uint<LIMBS>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {
-    let product = a.widening_mul_split(b);
+    let product = a.split_mul(b);
     montgomery_reduction::<LIMBS>(&product, modulus, mod_neg_inv)
 }
 

--- a/src/modular/mul.rs
+++ b/src/modular/mul.rs
@@ -8,7 +8,7 @@ pub(crate) const fn mul_montgomery_form<const LIMBS: usize>(
     modulus: &Uint<LIMBS>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {
-    let product = a.mul_wide(b);
+    let product = a.widening_mul_split(b);
     montgomery_reduction::<LIMBS>(&product, modulus, mod_neg_inv)
 }
 

--- a/src/modular/residue.rs
+++ b/src/modular/residue.rs
@@ -84,7 +84,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
 
     /// Internal helper function to generate a residue; this lets us cleanly wrap the constructors.
     const fn generate_residue(integer: &Uint<LIMBS>) -> Self {
-        let product = integer.mul_wide(&MOD::R2);
+        let product = integer.widening_mul_split(&MOD::R2);
         let montgomery_form =
             montgomery_reduction::<LIMBS>(&product, &MOD::MODULUS.0, MOD::MOD_NEG_INV);
 

--- a/src/modular/residue.rs
+++ b/src/modular/residue.rs
@@ -84,7 +84,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
 
     /// Internal helper function to generate a residue; this lets us cleanly wrap the constructors.
     const fn generate_residue(integer: &Uint<LIMBS>) -> Self {
-        let product = integer.widening_mul_split(&MOD::R2);
+        let product = integer.split_mul(&MOD::R2);
         let montgomery_form =
             montgomery_reduction::<LIMBS>(&product, &MOD::MODULUS.0, MOD::MOD_NEG_INV);
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -78,6 +78,7 @@ pub trait Integer:
     + WrappingAdd
     + WrappingSub
     + WrappingMul
+    + WrappingNeg
     + Zero
 {
     /// The value `1`.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,9 @@
 //! Traits provided by this crate
 
+pub use num_traits::{
+    WrappingAdd, WrappingMul, WrappingNeg, WrappingShl, WrappingShr, WrappingSub,
+};
+
 use crate::{Limb, NonZero};
 use core::fmt::Debug;
 use core::ops::{
@@ -71,6 +75,9 @@ pub trait Integer:
     + ShrAssign<u32>
     + SubMod
     + Sync
+    + WrappingAdd
+    + WrappingSub
+    + WrappingMul
     + Zero
 {
     /// The value `1`.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -79,6 +79,8 @@ pub trait Integer:
     + WrappingSub
     + WrappingMul
     + WrappingNeg
+    + WrappingShl
+    + WrappingShr
     + Zero
 {
     /// The value `1`.

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -1,6 +1,6 @@
 //! [`Uint`] addition operations.
 
-use crate::{Checked, CheckedAdd, ConstChoice, Limb, Uint, Wrapping, Zero};
+use crate::{Checked, CheckedAdd, ConstChoice, Limb, Uint, Wrapping, WrappingAdd, Zero};
 use core::ops::{Add, AddAssign};
 use subtle::CtOption;
 
@@ -45,12 +45,20 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> CheckedAdd<&Uint<LIMBS>> for Uint<LIMBS> {
+impl<const LIMBS: usize> Add for Uint<LIMBS> {
     type Output = Self;
 
-    fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
-        let (result, carry) = self.adc(rhs, Limb::ZERO);
-        CtOption::new(result, carry.is_zero())
+    fn add(self, rhs: Self) -> Self {
+        self.add(&rhs)
+    }
+}
+
+impl<const LIMBS: usize> Add<&Uint<LIMBS>> for Uint<LIMBS> {
+    type Output = Self;
+
+    fn add(self, rhs: &Self) -> Self {
+        self.checked_add(rhs)
+            .expect("attempted to add with overflow")
     }
 }
 
@@ -151,6 +159,21 @@ impl<const LIMBS: usize> AddAssign for Checked<Uint<LIMBS>> {
 impl<const LIMBS: usize> AddAssign<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS>> {
     fn add_assign(&mut self, other: &Self) {
         *self = *self + other;
+    }
+}
+
+impl<const LIMBS: usize> CheckedAdd<&Uint<LIMBS>> for Uint<LIMBS> {
+    type Output = Self;
+
+    fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
+        let (result, carry) = self.adc(rhs, Limb::ZERO);
+        CtOption::new(result, carry.is_zero())
+    }
+}
+
+impl<const LIMBS: usize> WrappingAdd for Uint<LIMBS> {
+    fn wrapping_add(&self, v: &Self) -> Self {
+        self.wrapping_add(v)
     }
 }
 

--- a/src/uint/boxed/add.rs
+++ b/src/uint/boxed/add.rs
@@ -1,8 +1,7 @@
 //! [`BoxedUint`] addition operations.
 
+use crate::{BoxedUint, CheckedAdd, Limb, Wrapping, WrappingAdd, Zero};
 use core::ops::{Add, AddAssign};
-
-use crate::{BoxedUint, CheckedAdd, Limb, Wrapping, Zero};
 use subtle::{Choice, ConditionallySelectable, CtOption};
 
 impl BoxedUint {
@@ -51,12 +50,28 @@ impl BoxedUint {
     }
 }
 
-impl CheckedAdd<&BoxedUint> for BoxedUint {
+impl Add for BoxedUint {
     type Output = Self;
 
-    fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
-        let (result, carry) = self.adc(rhs, Limb::ZERO);
-        CtOption::new(result, carry.is_zero())
+    fn add(self, rhs: Self) -> Self {
+        self.add(&rhs)
+    }
+}
+
+impl Add<&BoxedUint> for BoxedUint {
+    type Output = Self;
+
+    fn add(self, rhs: &Self) -> Self {
+        Add::add(&self, rhs)
+    }
+}
+
+impl Add<&BoxedUint> for &BoxedUint {
+    type Output = BoxedUint;
+
+    fn add(self, rhs: &BoxedUint) -> BoxedUint {
+        self.checked_add(rhs)
+            .expect("attempted to add with overflow")
     }
 }
 
@@ -101,6 +116,21 @@ impl AddAssign<Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
 impl AddAssign<&Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
     fn add_assign(&mut self, other: &Wrapping<BoxedUint>) {
         self.0.adc_assign(&other.0, Limb::ZERO);
+    }
+}
+
+impl CheckedAdd<&BoxedUint> for BoxedUint {
+    type Output = Self;
+
+    fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
+        let (result, carry) = self.adc(rhs, Limb::ZERO);
+        CtOption::new(result, carry.is_zero())
+    }
+}
+
+impl WrappingAdd for BoxedUint {
+    fn wrapping_add(&self, v: &Self) -> Self {
+        self.wrapping_add(v)
     }
 }
 

--- a/src/uint/boxed/mul.rs
+++ b/src/uint/boxed/mul.rs
@@ -1,6 +1,8 @@
 //! [`BoxedUint`] multiplication operations.
 
-use crate::{uint::mul::mul_limbs, BoxedUint, CheckedMul, Limb, WideningMul, Wrapping, Zero};
+use crate::{
+    uint::mul::mul_limbs, BoxedUint, CheckedMul, Limb, WideningMul, Wrapping, WrappingMul, Zero,
+};
 use core::ops::{Mul, MulAssign};
 use subtle::{Choice, CtOption};
 
@@ -51,21 +53,36 @@ impl CheckedMul<&BoxedUint> for BoxedUint {
     }
 }
 
-impl WideningMul for BoxedUint {
-    type Output = Self;
+impl Mul<BoxedUint> for BoxedUint {
+    type Output = BoxedUint;
 
-    #[inline]
-    fn widening_mul(&self, rhs: BoxedUint) -> Self {
-        self.mul(&rhs)
+    fn mul(self, rhs: BoxedUint) -> Self {
+        BoxedUint::mul(&self, &rhs)
     }
 }
 
-impl WideningMul<&BoxedUint> for BoxedUint {
-    type Output = Self;
+impl Mul<&BoxedUint> for BoxedUint {
+    type Output = BoxedUint;
 
-    #[inline]
-    fn widening_mul(&self, rhs: &BoxedUint) -> Self {
-        self.mul(rhs)
+    fn mul(self, rhs: &BoxedUint) -> Self {
+        BoxedUint::mul(&self, rhs)
+    }
+}
+
+impl Mul<BoxedUint> for &BoxedUint {
+    type Output = BoxedUint;
+
+    fn mul(self, rhs: BoxedUint) -> Self::Output {
+        BoxedUint::mul(self, &rhs)
+    }
+}
+
+impl Mul<&BoxedUint> for &BoxedUint {
+    type Output = BoxedUint;
+
+    fn mul(self, rhs: &BoxedUint) -> Self::Output {
+        self.checked_mul(rhs)
+            .expect("attempted to multiply with overflow")
     }
 }
 
@@ -110,6 +127,30 @@ impl MulAssign<Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
 impl MulAssign<&Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
     fn mul_assign(&mut self, other: &Wrapping<BoxedUint>) {
         *self = Wrapping(self.0.wrapping_mul(&other.0));
+    }
+}
+
+impl WideningMul for BoxedUint {
+    type Output = Self;
+
+    #[inline]
+    fn widening_mul(&self, rhs: BoxedUint) -> Self {
+        self.mul(&rhs)
+    }
+}
+
+impl WideningMul<&BoxedUint> for BoxedUint {
+    type Output = Self;
+
+    #[inline]
+    fn widening_mul(&self, rhs: &BoxedUint) -> Self {
+        self.mul(rhs)
+    }
+}
+
+impl WrappingMul for BoxedUint {
+    fn wrapping_mul(&self, v: &Self) -> Self {
+        self.wrapping_mul(v)
     }
 }
 

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -132,7 +132,7 @@ mod tests {
                         assert!(c < **p, "not reduced: {} >= {} ", c, p);
 
                         let expected = {
-                            let (lo, hi) = a.widening_mul_split(&b);
+                            let (lo, hi) = a.split_mul(&b);
                             let mut prod = Uint::<{ 2 * $size }>::ZERO;
                             prod.limbs[..$size].clone_from_slice(&lo.limbs);
                             prod.limbs[$size..].clone_from_slice(&hi.limbs);

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -132,7 +132,7 @@ mod tests {
                         assert!(c < **p, "not reduced: {} >= {} ", c, p);
 
                         let expected = {
-                            let (lo, hi) = a.mul_wide(&b);
+                            let (lo, hi) = a.widening_mul_split(&b);
                             let mut prod = Uint::<{ 2 * $size }>::ZERO;
                             prod.limbs[..$size].clone_from_slice(&lo.limbs);
                             prod.limbs[$size..].clone_from_slice(&hi.limbs);

--- a/src/uint/boxed/neg.rs
+++ b/src/uint/boxed/neg.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] negation operations.
 
-use crate::{BoxedUint, Limb, WideWord, Word, Wrapping};
+use crate::{BoxedUint, Limb, WideWord, Word, Wrapping, WrappingNeg};
 use core::ops::Neg;
 use subtle::Choice;
 
@@ -30,6 +30,12 @@ impl BoxedUint {
         }
 
         ret.into()
+    }
+}
+
+impl WrappingNeg for BoxedUint {
+    fn wrapping_neg(&self) -> Self {
+        self.wrapping_neg()
     }
 }
 

--- a/src/uint/boxed/sub.rs
+++ b/src/uint/boxed/sub.rs
@@ -1,7 +1,7 @@
 //! [`BoxedUint`] subtraction operations.
 
-use crate::{BoxedUint, CheckedSub, Limb, Wrapping, Zero};
-use core::ops::SubAssign;
+use crate::{BoxedUint, CheckedSub, Limb, Wrapping, WrappingSub, Zero};
+use core::ops::{Sub, SubAssign};
 use subtle::{Choice, ConditionallySelectable, CtOption};
 
 impl BoxedUint {
@@ -59,6 +59,31 @@ impl CheckedSub<&BoxedUint> for BoxedUint {
     }
 }
 
+impl Sub for BoxedUint {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self {
+        self.sub(&rhs)
+    }
+}
+
+impl Sub<&BoxedUint> for BoxedUint {
+    type Output = Self;
+
+    fn sub(self, rhs: &Self) -> Self {
+        Sub::sub(&self, rhs)
+    }
+}
+
+impl Sub<&BoxedUint> for &BoxedUint {
+    type Output = BoxedUint;
+
+    fn sub(self, rhs: &BoxedUint) -> BoxedUint {
+        self.checked_sub(rhs)
+            .expect("attempted to subtract with underflow")
+    }
+}
+
 impl SubAssign<Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
     fn sub_assign(&mut self, other: Wrapping<BoxedUint>) {
         self.0.sbb_assign(&other.0, Limb::ZERO);
@@ -68,6 +93,12 @@ impl SubAssign<Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
 impl SubAssign<&Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
     fn sub_assign(&mut self, other: &Wrapping<BoxedUint>) {
         self.0.sbb_assign(&other.0, Limb::ZERO);
+    }
+}
+
+impl WrappingSub for BoxedUint {
+    fn wrapping_sub(&self, v: &Self) -> Self {
+        self.wrapping_sub(v)
     }
 }
 

--- a/src/uint/concat.rs
+++ b/src/uint/concat.rs
@@ -61,7 +61,7 @@ mod tests {
 
     #[test]
     fn convert() {
-        let res: U128 = U64::ONE.widening_mul_split(&U64::ONE).into();
+        let res: U128 = U64::ONE.split_mul(&U64::ONE).into();
         assert_eq!(res, U128::ONE);
 
         let res: U128 = U64::ONE.square_wide().into();

--- a/src/uint/concat.rs
+++ b/src/uint/concat.rs
@@ -61,7 +61,7 @@ mod tests {
 
     #[test]
     fn convert() {
-        let res: U128 = U64::ONE.mul_wide(&U64::ONE).into();
+        let res: U128 = U64::ONE.widening_mul_split(&U64::ONE).into();
         assert_eq!(res, U128::ONE);
 
         let res: U128 = U64::ONE.square_wide().into();

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -28,7 +28,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mut rem = *self;
         let mut quo = Self::ZERO;
         // If there is overflow, it means `mb == 0`, so `rhs == 0`.
-        let (mut c, _overflow) = rhs.0.overflowing_shl(Self::BITS - mb);
+        let mut c = rhs.0.wrapping_shl(Self::BITS - mb);
 
         let mut i = Self::BITS;
         let mut done = ConstChoice::FALSE;
@@ -64,7 +64,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mut rem = *self;
         let mut quo = Self::ZERO;
         // If there is overflow, it means `mb == 0`, so `rhs == 0`.
-        let (mut c, _overflow) = rhs.0.overflowing_shl_vartime(bd);
+        let mut c = rhs.0.wrapping_shl_vartime(bd);
 
         loop {
             let (mut r, borrow) = rem.sbb(&c, Limb::ZERO);
@@ -92,7 +92,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mb = rhs.0.bits_vartime();
         let mut bd = Self::BITS - mb;
         let mut rem = *self;
-        let (mut c, _overflow) = rhs.0.overflowing_shl_vartime(bd);
+        let mut c = rhs.0.wrapping_shl_vartime(bd);
 
         loop {
             let (r, borrow) = rem.sbb(&c, Limb::ZERO);

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     Checked, CheckedMul, Concat, ConcatMixed, Limb, Uint, WideWord, WideningMul, Word, Wrapping,
-    Zero,
+    WrappingMul, Zero,
 };
 use core::ops::{Mul, MulAssign};
 use subtle::CtOption;
@@ -52,36 +52,39 @@ macro_rules! impl_schoolbook_multiplication {
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Multiply `self` by `rhs`, returning a concatenated "wide" result.
-    pub fn mul<const HLIMBS: usize>(
+    pub fn widening_mul<const HLIMBS: usize>(
         &self,
         rhs: &Uint<HLIMBS>,
     ) -> <Uint<HLIMBS> as ConcatMixed<Self>>::MixedOutput
     where
         Uint<HLIMBS>: ConcatMixed<Self>,
     {
-        let (lo, hi) = self.mul_wide(rhs);
+        let (lo, hi) = self.widening_mul_split(rhs);
         hi.concat_mixed(&lo)
     }
 
     /// Compute "wide" multiplication, with a product twice the size of the input.
     ///
     /// Returns a tuple containing the `(lo, hi)` components of the product.
-    pub const fn mul_wide<const HLIMBS: usize>(&self, rhs: &Uint<HLIMBS>) -> (Self, Uint<HLIMBS>) {
+    pub const fn widening_mul_split<const HLIMBS: usize>(
+        &self,
+        rhs: &Uint<HLIMBS>,
+    ) -> (Self, Uint<HLIMBS>) {
         let mut lo = Self::ZERO;
         let mut hi = Uint::<HLIMBS>::ZERO;
         impl_schoolbook_multiplication!(&self.limbs, &rhs.limbs, lo.limbs, hi.limbs);
         (lo, hi)
     }
 
-    /// Perform saturating multiplication, returning `MAX` on overflow.
-    pub const fn saturating_mul<const HLIMBS: usize>(&self, rhs: &Uint<HLIMBS>) -> Self {
-        let (res, overflow) = self.mul_wide(rhs);
-        Self::select(&res, &Self::MAX, overflow.is_nonzero())
-    }
-
     /// Perform wrapping multiplication, discarding overflow.
     pub const fn wrapping_mul<const H: usize>(&self, rhs: &Uint<H>) -> Self {
-        self.mul_wide(rhs).0
+        self.widening_mul_split(rhs).0
+    }
+
+    /// Perform saturating multiplication, returning `MAX` on overflow.
+    pub const fn saturating_mul<const HLIMBS: usize>(&self, rhs: &Uint<HLIMBS>) -> Self {
+        let (res, overflow) = self.widening_mul_split(rhs);
+        Self::select(&res, &Self::MAX, overflow.is_nonzero())
     }
 
     /// Square self, returning a concatenated "wide" result.
@@ -169,7 +172,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize, const HLIMBS: usize> CheckedMul<Uint<HLIMBS>> for Uint<LIMBS> {
-    type Output = Self;
+    type Output = Uint<LIMBS>;
 
     #[inline]
     fn checked_mul(&self, rhs: Uint<HLIMBS>) -> CtOption<Self> {
@@ -178,36 +181,45 @@ impl<const LIMBS: usize, const HLIMBS: usize> CheckedMul<Uint<HLIMBS>> for Uint<
 }
 
 impl<const LIMBS: usize, const HLIMBS: usize> CheckedMul<&Uint<HLIMBS>> for Uint<LIMBS> {
-    type Output = Self;
+    type Output = Uint<LIMBS>;
 
     #[inline]
     fn checked_mul(&self, rhs: &Uint<HLIMBS>) -> CtOption<Self> {
-        let (lo, hi) = self.mul_wide(rhs);
+        let (lo, hi) = self.widening_mul_split(rhs);
         CtOption::new(lo, hi.is_zero())
     }
 }
 
-impl<const LIMBS: usize, const HLIMBS: usize> WideningMul<Uint<HLIMBS>> for Uint<LIMBS>
-where
-    Uint<HLIMBS>: ConcatMixed<Self>,
-{
-    type Output = <Uint<HLIMBS> as ConcatMixed<Self>>::MixedOutput;
+impl<const LIMBS: usize, const HLIMBS: usize> Mul<Uint<HLIMBS>> for Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
 
-    #[inline]
-    fn widening_mul(&self, rhs: Uint<HLIMBS>) -> Self::Output {
+    fn mul(self, rhs: Uint<HLIMBS>) -> Self {
         self.mul(&rhs)
     }
 }
 
-impl<const LIMBS: usize, const HLIMBS: usize> WideningMul<&Uint<HLIMBS>> for Uint<LIMBS>
-where
-    Uint<HLIMBS>: ConcatMixed<Self>,
-{
-    type Output = <Uint<HLIMBS> as ConcatMixed<Self>>::MixedOutput;
+impl<const LIMBS: usize, const HLIMBS: usize> Mul<&Uint<HLIMBS>> for Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
 
-    #[inline]
-    fn widening_mul(&self, rhs: &Uint<HLIMBS>) -> Self::Output {
-        self.mul(rhs)
+    fn mul(self, rhs: &Uint<HLIMBS>) -> Self {
+        (&self).mul(rhs)
+    }
+}
+
+impl<const LIMBS: usize, const HLIMBS: usize> Mul<Uint<HLIMBS>> for &Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
+
+    fn mul(self, rhs: Uint<HLIMBS>) -> Self::Output {
+        self.mul(&rhs)
+    }
+}
+
+impl<const LIMBS: usize, const HLIMBS: usize> Mul<&Uint<HLIMBS>> for &Uint<LIMBS> {
+    type Output = Uint<LIMBS>;
+
+    fn mul(self, rhs: &Uint<HLIMBS>) -> Self::Output {
+        self.checked_mul(rhs)
+            .expect("attempted to multiply with overflow")
     }
 }
 
@@ -317,47 +329,33 @@ impl<const LIMBS: usize, const HLIMBS: usize> MulAssign<&Checked<Uint<HLIMBS>>>
     }
 }
 
-impl<const LIMBS: usize, const HLIMBS: usize> Mul<Uint<HLIMBS>> for Uint<LIMBS>
+impl<const LIMBS: usize, const HLIMBS: usize> WideningMul<Uint<HLIMBS>> for Uint<LIMBS>
 where
-    Uint<HLIMBS>: ConcatMixed<Uint<LIMBS>>,
+    Uint<HLIMBS>: ConcatMixed<Self>,
 {
     type Output = <Uint<HLIMBS> as ConcatMixed<Self>>::MixedOutput;
 
-    fn mul(self, other: Uint<HLIMBS>) -> Self::Output {
-        Uint::mul(&self, &other)
+    #[inline]
+    fn widening_mul(&self, rhs: Uint<HLIMBS>) -> Self::Output {
+        self.widening_mul(&rhs)
     }
 }
 
-impl<const LIMBS: usize, const HLIMBS: usize> Mul<&Uint<HLIMBS>> for Uint<LIMBS>
+impl<const LIMBS: usize, const HLIMBS: usize> WideningMul<&Uint<HLIMBS>> for Uint<LIMBS>
 where
-    Uint<HLIMBS>: ConcatMixed<Uint<LIMBS>>,
+    Uint<HLIMBS>: ConcatMixed<Self>,
 {
     type Output = <Uint<HLIMBS> as ConcatMixed<Self>>::MixedOutput;
 
-    fn mul(self, other: &Uint<HLIMBS>) -> Self::Output {
-        Uint::mul(&self, other)
+    #[inline]
+    fn widening_mul(&self, rhs: &Uint<HLIMBS>) -> Self::Output {
+        self.widening_mul(rhs)
     }
 }
 
-impl<const LIMBS: usize, const HLIMBS: usize> Mul<Uint<HLIMBS>> for &Uint<LIMBS>
-where
-    Uint<HLIMBS>: ConcatMixed<Uint<LIMBS>>,
-{
-    type Output = <Uint<HLIMBS> as ConcatMixed<Uint<LIMBS>>>::MixedOutput;
-
-    fn mul(self, other: Uint<HLIMBS>) -> Self::Output {
-        Uint::mul(self, &other)
-    }
-}
-
-impl<const LIMBS: usize, const HLIMBS: usize> Mul<&Uint<HLIMBS>> for &Uint<LIMBS>
-where
-    Uint<HLIMBS>: ConcatMixed<Uint<LIMBS>>,
-{
-    type Output = <Uint<HLIMBS> as ConcatMixed<Uint<LIMBS>>>::MixedOutput;
-
-    fn mul(self, other: &Uint<HLIMBS>) -> Self::Output {
-        Uint::mul(self, other)
+impl<const LIMBS: usize> WrappingMul for Uint<LIMBS> {
+    fn wrapping_mul(&self, v: &Self) -> Self {
+        self.wrapping_mul(v)
     }
 }
 
@@ -375,10 +373,22 @@ mod tests {
 
     #[test]
     fn mul_wide_zero_and_one() {
-        assert_eq!(U64::ZERO.mul_wide(&U64::ZERO), (U64::ZERO, U64::ZERO));
-        assert_eq!(U64::ZERO.mul_wide(&U64::ONE), (U64::ZERO, U64::ZERO));
-        assert_eq!(U64::ONE.mul_wide(&U64::ZERO), (U64::ZERO, U64::ZERO));
-        assert_eq!(U64::ONE.mul_wide(&U64::ONE), (U64::ONE, U64::ZERO));
+        assert_eq!(
+            U64::ZERO.widening_mul_split(&U64::ZERO),
+            (U64::ZERO, U64::ZERO)
+        );
+        assert_eq!(
+            U64::ZERO.widening_mul_split(&U64::ONE),
+            (U64::ZERO, U64::ZERO)
+        );
+        assert_eq!(
+            U64::ONE.widening_mul_split(&U64::ZERO),
+            (U64::ZERO, U64::ZERO)
+        );
+        assert_eq!(
+            U64::ONE.widening_mul_split(&U64::ONE),
+            (U64::ONE, U64::ZERO)
+        );
     }
 
     #[test]
@@ -387,7 +397,7 @@ mod tests {
 
         for &a_int in primes {
             for &b_int in primes {
-                let (lo, hi) = U64::from_u32(a_int).mul_wide(&U64::from_u32(b_int));
+                let (lo, hi) = U64::from_u32(a_int).widening_mul_split(&U64::from_u32(b_int));
                 let expected = U64::from_u64(a_int as u64 * b_int as u64);
                 assert_eq!(lo, expected);
                 assert!(bool::from(hi.is_zero()));
@@ -397,14 +407,14 @@ mod tests {
 
     #[test]
     fn mul_concat_even() {
-        assert_eq!(U64::ZERO * U64::MAX, U128::ZERO);
-        assert_eq!(U64::MAX * U64::ZERO, U128::ZERO);
+        assert_eq!(U64::ZERO.widening_mul(&U64::MAX), U128::ZERO);
+        assert_eq!(U64::MAX.widening_mul(&U64::ZERO), U128::ZERO);
         assert_eq!(
-            U64::MAX * U64::MAX,
+            U64::MAX.widening_mul(&U64::MAX),
             U128::from_u128(0xfffffffffffffffe_0000000000000001)
         );
         assert_eq!(
-            U64::ONE * U64::MAX,
+            U64::ONE.widening_mul(&U64::MAX),
             U128::from_u128(0x0000000000000000_ffffffffffffffff)
         );
     }
@@ -413,8 +423,8 @@ mod tests {
     fn mul_concat_mixed() {
         let a = U64::from_u64(0x0011223344556677);
         let b = U128::from_u128(0x8899aabbccddeeff_8899aabbccddeeff);
-        assert_eq!(a * b, U192::from(&a).saturating_mul(&b));
-        assert_eq!(b * a, U192::from(&b).saturating_mul(&a));
+        assert_eq!(a.widening_mul(&b), U192::from(&a).saturating_mul(&b));
+        assert_eq!(b.widening_mul(&a), U192::from(&b).saturating_mul(&a));
     }
 
     #[test]

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -43,7 +43,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             return Self::from_word(reduced as Word);
         }
 
-        let (lo, hi) = self.widening_mul_split(rhs);
+        let (lo, hi) = self.split_mul(rhs);
 
         // Now use Algorithm 14.47 for the reduction
         let (lo, carry) = mac_by_limb(&lo, &hi, c, Limb::ZERO);
@@ -134,7 +134,7 @@ mod tests {
                         assert!(c < **p, "not reduced: {} >= {} ", c, p);
 
                         let expected = {
-                            let (lo, hi) = a.widening_mul_split(&b);
+                            let (lo, hi) = a.split_mul(&b);
                             let mut prod = Uint::<{ 2 * $size }>::ZERO;
                             prod.limbs[..$size].clone_from_slice(&lo.limbs);
                             prod.limbs[$size..].clone_from_slice(&hi.limbs);

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -43,7 +43,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             return Self::from_word(reduced as Word);
         }
 
-        let (lo, hi) = self.mul_wide(rhs);
+        let (lo, hi) = self.widening_mul_split(rhs);
 
         // Now use Algorithm 14.47 for the reduction
         let (lo, carry) = mac_by_limb(&lo, &hi, c, Limb::ZERO);
@@ -134,7 +134,7 @@ mod tests {
                         assert!(c < **p, "not reduced: {} >= {} ", c, p);
 
                         let expected = {
-                            let (lo, hi) = a.mul_wide(&b);
+                            let (lo, hi) = a.widening_mul_split(&b);
                             let mut prod = Uint::<{ 2 * $size }>::ZERO;
                             prod.limbs[..$size].clone_from_slice(&lo.limbs);
                             prod.limbs[$size..].clone_from_slice(&hi.limbs);

--- a/src/uint/neg.rs
+++ b/src/uint/neg.rs
@@ -1,6 +1,6 @@
 use core::ops::Neg;
 
-use crate::{ConstChoice, Limb, Uint, WideWord, Word, Wrapping};
+use crate::{ConstChoice, Limb, Uint, WideWord, Word, Wrapping, WrappingNeg};
 
 impl<const LIMBS: usize> Neg for Wrapping<Uint<LIMBS>> {
     type Output = Self;
@@ -28,6 +28,12 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             i += 1;
         }
         Uint::new(ret)
+    }
+}
+
+impl<const LIMBS: usize> WrappingNeg for Uint<LIMBS> {
+    fn wrapping_neg(&self) -> Self {
+        self.wrapping_neg()
     }
 }
 

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -1,7 +1,7 @@
 //! [`Uint`] addition operations.
 
 use super::Uint;
-use crate::{Checked, CheckedSub, ConstChoice, Limb, Wrapping, Zero};
+use crate::{Checked, CheckedSub, ConstChoice, Limb, Wrapping, WrappingSub, Zero};
 use core::ops::{Sub, SubAssign};
 use subtle::CtOption;
 
@@ -53,6 +53,23 @@ impl<const LIMBS: usize> CheckedSub<&Uint<LIMBS>> for Uint<LIMBS> {
     fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
         let (result, underflow) = self.sbb(rhs, Limb::ZERO);
         CtOption::new(result, underflow.is_zero())
+    }
+}
+
+impl<const LIMBS: usize> Sub for Uint<LIMBS> {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self {
+        self.sub(&rhs)
+    }
+}
+
+impl<const LIMBS: usize> Sub<&Uint<LIMBS>> for Uint<LIMBS> {
+    type Output = Self;
+
+    fn sub(self, rhs: &Self) -> Self {
+        self.checked_sub(rhs)
+            .expect("attempted to subtract with underflow")
     }
 }
 
@@ -153,6 +170,12 @@ impl<const LIMBS: usize> SubAssign for Checked<Uint<LIMBS>> {
 impl<const LIMBS: usize> SubAssign<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS>> {
     fn sub_assign(&mut self, other: &Self) {
         *self = *self - other;
+    }
+}
+
+impl<const LIMBS: usize> WrappingSub for Uint<LIMBS> {
+    fn wrapping_sub(&self, v: &Self) -> Self {
+        self.wrapping_sub(v)
     }
 }
 

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -393,7 +393,7 @@ proptest! {
 
     #[test]
     fn residue_pow_bounded_exp(a in uint_mod_p(P), b in uint(), exponent_bits in any::<u8>()) {
-        let b_masked = b & (U256::ONE << exponent_bits.into()).wrapping_sub(&U256::ONE);
+        let b_masked = b & (U256::ONE << exponent_bits as u32).wrapping_sub(&U256::ONE);
 
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b_masked);


### PR DESCRIPTION
Until now we have used traits defined in this crate, primarily because many of these traits are predicates that return `bool` and in constant-time code we want those to return `Choice`/`CtOption`.

`Wrapping*` is an example of the sort of trait we'd want to incorporate unchanged, and there are potentially others, so this adds `num-traits` as a hard dependency (previously our only hard dependency was `subtle`). Note that `num-traits` itself has no transitive dependencies (or rather, they're optional but not enabled).

The `Wrapping*` traits have bounds on the corresponding op traits being impl'd with `Self` operands e.g. `WrappingAdd: Add<Self, Output = Self>` so this PR also adds impls of those traits.

We've previously avoided these as in `std` they panic on overflow/underflow in debug builds and silently wrap in release builds. This PR always panics.

This required some changes to the `Mul` impls which were conditional on `ConcatMixed` and implicitly widened. To accomodate impls which are always available and require no bounds (in order to allow us to impl `WideningMul`), and renames the following:

- `Uint::mul` -> `Uint::widening_mul`
- `Uint::mul_wide` -> `Uint::widening_mul_split`

TODO:

- [x] `WrappingNeg`
- [x] `WrappingShl`
- [x] `WrappingShr`

cc @xuganyu96 