### PR TITLE
Add `Zero::set_zero` method

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -135,8 +135,15 @@ pub trait Zero: ConstantTimeEq + Sized {
     /// # Returns
     ///
     /// If zero, returns `Choice(1)`. Otherwise, returns `Choice(0)`.
+    #[inline]
     fn is_zero(&self) -> Choice {
         self.ct_eq(&Self::zero())
+    }
+
+    /// Set `self` to its additive identity, i.e. `Self::zero`.
+    #[inline]
+    fn set_zero(&mut self) {
+        *self = Zero::zero();
     }
 }
 
@@ -149,6 +156,7 @@ pub trait ZeroConstant: Zero {
 }
 
 impl<T: ZeroConstant> Zero for T {
+    #[inline(always)]
     fn zero() -> T {
         Self::ZERO
     }

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -231,13 +231,8 @@ impl BoxedUint {
         limbs.into()
     }
 
-    /// Set the value of `self` to zero in-place.
-    pub(crate) fn set_to_zero(&mut self) {
-        self.limbs.as_mut().fill(Limb::ZERO)
-    }
-
     /// Set the value of `self` to zero in-place if `choice` is truthy.
-    pub(crate) fn conditional_set_to_zero(&mut self, choice: Choice) {
+    pub(crate) fn conditional_set_zero(&mut self, choice: Choice) {
         let nlimbs = self.nlimbs();
         let limbs = self.limbs.as_mut();
         for i in 0..nlimbs {
@@ -401,6 +396,10 @@ impl Zero for BoxedUint {
 
     fn is_zero(&self) -> Choice {
         self.is_zero()
+    }
+
+    fn set_zero(&mut self) {
+        self.limbs.as_mut().fill(Limb::ZERO)
     }
 }
 

--- a/src/uint/boxed/shl.rs
+++ b/src/uint/boxed/shl.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] bitwise left shift operations.
 
-use crate::{BoxedUint, Limb};
+use crate::{BoxedUint, Limb, Zero};
 use core::ops::{Shl, ShlAssign};
 use subtle::{Choice, ConstantTimeLess};
 
@@ -20,7 +20,7 @@ impl BoxedUint {
 
         for i in 0..shift_bits {
             let bit = Choice::from(((shift >> i) & 1) as u8);
-            temp.set_to_zero();
+            temp.set_zero();
             // Will not overflow by construction
             result
                 .shl_vartime_into(&mut temp, 1 << i)
@@ -28,7 +28,7 @@ impl BoxedUint {
             result.conditional_assign(&temp, bit);
         }
 
-        result.conditional_set_to_zero(overflow);
+        result.conditional_set_zero(overflow);
 
         (result, overflow)
     }

--- a/src/uint/boxed/shr.rs
+++ b/src/uint/boxed/shr.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] bitwise right shift operations.
 
-use crate::{BoxedUint, Limb};
+use crate::{BoxedUint, Limb, Zero};
 use core::ops::{Shr, ShrAssign};
 use subtle::{Choice, ConstantTimeLess};
 
@@ -20,7 +20,7 @@ impl BoxedUint {
 
         for i in 0..shift_bits {
             let bit = Choice::from(((shift >> i) & 1) as u8);
-            temp.set_to_zero();
+            temp.set_zero();
             // Will not overflow by construction
             result
                 .shr_vartime_into(&mut temp, 1 << i)
@@ -28,7 +28,7 @@ impl BoxedUint {
             result.conditional_assign(&temp, bit);
         }
 
-        result.conditional_set_to_zero(overflow);
+        result.conditional_set_zero(overflow);
 
         (result, overflow)
     }


### PR DESCRIPTION
Adds a method to the `Zero` trait for setting its value to zero in-place, subsuming the previous `BoxedUint::set_to_zero` function.

It's inspired by a similar method on `num_traits::Zero` (which we don't use so `is_zero` can return `Choice` and use `ConstantTimeEq` to compare values in constant-time).

https://docs.rs/num-traits/latest/num_traits/identities/trait.Zero.html#method.set_zero