### PR TITLE
BoxedUint: optimized `AddAssign`/`SubAssign` impls

### DIFF
--- a/src/uint/boxed/add.rs
+++ b/src/uint/boxed/add.rs
@@ -94,13 +94,13 @@ impl Add<&Wrapping<BoxedUint>> for &Wrapping<BoxedUint> {
 
 impl AddAssign<Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
     fn add_assign(&mut self, other: Wrapping<BoxedUint>) {
-        *self = Wrapping(self.0.wrapping_add(&other.0));
+        self.0.adc_assign(&other.0, Limb::ZERO);
     }
 }
 
 impl AddAssign<&Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
     fn add_assign(&mut self, other: &Wrapping<BoxedUint>) {
-        *self = Wrapping(self.0.wrapping_add(&other.0));
+        self.0.adc_assign(&other.0, Limb::ZERO);
     }
 }
 

--- a/src/uint/boxed/sub.rs
+++ b/src/uint/boxed/sub.rs
@@ -1,6 +1,7 @@
 //! [`BoxedUint`] subtraction operations.
 
-use crate::{BoxedUint, CheckedSub, Limb, Zero};
+use crate::{BoxedUint, CheckedSub, Limb, Wrapping, Zero};
+use core::ops::SubAssign;
 use subtle::{Choice, ConditionallySelectable, CtOption};
 
 impl BoxedUint {
@@ -55,6 +56,18 @@ impl CheckedSub<&BoxedUint> for BoxedUint {
     fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
         let (result, carry) = self.sbb(rhs, Limb::ZERO);
         CtOption::new(result, carry.is_zero())
+    }
+}
+
+impl SubAssign<Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
+    fn sub_assign(&mut self, other: Wrapping<BoxedUint>) {
+        self.0.sbb_assign(&other.0, Limb::ZERO);
+    }
+}
+
+impl SubAssign<&Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
+    fn sub_assign(&mut self, other: &Wrapping<BoxedUint>) {
+        self.0.sbb_assign(&other.0, Limb::ZERO);
     }
 }
 


### PR DESCRIPTION
Uses `adc_assign`/`sbb_assign` to perform these operations in-place.