### PR TITLE
BoxedUint: optimize `shr_assign`

### DIFF
--- a/src/uint/boxed/shl.rs
+++ b/src/uint/boxed/shl.rs
@@ -17,9 +17,8 @@ impl BoxedUint {
 
     /// Computes `self <<= shift`.
     ///
-    /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
-    /// or a falsy `Choice` otherwise.
-    fn overflowing_shl_assign(&mut self, shift: u32) -> Choice {
+    /// Returns a truthy `Choice` if `shift >= self.bits_precision()` or a falsy `Choice` otherwise.
+    pub fn overflowing_shl_assign(&mut self, shift: u32) -> Choice {
         // `floor(log2(bits_precision - 1))` is the number of bits in the representation of `shift`
         // (which lies in range `0 <= shift < bits_precision`).
         let shift_bits = u32::BITS - (self.bits_precision() - 1).leading_zeros();


### PR DESCRIPTION
Allows `shl_assign` to operate in-place on `self` (although it still requires a temporary buffer), ala what #423 did for `shl_assign`