### PR TITLE
Align with `core`/`std` on `overflowing_sh*`

### DIFF
--- a/benches/boxed_uint.rs
+++ b/benches/boxed_uint.rs
@@ -19,7 +19,7 @@ fn bench_shifts(c: &mut Criterion) {
     group.bench_function("shl", |b| {
         b.iter_batched(
             || BoxedUint::random(&mut OsRng, UINT_BITS),
-            |x| x.shl(UINT_BITS / 2 + 10),
+            |x| x.overflowing_shl(UINT_BITS / 2 + 10),
             BatchSize::SmallInput,
         )
     });
@@ -35,7 +35,7 @@ fn bench_shifts(c: &mut Criterion) {
     group.bench_function("shr", |b| {
         b.iter_batched(
             || BoxedUint::random(&mut OsRng, UINT_BITS),
-            |x| x.shr(UINT_BITS / 2 + 10),
+            |x| x.overflowing_shr(UINT_BITS / 2 + 10),
             BatchSize::SmallInput,
         )
     });

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -79,13 +79,17 @@ fn bench_shl(c: &mut Criterion) {
     let mut group = c.benchmark_group("left shift");
 
     group.bench_function("shl_vartime, small, U2048", |b| {
-        b.iter_batched(|| U2048::ONE, |x| x.shl_vartime(10), BatchSize::SmallInput)
+        b.iter_batched(
+            || U2048::ONE,
+            |x| x.overflowing_shl_vartime(10),
+            BatchSize::SmallInput,
+        )
     });
 
     group.bench_function("shl_vartime, large, U2048", |b| {
         b.iter_batched(
             || U2048::ONE,
-            |x| black_box(x.shl_vartime(1024 + 10)),
+            |x| black_box(x.overflowing_shl_vartime(1024 + 10)),
             BatchSize::SmallInput,
         )
     });
@@ -93,13 +97,17 @@ fn bench_shl(c: &mut Criterion) {
     group.bench_function("shl_vartime_wide, large, U2048", |b| {
         b.iter_batched(
             || (U2048::ONE, U2048::ONE),
-            |x| Uint::shl_vartime_wide(x, 1024 + 10),
+            |x| Uint::overflowing_shl_vartime_wide(x, 1024 + 10),
             BatchSize::SmallInput,
         )
     });
 
     group.bench_function("shl, U2048", |b| {
-        b.iter_batched(|| U2048::ONE, |x| x.shl(1024 + 10), BatchSize::SmallInput)
+        b.iter_batched(
+            || U2048::ONE,
+            |x| x.overflowing_shl(1024 + 10),
+            BatchSize::SmallInput,
+        )
     });
 
     group.finish();
@@ -109,13 +117,17 @@ fn bench_shr(c: &mut Criterion) {
     let mut group = c.benchmark_group("right shift");
 
     group.bench_function("shr_vartime, small, U2048", |b| {
-        b.iter_batched(|| U2048::ONE, |x| x.shr_vartime(10), BatchSize::SmallInput)
+        b.iter_batched(
+            || U2048::ONE,
+            |x| x.overflowing_shr_vartime(10),
+            BatchSize::SmallInput,
+        )
     });
 
     group.bench_function("shr_vartime, large, U2048", |b| {
         b.iter_batched(
             || U2048::ONE,
-            |x| x.shr_vartime(1024 + 10),
+            |x| x.overflowing_shr_vartime(1024 + 10),
             BatchSize::SmallInput,
         )
     });
@@ -123,13 +135,17 @@ fn bench_shr(c: &mut Criterion) {
     group.bench_function("shr_vartime_wide, large, U2048", |b| {
         b.iter_batched(
             || (U2048::ONE, U2048::ONE),
-            |x| Uint::shr_vartime_wide(x, 1024 + 10),
+            |x| Uint::overflowing_shr_vartime_wide(x, 1024 + 10),
             BatchSize::SmallInput,
         )
     });
 
     group.bench_function("shr, U2048", |b| {
-        b.iter_batched(|| U2048::ONE, |x| x.shr(1024 + 10), BatchSize::SmallInput)
+        b.iter_batched(
+            || U2048::ONE,
+            |x| x.overflowing_shr(1024 + 10),
+            BatchSize::SmallInput,
+        )
     });
 
     group.finish();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //!     U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
 //!
 //! // Compute `MODULUS` shifted right by 1 at compile time
-//! pub const MODULUS_SHR1: U256 = MODULUS.shr(1).0;
+//! pub const MODULUS_SHR1: U256 = MODULUS.shr(1);
 //! ```
 //!
 //! Note that large constant computations may accidentally trigger a the `const_eval_limit` of the compiler.

--- a/src/modular/div_by_2.rs
+++ b/src/modular/div_by_2.rs
@@ -18,7 +18,7 @@ pub(crate) fn div_by_2<const LIMBS: usize>(a: &Uint<LIMBS>, modulus: &Uint<LIMBS
     // ("+1" because both `a` and `modulus` are odd, we lose 0.5 in each integer division).
     // This will not overflow, so we can just use wrapping operations.
 
-    let (half, is_odd) = a.overflowing_shr1();
+    let (half, is_odd) = a.shr1_with_carry();
     let half_modulus = modulus.shr1();
 
     let if_even = half;

--- a/src/modular/div_by_2.rs
+++ b/src/modular/div_by_2.rs
@@ -18,7 +18,7 @@ pub(crate) fn div_by_2<const LIMBS: usize>(a: &Uint<LIMBS>, modulus: &Uint<LIMBS
     // ("+1" because both `a` and `modulus` are odd, we lose 0.5 in each integer division).
     // This will not overflow, so we can just use wrapping operations.
 
-    let (half, is_odd) = a.shr1_with_carry();
+    let (half, is_odd) = a.overflowing_shr1();
     let half_modulus = modulus.shr1();
 
     let if_even = half;

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -78,7 +78,7 @@ impl BoxedUint {
         let bits_precision = self.bits_precision();
         let mut rem = self.clone();
         let mut quo = Self::zero_with_precision(bits_precision);
-        let (mut c, _overflow) = rhs.shl(bits_precision - mb);
+        let (mut c, _overflow) = rhs.overflowing_shl(bits_precision - mb);
         let mut i = bits_precision;
         let mut done = Choice::from(0u8);
 

--- a/src/uint/boxed/shl.rs
+++ b/src/uint/boxed/shl.rs
@@ -154,8 +154,8 @@ mod tests {
     fn shl() {
         let one = BoxedUint::one_with_precision(128);
 
-        assert_eq!(BoxedUint::from(2u8), one.overflowing_shl(1).0);
-        assert_eq!(BoxedUint::from(4u8), one.overflowing_shl(2).0);
+        assert_eq!(BoxedUint::from(2u8), &one << 1);
+        assert_eq!(BoxedUint::from(4u8), &one << 2);
         assert_eq!(
             BoxedUint::from(0x80000000000000000u128),
             one.shl_vartime(67).unwrap()

--- a/src/uint/boxed/shl.rs
+++ b/src/uint/boxed/shl.rs
@@ -9,7 +9,7 @@ impl BoxedUint {
     ///
     /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
     /// or the result and a falsy `Choice` otherwise.
-    pub fn shl(&self, shift: u32) -> (Self, Choice) {
+    pub fn overflowing_shl(&self, shift: u32) -> (Self, Choice) {
         let mut result = self.clone();
         let overflow = result.overflowing_shl_assign(shift);
         (result, overflow)
@@ -125,7 +125,7 @@ impl Shl<u32> for &BoxedUint {
     type Output = BoxedUint;
 
     fn shl(self, shift: u32) -> BoxedUint {
-        let (result, overflow) = self.shl(shift);
+        let (result, overflow) = self.overflowing_shl(shift);
         assert!(!bool::from(overflow), "attempt to shift left with overflow");
         result
     }
@@ -154,8 +154,8 @@ mod tests {
     fn shl() {
         let one = BoxedUint::one_with_precision(128);
 
-        assert_eq!(BoxedUint::from(2u8), one.shl(1).0);
-        assert_eq!(BoxedUint::from(4u8), one.shl(2).0);
+        assert_eq!(BoxedUint::from(2u8), one.overflowing_shl(1).0);
+        assert_eq!(BoxedUint::from(4u8), one.overflowing_shl(2).0);
         assert_eq!(
             BoxedUint::from(0x80000000000000000u128),
             one.shl_vartime(67).unwrap()

--- a/src/uint/boxed/shr.rs
+++ b/src/uint/boxed/shr.rs
@@ -9,7 +9,7 @@ impl BoxedUint {
     ///
     /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
     /// or the result and a falsy `Choice` otherwise.
-    pub fn shr(&self, shift: u32) -> (Self, Choice) {
+    pub fn overflowing_shr(&self, shift: u32) -> (Self, Choice) {
         let mut result = self.clone();
         let overflow = result.overflowing_shr_assign(shift);
         (result, overflow)
@@ -129,7 +129,7 @@ impl Shr<u32> for &BoxedUint {
     type Output = BoxedUint;
 
     fn shr(self, shift: u32) -> BoxedUint {
-        let (result, overflow) = self.shr(shift);
+        let (result, overflow) = self.overflowing_shr(shift);
         assert!(
             !bool::from(overflow),
             "attempt to shift right with overflow"
@@ -163,10 +163,10 @@ mod tests {
     #[test]
     fn shr() {
         let n = BoxedUint::from(0x80000000000000000u128);
-        assert_eq!(BoxedUint::zero(), n.shr(68).0);
-        assert_eq!(BoxedUint::one(), n.shr(67).0);
-        assert_eq!(BoxedUint::from(2u8), n.shr(66).0);
-        assert_eq!(BoxedUint::from(4u8), n.shr(65).0);
+        assert_eq!(BoxedUint::zero(), n.overflowing_shr(68).0);
+        assert_eq!(BoxedUint::one(), n.overflowing_shr(67).0);
+        assert_eq!(BoxedUint::from(2u8), n.overflowing_shr(66).0);
+        assert_eq!(BoxedUint::from(4u8), n.overflowing_shr(65).0);
     }
 
     #[test]

--- a/src/uint/boxed/shr.rs
+++ b/src/uint/boxed/shr.rs
@@ -163,10 +163,10 @@ mod tests {
     #[test]
     fn shr() {
         let n = BoxedUint::from(0x80000000000000000u128);
-        assert_eq!(BoxedUint::zero(), n.overflowing_shr(68).0);
-        assert_eq!(BoxedUint::one(), n.overflowing_shr(67).0);
-        assert_eq!(BoxedUint::from(2u8), n.overflowing_shr(66).0);
-        assert_eq!(BoxedUint::from(4u8), n.overflowing_shr(65).0);
+        assert_eq!(BoxedUint::zero(), &n >> 68);
+        assert_eq!(BoxedUint::one(), &n >> 67);
+        assert_eq!(BoxedUint::from(2u8), &n >> 66);
+        assert_eq!(BoxedUint::from(4u8), &n >> 65);
     }
 
     #[test]

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -28,7 +28,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mut rem = *self;
         let mut quo = Self::ZERO;
         // If there is overflow, it means `mb == 0`, so `rhs == 0`.
-        let (mut c, _overflow) = rhs.0.shl(Self::BITS - mb);
+        let (mut c, _overflow) = rhs.0.overflowing_shl(Self::BITS - mb);
 
         let mut i = Self::BITS;
         let mut done = ConstChoice::FALSE;
@@ -64,7 +64,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mut rem = *self;
         let mut quo = Self::ZERO;
         // If there is overflow, it means `mb == 0`, so `rhs == 0`.
-        let (mut c, _overflow) = rhs.0.shl_vartime(bd);
+        let (mut c, _overflow) = rhs.0.overflowing_shl_vartime(bd);
 
         loop {
             let (mut r, borrow) = rem.sbb(&c, Limb::ZERO);
@@ -92,7 +92,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mb = rhs.0.bits_vartime();
         let mut bd = Self::BITS - mb;
         let mut rem = *self;
-        let (mut c, _overflow) = rhs.0.shl_vartime(bd);
+        let (mut c, _overflow) = rhs.0.overflowing_shl_vartime(bd);
 
         loop {
             let (r, borrow) = rem.sbb(&c, Limb::ZERO);
@@ -123,7 +123,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let (mut lower, mut upper) = lower_upper;
 
         // Factor of the modulus, split into two halves
-        let (mut c, _overflow) = Self::shl_vartime_wide((rhs.0, Uint::ZERO), bd);
+        let (mut c, _overflow) = Self::overflowing_shl_vartime_wide((rhs.0, Uint::ZERO), bd);
 
         loop {
             let (lower_sub, borrow) = lower.sbb(&c.0, Limb::ZERO);
@@ -135,7 +135,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
                 break;
             }
             bd -= 1;
-            let (new_c, _overflow) = Self::shr_vartime_wide(c, 1);
+            let (new_c, _overflow) = Self::overflowing_shr_vartime_wide(c, 1);
             c = new_c;
         }
 
@@ -634,8 +634,8 @@ mod tests {
     fn div() {
         let mut rng = ChaChaRng::from_seed([7u8; 32]);
         for _ in 0..25 {
-            let (num, _) = U256::random(&mut rng).shr_vartime(128);
-            let den = NonZero::new(U256::random(&mut rng).shr_vartime(128).0).unwrap();
+            let (num, _) = U256::random(&mut rng).overflowing_shr_vartime(128);
+            let den = NonZero::new(U256::random(&mut rng).overflowing_shr_vartime(128).0).unwrap();
             let n = num.checked_mul(den.as_ref());
             if n.is_some().into() {
                 let (q, _) = n.unwrap().div_rem(&den);
@@ -724,7 +724,7 @@ mod tests {
         for _ in 0..25 {
             let num = U256::random(&mut rng);
             let k = rng.next_u32() % 256;
-            let (den, _) = U256::ONE.shl_vartime(k);
+            let (den, _) = U256::ONE.overflowing_shl_vartime(k);
 
             let a = num.rem2k(k);
             let e = num.wrapping_rem(&den);

--- a/src/uint/inv_mod.rs
+++ b/src/uint/inv_mod.rs
@@ -30,7 +30,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             // b_{i+1} = (b_i - a * X_i) / 2
             b = Self::select(&b, &b.wrapping_sub(self), x_i_choice).shr1();
             // Store the X_i bit in the result (x = x | (1 << X_i))
-            let (shifted, _overflow) = Uint::from_word(x_i).shl_vartime(i);
+            let (shifted, _overflow) = Uint::from_word(x_i).overflowing_shl_vartime(i);
             x = x.bitor(&shifted);
 
             i += 1;
@@ -128,9 +128,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             let (new_u, cyy) = new_u.conditional_wrapping_add(modulus, cy);
             debug_assert!(cy.is_true_vartime() == cyy.is_true_vartime());
 
-            let (new_a, carry) = a.shr1_with_carry();
+            let (new_a, carry) = a.overflowing_shr1();
             debug_assert!(modulus_is_odd.not().or(carry.not()).is_true_vartime());
-            let (new_u, cy) = new_u.shr1_with_carry();
+            let (new_u, cy) = new_u.overflowing_shr1();
             let (new_u, cy) = new_u.conditional_wrapping_add(&m1hp, cy);
             debug_assert!(modulus_is_odd.not().or(cy.not()).is_true_vartime());
 
@@ -162,7 +162,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     pub const fn inv_mod(&self, modulus: &Self) -> (Self, ConstChoice) {
         // Decompose `modulus = s * 2^k` where `s` is odd
         let k = modulus.trailing_zeros();
-        let (s, _overflow) = modulus.shr(k);
+        let (s, _overflow) = modulus.overflowing_shr(k);
 
         // Decompose `self` into RNS with moduli `2^k` and `s` and calculate the inverses.
         // Using the fact that `(z^{-1} mod (m1 * m2)) mod m1 == z^{-1} mod m1`
@@ -178,7 +178,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         // This part is mod 2^k
         // Will not overflow since `modulus` is nonzero, and therefore `k < BITS`.
-        let (shifted, _overflow) = Uint::ONE.shl(k);
+        let (shifted, _overflow) = Uint::ONE.overflowing_shl(k);
         let mask = shifted.wrapping_sub(&Uint::ONE);
         let t = (b.wrapping_sub(&a).wrapping_mul(&m_odd_inv)).bitand(&mask);
 

--- a/src/uint/inv_mod.rs
+++ b/src/uint/inv_mod.rs
@@ -128,9 +128,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             let (new_u, cyy) = new_u.conditional_wrapping_add(modulus, cy);
             debug_assert!(cy.is_true_vartime() == cyy.is_true_vartime());
 
-            let (new_a, carry) = a.overflowing_shr1();
+            let (new_a, carry) = a.shr1_with_carry();
             debug_assert!(modulus_is_odd.not().or(carry.not()).is_true_vartime());
-            let (new_u, cy) = new_u.overflowing_shr1();
+            let (new_u, cy) = new_u.shr1_with_carry();
             let (new_u, cy) = new_u.conditional_wrapping_add(&m1hp, cy);
             debug_assert!(modulus_is_odd.not().or(cy.not()).is_true_vartime());
 

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -135,7 +135,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         // Double the current result, this accounts for the other half of the multiplication grid.
         // TODO: The top word is empty so we can also use a special purpose shl.
-        (lo, hi) = Self::shl_vartime_wide((lo, hi), 1).0;
+        (lo, hi) = Self::overflowing_shl_vartime_wide((lo, hi), 1).0;
 
         // Handle the diagonal of the multiplication grid, which finishes the multiplication grid.
         let mut carry = Limb::ZERO;

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -135,13 +135,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes `self << 1` in constant-time.
     pub(crate) const fn shl1(&self) -> Self {
-        self.overflowing_shl1().0
+        self.shl1_with_carry().0
     }
 
     /// Computes `self << 1` in constant-time, returning [`ConstChoice::TRUE`]
-    /// if the most significant bit was set (i.e. if overflow occurred), and [`ConstChoice::FALSE`] otherwise.
+    /// if the most significant bit was set, and [`ConstChoice::FALSE`] otherwise.
     #[inline(always)]
-    pub(crate) const fn overflowing_shl1(&self) -> (Self, ConstChoice) {
+    pub(crate) const fn shl1_with_carry(&self) -> (Self, ConstChoice) {
         let mut ret = Self::ZERO;
         let mut i = 0;
         let mut carry = Limb::ZERO;

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -5,9 +5,22 @@ use core::ops::{Shr, ShrAssign};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self >> shift`.
+    ///
+    /// Panics if `shift >= Self::BITS`.
+    pub const fn shr(&self, shift: u32) -> Self {
+        let (result, overflow) = self.overflowing_shr(shift);
+        assert!(
+            !overflow.is_true_vartime(),
+            "attempt to shift right with overflow"
+        );
+        result
+    }
+
+    /// Computes `self >> shift`.
+    ///
     /// If `shift >= Self::BITS`, returns zero as the first tuple element,
     /// and `ConstChoice::TRUE` as the second element.
-    pub const fn shr(&self, shift: u32) -> (Self, ConstChoice) {
+    pub const fn overflowing_shr(&self, shift: u32) -> (Self, ConstChoice) {
         // `floor(log2(BITS - 1))` is the number of bits in the representation of `shift`
         // (which lies in range `0 <= shift < BITS`).
         let shift_bits = u32::BITS - (Self::BITS - 1).leading_zeros();
@@ -17,7 +30,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mut i = 0;
         while i < shift_bits {
             let bit = ConstChoice::from_u32_lsb((shift >> i) & 1);
-            result = Uint::select(&result, &result.shr_vartime(1 << i).0, bit);
+            result = Uint::select(&result, &result.overflowing_shr_vartime(1 << i).0, bit);
             i += 1;
         }
 
@@ -25,6 +38,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Computes `self >> shift`.
+    ///
     /// If `shift >= Self::BITS`, returns zero as the first tuple element,
     /// and `ConstChoice::TRUE` as the second element.
     ///
@@ -33,7 +47,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// When used with a fixed `shift`, this function is constant-time with respect
     /// to `self`.
     #[inline(always)]
-    pub const fn shr_vartime(&self, shift: u32) -> (Self, ConstChoice) {
+    pub const fn overflowing_shr_vartime(&self, shift: u32) -> (Self, ConstChoice) {
         let mut limbs = [Limb::ZERO; LIMBS];
 
         if shift >= Self::BITS {
@@ -67,6 +81,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Computes a right shift on a wide input as `(lo, hi)`.
+    ///
     /// If `shift >= Self::BITS`, returns a tuple of zeros as the first element,
     /// and `ConstChoice::TRUE` as the second element.
     ///
@@ -75,7 +90,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// When used with a fixed `shift`, this function is constant-time with respect
     /// to `self`.
     #[inline(always)]
-    pub const fn shr_vartime_wide(
+    pub const fn overflowing_shr_vartime_wide(
         lower_upper: (Self, Self),
         shift: u32,
     ) -> ((Self, Self), ConstChoice) {
@@ -83,20 +98,25 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         if shift >= 2 * Self::BITS {
             ((Self::ZERO, Self::ZERO), ConstChoice::TRUE)
         } else if shift >= Self::BITS {
-            let (lower, _) = upper.shr_vartime(shift - Self::BITS);
+            let (lower, _) = upper.overflowing_shr_vartime(shift - Self::BITS);
             ((lower, Self::ZERO), ConstChoice::FALSE)
         } else {
-            let (new_upper, _) = upper.shr_vartime(shift);
-            let (lower_hi, _) = upper.shl_vartime(Self::BITS - shift);
-            let (lower_lo, _) = lower.shr_vartime(shift);
+            let (new_upper, _) = upper.overflowing_shr_vartime(shift);
+            let (lower_hi, _) = upper.overflowing_shl_vartime(Self::BITS - shift);
+            let (lower_lo, _) = lower.overflowing_shr_vartime(shift);
             ((lower_lo.bitor(&lower_hi), new_upper), ConstChoice::FALSE)
         }
     }
 
+    /// Computes `self >> 1` in constant-time.
+    pub(crate) const fn shr1(&self) -> Self {
+        self.overflowing_shr1().0
+    }
+
     /// Computes `self >> 1` in constant-time, returning [`ConstChoice::TRUE`]
-    /// if the least significant bit was set, and [`ConstChoice::FALSE`] otherwise.
+    /// if the least significant bit was set (i.e. if overflow occurred), and [`ConstChoice::FALSE`] otherwise.
     #[inline(always)]
-    pub(crate) const fn shr1_with_carry(&self) -> (Self, ConstChoice) {
+    pub(crate) const fn overflowing_shr1(&self) -> (Self, ConstChoice) {
         let mut ret = Self::ZERO;
         let mut i = LIMBS;
         let mut carry = Limb::ZERO;
@@ -108,12 +128,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
 
         (ret, ConstChoice::from_word_lsb(carry.0 >> Limb::HI_BIT))
-    }
-
-    /// Computes `self >> 1` in constant-time.
-    pub(crate) const fn shr1(&self) -> Self {
-        // TODO(tarcieri): optimized implementation
-        self.shr1_with_carry().0
     }
 }
 
@@ -129,12 +143,7 @@ impl<const LIMBS: usize> Shr<u32> for &Uint<LIMBS> {
     type Output = Uint<LIMBS>;
 
     fn shr(self, shift: u32) -> Uint<LIMBS> {
-        let (result, overflow) = Uint::<LIMBS>::shr(self, shift);
-        assert!(
-            !overflow.is_true_vartime(),
-            "attempt to shift right with overflow"
-        );
-        result
+        Uint::<LIMBS>::shr(self, shift)
     }
 }
 
@@ -162,8 +171,11 @@ mod tests {
 
     #[test]
     fn shr256_const() {
-        assert_eq!(N.shr(256), (U256::ZERO, ConstChoice::TRUE));
-        assert_eq!(N.shr_vartime(256), (U256::ZERO, ConstChoice::TRUE));
+        assert_eq!(N.overflowing_shr(256), (U256::ZERO, ConstChoice::TRUE));
+        assert_eq!(
+            N.overflowing_shr_vartime(256),
+            (U256::ZERO, ConstChoice::TRUE)
+        );
     }
 
     #[test]
@@ -175,7 +187,7 @@ mod tests {
     #[test]
     fn shr_wide_1_1_128() {
         assert_eq!(
-            Uint::shr_vartime_wide((U128::ONE, U128::ONE), 128),
+            Uint::overflowing_shr_vartime_wide((U128::ONE, U128::ONE), 128),
             ((U128::ONE, U128::ZERO), ConstChoice::FALSE)
         );
     }
@@ -183,7 +195,7 @@ mod tests {
     #[test]
     fn shr_wide_0_max_1() {
         assert_eq!(
-            Uint::shr_vartime_wide((U128::ZERO, U128::MAX), 1),
+            Uint::overflowing_shr_vartime_wide((U128::ZERO, U128::MAX), 1),
             ((U128::ONE << 127, U128::MAX >> 1), ConstChoice::FALSE)
         );
     }
@@ -191,7 +203,7 @@ mod tests {
     #[test]
     fn shr_wide_max_max_256() {
         assert_eq!(
-            Uint::shr_vartime_wide((U128::MAX, U128::MAX), 256),
+            Uint::overflowing_shr_vartime_wide((U128::MAX, U128::MAX), 256),
             ((U128::ZERO, U128::ZERO), ConstChoice::TRUE)
         );
     }

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -110,13 +110,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes `self >> 1` in constant-time.
     pub(crate) const fn shr1(&self) -> Self {
-        self.overflowing_shr1().0
+        self.shr1_with_carry().0
     }
 
     /// Computes `self >> 1` in constant-time, returning [`ConstChoice::TRUE`]
-    /// if the least significant bit was set (i.e. if overflow occurred), and [`ConstChoice::FALSE`] otherwise.
+    /// if the least significant bit was set, and [`ConstChoice::FALSE`] otherwise.
     #[inline(always)]
-    pub(crate) const fn overflowing_shr1(&self) -> (Self, ConstChoice) {
+    pub(crate) const fn shr1_with_carry(&self) -> (Self, ConstChoice) {
         let mut ret = Self::ZERO;
         let mut i = LIMBS;
         let mut carry = Limb::ZERO;

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -17,7 +17,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         // The initial guess: `x_0 = 2^ceil(b/2)`, where `2^(b-1) <= self < b`.
         // Will not overflow since `b <= BITS`.
-        let (mut x, _overflow) = Self::ONE.shl((self.bits() + 1) >> 1); // ≥ √(`self`)
+        let (mut x, _overflow) = Self::ONE.overflowing_shl((self.bits() + 1) >> 1); // ≥ √(`self`)
 
         // Repeat enough times to guarantee result has stabilized.
         let mut i = 0;
@@ -53,7 +53,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         // The initial guess: `x_0 = 2^ceil(b/2)`, where `2^(b-1) <= self < b`.
         // Will not overflow since `b <= BITS`.
-        let (mut x, _overflow) = Self::ONE.shl((self.bits() + 1) >> 1); // ≥ √(`self`)
+        let (mut x, _overflow) = Self::ONE.overflowing_shl((self.bits() + 1) >> 1); // ≥ √(`self`)
 
         // Stop right away if `x` is zero to avoid divizion by zero.
         while !x.cmp_vartime(&Self::ZERO).is_eq() {

--- a/tests/boxed_uint_proptests.rs
+++ b/tests/boxed_uint_proptests.rs
@@ -222,7 +222,7 @@ proptest! {
         let shift = u32::from(shift) % (a.bits_precision() * 2);
 
         let expected = to_uint((a_bi << shift as usize) & ((BigUint::one() << a.bits_precision() as usize) - BigUint::one()));
-        let (actual, overflow) = a.shl(shift);
+        let (actual, overflow) = a.overflowing_shl(shift);
 
         assert_eq!(expected, actual);
         if shift >= a.bits_precision() {
@@ -257,7 +257,7 @@ proptest! {
         let shift = u32::from(shift) % (a.bits_precision() * 2);
 
         let expected = to_uint(a_bi >> shift as usize);
-        let (actual, overflow) = a.shr(shift);
+        let (actual, overflow) = a.overflowing_shr(shift);
 
         assert_eq!(expected, actual);
         if shift >= a.bits_precision() {

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -64,7 +64,7 @@ proptest! {
         let shift = u32::from(shift) % (U256::BITS * 2);
 
         let expected = to_uint((a_bi << shift as usize) & ((BigUint::one() << U256::BITS as usize) - BigUint::one()));
-        let (actual, overflow) = a.shl_vartime(shift.into());
+        let (actual, overflow) = a.overflowing_shl_vartime(shift.into());
 
         assert_eq!(expected, actual);
         if shift >= U256::BITS {
@@ -81,7 +81,7 @@ proptest! {
         let shift = u32::from(shift) % (U256::BITS * 2);
 
         let expected = to_uint((a_bi << shift as usize) & ((BigUint::one() << U256::BITS as usize) - BigUint::one()));
-        let (actual, overflow) = a.shl(shift);
+        let (actual, overflow) = a.overflowing_shl(shift);
 
         assert_eq!(expected, actual);
         if shift >= U256::BITS {
@@ -98,7 +98,7 @@ proptest! {
         let shift = u32::from(shift) % (U256::BITS * 2);
 
         let expected = to_uint(a_bi >> shift as usize);
-        let (actual, overflow) = a.shr_vartime(shift);
+        let (actual, overflow) = a.overflowing_shr_vartime(shift);
 
         assert_eq!(expected, actual);
         if shift >= U256::BITS {
@@ -115,7 +115,7 @@ proptest! {
         let shift = u32::from(shift) % (U256::BITS * 2);
 
         let expected = to_uint(a_bi >> shift as usize);
-        let (actual, overflow) = a.shr(shift);
+        let (actual, overflow) = a.overflowing_shr(shift);
 
         assert_eq!(expected, actual);
         if shift >= U256::BITS {


### PR DESCRIPTION
Changes all shift functions which return an overflow flag (as a `Choice` or `ConstChoice`) to use the `overflowing_sh*` name prefix, which aligns with similar APIs in `core`/`std`.

In their place, adds new `Uint::{shl, shr}` functions which provide the trait-like behavior (i.e. panic on overflow) but work in `const fn` contexts (and can now panic at compile time on overflow).