### PR TITLE
Add traits to connect integers and residue represenations

### DIFF
--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -252,14 +252,14 @@ impl Retrieve for BoxedMontyForm {
 }
 
 impl MontyFormLike for BoxedMontyForm {
-    type Raw = BoxedUint;
+    type Integer = BoxedUint;
     type Params = BoxedMontyParams;
 
-    fn new_params(modulus: Self::Raw) -> CtOption<Self::Params> {
+    fn new_params(modulus: Self::Integer) -> CtOption<Self::Params> {
         BoxedMontyParams::new(modulus)
     }
 
-    fn new(value: Self::Raw, params: Self::Params) -> Self {
+    fn new(value: Self::Integer, params: Self::Params) -> Self {
         BoxedMontyForm::new(value, params)
     }
 

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -12,7 +12,7 @@ use super::{
     reduction::{montgomery_reduction_boxed, montgomery_reduction_boxed_mut},
     Retrieve,
 };
-use crate::{BoxedUint, ConstantTimeSelect, Integer, Limb, MontyFormLike, NonZero, Word};
+use crate::{BoxedUint, ConstantTimeSelect, Integer, Limb, Monty, NonZero, Word};
 use subtle::CtOption;
 
 #[cfg(feature = "std")]
@@ -251,7 +251,7 @@ impl Retrieve for BoxedMontyForm {
     }
 }
 
-impl MontyFormLike for BoxedMontyForm {
+impl Monty for BoxedMontyForm {
     type Integer = BoxedUint;
     type Params = BoxedMontyParams;
 

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -12,7 +12,7 @@ use super::{
     reduction::{montgomery_reduction_boxed, montgomery_reduction_boxed_mut},
     Retrieve,
 };
-use crate::{BoxedUint, ConstantTimeSelect, Integer, Limb, NonZero, Word};
+use crate::{BoxedUint, ConstantTimeSelect, Integer, Limb, MontyFormLike, NonZero, Word};
 use subtle::CtOption;
 
 #[cfg(feature = "std")]
@@ -248,6 +248,27 @@ impl Retrieve for BoxedMontyForm {
     type Output = BoxedUint;
     fn retrieve(&self) -> BoxedUint {
         self.retrieve()
+    }
+}
+
+impl MontyFormLike for BoxedMontyForm {
+    type Raw = BoxedUint;
+    type Params = BoxedMontyParams;
+
+    fn new_params(modulus: Self::Raw) -> CtOption<Self::Params> {
+        BoxedMontyParams::new(modulus)
+    }
+
+    fn new(value: Self::Raw, params: Self::Params) -> Self {
+        BoxedMontyForm::new(value, params)
+    }
+
+    fn zero(params: Self::Params) -> Self {
+        BoxedMontyForm::zero(params)
+    }
+
+    fn one(params: Self::Params) -> Self {
+        BoxedMontyForm::one(params)
     }
 }
 

--- a/src/modular/boxed_monty_form/mul.rs
+++ b/src/modular/boxed_monty_form/mul.rs
@@ -7,8 +7,8 @@
 
 use super::{BoxedMontyForm, BoxedMontyParams};
 use crate::{
-    modular::reduction::montgomery_reduction_boxed_mut, traits::Square, uint::mul::mul_limbs,
-    BoxedUint, Limb, Word, Zero,
+    modular::reduction::montgomery_reduction_boxed_mut, uint::mul::mul_limbs, BoxedUint, Limb,
+    Square, SquareAssign, Word, Zero,
 };
 use core::{
     borrow::Borrow,
@@ -91,6 +91,12 @@ impl MulAssign<&BoxedMontyForm> for BoxedMontyForm {
 impl Square for BoxedMontyForm {
     fn square(&self) -> Self {
         BoxedMontyForm::square(self)
+    }
+}
+
+impl SquareAssign for BoxedMontyForm {
+    fn square_assign(&mut self) {
+        MontgomeryMultiplier::from(self.params.borrow()).square_assign(&mut self.montgomery_form);
     }
 }
 

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -13,7 +13,7 @@ use super::{
     reduction::montgomery_reduction,
     Retrieve,
 };
-use crate::{Limb, NonZero, Uint, Word, Zero};
+use crate::{Limb, MontyFormLike, NonZero, Uint, Word, Zero};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 /// Parameters to efficiently go to/from the Montgomery form for an odd modulus provided at runtime.
@@ -205,6 +205,27 @@ impl<const LIMBS: usize> Retrieve for MontyForm<LIMBS> {
     type Output = Uint<LIMBS>;
     fn retrieve(&self) -> Self::Output {
         self.retrieve()
+    }
+}
+
+impl<const LIMBS: usize> MontyFormLike for MontyForm<LIMBS> {
+    type Raw = Uint<LIMBS>;
+    type Params = MontyParams<LIMBS>;
+
+    fn new_params(modulus: Self::Raw) -> CtOption<Self::Params> {
+        MontyParams::new(&modulus)
+    }
+
+    fn new(value: Self::Raw, params: Self::Params) -> Self {
+        MontyForm::new(&value, params)
+    }
+
+    fn zero(params: Self::Params) -> Self {
+        MontyForm::zero(params)
+    }
+
+    fn one(params: Self::Params) -> Self {
+        MontyForm::one(params)
     }
 }
 

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -13,7 +13,7 @@ use super::{
     reduction::montgomery_reduction,
     Retrieve,
 };
-use crate::{Limb, MontyFormLike, NonZero, Uint, Word, Zero};
+use crate::{Limb, Monty, NonZero, Uint, Word, Zero};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 /// Parameters to efficiently go to/from the Montgomery form for an odd modulus provided at runtime.
@@ -208,7 +208,7 @@ impl<const LIMBS: usize> Retrieve for MontyForm<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> MontyFormLike for MontyForm<LIMBS> {
+impl<const LIMBS: usize> Monty for MontyForm<LIMBS> {
     type Integer = Uint<LIMBS>;
     type Params = MontyParams<LIMBS>;
 

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -209,14 +209,14 @@ impl<const LIMBS: usize> Retrieve for MontyForm<LIMBS> {
 }
 
 impl<const LIMBS: usize> MontyFormLike for MontyForm<LIMBS> {
-    type Raw = Uint<LIMBS>;
+    type Integer = Uint<LIMBS>;
     type Params = MontyParams<LIMBS>;
 
-    fn new_params(modulus: Self::Raw) -> CtOption<Self::Params> {
+    fn new_params(modulus: Self::Integer) -> CtOption<Self::Params> {
         MontyParams::new(&modulus)
     }
 
-    fn new(value: Self::Raw, params: Self::Params) -> Self {
+    fn new(value: Self::Integer, params: Self::Params) -> Self {
         MontyForm::new(&value, params)
     }
 

--- a/src/modular/monty_form/mul.rs
+++ b/src/modular/monty_form/mul.rs
@@ -3,7 +3,7 @@
 use super::MontyForm;
 use crate::{
     modular::mul::{mul_montgomery_form, square_montgomery_form},
-    traits::Square,
+    Square, SquareAssign,
 };
 use core::ops::{Mul, MulAssign};
 
@@ -80,5 +80,11 @@ impl<const LIMBS: usize> MulAssign<MontyForm<LIMBS>> for MontyForm<LIMBS> {
 impl<const LIMBS: usize> Square for MontyForm<LIMBS> {
     fn square(&self) -> Self {
         MontyForm::square(self)
+    }
+}
+
+impl<const LIMBS: usize> SquareAssign for MontyForm<LIMBS> {
+    fn square_assign(&mut self) {
+        *self = self.square()
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -141,6 +141,10 @@ pub trait Integer:
     + WrappingShr
     + Zero
 {
+    /// The corresponding Montgomery representation,
+    /// optimized for the performance of modular operations at the price of a conversion overhead.
+    type MontyForm: MontyFormLike<Integer = Self>;
+
     /// The value `1`.
     fn one() -> Self;
 
@@ -514,16 +518,10 @@ pub trait WideningMul<Rhs = Self>: Sized {
     fn widening_mul(&self, rhs: Rhs) -> Self::Output;
 }
 
-/// This integer has a representation optimized for the performance of modular operations.
-pub trait HasMontyForm {
-    /// The representation type.
-    type MontyForm: MontyFormLike<Raw = Self>;
-}
-
 /// A representation of an integer optimized for the performance of modular operations.
 pub trait MontyFormLike {
     /// The original integer type.
-    type Raw: HasMontyForm<MontyForm = Self>;
+    type Integer: Integer<MontyForm = Self>;
 
     /// The precomputed data needed for this representation.
     type Params: Clone;
@@ -532,10 +530,10 @@ pub trait MontyFormLike {
     ///
     /// Can return `None` if `modulus` is not valid for the representation;
     /// see the documentation of the specific type for the requirements.
-    fn new_params(modulus: Self::Raw) -> CtOption<Self::Params>;
+    fn new_params(modulus: Self::Integer) -> CtOption<Self::Params>;
 
     /// Convert the value into the representation using precomputed data.
-    fn new(value: Self::Raw, params: Self::Params) -> Self;
+    fn new(value: Self::Integer, params: Self::Params) -> Self;
 
     /// Returns zero in this representation.
     fn zero(params: Self::Params) -> Self;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -552,7 +552,7 @@ pub trait Monty:
     /// The precomputed data needed for this representation.
     type Params: Clone;
 
-    /// Create the precomputed data.
+    /// Create the precomputed data for Montgomery representation of integers modulo `modulus`.
     ///
     /// `modulus` must be odd, otherwise returns `None`.
     fn new_params(modulus: Self::Integer) -> CtOption<Self::Params>;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -11,8 +11,8 @@ pub(crate) use sealed::PrecomputeInverterWithAdjuster;
 use crate::{Limb, NonZero};
 use core::fmt::Debug;
 use core::ops::{
-    Add, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign, Mul, Not,
-    Rem, Shl, ShlAssign, Shr, ShrAssign, Sub,
+    Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
+    Mul, MulAssign, Neg, Not, Rem, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
 };
 use subtle::{
     Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
@@ -429,14 +429,16 @@ pub trait Encoding: Sized {
 }
 
 /// Support for optimized squaring
-pub trait Square: Sized
-where
-    for<'a> &'a Self: Mul<&'a Self, Output = Self>,
-{
-    /// Computes the same as `self.mul(self)`, but may be more efficient.
-    fn square(&self) -> Self {
-        self * self
-    }
+pub trait Square {
+    /// Computes the same as `self * self`, but may be more efficient.
+    fn square(&self) -> Self;
+}
+
+/// Support for optimized squaring in-place
+pub trait SquareAssign {
+    /// Computes the same as `self * self`, but may be more efficient.
+    /// Writes the result in `self`.
+    fn square_assign(&mut self);
 }
 
 /// Constant-time exponentiation.
@@ -519,7 +521,31 @@ pub trait WideningMul<Rhs = Self>: Sized {
 }
 
 /// A representation of an integer optimized for the performance of modular operations.
-pub trait MontyFormLike {
+pub trait MontyFormLike:
+    'static
+    + Clone
+    + Debug
+    + Eq
+    + Sized
+    + Send
+    + Sync
+    + Add<Output = Self>
+    + for<'a> Add<&'a Self, Output = Self>
+    + AddAssign
+    + for<'a> AddAssign<&'a Self>
+    + Sub<Output = Self>
+    + for<'a> Sub<&'a Self, Output = Self>
+    + SubAssign
+    + for<'a> SubAssign<&'a Self>
+    + Mul<Output = Self>
+    + for<'a> Mul<&'a Self, Output = Self>
+    + MulAssign
+    + for<'a> MulAssign<&'a Self>
+    + Neg<Output = Self>
+    + PowBoundedExp<Self::Integer>
+    + Square
+    + SquareAssign
+{
     /// The original integer type.
     type Integer: Integer<MontyForm = Self>;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -143,7 +143,7 @@ pub trait Integer:
 {
     /// The corresponding Montgomery representation,
     /// optimized for the performance of modular operations at the price of a conversion overhead.
-    type MontyForm: MontyFormLike<Integer = Self>;
+    type Monty: Monty<Integer = Self>;
 
     /// The value `1`.
     fn one() -> Self;
@@ -521,7 +521,7 @@ pub trait WideningMul<Rhs = Self>: Sized {
 }
 
 /// A representation of an integer optimized for the performance of modular operations.
-pub trait MontyFormLike:
+pub trait Monty:
     'static
     + Clone
     + Debug
@@ -547,7 +547,7 @@ pub trait MontyFormLike:
     + SquareAssign
 {
     /// The original integer type.
-    type Integer: Integer<MontyForm = Self>;
+    type Integer: Integer<Monty = Self>;
 
     /// The precomputed data needed for this representation.
     type Params: Clone;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -554,8 +554,7 @@ pub trait Monty:
 
     /// Create the precomputed data.
     ///
-    /// Can return `None` if `modulus` is not valid for the representation;
-    /// see the documentation of the specific type for the requirements.
+    /// `modulus` must be odd, otherwise returns `None`.
     fn new_params(modulus: Self::Integer) -> CtOption<Self::Params>;
 
     /// Convert the value into the representation using precomputed data.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -513,3 +513,33 @@ pub trait WideningMul<Rhs = Self>: Sized {
     /// Perform widening multiplication.
     fn widening_mul(&self, rhs: Rhs) -> Self::Output;
 }
+
+/// This integer has a representation optimized for the performance of modular operations.
+pub trait HasMontyForm {
+    /// The representation type.
+    type MontyForm: MontyFormLike<Raw = Self>;
+}
+
+/// A representation of an integer optimized for the performance of modular operations.
+pub trait MontyFormLike {
+    /// The original integer type.
+    type Raw: HasMontyForm<MontyForm = Self>;
+
+    /// The precomputed data needed for this representation.
+    type Params: Clone;
+
+    /// Create the precomputed data.
+    ///
+    /// Can return `None` if `modulus` is not valid for the representation;
+    /// see the documentation of the specific type for the requirements.
+    fn new_params(modulus: Self::Raw) -> CtOption<Self::Params>;
+
+    /// Convert the value into the representation using precomputed data.
+    fn new(value: Self::Raw, params: Self::Params) -> Self;
+
+    /// Returns zero in this representation.
+    fn zero(params: Self::Params) -> Self;
+
+    /// Returns one in this representation.
+    fn one(params: Self::Params) -> Self;
+}

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -40,8 +40,9 @@ pub(crate) mod boxed;
 mod rand;
 
 use crate::{
-    modular::BernsteinYangInverter, Bounded, ConstCtOption, Constants, Encoding, FixedInteger,
-    Integer, Limb, NonZero, PrecomputeInverter, PrecomputeInverterWithAdjuster, Word, ZeroConstant,
+    modular::{BernsteinYangInverter, MontyForm},
+    Bounded, ConstCtOption, Constants, Encoding, FixedInteger, HasMontyForm, Integer, Limb,
+    NonZero, PrecomputeInverter, PrecomputeInverterWithAdjuster, Word, ZeroConstant,
 };
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
@@ -258,6 +259,10 @@ impl<const LIMBS: usize> Integer for Uint<LIMBS> {
     fn nlimbs(&self) -> usize {
         Self::LIMBS
     }
+}
+
+impl<const LIMBS: usize> HasMontyForm for Uint<LIMBS> {
+    type MontyForm = MontyForm<LIMBS>;
 }
 
 impl<const LIMBS: usize> ZeroConstant for Uint<LIMBS> {

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -236,7 +236,7 @@ impl<const LIMBS: usize> FixedInteger for Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize> Integer for Uint<LIMBS> {
-    type MontyForm = MontyForm<LIMBS>;
+    type Monty = MontyForm<LIMBS>;
 
     fn one() -> Self {
         Self::ONE

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -41,8 +41,8 @@ mod rand;
 
 use crate::{
     modular::{BernsteinYangInverter, MontyForm},
-    Bounded, ConstCtOption, Constants, Encoding, FixedInteger, HasMontyForm, Integer, Limb,
-    NonZero, PrecomputeInverter, PrecomputeInverterWithAdjuster, Word, ZeroConstant,
+    Bounded, ConstCtOption, Constants, Encoding, FixedInteger, Integer, Limb, NonZero,
+    PrecomputeInverter, PrecomputeInverterWithAdjuster, Word, ZeroConstant,
 };
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
@@ -236,6 +236,8 @@ impl<const LIMBS: usize> FixedInteger for Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize> Integer for Uint<LIMBS> {
+    type MontyForm = MontyForm<LIMBS>;
+
     fn one() -> Self {
         Self::ONE
     }
@@ -259,10 +261,6 @@ impl<const LIMBS: usize> Integer for Uint<LIMBS> {
     fn nlimbs(&self) -> usize {
         Self::LIMBS
     }
-}
-
-impl<const LIMBS: usize> HasMontyForm for Uint<LIMBS> {
-    type MontyForm = MontyForm<LIMBS>;
 }
 
 impl<const LIMBS: usize> ZeroConstant for Uint<LIMBS> {

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -284,7 +284,7 @@ impl Default for BoxedUint {
 }
 
 impl Integer for BoxedUint {
-    type MontyForm = BoxedMontyForm;
+    type Monty = BoxedMontyForm;
 
     fn one() -> Self {
         Self::one()

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -25,7 +25,7 @@ mod sub_mod;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{modular::BoxedMontyForm, HasMontyForm, Integer, Limb, NonZero, Word, Zero};
+use crate::{modular::BoxedMontyForm, Integer, Limb, NonZero, Word, Zero};
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
@@ -284,6 +284,8 @@ impl Default for BoxedUint {
 }
 
 impl Integer for BoxedUint {
+    type MontyForm = BoxedMontyForm;
+
     fn one() -> Self {
         Self::one()
     }
@@ -341,10 +343,6 @@ impl num_traits::One for BoxedUint {
     fn is_one(&self) -> bool {
         self.is_one().into()
     }
-}
-
-impl HasMontyForm for BoxedUint {
-    type MontyForm = BoxedMontyForm;
 }
 
 #[cfg(feature = "zeroize")]

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -25,7 +25,7 @@ mod sub_mod;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{Integer, Limb, NonZero, Word, Zero};
+use crate::{modular::BoxedMontyForm, HasMontyForm, Integer, Limb, NonZero, Word, Zero};
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
@@ -341,6 +341,10 @@ impl num_traits::One for BoxedUint {
     fn is_one(&self) -> bool {
         self.is_one().into()
     }
+}
+
+impl HasMontyForm for BoxedUint {
+    type MontyForm = BoxedMontyForm;
 }
 
 #[cfg(feature = "zeroize")]


### PR DESCRIPTION
A part of #348 
Fixes #448

All the naming is up for debate (see also #351)

- add `Monty` associated type to `Integer` linking it to the corresponding Montgomery form
- add `Monty` trait with an associated type linking back to the corresponding `Integer` and a bunch of bounds (similar to `Integer`)
- remove the bound on `Square` which made it hard to make `Square` a bound to other traits. This means that there's no default implementation anymore.
- add `SquareAssign` trait.

I will make a separate PR adding `div_by_2()` to `Monty` after #436 is merged
