### PR TITLE
Expand `num_traits` impls

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -21,7 +21,7 @@ mod rand;
 
 use crate::{Bounded, Constants, ZeroConstant};
 use core::fmt;
-use subtle::{Choice, ConditionallySelectable};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 #[cfg(feature = "serde")]
 use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -103,14 +103,34 @@ impl Constants for Limb {
     const MAX: Self = Self::MAX;
 }
 
-impl ZeroConstant for Limb {
-    const ZERO: Self = Self::ZERO;
-}
-
 impl ConditionallySelectable for Limb {
     #[inline]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Self(Word::conditional_select(&a.0, &b.0, choice))
+    }
+}
+
+impl ZeroConstant for Limb {
+    const ZERO: Self = Self::ZERO;
+}
+
+impl num_traits::Zero for Limb {
+    fn zero() -> Self {
+        Self::ZERO
+    }
+
+    fn is_zero(&self) -> bool {
+        self.ct_eq(&Self::ZERO).into()
+    }
+}
+
+impl num_traits::One for Limb {
+    fn one() -> Self {
+        Self::ONE
+    }
+
+    fn is_one(&self) -> bool {
+        self.ct_eq(&Self::ONE).into()
     }
 }
 

--- a/src/limb/add.rs
+++ b/src/limb/add.rs
@@ -1,6 +1,6 @@
 //! Limb addition
 
-use crate::{Checked, CheckedAdd, Limb, WideWord, Word, Wrapping, Zero};
+use crate::{Checked, CheckedAdd, Limb, WideWord, Word, Wrapping, WrappingAdd, Zero};
 use core::ops::{Add, AddAssign};
 use subtle::CtOption;
 
@@ -28,55 +28,25 @@ impl Limb {
     }
 }
 
-impl CheckedAdd for Limb {
+impl Add for Limb {
     type Output = Self;
 
     #[inline]
-    fn checked_add(&self, rhs: Self) -> CtOption<Self> {
-        let (result, carry) = self.adc(rhs, Limb::ZERO);
-        CtOption::new(result, carry.is_zero())
-    }
-}
-
-impl Add for Wrapping<Limb> {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Wrapping<Limb> {
-        Wrapping(self.0.wrapping_add(rhs.0))
-    }
-}
-
-impl Add<&Wrapping<Limb>> for Wrapping<Limb> {
-    type Output = Wrapping<Limb>;
-
-    fn add(self, rhs: &Wrapping<Limb>) -> Wrapping<Limb> {
-        Wrapping(self.0.wrapping_add(rhs.0))
-    }
-}
-
-impl Add<Wrapping<Limb>> for &Wrapping<Limb> {
-    type Output = Wrapping<Limb>;
-
-    fn add(self, rhs: Wrapping<Limb>) -> Wrapping<Limb> {
-        Wrapping(self.0.wrapping_add(rhs.0))
-    }
-}
-
-impl Add<&Wrapping<Limb>> for &Wrapping<Limb> {
-    type Output = Wrapping<Limb>;
-
-    fn add(self, rhs: &Wrapping<Limb>) -> Wrapping<Limb> {
-        Wrapping(self.0.wrapping_add(rhs.0))
+    fn add(self, rhs: Self) -> Self {
+        self.checked_add(rhs)
+            .expect("attempted to add with overflow")
     }
 }
 
 impl AddAssign for Wrapping<Limb> {
+    #[inline]
     fn add_assign(&mut self, other: Self) {
         *self = *self + other;
     }
 }
 
 impl AddAssign<&Wrapping<Limb>> for Wrapping<Limb> {
+    #[inline]
     fn add_assign(&mut self, other: &Self) {
         *self = *self + other;
     }
@@ -85,6 +55,7 @@ impl AddAssign<&Wrapping<Limb>> for Wrapping<Limb> {
 impl Add for Checked<Limb> {
     type Output = Self;
 
+    #[inline]
     fn add(self, rhs: Self) -> Checked<Limb> {
         Checked(
             self.0
@@ -96,6 +67,7 @@ impl Add for Checked<Limb> {
 impl Add<&Checked<Limb>> for Checked<Limb> {
     type Output = Checked<Limb>;
 
+    #[inline]
     fn add(self, rhs: &Checked<Limb>) -> Checked<Limb> {
         Checked(
             self.0
@@ -107,6 +79,7 @@ impl Add<&Checked<Limb>> for Checked<Limb> {
 impl Add<Checked<Limb>> for &Checked<Limb> {
     type Output = Checked<Limb>;
 
+    #[inline]
     fn add(self, rhs: Checked<Limb>) -> Checked<Limb> {
         Checked(
             self.0
@@ -118,6 +91,7 @@ impl Add<Checked<Limb>> for &Checked<Limb> {
 impl Add<&Checked<Limb>> for &Checked<Limb> {
     type Output = Checked<Limb>;
 
+    #[inline]
     fn add(self, rhs: &Checked<Limb>) -> Checked<Limb> {
         Checked(
             self.0
@@ -127,14 +101,33 @@ impl Add<&Checked<Limb>> for &Checked<Limb> {
 }
 
 impl AddAssign for Checked<Limb> {
+    #[inline]
     fn add_assign(&mut self, other: Self) {
         *self = *self + other;
     }
 }
 
 impl AddAssign<&Checked<Limb>> for Checked<Limb> {
+    #[inline]
     fn add_assign(&mut self, other: &Self) {
         *self = *self + other;
+    }
+}
+
+impl CheckedAdd for Limb {
+    type Output = Self;
+
+    #[inline]
+    fn checked_add(&self, rhs: Self) -> CtOption<Self> {
+        let (result, carry) = self.adc(rhs, Limb::ZERO);
+        CtOption::new(result, carry.is_zero())
+    }
+}
+
+impl WrappingAdd for Limb {
+    #[inline]
+    fn wrapping_add(&self, v: &Self) -> Self {
+        self.wrapping_add(*v)
     }
 }
 

--- a/src/limb/mul.rs
+++ b/src/limb/mul.rs
@@ -2,6 +2,7 @@
 
 use crate::{Checked, CheckedMul, Limb, WideWord, Word, Wrapping, Zero};
 use core::ops::{Mul, MulAssign};
+use num_traits::WrappingMul;
 use subtle::CtOption;
 
 impl Limb {
@@ -45,45 +46,52 @@ impl CheckedMul for Limb {
     }
 }
 
-impl Mul for Wrapping<Limb> {
-    type Output = Self;
+impl Mul<Limb> for Limb {
+    type Output = Limb;
 
-    fn mul(self, rhs: Self) -> Wrapping<Limb> {
-        Wrapping(self.0.wrapping_mul(rhs.0))
+    #[inline]
+    fn mul(self, rhs: Limb) -> Self {
+        self.checked_mul(rhs)
+            .expect("attempted to multiply with overflow")
     }
 }
 
-impl Mul<&Wrapping<Limb>> for Wrapping<Limb> {
-    type Output = Wrapping<Limb>;
+impl Mul<&Limb> for Limb {
+    type Output = Limb;
 
-    fn mul(self, rhs: &Wrapping<Limb>) -> Wrapping<Limb> {
-        Wrapping(self.0.wrapping_mul(rhs.0))
+    #[inline]
+    fn mul(self, rhs: &Limb) -> Self {
+        self * *rhs
     }
 }
 
-impl Mul<Wrapping<Limb>> for &Wrapping<Limb> {
-    type Output = Wrapping<Limb>;
+impl Mul<Limb> for &Limb {
+    type Output = Limb;
 
-    fn mul(self, rhs: Wrapping<Limb>) -> Wrapping<Limb> {
-        Wrapping(self.0.wrapping_mul(rhs.0))
+    #[inline]
+    fn mul(self, rhs: Limb) -> Self::Output {
+        *self * rhs
     }
 }
 
-impl Mul<&Wrapping<Limb>> for &Wrapping<Limb> {
-    type Output = Wrapping<Limb>;
+impl Mul<&Limb> for &Limb {
+    type Output = Limb;
 
-    fn mul(self, rhs: &Wrapping<Limb>) -> Wrapping<Limb> {
-        Wrapping(self.0.wrapping_mul(rhs.0))
+    #[inline]
+    fn mul(self, rhs: &Limb) -> Self::Output {
+        *self * *rhs
     }
 }
 
 impl MulAssign for Wrapping<Limb> {
+    #[inline]
     fn mul_assign(&mut self, other: Self) {
         *self = *self * other;
     }
 }
 
 impl MulAssign<&Wrapping<Limb>> for Wrapping<Limb> {
+    #[inline]
     fn mul_assign(&mut self, other: &Self) {
         *self = *self * other;
     }
@@ -92,6 +100,7 @@ impl MulAssign<&Wrapping<Limb>> for Wrapping<Limb> {
 impl Mul for Checked<Limb> {
     type Output = Self;
 
+    #[inline]
     fn mul(self, rhs: Self) -> Checked<Limb> {
         Checked(
             self.0
@@ -103,6 +112,7 @@ impl Mul for Checked<Limb> {
 impl Mul<&Checked<Limb>> for Checked<Limb> {
     type Output = Checked<Limb>;
 
+    #[inline]
     fn mul(self, rhs: &Checked<Limb>) -> Checked<Limb> {
         Checked(
             self.0
@@ -114,6 +124,7 @@ impl Mul<&Checked<Limb>> for Checked<Limb> {
 impl Mul<Checked<Limb>> for &Checked<Limb> {
     type Output = Checked<Limb>;
 
+    #[inline]
     fn mul(self, rhs: Checked<Limb>) -> Checked<Limb> {
         Checked(
             self.0
@@ -125,6 +136,7 @@ impl Mul<Checked<Limb>> for &Checked<Limb> {
 impl Mul<&Checked<Limb>> for &Checked<Limb> {
     type Output = Checked<Limb>;
 
+    #[inline]
     fn mul(self, rhs: &Checked<Limb>) -> Checked<Limb> {
         Checked(
             self.0
@@ -134,14 +146,23 @@ impl Mul<&Checked<Limb>> for &Checked<Limb> {
 }
 
 impl MulAssign for Checked<Limb> {
+    #[inline]
     fn mul_assign(&mut self, other: Self) {
         *self = *self * other;
     }
 }
 
 impl MulAssign<&Checked<Limb>> for Checked<Limb> {
+    #[inline]
     fn mul_assign(&mut self, other: &Self) {
         *self = *self * other;
+    }
+}
+
+impl WrappingMul for Limb {
+    #[inline]
+    fn wrapping_mul(&self, v: &Self) -> Self {
+        self.wrapping_mul(*v)
     }
 }
 

--- a/src/limb/neg.rs
+++ b/src/limb/neg.rs
@@ -1,20 +1,19 @@
 //! Limb negation
 
-use crate::{Limb, Wrapping};
-use core::ops::Neg;
-
-impl Neg for Wrapping<Limb> {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        Self(self.0.wrapping_neg())
-    }
-}
+use crate::Limb;
+use num_traits::WrappingNeg;
 
 impl Limb {
     /// Perform wrapping negation.
     #[inline(always)]
     pub const fn wrapping_neg(self) -> Self {
         Limb(self.0.wrapping_neg())
+    }
+}
+
+impl WrappingNeg for Limb {
+    #[inline]
+    fn wrapping_neg(&self) -> Self {
+        Self(self.0.wrapping_neg())
     }
 }

--- a/src/limb/sub.rs
+++ b/src/limb/sub.rs
@@ -1,6 +1,6 @@
 //! Limb subtraction
 
-use crate::{Checked, CheckedSub, Limb, WideWord, Word, Wrapping, Zero};
+use crate::{Checked, CheckedSub, Limb, WideWord, Word, Wrapping, WrappingSub, Zero};
 use core::ops::{Sub, SubAssign};
 use subtle::CtOption;
 
@@ -39,45 +39,34 @@ impl CheckedSub for Limb {
     }
 }
 
-impl Sub for Wrapping<Limb> {
+impl Sub for Limb {
     type Output = Self;
 
-    fn sub(self, rhs: Self) -> Wrapping<Limb> {
-        Wrapping(self.0.wrapping_sub(rhs.0))
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        self.checked_sub(rhs)
+            .expect("attempted to subtract with underflow")
     }
 }
 
-impl Sub<&Wrapping<Limb>> for Wrapping<Limb> {
-    type Output = Wrapping<Limb>;
+impl Sub<&Self> for Limb {
+    type Output = Self;
 
-    fn sub(self, rhs: &Wrapping<Limb>) -> Wrapping<Limb> {
-        Wrapping(self.0.wrapping_sub(rhs.0))
-    }
-}
-
-impl Sub<Wrapping<Limb>> for &Wrapping<Limb> {
-    type Output = Wrapping<Limb>;
-
-    fn sub(self, rhs: Wrapping<Limb>) -> Wrapping<Limb> {
-        Wrapping(self.0.wrapping_sub(rhs.0))
-    }
-}
-
-impl Sub<&Wrapping<Limb>> for &Wrapping<Limb> {
-    type Output = Wrapping<Limb>;
-
-    fn sub(self, rhs: &Wrapping<Limb>) -> Wrapping<Limb> {
-        Wrapping(self.0.wrapping_sub(rhs.0))
+    #[inline]
+    fn sub(self, rhs: &Self) -> Self {
+        self - *rhs
     }
 }
 
 impl SubAssign for Wrapping<Limb> {
+    #[inline]
     fn sub_assign(&mut self, other: Self) {
         *self = *self - other;
     }
 }
 
 impl SubAssign<&Wrapping<Limb>> for Wrapping<Limb> {
+    #[inline]
     fn sub_assign(&mut self, other: &Self) {
         *self = *self - other;
     }
@@ -86,6 +75,7 @@ impl SubAssign<&Wrapping<Limb>> for Wrapping<Limb> {
 impl Sub for Checked<Limb> {
     type Output = Self;
 
+    #[inline]
     fn sub(self, rhs: Self) -> Checked<Limb> {
         Checked(
             self.0
@@ -97,6 +87,7 @@ impl Sub for Checked<Limb> {
 impl Sub<&Checked<Limb>> for Checked<Limb> {
     type Output = Checked<Limb>;
 
+    #[inline]
     fn sub(self, rhs: &Checked<Limb>) -> Checked<Limb> {
         Checked(
             self.0
@@ -108,6 +99,7 @@ impl Sub<&Checked<Limb>> for Checked<Limb> {
 impl Sub<Checked<Limb>> for &Checked<Limb> {
     type Output = Checked<Limb>;
 
+    #[inline]
     fn sub(self, rhs: Checked<Limb>) -> Checked<Limb> {
         Checked(
             self.0
@@ -119,6 +111,7 @@ impl Sub<Checked<Limb>> for &Checked<Limb> {
 impl Sub<&Checked<Limb>> for &Checked<Limb> {
     type Output = Checked<Limb>;
 
+    #[inline]
     fn sub(self, rhs: &Checked<Limb>) -> Checked<Limb> {
         Checked(
             self.0
@@ -128,14 +121,23 @@ impl Sub<&Checked<Limb>> for &Checked<Limb> {
 }
 
 impl SubAssign for Checked<Limb> {
+    #[inline]
     fn sub_assign(&mut self, other: Self) {
         *self = *self - other;
     }
 }
 
 impl SubAssign<&Checked<Limb>> for Checked<Limb> {
+    #[inline]
     fn sub_assign(&mut self, other: &Self) {
         *self = *self - other;
+    }
+}
+
+impl WrappingSub for Limb {
+    #[inline]
+    fn wrapping_sub(&self, v: &Self) -> Self {
+        self.wrapping_sub(*v)
     }
 }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -40,7 +40,7 @@ mod rand;
 
 use crate::{Bounded, Constants, Encoding, FixedInteger, Integer, Limb, Word, ZeroConstant};
 use core::fmt;
-use subtle::{Choice, ConditionallySelectable};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 #[cfg(feature = "serde")]
 use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -251,6 +251,26 @@ impl<const LIMBS: usize> Integer for Uint<LIMBS> {
 
 impl<const LIMBS: usize> ZeroConstant for Uint<LIMBS> {
     const ZERO: Self = Self::ZERO;
+}
+
+impl<const LIMBS: usize> num_traits::Zero for Uint<LIMBS> {
+    fn zero() -> Self {
+        Self::ZERO
+    }
+
+    fn is_zero(&self) -> bool {
+        self.ct_eq(&Self::ZERO).into()
+    }
+}
+
+impl<const LIMBS: usize> num_traits::One for Uint<LIMBS> {
+    fn one() -> Self {
+        Self::ONE
+    }
+
+    fn is_one(&self) -> bool {
+        self.ct_eq(&Self::ONE).into()
+    }
 }
 
 impl<const LIMBS: usize> fmt::Debug for Uint<LIMBS> {

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -62,38 +62,6 @@ impl<const LIMBS: usize> Add<&Uint<LIMBS>> for Uint<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Add for Wrapping<Uint<LIMBS>> {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Wrapping<Uint<LIMBS>> {
-        Wrapping(self.0.wrapping_add(&rhs.0))
-    }
-}
-
-impl<const LIMBS: usize> Add<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
-    type Output = Wrapping<Uint<LIMBS>>;
-
-    fn add(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
-        Wrapping(self.0.wrapping_add(&rhs.0))
-    }
-}
-
-impl<const LIMBS: usize> Add<Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
-    type Output = Wrapping<Uint<LIMBS>>;
-
-    fn add(self, rhs: Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
-        Wrapping(self.0.wrapping_add(&rhs.0))
-    }
-}
-
-impl<const LIMBS: usize> Add<&Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
-    type Output = Wrapping<Uint<LIMBS>>;
-
-    fn add(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
-        Wrapping(self.0.wrapping_add(&rhs.0))
-    }
-}
-
 impl<const LIMBS: usize> AddAssign for Wrapping<Uint<LIMBS>> {
     fn add_assign(&mut self, other: Self) {
         *self = *self + other;

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -403,6 +403,26 @@ impl Zero for BoxedUint {
     }
 }
 
+impl num_traits::Zero for BoxedUint {
+    fn zero() -> Self {
+        Self::zero()
+    }
+
+    fn is_zero(&self) -> bool {
+        self.is_zero().into()
+    }
+}
+
+impl num_traits::One for BoxedUint {
+    fn one() -> Self {
+        Self::one()
+    }
+
+    fn is_one(&self) -> bool {
+        self.is_one().into()
+    }
+}
+
 #[cfg(feature = "zeroize")]
 impl Zeroize for BoxedUint {
     fn zeroize(&mut self) {

--- a/src/uint/boxed/add.rs
+++ b/src/uint/boxed/add.rs
@@ -75,38 +75,6 @@ impl Add<&BoxedUint> for &BoxedUint {
     }
 }
 
-impl Add<Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
-    type Output = Self;
-
-    fn add(self, rhs: Wrapping<BoxedUint>) -> Wrapping<BoxedUint> {
-        Wrapping(self.0.wrapping_add(&rhs.0))
-    }
-}
-
-impl Add<&Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
-    type Output = Self;
-
-    fn add(self, rhs: &Wrapping<BoxedUint>) -> Wrapping<BoxedUint> {
-        Wrapping(self.0.wrapping_add(&rhs.0))
-    }
-}
-
-impl Add<Wrapping<BoxedUint>> for &Wrapping<BoxedUint> {
-    type Output = Wrapping<BoxedUint>;
-
-    fn add(self, rhs: Wrapping<BoxedUint>) -> Wrapping<BoxedUint> {
-        Wrapping(self.0.wrapping_add(&rhs.0))
-    }
-}
-
-impl Add<&Wrapping<BoxedUint>> for &Wrapping<BoxedUint> {
-    type Output = Wrapping<BoxedUint>;
-
-    fn add(self, rhs: &Wrapping<BoxedUint>) -> Wrapping<BoxedUint> {
-        Wrapping(self.0.wrapping_add(&rhs.0))
-    }
-}
-
 impl AddAssign<Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
     fn add_assign(&mut self, other: Wrapping<BoxedUint>) {
         self.0.adc_assign(&other.0, Limb::ZERO);

--- a/src/uint/boxed/mul.rs
+++ b/src/uint/boxed/mul.rs
@@ -86,38 +86,6 @@ impl Mul<&BoxedUint> for &BoxedUint {
     }
 }
 
-impl Mul<Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
-    type Output = Self;
-
-    fn mul(self, rhs: Wrapping<BoxedUint>) -> Wrapping<BoxedUint> {
-        Wrapping(self.0.wrapping_mul(&rhs.0))
-    }
-}
-
-impl Mul<&Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
-    type Output = Self;
-
-    fn mul(self, rhs: &Wrapping<BoxedUint>) -> Wrapping<BoxedUint> {
-        Wrapping(self.0.wrapping_mul(&rhs.0))
-    }
-}
-
-impl Mul<Wrapping<BoxedUint>> for &Wrapping<BoxedUint> {
-    type Output = Wrapping<BoxedUint>;
-
-    fn mul(self, rhs: Wrapping<BoxedUint>) -> Wrapping<BoxedUint> {
-        Wrapping(self.0.wrapping_mul(&rhs.0))
-    }
-}
-
-impl Mul<&Wrapping<BoxedUint>> for &Wrapping<BoxedUint> {
-    type Output = Wrapping<BoxedUint>;
-
-    fn mul(self, rhs: &Wrapping<BoxedUint>) -> Wrapping<BoxedUint> {
-        Wrapping(self.0.wrapping_mul(&rhs.0))
-    }
-}
-
 impl MulAssign<Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
     fn mul_assign(&mut self, other: Wrapping<BoxedUint>) {
         *self = Wrapping(self.0.wrapping_mul(&other.0));

--- a/src/uint/boxed/neg.rs
+++ b/src/uint/boxed/neg.rs
@@ -1,16 +1,7 @@
 //! [`BoxedUint`] negation operations.
 
-use crate::{BoxedUint, Limb, WideWord, Word, Wrapping, WrappingNeg};
-use core::ops::Neg;
+use crate::{BoxedUint, Limb, WideWord, Word, WrappingNeg};
 use subtle::Choice;
-
-impl Neg for Wrapping<BoxedUint> {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        Self(self.0.wrapping_neg())
-    }
-}
 
 impl BoxedUint {
     /// Negates based on `choice` by wrapping the integer.

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -222,58 +222,14 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Mul<&Uint<RHS_LIMBS>> for &Uint
     }
 }
 
-impl<const LIMBS: usize, const RHS_LIMBS: usize> Mul<Wrapping<Uint<RHS_LIMBS>>>
-    for Wrapping<Uint<LIMBS>>
-{
-    type Output = Self;
-
-    fn mul(self, rhs: Wrapping<Uint<RHS_LIMBS>>) -> Wrapping<Uint<LIMBS>> {
-        Wrapping(self.0.wrapping_mul(&rhs.0))
-    }
-}
-
-impl<const LIMBS: usize, const RHS_LIMBS: usize> Mul<&Wrapping<Uint<RHS_LIMBS>>>
-    for Wrapping<Uint<LIMBS>>
-{
-    type Output = Self;
-
-    fn mul(self, rhs: &Wrapping<Uint<RHS_LIMBS>>) -> Wrapping<Uint<LIMBS>> {
-        Wrapping(self.0.wrapping_mul(&rhs.0))
-    }
-}
-
-impl<const LIMBS: usize, const RHS_LIMBS: usize> Mul<Wrapping<Uint<RHS_LIMBS>>>
-    for &Wrapping<Uint<LIMBS>>
-{
-    type Output = Wrapping<Uint<LIMBS>>;
-
-    fn mul(self, rhs: Wrapping<Uint<RHS_LIMBS>>) -> Wrapping<Uint<LIMBS>> {
-        Wrapping(self.0.wrapping_mul(&rhs.0))
-    }
-}
-
-impl<const LIMBS: usize, const RHS_LIMBS: usize> Mul<&Wrapping<Uint<RHS_LIMBS>>>
-    for &Wrapping<Uint<LIMBS>>
-{
-    type Output = Wrapping<Uint<LIMBS>>;
-
-    fn mul(self, rhs: &Wrapping<Uint<RHS_LIMBS>>) -> Wrapping<Uint<LIMBS>> {
-        Wrapping(self.0.wrapping_mul(&rhs.0))
-    }
-}
-
-impl<const LIMBS: usize, const RHS_LIMBS: usize> MulAssign<Wrapping<Uint<RHS_LIMBS>>>
-    for Wrapping<Uint<LIMBS>>
-{
-    fn mul_assign(&mut self, other: Wrapping<Uint<RHS_LIMBS>>) {
+impl<const LIMBS: usize> MulAssign<Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    fn mul_assign(&mut self, other: Wrapping<Uint<LIMBS>>) {
         *self = *self * other;
     }
 }
 
-impl<const LIMBS: usize, const RHS_LIMBS: usize> MulAssign<&Wrapping<Uint<RHS_LIMBS>>>
-    for Wrapping<Uint<LIMBS>>
-{
-    fn mul_assign(&mut self, other: &Wrapping<Uint<RHS_LIMBS>>) {
+impl<const LIMBS: usize> MulAssign<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
+    fn mul_assign(&mut self, other: &Wrapping<Uint<LIMBS>>) {
         *self = *self * other;
     }
 }

--- a/src/uint/neg.rs
+++ b/src/uint/neg.rs
@@ -1,14 +1,4 @@
-use core::ops::Neg;
-
-use crate::{ConstChoice, Limb, Uint, WideWord, Word, Wrapping, WrappingNeg};
-
-impl<const LIMBS: usize> Neg for Wrapping<Uint<LIMBS>> {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        Self(self.0.wrapping_neg())
-    }
-}
+use crate::{ConstChoice, Limb, Uint, WideWord, Word, WrappingNeg};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Negates based on `choice` by wrapping the integer.
@@ -32,6 +22,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize> WrappingNeg for Uint<LIMBS> {
+    #[inline]
     fn wrapping_neg(&self) -> Self {
         self.wrapping_neg()
     }

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -73,38 +73,6 @@ impl<const LIMBS: usize> Sub<&Uint<LIMBS>> for Uint<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Sub for Wrapping<Uint<LIMBS>> {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Wrapping<Uint<LIMBS>> {
-        Wrapping(self.0.wrapping_sub(&rhs.0))
-    }
-}
-
-impl<const LIMBS: usize> Sub<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
-    type Output = Wrapping<Uint<LIMBS>>;
-
-    fn sub(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
-        Wrapping(self.0.wrapping_sub(&rhs.0))
-    }
-}
-
-impl<const LIMBS: usize> Sub<Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
-    type Output = Wrapping<Uint<LIMBS>>;
-
-    fn sub(self, rhs: Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
-        Wrapping(self.0.wrapping_sub(&rhs.0))
-    }
-}
-
-impl<const LIMBS: usize> Sub<&Wrapping<Uint<LIMBS>>> for &Wrapping<Uint<LIMBS>> {
-    type Output = Wrapping<Uint<LIMBS>>;
-
-    fn sub(self, rhs: &Wrapping<Uint<LIMBS>>) -> Wrapping<Uint<LIMBS>> {
-        Wrapping(self.0.wrapping_sub(&rhs.0))
-    }
-}
-
 impl<const LIMBS: usize> SubAssign for Wrapping<Uint<LIMBS>> {
     fn sub_assign(&mut self, other: Self) {
         *self = *self - other;

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -1,7 +1,10 @@
 //! Wrapping arithmetic.
 
-use crate::Zero;
-use core::fmt;
+use crate::{WrappingAdd, WrappingMul, WrappingNeg, WrappingShl, WrappingShr, WrappingSub, Zero};
+use core::{
+    fmt,
+    ops::{Add, Mul, Neg, Shl, Shr, Sub},
+};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 #[cfg(feature = "rand_core")]
@@ -17,9 +20,210 @@ use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Wrapping<T>(pub T);
 
+impl<T: WrappingAdd> Add<Self> for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn add(self, rhs: Self) -> Self::Output {
+        Wrapping(self.0.wrapping_add(&rhs.0))
+    }
+}
+
+impl<T: WrappingAdd> Add<&Self> for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn add(self, rhs: &Self) -> Self::Output {
+        Wrapping(self.0.wrapping_add(&rhs.0))
+    }
+}
+
+impl<T: WrappingAdd> Add<Wrapping<T>> for &Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn add(self, rhs: Wrapping<T>) -> Self::Output {
+        Wrapping(self.0.wrapping_add(&rhs.0))
+    }
+}
+
+impl<T: WrappingAdd> Add<&Wrapping<T>> for &Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn add(self, rhs: &Wrapping<T>) -> Self::Output {
+        Wrapping(self.0.wrapping_add(&rhs.0))
+    }
+}
+
+impl<T: WrappingSub> Sub<Self> for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn sub(self, rhs: Self) -> Self::Output {
+        Wrapping(self.0.wrapping_sub(&rhs.0))
+    }
+}
+
+impl<T: WrappingSub> Sub<&Self> for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn sub(self, rhs: &Self) -> Self::Output {
+        Wrapping(self.0.wrapping_sub(&rhs.0))
+    }
+}
+
+impl<T: WrappingSub> Sub<Wrapping<T>> for &Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn sub(self, rhs: Wrapping<T>) -> Self::Output {
+        Wrapping(self.0.wrapping_sub(&rhs.0))
+    }
+}
+
+impl<T: WrappingSub> Sub<&Wrapping<T>> for &Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn sub(self, rhs: &Wrapping<T>) -> Self::Output {
+        Wrapping(self.0.wrapping_sub(&rhs.0))
+    }
+}
+
+impl<T: WrappingMul> Mul<Self> for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn mul(self, rhs: Self) -> Self::Output {
+        Wrapping(self.0.wrapping_mul(&rhs.0))
+    }
+}
+
+impl<T: WrappingMul> Mul<&Self> for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn mul(self, rhs: &Self) -> Self::Output {
+        Wrapping(self.0.wrapping_mul(&rhs.0))
+    }
+}
+
+impl<T: WrappingMul> Mul<Wrapping<T>> for &Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn mul(self, rhs: Wrapping<T>) -> Self::Output {
+        Wrapping(self.0.wrapping_mul(&rhs.0))
+    }
+}
+
+impl<T: WrappingMul> Mul<&Wrapping<T>> for &Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn mul(self, rhs: &Wrapping<T>) -> Self::Output {
+        Wrapping(self.0.wrapping_mul(&rhs.0))
+    }
+}
+
+impl<T: WrappingNeg> Neg for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn neg(self) -> Self::Output {
+        Wrapping(self.0.wrapping_neg())
+    }
+}
+
+impl<T: WrappingNeg> Neg for &Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn neg(self) -> Self::Output {
+        Wrapping(self.0.wrapping_neg())
+    }
+}
+
+impl<T: WrappingShl> Shl<u32> for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn shl(self, rhs: u32) -> Self::Output {
+        Wrapping(self.0.wrapping_shl(rhs))
+    }
+}
+
+impl<T: WrappingShl> Shl<u32> for &Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn shl(self, rhs: u32) -> Self::Output {
+        Wrapping(self.0.wrapping_shl(rhs))
+    }
+}
+
+impl<T: WrappingShr> Shr<u32> for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn shr(self, rhs: u32) -> Self::Output {
+        Wrapping(self.0.wrapping_shr(rhs))
+    }
+}
+
+impl<T: WrappingShr> Shr<u32> for &Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline]
+    fn shr(self, rhs: u32) -> Self::Output {
+        Wrapping(self.0.wrapping_shr(rhs))
+    }
+}
+
+impl<T: ConditionallySelectable> ConditionallySelectable for Wrapping<T> {
+    #[inline]
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        Wrapping(T::conditional_select(&a.0, &b.0, choice))
+    }
+}
+
+impl<T: ConstantTimeEq> ConstantTimeEq for Wrapping<T> {
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0.ct_eq(&other.0)
+    }
+}
+
 impl<T: Zero> Zero for Wrapping<T> {
+    #[inline]
     fn zero() -> Self {
         Wrapping(T::zero())
+    }
+}
+
+impl<T: num_traits::Zero + WrappingAdd> num_traits::Zero for Wrapping<T> {
+    #[inline]
+    fn zero() -> Self {
+        Wrapping(T::zero())
+    }
+
+    #[inline]
+    fn is_zero(&self) -> bool {
+        self.0.is_zero()
+    }
+}
+
+impl<T: num_traits::One + WrappingMul + PartialEq> num_traits::One for Wrapping<T> {
+    #[inline]
+    fn one() -> Self {
+        Wrapping(T::one())
+    }
+
+    #[inline]
+    fn is_one(&self) -> bool {
+        self.0.is_one()
     }
 }
 
@@ -50,18 +254,6 @@ impl<T: fmt::LowerHex> fmt::LowerHex for Wrapping<T> {
 impl<T: fmt::UpperHex> fmt::UpperHex for Wrapping<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
-    }
-}
-
-impl<T: ConditionallySelectable> ConditionallySelectable for Wrapping<T> {
-    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        Wrapping(T::conditional_select(&a.0, &b.0, choice))
-    }
-}
-
-impl<T: ConstantTimeEq> ConstantTimeEq for Wrapping<T> {
-    fn ct_eq(&self, other: &Self) -> Choice {
-        self.0.ct_eq(&other.0)
     }
 }
 


### PR DESCRIPTION
Impls `num_traits::{Zero, One}` for:
- `Limb`
- `Uint`
- `BoxedUint`
- `Wrapping`

To impl the traits for `Wrapping`, it required generic impls of `Add` and `Mul`, which are possible thanks to the `WrappingAdd`/`WrappingMul` traits.

These subsume the per-type impls that existed previously.