### PR TITLE
Bring `Checked*` traits in line with `Wrapping*`

### DIFF
--- a/src/checked.rs
+++ b/src/checked.rs
@@ -1,5 +1,7 @@
 //! Checked arithmetic.
 
+use crate::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
+use core::ops::{Add, Div, Mul, Sub};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "serde")]
@@ -19,12 +21,243 @@ impl<T> Checked<T> {
     }
 }
 
-impl<T> Default for Checked<T>
+impl<T> Add<Self> for Checked<T>
 where
-    T: Default,
+    T: CheckedAdd + ConditionallySelectable + Default,
 {
-    fn default() -> Self {
-        Self::new(T::default())
+    type Output = Checked<T>;
+
+    #[inline]
+    fn add(self, rhs: Self) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(&rhs))),
+        )
+    }
+}
+
+impl<T> Add<&Self> for Checked<T>
+where
+    T: CheckedAdd + ConditionallySelectable + Default,
+{
+    type Output = Checked<T>;
+
+    #[inline]
+    fn add(self, rhs: &Self) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(&rhs))),
+        )
+    }
+}
+
+impl<T> Add<Checked<T>> for &Checked<T>
+where
+    T: CheckedAdd + ConditionallySelectable + Default,
+{
+    type Output = Checked<T>;
+
+    #[inline]
+    fn add(self, rhs: Checked<T>) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(&rhs))),
+        )
+    }
+}
+
+impl<T> Add<&Checked<T>> for &Checked<T>
+where
+    T: CheckedAdd + ConditionallySelectable + Default,
+{
+    type Output = Checked<T>;
+
+    #[inline]
+    fn add(self, rhs: &Checked<T>) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(&rhs))),
+        )
+    }
+}
+
+impl<T> Sub<Self> for Checked<T>
+where
+    T: CheckedSub + ConditionallySelectable + Default,
+{
+    type Output = Checked<T>;
+
+    #[inline]
+    fn sub(self, rhs: Self) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(&rhs))),
+        )
+    }
+}
+
+impl<T> Sub<&Self> for Checked<T>
+where
+    T: CheckedSub + ConditionallySelectable + Default,
+{
+    type Output = Checked<T>;
+
+    #[inline]
+    fn sub(self, rhs: &Self) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(&rhs))),
+        )
+    }
+}
+
+impl<T> Sub<Checked<T>> for &Checked<T>
+where
+    T: CheckedSub + ConditionallySelectable + Default,
+{
+    type Output = Checked<T>;
+
+    #[inline]
+    fn sub(self, rhs: Checked<T>) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(&rhs))),
+        )
+    }
+}
+
+impl<T> Sub<&Checked<T>> for &Checked<T>
+where
+    T: CheckedSub + ConditionallySelectable + Default,
+{
+    type Output = Checked<T>;
+
+    #[inline]
+    fn sub(self, rhs: &Checked<T>) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(&rhs))),
+        )
+    }
+}
+
+impl<T> Mul<Self> for Checked<T>
+where
+    T: CheckedMul + ConditionallySelectable + Default,
+{
+    type Output = Checked<T>;
+
+    #[inline]
+    fn mul(self, rhs: Self) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_mul(&rhs))),
+        )
+    }
+}
+
+impl<T> Mul<&Self> for Checked<T>
+where
+    T: CheckedMul + ConditionallySelectable + Default,
+{
+    type Output = Checked<T>;
+
+    #[inline]
+    fn mul(self, rhs: &Self) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_mul(&rhs))),
+        )
+    }
+}
+
+impl<T> Mul<Checked<T>> for &Checked<T>
+where
+    T: CheckedMul + ConditionallySelectable + Default,
+{
+    type Output = Checked<T>;
+
+    #[inline]
+    fn mul(self, rhs: Checked<T>) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_mul(&rhs))),
+        )
+    }
+}
+
+impl<T> Mul<&Checked<T>> for &Checked<T>
+where
+    T: CheckedMul + ConditionallySelectable + Default,
+{
+    type Output = Checked<T>;
+
+    #[inline]
+    fn mul(self, rhs: &Checked<T>) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_mul(&rhs))),
+        )
+    }
+}
+
+impl<T> Div<Self> for Checked<T>
+where
+    T: CheckedDiv + ConditionallySelectable + Default,
+{
+    type Output = Checked<T>;
+
+    #[inline]
+    fn div(self, rhs: Self) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_div(&rhs))),
+        )
+    }
+}
+
+impl<T> Div<&Self> for Checked<T>
+where
+    T: CheckedDiv + ConditionallySelectable + Default,
+{
+    type Output = Checked<T>;
+
+    #[inline]
+    fn div(self, rhs: &Self) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_div(&rhs))),
+        )
+    }
+}
+
+impl<T> Div<Checked<T>> for &Checked<T>
+where
+    T: CheckedDiv + ConditionallySelectable + Default,
+{
+    type Output = Checked<T>;
+
+    #[inline]
+    fn div(self, rhs: Checked<T>) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_div(&rhs))),
+        )
+    }
+}
+
+impl<T> Div<&Checked<T>> for &Checked<T>
+where
+    T: CheckedDiv + ConditionallySelectable + Default,
+{
+    type Output = Checked<T>;
+
+    #[inline]
+    fn div(self, rhs: &Checked<T>) -> Self::Output {
+        Checked(
+            self.0
+                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_div(&rhs))),
+        )
     }
 }
 
@@ -39,6 +272,15 @@ impl<T: ConstantTimeEq> ConstantTimeEq for Checked<T> {
     #[inline]
     fn ct_eq(&self, rhs: &Self) -> Choice {
         self.0.ct_eq(&rhs.0)
+    }
+}
+
+impl<T> Default for Checked<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self::new(T::default())
     }
 }
 

--- a/src/limb/add.rs
+++ b/src/limb/add.rs
@@ -33,7 +33,7 @@ impl Add for Limb {
 
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        self.checked_add(rhs)
+        self.checked_add(&rhs)
             .expect("attempted to add with overflow")
     }
 }
@@ -52,54 +52,6 @@ impl AddAssign<&Wrapping<Limb>> for Wrapping<Limb> {
     }
 }
 
-impl Add for Checked<Limb> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, rhs: Self) -> Checked<Limb> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(rhs))),
-        )
-    }
-}
-
-impl Add<&Checked<Limb>> for Checked<Limb> {
-    type Output = Checked<Limb>;
-
-    #[inline]
-    fn add(self, rhs: &Checked<Limb>) -> Checked<Limb> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(rhs))),
-        )
-    }
-}
-
-impl Add<Checked<Limb>> for &Checked<Limb> {
-    type Output = Checked<Limb>;
-
-    #[inline]
-    fn add(self, rhs: Checked<Limb>) -> Checked<Limb> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(rhs))),
-        )
-    }
-}
-
-impl Add<&Checked<Limb>> for &Checked<Limb> {
-    type Output = Checked<Limb>;
-
-    #[inline]
-    fn add(self, rhs: &Checked<Limb>) -> Checked<Limb> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(rhs))),
-        )
-    }
-}
-
 impl AddAssign for Checked<Limb> {
     #[inline]
     fn add_assign(&mut self, other: Self) {
@@ -115,11 +67,9 @@ impl AddAssign<&Checked<Limb>> for Checked<Limb> {
 }
 
 impl CheckedAdd for Limb {
-    type Output = Self;
-
     #[inline]
-    fn checked_add(&self, rhs: Self) -> CtOption<Self> {
-        let (result, carry) = self.adc(rhs, Limb::ZERO);
+    fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
+        let (result, carry) = self.adc(*rhs, Limb::ZERO);
         CtOption::new(result, carry.is_zero())
     }
 }
@@ -161,13 +111,13 @@ mod tests {
 
     #[test]
     fn checked_add_ok() {
-        let result = Limb::ZERO.checked_add(Limb::ONE);
+        let result = Limb::ZERO.checked_add(&Limb::ONE);
         assert_eq!(result.unwrap(), Limb::ONE);
     }
 
     #[test]
     fn checked_add_overflow() {
-        let result = Limb::MAX.checked_add(Limb::ONE);
+        let result = Limb::MAX.checked_add(&Limb::ONE);
         assert!(!bool::from(result.is_some()));
     }
 }

--- a/src/limb/sub.rs
+++ b/src/limb/sub.rs
@@ -30,11 +30,9 @@ impl Limb {
 }
 
 impl CheckedSub for Limb {
-    type Output = Self;
-
     #[inline]
-    fn checked_sub(&self, rhs: Self) -> CtOption<Self> {
-        let (result, underflow) = self.sbb(rhs, Limb::ZERO);
+    fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
+        let (result, underflow) = self.sbb(*rhs, Limb::ZERO);
         CtOption::new(result, underflow.is_zero())
     }
 }
@@ -44,7 +42,7 @@ impl Sub for Limb {
 
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        self.checked_sub(rhs)
+        self.checked_sub(&rhs)
             .expect("attempted to subtract with underflow")
     }
 }
@@ -69,54 +67,6 @@ impl SubAssign<&Wrapping<Limb>> for Wrapping<Limb> {
     #[inline]
     fn sub_assign(&mut self, other: &Self) {
         *self = *self - other;
-    }
-}
-
-impl Sub for Checked<Limb> {
-    type Output = Self;
-
-    #[inline]
-    fn sub(self, rhs: Self) -> Checked<Limb> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(rhs))),
-        )
-    }
-}
-
-impl Sub<&Checked<Limb>> for Checked<Limb> {
-    type Output = Checked<Limb>;
-
-    #[inline]
-    fn sub(self, rhs: &Checked<Limb>) -> Checked<Limb> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(rhs))),
-        )
-    }
-}
-
-impl Sub<Checked<Limb>> for &Checked<Limb> {
-    type Output = Checked<Limb>;
-
-    #[inline]
-    fn sub(self, rhs: Checked<Limb>) -> Checked<Limb> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(rhs))),
-        )
-    }
-}
-
-impl Sub<&Checked<Limb>> for &Checked<Limb> {
-    type Output = Checked<Limb>;
-
-    #[inline]
-    fn sub(self, rhs: &Checked<Limb>) -> Checked<Limb> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(rhs))),
-        )
     }
 }
 
@@ -172,13 +122,13 @@ mod tests {
 
     #[test]
     fn checked_sub_ok() {
-        let result = Limb::ONE.checked_sub(Limb::ONE);
+        let result = Limb::ONE.checked_sub(&Limb::ONE);
         assert_eq!(result.unwrap(), Limb::ZERO);
     }
 
     #[test]
     fn checked_sub_overflow() {
-        let result = Limb::ZERO.checked_sub(Limb::ONE);
+        let result = Limb::ZERO.checked_sub(&Limb::ONE);
         assert!(!bool::from(result.is_some()));
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -41,10 +41,10 @@ pub trait Integer:
     + for<'a> BitAndAssign<&'a Self>
     + for<'a> BitOrAssign<&'a Self>
     + for<'a> BitXorAssign<&'a Self>
-    + for<'a> CheckedAdd<&'a Self, Output = Self>
-    + for<'a> CheckedSub<&'a Self, Output = Self>
-    + for<'a> CheckedMul<&'a Self, Output = Self>
-    + for<'a> CheckedDiv<&'a Self, Output = Self>
+    + CheckedAdd
+    + CheckedSub
+    + CheckedMul
+    + CheckedDiv
     + Clone
     // + ConditionallySelectable (see dalek-cryptography/subtle#94)
     + ConstantTimeEq
@@ -248,42 +248,30 @@ pub trait MulMod<Rhs = Self> {
 
 /// Checked addition.
 pub trait CheckedAdd<Rhs = Self>: Sized {
-    /// Output type.
-    type Output;
-
-    /// Perform checked subtraction, returning a [`CtOption`] which `is_some` only if the operation
+    /// Perform checked addition, returning a [`CtOption`] which `is_some` only if the operation
     /// did not overflow.
-    fn checked_add(&self, rhs: Rhs) -> CtOption<Self>;
+    fn checked_add(&self, rhs: &Rhs) -> CtOption<Self>;
 }
 
 /// Checked division.
 pub trait CheckedDiv<Rhs = Self>: Sized {
-    /// Output type.
-    type Output;
-
     /// Perform checked division, returning a [`CtOption`] which `is_some` only if the divisor is
     /// non-zero.
-    fn checked_div(&self, rhs: Rhs) -> CtOption<Self>;
+    fn checked_div(&self, rhs: &Rhs) -> CtOption<Self>;
 }
 
 /// Checked multiplication.
 pub trait CheckedMul<Rhs = Self>: Sized {
-    /// Output type.
-    type Output;
-
     /// Perform checked multiplication, returning a [`CtOption`] which `is_some`
     /// only if the operation did not overflow.
-    fn checked_mul(&self, rhs: Rhs) -> CtOption<Self>;
+    fn checked_mul(&self, rhs: &Rhs) -> CtOption<Self>;
 }
 
 /// Checked subtraction.
 pub trait CheckedSub<Rhs = Self>: Sized {
-    /// Output type.
-    type Output;
-
     /// Perform checked subtraction, returning a [`CtOption`] which `is_some`
     /// only if the operation did not underflow.
-    fn checked_sub(&self, rhs: Rhs) -> CtOption<Self>;
+    fn checked_sub(&self, rhs: &Rhs) -> CtOption<Self>;
 }
 
 /// Concatenate two numbers into a "wide" double-width value, using the `lo`

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -74,50 +74,6 @@ impl<const LIMBS: usize> AddAssign<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIM
     }
 }
 
-impl<const LIMBS: usize> Add for Checked<Uint<LIMBS>> {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Checked<Uint<LIMBS>> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(&rhs))),
-        )
-    }
-}
-
-impl<const LIMBS: usize> Add<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS>> {
-    type Output = Checked<Uint<LIMBS>>;
-
-    fn add(self, rhs: &Checked<Uint<LIMBS>>) -> Checked<Uint<LIMBS>> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(&rhs))),
-        )
-    }
-}
-
-impl<const LIMBS: usize> Add<Checked<Uint<LIMBS>>> for &Checked<Uint<LIMBS>> {
-    type Output = Checked<Uint<LIMBS>>;
-
-    fn add(self, rhs: Checked<Uint<LIMBS>>) -> Checked<Uint<LIMBS>> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(&rhs))),
-        )
-    }
-}
-
-impl<const LIMBS: usize> Add<&Checked<Uint<LIMBS>>> for &Checked<Uint<LIMBS>> {
-    type Output = Checked<Uint<LIMBS>>;
-
-    fn add(self, rhs: &Checked<Uint<LIMBS>>) -> Checked<Uint<LIMBS>> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_add(&rhs))),
-        )
-    }
-}
-
 impl<const LIMBS: usize> AddAssign for Checked<Uint<LIMBS>> {
     fn add_assign(&mut self, other: Self) {
         *self = *self + other;
@@ -130,9 +86,7 @@ impl<const LIMBS: usize> AddAssign<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS
     }
 }
 
-impl<const LIMBS: usize> CheckedAdd<&Uint<LIMBS>> for Uint<LIMBS> {
-    type Output = Self;
-
+impl<const LIMBS: usize> CheckedAdd for Uint<LIMBS> {
     fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
         let (result, carry) = self.adc(rhs, Limb::ZERO);
         CtOption::new(result, carry.is_zero())

--- a/src/uint/boxed/add.rs
+++ b/src/uint/boxed/add.rs
@@ -87,9 +87,7 @@ impl AddAssign<&Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
     }
 }
 
-impl CheckedAdd<&BoxedUint> for BoxedUint {
-    type Output = Self;
-
+impl CheckedAdd for BoxedUint {
     fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
         let (result, carry) = self.adc(rhs, Limb::ZERO);
         CtOption::new(result, carry.is_zero())

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -132,17 +132,7 @@ impl BoxedUint {
     }
 }
 
-impl CheckedDiv<BoxedUint> for BoxedUint {
-    type Output = Self;
-
-    fn checked_div(&self, rhs: BoxedUint) -> CtOption<Self> {
-        self.checked_div(&rhs)
-    }
-}
-
-impl CheckedDiv<&BoxedUint> for BoxedUint {
-    type Output = Self;
-
+impl CheckedDiv for BoxedUint {
     fn checked_div(&self, rhs: &BoxedUint) -> CtOption<Self> {
         self.checked_div(rhs)
     }

--- a/src/uint/boxed/mul.rs
+++ b/src/uint/boxed/mul.rs
@@ -28,17 +28,7 @@ impl BoxedUint {
     }
 }
 
-impl CheckedMul<BoxedUint> for BoxedUint {
-    type Output = Self;
-
-    fn checked_mul(&self, rhs: BoxedUint) -> CtOption<Self> {
-        self.checked_mul(&rhs)
-    }
-}
-
-impl CheckedMul<&BoxedUint> for BoxedUint {
-    type Output = Self;
-
+impl CheckedMul for BoxedUint {
     fn checked_mul(&self, rhs: &BoxedUint) -> CtOption<Self> {
         let product = self.mul(rhs);
 

--- a/src/uint/boxed/sub.rs
+++ b/src/uint/boxed/sub.rs
@@ -50,9 +50,7 @@ impl BoxedUint {
     }
 }
 
-impl CheckedSub<&BoxedUint> for BoxedUint {
-    type Output = Self;
-
+impl CheckedSub for BoxedUint {
     fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
         let (result, carry) = self.sbb(rhs, Limb::ZERO);
         CtOption::new(result, carry.is_zero())

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -399,17 +399,7 @@ impl<const LIMBS: usize> RemAssign<&NonZero<Limb>> for Wrapping<Uint<LIMBS>> {
 // Division by an Uint
 //
 
-impl<const LIMBS: usize> CheckedDiv<Uint<LIMBS>> for Uint<LIMBS> {
-    type Output = Self;
-
-    fn checked_div(&self, rhs: Uint<LIMBS>) -> CtOption<Self> {
-        self.checked_div(&rhs)
-    }
-}
-
-impl<const LIMBS: usize> CheckedDiv<&Uint<LIMBS>> for Uint<LIMBS> {
-    type Output = Self;
-
+impl<const LIMBS: usize> CheckedDiv for Uint<LIMBS> {
     fn checked_div(&self, rhs: &Uint<LIMBS>) -> CtOption<Self> {
         self.checked_div(rhs)
     }

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -171,17 +171,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> CheckedMul<Uint<RHS_LIMBS>> for Uint<LIMBS> {
-    type Output = Uint<LIMBS>;
-
-    #[inline]
-    fn checked_mul(&self, rhs: Uint<RHS_LIMBS>) -> CtOption<Self> {
-        self.checked_mul(&rhs)
-    }
-}
-
-impl<const LIMBS: usize, const RHS_LIMBS: usize> CheckedMul<&Uint<RHS_LIMBS>> for Uint<LIMBS> {
-    type Output = Uint<LIMBS>;
-
     #[inline]
     fn checked_mul(&self, rhs: &Uint<RHS_LIMBS>) -> CtOption<Self> {
         let (lo, hi) = self.split_mul(rhs);
@@ -234,58 +223,14 @@ impl<const LIMBS: usize> MulAssign<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIM
     }
 }
 
-impl<const LIMBS: usize, const RHS_LIMBS: usize> Mul<Checked<Uint<RHS_LIMBS>>>
-    for Checked<Uint<LIMBS>>
-{
-    type Output = Self;
-
-    fn mul(self, rhs: Checked<Uint<RHS_LIMBS>>) -> Checked<Uint<LIMBS>> {
-        Checked(self.0.and_then(|a| rhs.0.and_then(|b| a.checked_mul(&b))))
-    }
-}
-
-impl<const LIMBS: usize, const RHS_LIMBS: usize> Mul<&Checked<Uint<RHS_LIMBS>>>
-    for Checked<Uint<LIMBS>>
-{
-    type Output = Checked<Uint<LIMBS>>;
-
-    fn mul(self, rhs: &Checked<Uint<RHS_LIMBS>>) -> Checked<Uint<LIMBS>> {
-        Checked(self.0.and_then(|a| rhs.0.and_then(|b| a.checked_mul(&b))))
-    }
-}
-
-impl<const LIMBS: usize, const RHS_LIMBS: usize> Mul<Checked<Uint<RHS_LIMBS>>>
-    for &Checked<Uint<LIMBS>>
-{
-    type Output = Checked<Uint<LIMBS>>;
-
-    fn mul(self, rhs: Checked<Uint<RHS_LIMBS>>) -> Checked<Uint<LIMBS>> {
-        Checked(self.0.and_then(|a| rhs.0.and_then(|b| a.checked_mul(&b))))
-    }
-}
-
-impl<const LIMBS: usize, const RHS_LIMBS: usize> Mul<&Checked<Uint<RHS_LIMBS>>>
-    for &Checked<Uint<LIMBS>>
-{
-    type Output = Checked<Uint<LIMBS>>;
-
-    fn mul(self, rhs: &Checked<Uint<RHS_LIMBS>>) -> Checked<Uint<LIMBS>> {
-        Checked(self.0.and_then(|a| rhs.0.and_then(|b| a.checked_mul(&b))))
-    }
-}
-
-impl<const LIMBS: usize, const RHS_LIMBS: usize> MulAssign<Checked<Uint<RHS_LIMBS>>>
-    for Checked<Uint<LIMBS>>
-{
-    fn mul_assign(&mut self, other: Checked<Uint<RHS_LIMBS>>) {
+impl<const LIMBS: usize> MulAssign<Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS>> {
+    fn mul_assign(&mut self, other: Checked<Uint<LIMBS>>) {
         *self = *self * other;
     }
 }
 
-impl<const LIMBS: usize, const RHS_LIMBS: usize> MulAssign<&Checked<Uint<RHS_LIMBS>>>
-    for Checked<Uint<LIMBS>>
-{
-    fn mul_assign(&mut self, other: &Checked<Uint<RHS_LIMBS>>) {
+impl<const LIMBS: usize> MulAssign<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS>> {
+    fn mul_assign(&mut self, other: &Checked<Uint<LIMBS>>) {
         *self = *self * other;
     }
 }

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -47,9 +47,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> CheckedSub<&Uint<LIMBS>> for Uint<LIMBS> {
-    type Output = Self;
-
+impl<const LIMBS: usize> CheckedSub for Uint<LIMBS> {
     fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
         let (result, underflow) = self.sbb(rhs, Limb::ZERO);
         CtOption::new(result, underflow.is_zero())
@@ -82,50 +80,6 @@ impl<const LIMBS: usize> SubAssign for Wrapping<Uint<LIMBS>> {
 impl<const LIMBS: usize> SubAssign<&Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
     fn sub_assign(&mut self, other: &Self) {
         *self = *self - other;
-    }
-}
-
-impl<const LIMBS: usize> Sub for Checked<Uint<LIMBS>> {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Checked<Uint<LIMBS>> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(&rhs))),
-        )
-    }
-}
-
-impl<const LIMBS: usize> Sub<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS>> {
-    type Output = Checked<Uint<LIMBS>>;
-
-    fn sub(self, rhs: &Checked<Uint<LIMBS>>) -> Checked<Uint<LIMBS>> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(&rhs))),
-        )
-    }
-}
-
-impl<const LIMBS: usize> Sub<Checked<Uint<LIMBS>>> for &Checked<Uint<LIMBS>> {
-    type Output = Checked<Uint<LIMBS>>;
-
-    fn sub(self, rhs: Checked<Uint<LIMBS>>) -> Checked<Uint<LIMBS>> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(&rhs))),
-        )
-    }
-}
-
-impl<const LIMBS: usize> Sub<&Checked<Uint<LIMBS>>> for &Checked<Uint<LIMBS>> {
-    type Output = Checked<Uint<LIMBS>>;
-
-    fn sub(self, rhs: &Checked<Uint<LIMBS>>) -> Checked<Uint<LIMBS>> {
-        Checked(
-            self.0
-                .and_then(|lhs| rhs.0.and_then(|rhs| lhs.checked_sub(&rhs))),
-        )
     }
 }
 


### PR DESCRIPTION
This crate defines its own `Checked*` traits in order to use `CtOption<T>` rather than `Option<T>`, however it gets its `Wrapping*` traits from `num-bigint`.

This brings the `Checked*` traits more in line with `Wrapping*`, automatically taking a reference to the `rhs` parameter, which eliminates the need to use HRTBs in `Integer`'s definition.