### PR TITLE
Bernstein-Yang cleanups

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.70.0 # MSRV
+          - 1.73.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -48,7 +48,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.70.0 # MSRV
+            rust: 1.73.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -56,7 +56,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.70.0 # MSRV
+            rust: 1.73.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -126,7 +126,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.72.0
+          toolchain: 1.73.0
           components: clippy
       - run: cargo clippy --all --all-features -- -D warnings
 
@@ -146,7 +146,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.70.0
+          toolchain: 1.73.0
       - run: cargo build --benches
       - run: cargo build --all-features --benches
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["arbitrary", "crypto", "bignum", "integer", "precision"]
 readme = "README.md"
 resolver = "2"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.73"
 
 [dependencies]
 subtle = { version = "2.5", default-features = false }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ microcontrollers).
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.70** at a minimum.
+This crate requires **Rust 1.73** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -68,7 +68,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/crypto-bigint/actions/workflows/crypto-bigint.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/crypto-bigint/actions/workflows/crypto-bigint.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.70+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.73+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300602-crypto-bigint
 

--- a/src/modular/bernstein_yang.rs
+++ b/src/modular/bernstein_yang.rs
@@ -10,7 +10,7 @@
 
 #![allow(clippy::needless_range_loop)]
 
-use crate::Word;
+use crate::{Uint, Word};
 
 /// Type of the modular multiplicative inverter based on the Bernstein-Yang method.
 /// The inverter can be created for a specified modulus M and adjusting parameter A
@@ -36,12 +36,12 @@ use crate::Word;
 /// - P. Wuille, "The safegcd implementation in libsecp256k1 explained",
 /// <https://github.com/bitcoin-core/secp256k1/blob/master/doc/safegcd_implementation.md>
 #[derive(Debug)]
-pub struct BernsteinYangInverter<const L: usize> {
+pub struct BernsteinYangInverter<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> {
     /// Modulus
-    modulus: CInt<62, L>,
+    modulus: Uint62L<UNSAT_LIMBS>,
 
     /// Adjusting parameter
-    adjuster: CInt<62, L>,
+    adjuster: Uint62L<UNSAT_LIMBS>,
 
     /// Multiplicative inverse of the modulus modulo 2^62
     inverse: i64,
@@ -50,26 +50,32 @@ pub struct BernsteinYangInverter<const L: usize> {
 /// Type of the Bernstein-Yang transition matrix multiplied by 2^62
 type Matrix = [[i64; 2]; 2];
 
-impl<const L: usize> BernsteinYangInverter<L> {
+impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
+    BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>
+{
     /// Creates the inverter for specified modulus and adjusting parameter
     #[allow(trivial_numeric_casts)]
     pub const fn new(modulus: &[Word], adjuster: &[Word]) -> Self {
+        if UNSAT_LIMBS != unsat_nlimbs(SAT_LIMBS) {
+            panic!("BernsteinYangInverter has incorrect number of limbs");
+        }
+
         Self {
-            modulus: CInt::<62, L>(convert_in::<{ Word::BITS as usize }, 62, L>(modulus)),
-            adjuster: CInt::<62, L>(convert_in::<{ Word::BITS as usize }, 62, L>(adjuster)),
-            inverse: inv_mod62(modulus),
+            modulus: Uint62L::<UNSAT_LIMBS>(sat_to_unsat::<UNSAT_LIMBS>(modulus)),
+            adjuster: Uint62L::<UNSAT_LIMBS>(sat_to_unsat::<UNSAT_LIMBS>(adjuster)),
+            inverse: inv_mod2_62(modulus),
         }
     }
 
     /// Returns either the adjusted modular multiplicative inverse for the argument or None
     /// depending on invertibility of the argument, i.e. its coprimality with the modulus
-    pub const fn invert<const S: usize>(&self, value: &[Word]) -> Option<[Word; S]> {
-        let (mut d, mut e) = (CInt::ZERO, self.adjuster);
-        let mut g = CInt::<62, L>(convert_in::<{ Word::BITS as usize }, 62, L>(value));
+    pub const fn invert(&self, value: &Uint<SAT_LIMBS>) -> Option<Uint<SAT_LIMBS>> {
+        let (mut d, mut e) = (Uint62L::ZERO, self.adjuster);
+        let mut g = Uint62L::<UNSAT_LIMBS>(sat_to_unsat::<UNSAT_LIMBS>(value.as_words()));
         let (mut delta, mut f) = (1, self.modulus);
         let mut matrix;
 
-        while !g.eq(&CInt::ZERO) {
+        while !g.eq(&Uint62L::ZERO) {
             (delta, matrix) = Self::jump(&f, &g, delta);
             (f, g) = Self::fg(f, g, matrix);
             (d, e) = self.de(d, e, matrix);
@@ -77,19 +83,23 @@ impl<const L: usize> BernsteinYangInverter<L> {
         // At this point the absolute value of "f" equals the greatest common divisor
         // of the integer to be inverted and the modulus the inverter was created for.
         // Thus, if "f" is neither 1 nor -1, then the sought inverse does not exist
-        let antiunit = f.eq(&CInt::MINUS_ONE);
-        if !f.eq(&CInt::ONE) && !antiunit {
+        let antiunit = f.eq(&Uint62L::MINUS_ONE);
+        if !f.eq(&Uint62L::ONE) && !antiunit {
             return None;
         }
-        Some(convert_out::<62, { Word::BITS as usize }, S>(
-            &self.norm(d, antiunit).0,
-        ))
+
+        let words = unsat_to_sat::<SAT_LIMBS>(&self.norm(d, antiunit).0);
+        Some(Uint::from_words(words))
     }
 
     /// Returns the Bernstein-Yang transition matrix multiplied by 2^62 and the new value
     /// of the delta variable for the 62 basic steps of the Bernstein-Yang method, which
     /// are to be performed sequentially for specified initial values of f, g and delta
-    const fn jump(f: &CInt<62, L>, g: &CInt<62, L>, mut delta: i64) -> (i64, Matrix) {
+    const fn jump(
+        f: &Uint62L<UNSAT_LIMBS>,
+        g: &Uint62L<UNSAT_LIMBS>,
+        mut delta: i64,
+    ) -> (i64, Matrix) {
         // This function is defined because the method "min" of the i64 type is not constant
         const fn min(a: i64, b: i64) -> i64 {
             if a > b {
@@ -130,7 +140,11 @@ impl<const L: usize> BernsteinYangInverter<L> {
 
     /// Returns the updated values of the variables f and g for specified initial ones and Bernstein-Yang transition
     /// matrix multiplied by 2^62. The returned vector is "matrix * (f, g)' / 2^62", where "'" is the transpose operator
-    const fn fg(f: CInt<62, L>, g: CInt<62, L>, t: Matrix) -> (CInt<62, L>, CInt<62, L>) {
+    const fn fg(
+        f: Uint62L<UNSAT_LIMBS>,
+        g: Uint62L<UNSAT_LIMBS>,
+        t: Matrix,
+    ) -> (Uint62L<UNSAT_LIMBS>, Uint62L<UNSAT_LIMBS>) {
         (
             f.mul(t[0][0]).add(&g.mul(t[0][1])).shift(),
             f.mul(t[1][0]).add(&g.mul(t[1][1])).shift(),
@@ -141,8 +155,13 @@ impl<const L: usize> BernsteinYangInverter<L> {
     /// matrix multiplied by 2^62. The returned vector is congruent modulo M to "matrix * (d, e)' / 2^62 (mod M)",
     /// where M is the modulus the inverter was created for and "'" stands for the transpose operator. Both the input
     /// and output values lie in the interval (-2 * M, M)
-    const fn de(&self, d: CInt<62, L>, e: CInt<62, L>, t: Matrix) -> (CInt<62, L>, CInt<62, L>) {
-        let mask = CInt::<62, L>::MASK as i64;
+    const fn de(
+        &self,
+        d: Uint62L<UNSAT_LIMBS>,
+        e: Uint62L<UNSAT_LIMBS>,
+        t: Matrix,
+    ) -> (Uint62L<UNSAT_LIMBS>, Uint62L<UNSAT_LIMBS>) {
+        let mask = Uint62L::<UNSAT_LIMBS>::MASK as i64;
         let mut md = t[0][0] * d.is_negative() as i64 + t[0][1] * e.is_negative() as i64;
         let mut me = t[1][0] * d.is_negative() as i64 + t[1][1] * e.is_negative() as i64;
 
@@ -173,7 +192,7 @@ impl<const L: usize> BernsteinYangInverter<L> {
     /// Returns either "value (mod M)" or "-value (mod M)", where M is the modulus the
     /// inverter was created for, depending on "negate", which determines the presence
     /// of "-" in the used formula. The input integer lies in the interval (-2 * M, M)
-    const fn norm(&self, mut value: CInt<62, L>, negate: bool) -> CInt<62, L> {
+    const fn norm(&self, mut value: Uint62L<UNSAT_LIMBS>, negate: bool) -> Uint62L<UNSAT_LIMBS> {
         if value.is_negative() {
             value = value.add(&self.modulus);
         }
@@ -195,7 +214,7 @@ impl<const L: usize> BernsteinYangInverter<L> {
 /// For better understanding the implementation, the following paper is recommended:
 /// J. Hurchalla, "An Improved Integer Multiplicative Inverse (modulo 2^w)",
 /// https://arxiv.org/pdf/2204.04342.pdf
-const fn inv_mod62(value: &[Word]) -> i64 {
+const fn inv_mod2_62(value: &[Word]) -> i64 {
     let value = {
         #[cfg(target_pointer_width = "32")]
         {
@@ -217,11 +236,11 @@ const fn inv_mod62(value: &[Word]) -> i64 {
     (x.wrapping_mul(y.wrapping_add(1)) & (u64::MAX >> 2)) as i64
 }
 
-/// Write an impl of a `convert_*` function.
+/// Write an impl of a limb conversion function.
 ///
-/// Workaround for making this function generic while still allowing it to be `const fn`.
-macro_rules! impl_convert {
-    ($input_type:ty, $output_type:ty, $input:expr) => {{
+/// Workaround for making this function generic around limb types while still allowing it to be `const fn`.
+macro_rules! impl_limb_convert {
+    ($input_type:ty, $input_bits:expr, $output_type:ty, $output_bits:expr, $output_size:expr, $input:expr) => {{
         // This function is defined because the method "min" of the usize type is not constant
         const fn min(a: usize, b: usize) -> usize {
             if a > b {
@@ -231,18 +250,18 @@ macro_rules! impl_convert {
             }
         }
 
-        let total = min($input.len() * I, S * O);
-        let mut output = [0 as $output_type; S];
+        let total = min($input.len() * $input_bits, $output_size * $output_bits);
+        let mut output = [0 as $output_type; $output_size];
         let mut bits = 0;
 
         while bits < total {
-            let (i, o) = (bits % I, bits % O);
-            output[bits / O] |= ($input[bits / I] >> i) as $output_type << o;
-            bits += min(I - i, O - o);
+            let (i, o) = (bits % $input_bits, bits % $output_bits);
+            output[bits / $output_bits] |= ($input[bits / $input_bits] >> i) as $output_type << o;
+            bits += min($input_bits - i, $output_bits - o);
         }
 
-        let mask = (<$output_type>::MAX as $output_type) >> (<$output_type>::BITS as usize - O);
-        let mut filled = total / O + if total % O > 0 { 1 } else { 0 };
+        let mask = (<$output_type>::MAX as $output_type) >> (<$output_type>::BITS as usize - $output_bits);
+        let mut filled = total / $output_bits + if total % $output_bits > 0 { 1 } else { 0 };
 
         while filled > 0 {
             filled -= 1;
@@ -253,56 +272,74 @@ macro_rules! impl_convert {
     }};
 }
 
-/// Returns a big unsigned integer as an array of O-bit chunks, which is equal modulo
-/// 2 ^ (O * S) to the input big unsigned integer stored as an array of I-bit chunks.
-/// The ordering of the chunks in these arrays is little-endian
-#[allow(trivial_numeric_casts)]
-const fn convert_in<const I: usize, const O: usize, const S: usize>(input: &[Word]) -> [u64; S] {
-    impl_convert!(Word, u64, input)
-}
-
-/// Returns a big unsigned integer as an array of O-bit chunks, which is equal modulo
-/// 2 ^ (O * S) to the input big unsigned integer stored as an array of I-bit chunks.
-/// The ordering of the chunks in these arrays is little-endian
-#[allow(trivial_numeric_casts)]
-const fn convert_out<const I: usize, const O: usize, const S: usize>(input: &[u64]) -> [Word; S] {
-    impl_convert!(u64, Word, input)
-}
-
-/// Big signed (B * L)-bit integer type, whose variables store
-/// numbers in the two's complement code as arrays of B-bit chunks.
+/// Convert from 64-bit saturated representation used by `Uint` to the 62-bit unsaturated representation used by
+/// `Uint62`.
+///
+/// Returns a big unsigned integer as an array of 62-bit chunks, which is equal modulo 2 ^ (62 * S) to the input big
+/// unsigned integer stored as an array of 64-bit chunks.
+///
 /// The ordering of the chunks in these arrays is little-endian.
+#[allow(trivial_numeric_casts)]
+const fn sat_to_unsat<const S: usize>(input: &[Word]) -> [u64; S] {
+    impl_limb_convert!(Word, Word::BITS as usize, u64, 62, S, input)
+}
+
+/// Convert from 62-bit unsaturated representation used by `Uint62` to the 64-bit saturated representation used by
+/// `Uint`.
+///
+/// Returns a big unsigned integer as an array of 64-bit chunks, which is equal modulo 2 ^ (64 * S) to the input big
+/// unsigned integer stored as an array of 62-bit chunks.
+///
+/// The ordering of the chunks in these arrays is little-endian
+#[allow(trivial_numeric_casts)]
+const fn unsat_to_sat<const S: usize>(input: &[u64]) -> [Word; S] {
+    impl_limb_convert!(u64, 62, Word, Word::BITS as usize, S, input)
+}
+
+/// Compute the number of unsaturated limbs needed to represent a value with the given number of saturated limbs.
+const fn unsat_nlimbs(mut sat_nlimbs: usize) -> usize {
+    sat_nlimbs /= (64 / Word::BITS) as usize;
+    sat_nlimbs + (sat_nlimbs * 2).div_ceil(64) + 1
+}
+
+/// `Uint`-like (62 * LIMBS)-bit integer type, whose variables store numbers in the two's complement code as arrays of
+/// 62-bit limbs.
+///
+/// The ordering of the chunks in these arrays is little-endian.
+///
 /// The arithmetic operations for this type are wrapping ones.
 #[derive(Clone, Copy, Debug)]
-struct CInt<const B: usize, const L: usize>(pub [u64; L]);
+struct Uint62L<const LIMBS: usize>(pub [u64; LIMBS]);
 
-impl<const B: usize, const L: usize> CInt<B, L> {
-    /// Mask, in which the B lowest bits are 1 and only they
-    pub const MASK: u64 = u64::MAX >> (64 - B);
+impl<const LIMBS: usize> Uint62L<LIMBS> {
+    /// Number of bits in each limb.
+    pub const LIMB_BITS: usize = 62;
 
-    /// Representation of -1
-    pub const MINUS_ONE: Self = Self([Self::MASK; L]);
+    /// Mask, in which the B lowest bits are 1 and only they.
+    pub const MASK: u64 = u64::MAX >> (64 - Self::LIMB_BITS);
 
-    /// Representation of 0
-    pub const ZERO: Self = Self([0; L]);
+    /// Representation of -1.
+    pub const MINUS_ONE: Self = Self([Self::MASK; LIMBS]);
 
-    /// Representation of 1
+    /// Representation of 0.
+    pub const ZERO: Self = Self([0; LIMBS]);
+
+    /// Representation of 1.
     pub const ONE: Self = {
-        let mut data = [0; L];
+        let mut data = [0; LIMBS];
         data[0] = 1;
         Self(data)
     };
 
-    /// Returns the result of applying B-bit right
-    /// arithmetical shift to the current number
+    /// Returns the result of applying 62-bit right arithmetical shift to the current number.
     pub const fn shift(&self) -> Self {
-        let mut data = [0; L];
+        let mut data = [0; LIMBS];
         if self.is_negative() {
-            data[L - 1] = Self::MASK;
+            data[LIMBS - 1] = Self::MASK;
         }
 
         let mut i = 0;
-        while i < L - 1 {
+        while i < LIMBS - 1 {
             data[i] = self.0[i + 1];
             i += 1;
         }
@@ -310,22 +347,22 @@ impl<const B: usize, const L: usize> CInt<B, L> {
         Self(data)
     }
 
-    /// Returns the lowest B bits of the current number
+    /// Returns the lowest 62 bits of the current number.
     pub const fn lowest(&self) -> u64 {
         self.0[0]
     }
 
-    /// Returns "true" iff the current number is negative
+    /// Returns "true" iff the current number is negative.
     pub const fn is_negative(&self) -> bool {
-        self.0[L - 1] > (Self::MASK >> 1)
+        self.0[LIMBS - 1] > (Self::MASK >> 1)
     }
 
-    /// Const fn equivalent for `PartialEq::eq`
+    /// Const fn equivalent for `PartialEq::eq`.
     pub const fn eq(&self, other: &Self) -> bool {
         let mut ret = true;
         let mut i = 0;
 
-        while i < L {
+        while i < LIMBS {
             ret &= self.0[i] == other.0[i];
             i += 1;
         }
@@ -333,41 +370,41 @@ impl<const B: usize, const L: usize> CInt<B, L> {
         ret
     }
 
-    /// Const fn equivalent for `Add::add`
+    /// Const fn equivalent for `Add::add`.
     pub const fn add(&self, other: &Self) -> Self {
-        let (mut data, mut carry) = ([0; L], 0);
+        let (mut data, mut carry) = ([0; LIMBS], 0);
         let mut i = 0;
 
-        while i < L {
+        while i < LIMBS {
             let sum = self.0[i] + other.0[i] + carry;
-            data[i] = sum & CInt::<B, L>::MASK;
-            carry = sum >> B;
+            data[i] = sum & Self::MASK;
+            carry = sum >> Self::LIMB_BITS;
             i += 1;
         }
 
         Self(data)
     }
 
-    /// Const fn equivalent for `Neg::neg`
+    /// Const fn equivalent for `Neg::neg`.
     pub const fn neg(&self) -> Self {
         // For the two's complement code the additive negation is the result
         // of adding 1 to the bitwise inverted argument's representation
-        let (mut data, mut carry) = ([0; L], 1);
+        let (mut data, mut carry) = ([0; LIMBS], 1);
         let mut i = 0;
 
-        while i < L {
+        while i < LIMBS {
             let sum = (self.0[i] ^ Self::MASK) + carry;
             data[i] = sum & Self::MASK;
-            carry = sum >> B;
+            carry = sum >> Self::LIMB_BITS;
             i += 1;
         }
 
         Self(data)
     }
 
-    /// Const fn equivalent for `Mul::<i64>::mul`
+    /// Const fn equivalent for `Mul::<i64>::mul`.
     pub const fn mul(&self, other: i64) -> Self {
-        let mut data = [0; L];
+        let mut data = [0; LIMBS];
         // If the short multiplicand is non-negative, the standard multiplication
         // algorithm is performed. Otherwise, the product of the additively negated
         // multiplicands is found as follows. Since for the two's complement code
@@ -387,10 +424,10 @@ impl<const B: usize, const L: usize> CInt<B, L> {
         };
 
         let mut i = 0;
-        while i < L {
+        while i < LIMBS {
             let sum = (carry as u128) + ((self.0[i] ^ mask) as u128) * (other as u128);
             data[i] = sum as u64 & Self::MASK;
-            carry = (sum >> B) as u64;
+            carry = (sum >> Self::LIMB_BITS) as u64;
             i += 1;
         }
 

--- a/tests/bernstein_yang_proptests.proptest-regressions
+++ b/tests/bernstein_yang_proptests.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 070600f4b9e9a406b4ee112524b52a66822ecae8c9ac74779c2018b4410f34c3 # shrinks to x = Uint(0x0100000000000000000000000000000000000000000000000000000000000000)

--- a/tests/bernstein_yang_proptests.rs
+++ b/tests/bernstein_yang_proptests.rs
@@ -32,14 +32,13 @@ proptest! {
         let p_bi = to_biguint(&P);
 
         let expected_is_some = x_bi.gcd(&p_bi) == BigUint::one();
-
-        let inverter = BernsteinYangInverter::<6>::new(P.as_words(), &[1]);
-        let actual = inverter.invert::<{U256::LIMBS}>(x.as_words());
+        let inverter = BernsteinYangInverter::<{U256::LIMBS}, 6>::new(P.as_words(), &[1]);
+        let actual = inverter.invert(&x);
 
         prop_assert_eq!(bool::from(expected_is_some), actual.is_some());
 
         if let Some(actual) = actual {
-            let inv_bi = to_biguint(&U256::from(actual));
+            let inv_bi = to_biguint(&actual);
             let res = (inv_bi * x_bi) % p_bi;
             prop_assert_eq!(res, BigUint::one());
         }


### PR DESCRIPTION
Refactors the `CInt` type into `Uint62L` which always uses a 62-bit unsaturated representation. This is mostly to reduce the overall number of const generic parameters involved, since Bernstein-Yang always uses a 62-bit unsaturated representation (at least as currently implemented).

Moves the `S` parameter from `invert` into the `BernsteinYangInverter` struct itself. This allows the type to always "know" its associated inverter, rather than leaving it up to the end user to calculate.

Also changes the `invert` method to accept a `Uint` as input.