### PR TITLE
Add `Inverter` trait

### DIFF
--- a/src/modular/bernstein_yang.rs
+++ b/src/modular/bernstein_yang.rs
@@ -53,17 +53,17 @@ type Matrix = [[i64; 2]; 2];
 impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
     BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>
 {
-    /// Creates the inverter for specified modulus and adjusting parameter
+    /// Creates the inverter for specified modulus and adjusting parameter.
     #[allow(trivial_numeric_casts)]
-    pub const fn new(modulus: &[Word], adjuster: &[Word]) -> Self {
+    pub const fn new(modulus: &Uint<SAT_LIMBS>, adjuster: &Uint<SAT_LIMBS>) -> Self {
         if UNSAT_LIMBS != unsat_nlimbs(SAT_LIMBS) {
             panic!("BernsteinYangInverter has incorrect number of limbs");
         }
 
         Self {
-            modulus: Uint62L::<UNSAT_LIMBS>(sat_to_unsat::<UNSAT_LIMBS>(modulus)),
-            adjuster: Uint62L::<UNSAT_LIMBS>(sat_to_unsat::<UNSAT_LIMBS>(adjuster)),
-            inverse: inv_mod2_62(modulus),
+            modulus: Uint62L::<UNSAT_LIMBS>(sat_to_unsat::<UNSAT_LIMBS>(modulus.as_words())),
+            adjuster: Uint62L::<UNSAT_LIMBS>(sat_to_unsat::<UNSAT_LIMBS>(adjuster.as_words())),
+            inverse: inv_mod2_62(modulus.as_words()),
         }
     }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -138,6 +138,23 @@ pub trait Integer:
     }
 }
 
+/// Obtain a precomputed inverter for efficiently computing modular inversions for a given modulus.
+pub trait Inverter: Integer {
+    /// Inverter type for integers of this size.
+    type Inverter: Sized;
+
+    /// Obtain a precomputed inverter for `&self` as the modulus, using `Self::one()` as an adjusting parameter.
+    ///
+    /// Returns `None` if `self` is even.
+    fn inverter(&self) -> Self::Inverter {
+        Self::inverter_with_adjuster(self, &Self::one())
+    }
+
+    /// Obtain a precomputed inverter for `&self` as the modulus, supplying a custom adjusting parameter (e.g. R^2 for
+    /// when computing inversions in Montgomery form).
+    fn inverter_with_adjuster(&self, adjuster: &Self) -> Self::Inverter;
+}
+
 /// Fixed-width integers.
 pub trait FixedInteger: Bounded + ConditionallySelectable + Constants + Copy + Integer {
     /// The number of limbs used on this platform.

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -38,7 +38,10 @@ pub(crate) mod boxed;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{Bounded, Constants, Encoding, FixedInteger, Integer, Limb, Word, ZeroConstant};
+use crate::{
+    modular::BernsteinYangInverter, Bounded, Constants, Encoding, FixedInteger, Integer, Inverter,
+    Limb, Word, ZeroConstant,
+};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 

--- a/tests/bernstein_yang_proptests.rs
+++ b/tests/bernstein_yang_proptests.rs
@@ -1,6 +1,6 @@
 //! Equivalence tests for Bernstein-Yang inversions.
 
-use crypto_bigint::{modular::BernsteinYangInverter, Encoding, U256};
+use crypto_bigint::{Encoding, Inverter, U256};
 use num_bigint::BigUint;
 use num_integer::Integer;
 use num_traits::One;
@@ -32,7 +32,7 @@ proptest! {
         let p_bi = to_biguint(&P);
 
         let expected_is_some = x_bi.gcd(&p_bi) == BigUint::one();
-        let inverter = BernsteinYangInverter::<{U256::LIMBS}, 6>::new(P.as_words(), &[1]);
+        let inverter = P.inverter();
         let actual = inverter.invert(&x);
 
         prop_assert_eq!(bool::from(expected_is_some), actual.is_some());


### PR DESCRIPTION
Adds a trait for obtaining a `BernsteinYangInverter` for the given `Uint` modulus, precomputing the number of unsaturated limbs needed for the 62-bit unsaturated form used by Bernstein-Yang at compile time, and associating the proper `BernsteinYangInverter` for a given `Uint` size as an associated type.

This should make it possible to obtain a `BernsteinYangInverter` for a `Residue`/`DynResidue`, though that's left as a followup exercise.