### PR TITLE
Add new `Inverter` trait; rename `PrecomputeInverter`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -63,6 +63,15 @@ macro_rules! nlimbs {
     };
 }
 
+/// Calculate the number of 62-bit unsaturated limbs required to represent the given number of bits when performing
+/// Bernstein-Yang inversions.
+// TODO(tarcieri): replace with `generic_const_exprs` (rust-lang/rust#76560) when stable
+macro_rules! bernstein_yang_nlimbs {
+    ($bits:expr) => {
+        (($bits / 64) + (($bits / 64) * 2).div_ceil(64) + 1)
+    };
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(target_pointer_width = "32")]

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -39,8 +39,8 @@ pub(crate) mod boxed;
 mod rand;
 
 use crate::{
-    modular::BernsteinYangInverter, Bounded, Constants, Encoding, FixedInteger, Integer, Inverter,
-    Limb, Word, ZeroConstant,
+    modular::BernsteinYangInverter, Bounded, Constants, Encoding, FixedInteger, Integer, Limb,
+    PrecomputeInverter, Word, ZeroConstant,
 };
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};

--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -1,26 +1,22 @@
 //! Macros used to define traits on aliases of `Uint`.
 
-/// Calculate the number of 62-bit unsaturated limbs required to represent the given number of bits when performing
-/// Bernstein-Yang inversions.
-// TODO(tarcieri): replace with `generic_const_exprs` (rust-lang/rust#76560) when stable
-#[macro_export]
-macro_rules! bernstein_yang_nlimbs {
-    ($bits:expr) => {
-        (($bits / 64) + (($bits / 64) * 2).div_ceil(64) + 1)
-    };
-}
-
 /// Impl the `Inverter` trait, where we need to compute the number of unsaturated limbs for a given number of bits.
 macro_rules! impl_inverter_trait {
     ($name:ident, $bits:expr) => {
-        impl Inverter for $name {
+        impl PrecomputeInverter for $name {
             #[allow(trivial_numeric_casts)]
             type Inverter = BernsteinYangInverter<
                 { nlimbs!($bits) },
                 { bernstein_yang_nlimbs!($bits as usize) },
             >;
 
-            fn inverter_with_adjuster(&self, adjuster: &Self) -> Self::Inverter {
+            type Output = $name;
+
+            fn precompute_inverter(&self) -> Self::Inverter {
+                Self::precompute_inverter_with_adjuster(self, &Self::ONE)
+            }
+
+            fn precompute_inverter_with_adjuster(&self, adjuster: &Self) -> Self::Inverter {
                 Self::Inverter::new(self, adjuster)
             }
         }

--- a/tests/bernstein_yang_proptests.rs
+++ b/tests/bernstein_yang_proptests.rs
@@ -1,6 +1,6 @@
 //! Equivalence tests for Bernstein-Yang inversions.
 
-use crypto_bigint::{Encoding, Inverter, U256};
+use crypto_bigint::{Encoding, PrecomputeInverter, U256};
 use num_bigint::BigUint;
 use num_integer::Integer;
 use num_traits::One;
@@ -32,7 +32,7 @@ proptest! {
         let p_bi = to_biguint(&P);
 
         let expected_is_some = x_bi.gcd(&p_bi) == BigUint::one();
-        let inverter = P.inverter();
+        let inverter = P.precompute_inverter();
         let actual = inverter.invert(&x);
 
         prop_assert_eq!(bool::from(expected_is_some), actual.is_some());


### PR DESCRIPTION
Adds a trait for abstracting over various sized `BernsteinYangInverter` (and prospectively a `BoxedBernsteinYangInverter`) types, which also opens the door to impl'ing `PrecomputeInverter` for `*ResidueParams`, where the inverter would accept a `*Residue` as input/output and invert in Montgomery form.

The `PrecomputeInverter::Inverter` type is now bounded on the new `Inverter` trait, making it useful in generic code.