### PR TITLE
Bernstein-Yang: fallible constructors; return `CtOption`

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -168,8 +168,7 @@ pub trait Inverter {
     type Output;
 
     /// Compute a modular inversion, returning `None` if `value` is zero.
-    // TODO(tarcieri): return `CtOption` instead?
-    fn invert(&self, value: &Self::Output) -> Option<Self::Output>;
+    fn invert(&self, value: &Self::Output) -> CtOption<Self::Output>;
 
     /// Compute a modular inversion of a non-zero input.
     fn invert_nz(&self, value: &NonZero<Self::Output>) -> Self::Output

--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -3,6 +3,7 @@
 /// Impl the `Inverter` trait, where we need to compute the number of unsaturated limbs for a given number of bits.
 macro_rules! impl_inverter_trait {
     ($name:ident, $bits:expr) => {
+        /// Precompute a Bernstein-Yang inverter using `self` as the modulus. Panics if called on an even number!
         impl PrecomputeInverter for $name {
             #[allow(trivial_numeric_casts)]
             type Inverter = BernsteinYangInverter<
@@ -17,7 +18,9 @@ macro_rules! impl_inverter_trait {
             }
 
             fn precompute_inverter_with_adjuster(&self, adjuster: &Self) -> Self::Inverter {
-                Self::Inverter::new(self, adjuster)
+                let (ret, is_some) = Self::Inverter::new(self, adjuster);
+                assert!(bool::from(is_some), "modulus must be odd");
+                ret
             }
         }
     };

--- a/tests/bernstein_yang_proptests.rs
+++ b/tests/bernstein_yang_proptests.rs
@@ -1,6 +1,6 @@
 //! Equivalence tests for Bernstein-Yang inversions.
 
-use crypto_bigint::{Encoding, PrecomputeInverter, U256};
+use crypto_bigint::{Encoding, Inverter, PrecomputeInverter, U256};
 use num_bigint::BigUint;
 use num_integer::Integer;
 use num_traits::One;
@@ -35,9 +35,9 @@ proptest! {
         let inverter = P.precompute_inverter();
         let actual = inverter.invert(&x);
 
-        prop_assert_eq!(bool::from(expected_is_some), actual.is_some());
+        prop_assert_eq!(expected_is_some, actual.is_some().into());
 
-        if let Some(actual) = actual {
+        if let Some(actual) = actual.into() {
             let inv_bi = to_biguint(&actual);
             let res = (inv_bi * x_bi) % p_bi;
             prop_assert_eq!(res, BigUint::one());


### PR DESCRIPTION
Adds a `ConstChoice` to the `const fn` versions of a Bernstein-Yang constructor as well as computing inversions on non-`NonZero` inputs.

Changes the `Inverter` trait to return `CtChoice` on non-`NonZero` inputs (`NonZero` inputs are still infallible).

The `PrecomputeInverter` impl on `Uint` now panics if called on an even modulus, which may not be ideal, but allows a prospective impl on `*ResidueParams` to be infallible, which is the main way this is intended to be used (though the impl on `Uint` will be the core).