### PR TITLE
Add `ResidueInverter`

### DIFF
--- a/src/modular.rs
+++ b/src/modular.rs
@@ -35,7 +35,7 @@ pub use self::{
     bernstein_yang::BernsteinYangInverter,
     dyn_residue::{DynResidue, DynResidueParams},
     reduction::montgomery_reduction,
-    residue::{Residue, ResidueParams},
+    residue::{inv::ResidueInverter, Residue, ResidueParams},
 };
 
 #[cfg(feature = "alloc")]

--- a/src/modular/bernstein_yang.rs
+++ b/src/modular/bernstein_yang.rs
@@ -36,10 +36,10 @@ use subtle::CtOption;
 /// <https://gcd.cr.yp.to/safegcd-20190413.pdf>
 /// - P. Wuille, "The safegcd implementation in libsecp256k1 explained",
 /// <https://github.com/bitcoin-core/secp256k1/blob/master/doc/safegcd_implementation.md>
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BernsteinYangInverter<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> {
     /// Modulus
-    modulus: Uint62L<UNSAT_LIMBS>,
+    pub(super) modulus: Uint62L<UNSAT_LIMBS>,
 
     /// Adjusting parameter
     adjuster: Uint62L<UNSAT_LIMBS>,
@@ -316,7 +316,7 @@ const fn unsat_to_sat<const S: usize>(input: &[u64]) -> [Word; S] {
 ///
 /// The arithmetic operations for this type are wrapping ones.
 #[derive(Clone, Copy, Debug)]
-struct Uint62L<const LIMBS: usize>(pub [u64; LIMBS]);
+pub(super) struct Uint62L<const LIMBS: usize>(pub [u64; LIMBS]);
 
 impl<const LIMBS: usize> Uint62L<LIMBS> {
     /// Number of bits in each limb.

--- a/src/modular/residue/inv.rs
+++ b/src/modular/residue/inv.rs
@@ -1,8 +1,11 @@
 //! Multiplicative inverses of residues with a constant modulus.
 
 use super::{Residue, ResidueParams};
-use crate::{modular::inv::inv_montgomery_form, traits::Invert, ConstChoice, NonZero};
-use core::marker::PhantomData;
+use crate::{
+    modular::{inv::inv_montgomery_form, BernsteinYangInverter},
+    ConstChoice, Invert, Inverter, NonZero, PrecomputeInverter, Uint,
+};
+use core::{fmt, marker::PhantomData};
 use subtle::CtOption;
 
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
@@ -44,9 +47,81 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Invert for NonZero<Residue<M
     }
 }
 
+/// Bernstein-Yang inverter which inverts [`Residue`] types.
+pub struct ResidueInverter<MOD: ResidueParams<LIMBS>, const LIMBS: usize>
+where
+    Uint<LIMBS>: PrecomputeInverter<Output = Uint<LIMBS>>,
+{
+    inverter: <Uint<LIMBS> as PrecomputeInverter>::Inverter,
+    phantom: PhantomData<MOD>,
+}
+
+impl<MOD: ResidueParams<SAT_LIMBS>, const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
+    ResidueInverter<MOD, SAT_LIMBS>
+where
+    Uint<SAT_LIMBS>: PrecomputeInverter<
+        Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>,
+        Output = Uint<SAT_LIMBS>,
+    >,
+{
+    /// Create a new [`ResidueInverter`] for the given [`ResidueParams`].
+    pub const fn new() -> Self {
+        Self {
+            // Ensured always valid because the modulus has been checked in advance
+            inverter: BernsteinYangInverter::new(&MOD::MODULUS.0, &MOD::R2).0,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Returns either the adjusted modular multiplicative inverse for the argument or None
+    /// depending on invertibility of the argument, i.e. its coprimality with the modulus.
+    pub const fn inv(
+        &self,
+        value: &Residue<MOD, SAT_LIMBS>,
+    ) -> (Residue<MOD, SAT_LIMBS>, ConstChoice) {
+        let (montgomery_form, is_some) = self.inverter.inv(&value.montgomery_form);
+        let ret = Residue {
+            montgomery_form,
+            phantom: PhantomData,
+        };
+        (ret, is_some)
+    }
+}
+
+impl<MOD: ResidueParams<SAT_LIMBS>, const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> Inverter
+    for ResidueInverter<MOD, SAT_LIMBS>
+where
+    Uint<SAT_LIMBS>: PrecomputeInverter<
+        Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>,
+        Output = Uint<SAT_LIMBS>,
+    >,
+{
+    type Output = Residue<MOD, SAT_LIMBS>;
+
+    fn invert(&self, value: &Residue<MOD, SAT_LIMBS>) -> CtOption<Self::Output> {
+        let (ret, choice) = self.inv(value);
+        CtOption::new(ret, choice.into())
+    }
+}
+
+impl<MOD: ResidueParams<SAT_LIMBS>, const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> fmt::Debug
+    for ResidueInverter<MOD, SAT_LIMBS>
+where
+    Uint<SAT_LIMBS>: PrecomputeInverter<
+        Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>,
+        Output = Uint<SAT_LIMBS>,
+    >,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ResidueInverter")
+            .field("modulus", &self.inverter.modulus)
+            .finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::{const_residue, impl_modulus, modular::residue::ResidueParams, U256};
+    use crate::{const_residue, impl_modulus, modular::residue::ResidueParams, Inverter, U256};
 
     impl_modulus!(
         Modulus,
@@ -61,6 +136,19 @@ mod tests {
         let x_mod = const_residue!(x, Modulus);
 
         let (inv, _is_some) = x_mod.invert();
+        let res = x_mod * inv;
+
+        assert_eq!(res.retrieve(), U256::ONE);
+    }
+
+    #[test]
+    fn test_self_inverse_precomputed() {
+        let x =
+            U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");
+        let x_mod = const_residue!(x, Modulus);
+        let inverter = Modulus::precompute_inverter();
+
+        let inv = inverter.invert(&x_mod).unwrap();
         let res = x_mod * inv;
 
         assert_eq!(res.retrieve(), U256::ONE);

--- a/tests/boxed_residue_proptests.rs
+++ b/tests/boxed_residue_proptests.rs
@@ -93,6 +93,22 @@ proptest! {
     }
 
     #[test]
+    fn precomputed_inv(x in uint(), n in modulus()) {
+        let x = reduce(&x, n.clone());
+        let actual = Option::<BoxedResidue>::from(x.invert()).map(|a| a.retrieve());
+
+        let x_bi = retrieve_biguint(&x);
+        let n_bi = to_biguint(n.modulus());
+        let expected = x_bi.mod_inverse(&n_bi);
+
+        match (expected, actual) {
+            (Some(exp), Some(act)) => prop_assert_eq!(exp, to_biguint(&act).into()),
+            (None, None) => (),
+            (_, _) => panic!("disagreement on if modular inverse exists")
+        }
+    }
+
+    #[test]
     fn mul((a, b) in residue_pair()) {
         let p = a.params().modulus();
         let actual = &a * &b;


### PR DESCRIPTION
Adds support for computing modular inverses of `Residue`s using Bernstein-Yang.

The implementation supports fully `const fn` usage(!), as well as a trait-based API using the `Inverter` trait.

It's composed in terms of the `Inverter` impl on `Uint`.

Includes one test using the same vector as `Residue::invert`.