### PR TITLE
Add `DynResidueInverter`

### DIFF
--- a/src/modular.rs
+++ b/src/modular.rs
@@ -33,7 +33,7 @@ pub(crate) mod boxed_residue;
 
 pub use self::{
     bernstein_yang::BernsteinYangInverter,
-    dyn_residue::{DynResidue, DynResidueParams},
+    dyn_residue::{inv::DynResidueInverter, DynResidue, DynResidueParams},
     reduction::montgomery_reduction,
     residue::{inv::ResidueInverter, Residue, ResidueParams},
 };

--- a/src/modular/dyn_residue.rs
+++ b/src/modular/dyn_residue.rs
@@ -1,7 +1,7 @@
 //! Implements `DynResidue`s, supporting modular arithmetic with a modulus set at runtime.
 
 mod add;
-mod inv;
+pub(super) mod inv;
 mod mul;
 mod neg;
 mod pow;
@@ -17,7 +17,7 @@ use crate::{Limb, NonZero, Uint, Word, Zero};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 /// Parameters to efficiently go to/from the Montgomery form for an odd modulus provided at runtime.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DynResidueParams<const LIMBS: usize> {
     /// The constant modulus
     modulus: Uint<LIMBS>,

--- a/src/modular/dyn_residue/inv.rs
+++ b/src/modular/dyn_residue/inv.rs
@@ -1,7 +1,12 @@
 //! Multiplicative inverses of residues with a modulus set at runtime.
 
-use super::DynResidue;
-use crate::{modular::inv::inv_montgomery_form, traits::Invert, ConstChoice};
+use super::{DynResidue, DynResidueParams};
+use crate::{
+    modular::{inv::inv_montgomery_form, BernsteinYangInverter},
+    traits::Invert,
+    ConstChoice, Inverter, PrecomputeInverter, Uint,
+};
+use core::fmt;
 use subtle::CtOption;
 
 impl<const LIMBS: usize> DynResidue<LIMBS> {
@@ -31,5 +36,105 @@ impl<const LIMBS: usize> Invert for DynResidue<LIMBS> {
     fn invert(&self) -> Self::Output {
         let (value, is_some) = self.invert();
         CtOption::new(value, is_some.into())
+    }
+}
+
+impl<const LIMBS: usize> PrecomputeInverter for DynResidueParams<LIMBS>
+where
+    Uint<LIMBS>: PrecomputeInverter<Output = Uint<LIMBS>>,
+{
+    type Inverter = DynResidueInverter<LIMBS>;
+    type Output = DynResidue<LIMBS>;
+
+    fn precompute_inverter(&self) -> DynResidueInverter<LIMBS> {
+        DynResidueInverter {
+            inverter: self.modulus.precompute_inverter_with_adjuster(&self.r2),
+            residue_params: *self,
+        }
+    }
+
+    fn precompute_inverter_with_adjuster(&self, _adjuster: &Self) -> Self::Inverter {
+        todo!()
+    }
+}
+
+/// Bernstein-Yang inverter which inverts [`DynResidue`] types.
+pub struct DynResidueInverter<const LIMBS: usize>
+where
+    Uint<LIMBS>: PrecomputeInverter<Output = Uint<LIMBS>>,
+{
+    inverter: <Uint<LIMBS> as PrecomputeInverter>::Inverter,
+    residue_params: DynResidueParams<LIMBS>,
+}
+
+impl<const LIMBS: usize> Inverter for DynResidueInverter<LIMBS>
+where
+    Uint<LIMBS>: PrecomputeInverter<Output = Uint<LIMBS>>,
+{
+    type Output = DynResidue<LIMBS>;
+
+    fn invert(&self, value: &DynResidue<LIMBS>) -> CtOption<Self::Output> {
+        debug_assert_eq!(self.residue_params, value.residue_params);
+
+        self.inverter
+            .invert(&value.montgomery_form)
+            .map(|montgomery_form| DynResidue {
+                montgomery_form,
+                residue_params: value.residue_params,
+            })
+    }
+}
+
+impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> fmt::Debug for DynResidueInverter<SAT_LIMBS>
+where
+    Uint<SAT_LIMBS>: PrecomputeInverter<
+        Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>,
+        Output = Uint<SAT_LIMBS>,
+    >,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DynResidueInverter")
+            .field("modulus", &self.inverter.modulus)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DynResidue, DynResidueParams};
+    use crate::{Inverter, PrecomputeInverter, U256};
+
+    fn residue_params() -> DynResidueParams<{ U256::LIMBS }> {
+        DynResidueParams::new(&U256::from_be_hex(
+            "15477BCCEFE197328255BFA79A1217899016D927EF460F4FF404029D24FA4409",
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn test_self_inverse() {
+        let params = residue_params();
+        let x =
+            U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");
+        let x_mod = DynResidue::new(&x, params);
+
+        let (inv, _is_some) = x_mod.invert();
+        let res = x_mod * inv;
+
+        assert_eq!(res.retrieve(), U256::ONE);
+    }
+
+    #[test]
+    fn test_self_inverse_precomuted() {
+        let params = residue_params();
+        let x =
+            U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");
+        let x_mod = DynResidue::new(&x, params);
+
+        let inverter = params.precompute_inverter();
+        let inv = inverter.invert(&x_mod).unwrap();
+        let res = x_mod * inv;
+
+        assert_eq!(res.retrieve(), U256::ONE);
     }
 }

--- a/src/modular/residue/inv.rs
+++ b/src/modular/residue/inv.rs
@@ -121,7 +121,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{const_residue, impl_modulus, modular::residue::ResidueParams, Inverter, U256};
+    use super::ResidueParams;
+    use crate::{const_residue, impl_modulus, Inverter, U256};
 
     impl_modulus!(
         Modulus,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -167,17 +167,8 @@ pub trait Inverter {
     /// Output of an inversion.
     type Output;
 
-    /// Compute a modular inversion, returning `None` if `value` is zero.
+    /// Compute a modular inversion, returning `None` if the result is undefined (i.e. `value` is zero).
     fn invert(&self, value: &Self::Output) -> CtOption<Self::Output>;
-
-    /// Compute a modular inversion of a non-zero input.
-    fn invert_nz(&self, value: &NonZero<Self::Output>) -> Self::Output
-    where
-        Self::Output: Zero,
-    {
-        self.invert(&value.0)
-            .expect("non-zero inputs are always invertable")
-    }
 }
 
 /// Zero values.


### PR DESCRIPTION
Ala `ResidueInverter` added in #446, adds support for computing modular inverses of `DynResidue`s using Bernstein-Yang.