### PR TITLE
Extract sealed `PrecomputeInverterWithAdjuster` trait

### DIFF
--- a/src/modular/dyn_residue/inv.rs
+++ b/src/modular/dyn_residue/inv.rs
@@ -4,7 +4,7 @@ use super::{DynResidue, DynResidueParams};
 use crate::{
     modular::{inv::inv_montgomery_form, BernsteinYangInverter},
     traits::Invert,
-    ConstChoice, Inverter, PrecomputeInverter, Uint,
+    ConstChoice, Inverter, PrecomputeInverter, PrecomputeInverterWithAdjuster, Uint,
 };
 use core::fmt;
 use subtle::CtOption;
@@ -41,7 +41,7 @@ impl<const LIMBS: usize> Invert for DynResidue<LIMBS> {
 
 impl<const LIMBS: usize> PrecomputeInverter for DynResidueParams<LIMBS>
 where
-    Uint<LIMBS>: PrecomputeInverter<Output = Uint<LIMBS>>,
+    Uint<LIMBS>: PrecomputeInverter<Output = Uint<LIMBS>> + PrecomputeInverterWithAdjuster,
 {
     type Inverter = DynResidueInverter<LIMBS>;
     type Output = DynResidue<LIMBS>;
@@ -51,10 +51,6 @@ where
             inverter: self.modulus.precompute_inverter_with_adjuster(&self.r2),
             residue_params: *self,
         }
-    }
-
-    fn precompute_inverter_with_adjuster(&self, _adjuster: &Self) -> Self::Inverter {
-        todo!()
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,8 +1,12 @@
 //! Traits provided by this crate
 
+mod sealed;
+
 pub use num_traits::{
     WrappingAdd, WrappingMul, WrappingNeg, WrappingShl, WrappingShr, WrappingSub,
 };
+
+pub(crate) use sealed::PrecomputeInverterWithAdjuster;
 
 use crate::{Limb, NonZero};
 use core::fmt::Debug;
@@ -156,10 +160,6 @@ pub trait PrecomputeInverter {
     ///
     /// Returns `None` if `self` is even.
     fn precompute_inverter(&self) -> Self::Inverter;
-
-    /// Obtain a precomputed inverter for `&self` as the modulus, supplying a custom adjusting parameter (e.g. R^2 for
-    /// when computing inversions in Montgomery form).
-    fn precompute_inverter_with_adjuster(&self, adjuster: &Self) -> Self::Inverter;
 }
 
 /// Trait impl'd by precomputed modular inverters.

--- a/src/traits/sealed.rs
+++ b/src/traits/sealed.rs
@@ -1,0 +1,10 @@
+//! Sealed traits.
+
+use super::PrecomputeInverter;
+
+/// Obtain a precomputed inverter which applies the given adjustment factor, i.e. for Montgomery form.
+pub trait PrecomputeInverterWithAdjuster: PrecomputeInverter {
+    /// Obtain a precomputed inverter for `&self` as the modulus, supplying a custom adjusting parameter (e.g. R^2 for
+    /// when computing inversions in Montgomery form).
+    fn precompute_inverter_with_adjuster(&self, adjuster: &Self) -> Self::Inverter;
+}

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -40,7 +40,7 @@ mod rand;
 
 use crate::{
     modular::BernsteinYangInverter, Bounded, Constants, Encoding, FixedInteger, Integer, Limb,
-    PrecomputeInverter, Word, ZeroConstant,
+    PrecomputeInverter, PrecomputeInverterWithAdjuster, Word, ZeroConstant,
 };
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};

--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -1,7 +1,7 @@
 //! Macros used to define traits on aliases of `Uint`.
 
 /// Impl the `Inverter` trait, where we need to compute the number of unsaturated limbs for a given number of bits.
-macro_rules! impl_inverter_trait {
+macro_rules! impl_precompute_inverter_trait {
     ($name:ident, $bits:expr) => {
         /// Precompute a Bernstein-Yang inverter using `self` as the modulus. Panics if called on an even number!
         impl PrecomputeInverter for $name {
@@ -16,7 +16,9 @@ macro_rules! impl_inverter_trait {
             fn precompute_inverter(&self) -> Self::Inverter {
                 Self::precompute_inverter_with_adjuster(self, &Self::ONE)
             }
+        }
 
+        impl PrecomputeInverterWithAdjuster for $name {
             fn precompute_inverter_with_adjuster(&self, adjuster: &Self) -> Self::Inverter {
                 let (ret, is_some) = Self::Inverter::new(self, adjuster);
                 assert!(bool::from(is_some), "modulus must be odd");
@@ -62,7 +64,7 @@ macro_rules! impl_uint_aliases {
                 }
             }
 
-            impl_inverter_trait!($name, $bits);
+            impl_precompute_inverter_trait!($name, $bits);
         )+
      };
 }


### PR DESCRIPTION
This trait is needed for the Montgomery form types to instantiate a Bernstein-Yang inverter which operates in the Montgomery domain, by passing R^2 as the adjuster.

It's sealed for now, but could be made public if needed (which might be the case for writing generic trait bounds).

It's extracted from the `PrecomputeInverter` trait, where previously the impl for `DynResidueParams` had a `todo!()` about what to do with this method. Splitting it out into a separate trait resolves this issue.