### PR TITLE
Add `ConstantTimeSelect` trait

### DIFF
--- a/src/modular/boxed_residue.rs
+++ b/src/modular/boxed_residue.rs
@@ -12,7 +12,7 @@ use super::{
     reduction::{montgomery_reduction_boxed, montgomery_reduction_boxed_mut},
     Retrieve,
 };
-use crate::{BoxedUint, Integer, Limb, NonZero, Word};
+use crate::{BoxedUint, ConstantTimeSelect, Integer, Limb, NonZero, Word};
 use subtle::CtOption;
 
 #[cfg(feature = "std")]
@@ -49,7 +49,7 @@ impl BoxedResidueParams {
 
         // Use a surrogate value of `1` in case a modulus of `0` is passed.
         // This will be rejected by the `is_odd` check above, which will fail and return `None`.
-        let modulus_nz = NonZero::new(BoxedUint::conditional_select(
+        let modulus_nz = NonZero::new(BoxedUint::ct_select(
             &modulus,
             &BoxedUint::one_with_precision(bits_precision),
             modulus.is_zero(),
@@ -82,7 +82,7 @@ impl BoxedResidueParams {
 
         // Use a surrogate value of `1` in case a modulus of `0` is passed.
         // This will be rejected by the `is_odd` check above, which will fail and return `None`.
-        let modulus_nz = NonZero::new(BoxedUint::conditional_select(
+        let modulus_nz = NonZero::new(BoxedUint::ct_select(
             &modulus,
             &BoxedUint::one_with_precision(bits_precision),
             modulus.is_zero(),

--- a/src/modular/boxed_residue/pow.rs
+++ b/src/modular/boxed_residue/pow.rs
@@ -1,7 +1,7 @@
 //! Modular exponentiation support for [`BoxedResidue`].
 
 use super::{mul::MontgomeryMultiplier, BoxedResidue};
-use crate::{BoxedUint, Limb, PowBoundedExp, Word};
+use crate::{BoxedUint, ConstantTimeSelect, Limb, PowBoundedExp, Word};
 use alloc::vec::Vec;
 use subtle::{ConstantTimeEq, ConstantTimeLess};
 
@@ -103,7 +103,7 @@ fn pow_montgomery_form(
             // Constant-time lookup in the array of powers
             power.limbs.copy_from_slice(&powers[0].limbs);
             for i in 1..(1 << WINDOW) {
-                power.conditional_assign(&powers[i as usize], i.ct_eq(&idx));
+                power.ct_assign(&powers[i as usize], i.ct_eq(&idx));
             }
 
             multiplier.mul_amm_assign(&mut z, &power);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -54,7 +54,7 @@ pub trait ConstantTimeSelect: Clone {
     #[inline]
     fn ct_swap(a: &mut Self, b: &mut Self, choice: Choice) {
         let t: Self = a.clone();
-        a.ct_assign(&b, choice);
+        a.ct_assign(b, choice);
         b.ct_assign(&t, choice);
     }
 }

--- a/src/uint/boxed/ct.rs
+++ b/src/uint/boxed/ct.rs
@@ -1,17 +1,13 @@
 //! Constant-time helper functions.
 
 use super::BoxedUint;
-use crate::Limb;
-use subtle::{Choice, ConditionallySelectable, CtOption};
+use crate::{ConstantTimeSelect, Limb};
+use subtle::{Choice, ConditionallySelectable};
 
-impl BoxedUint {
-    /// Conditionally select `a` or `b` in constant time depending on [`Choice`].
-    ///
-    /// NOTE: can't impl `subtle`'s [`ConditionallySelectable`] trait due to its `Copy` bound, so
-    /// this is an inherent function instead.
-    ///
-    /// Panics if `a` and `b` don't have the same precision.
-    pub fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+/// NOTE: can't impl `subtle`'s [`ConditionallySelectable`] trait due to its `Copy` bound
+impl ConstantTimeSelect for BoxedUint {
+    #[inline]
+    fn ct_select(a: &Self, b: &Self, choice: Choice) -> Self {
         debug_assert_eq!(a.bits_precision(), b.bits_precision());
         let mut limbs = vec![Limb::ZERO; a.nlimbs()].into_boxed_slice();
 
@@ -22,14 +18,8 @@ impl BoxedUint {
         Self { limbs }
     }
 
-    /// Conditionally assign `other` to `self`, according to `choice`.
-    ///
-    /// NOTE: can't impl `subtle`'s [`ConditionallySelectable`] trait due to its `Copy` bound, so
-    /// this is an inherent function instead.
-    ///
-    /// Panics if `a` and `b` don't have the same precision.
     #[inline]
-    pub fn conditional_assign(&mut self, other: &Self, choice: Choice) {
+    fn ct_assign(&mut self, other: &Self, choice: Choice) {
         debug_assert_eq!(self.bits_precision(), other.bits_precision());
 
         for i in 0..self.nlimbs() {
@@ -37,146 +27,28 @@ impl BoxedUint {
         }
     }
 
-    /// Conditionally swap `self` and `other` if `choice == 1`; otherwise,
-    /// reassign both unto themselves.
-    ///
-    /// NOTE: can't impl `subtle`'s [`ConditionallySelectable`] trait due to its `Copy` bound, so
-    /// this is an inherent function instead.
-    ///
-    /// Panics if `a` and `b` don't have the same precision.
     #[inline]
-    pub fn conditional_swap(a: &mut Self, b: &mut Self, choice: Choice) {
+    fn ct_swap(a: &mut Self, b: &mut Self, choice: Choice) {
         debug_assert_eq!(a.bits_precision(), b.bits_precision());
 
         for i in 0..a.nlimbs() {
             Limb::conditional_swap(&mut a.limbs[i], &mut b.limbs[i], choice);
         }
     }
-
-    /// Conditional `map`: workaround which provides a [`CtOption::map`]-like API.
-    ///
-    /// Ensures both functions are called regardless of whether the first returns some/none with an
-    /// argument whose precision matches `self`. Note this still requires branching on the
-    /// intermediate [`CtOption`] value and therefore isn't fully constant time, but the best we can
-    /// do without upstream changes to `subtle` (see dalek-cryptography/subtle#94).
-    ///
-    /// Workaround due to `Copy` in [`ConditionallySelectable`] supertrait bounds.
-    pub fn conditional_map<C, F, T>(&self, condition: C, f: F) -> CtOption<T>
-    where
-        C: Fn(&Self) -> CtOption<Self>,
-        F: Fn(Self) -> T,
-    {
-        let conditional_val = condition(self);
-        let is_some = conditional_val.is_some();
-
-        let placeholder = Self::zero_with_precision(self.bits_precision());
-        let value = Option::<Self>::from(conditional_val).unwrap_or(placeholder);
-        debug_assert_eq!(self.bits_precision(), value.bits_precision());
-        CtOption::new(f(value), is_some)
-    }
-
-    /// Conditional `and_then`: workaround which provides a [`CtOption::and_then`]-like API.
-    ///
-    /// Ensures both functions are called regardless of whether the first returns some/none with an
-    /// argument whose precision matches `self`. Note this still requires branching on the
-    /// intermediate [`CtOption`] value and therefore isn't fully constant time, but the best we can
-    /// do without upstream changes to `subtle` (see dalek-cryptography/subtle#94).
-    ///
-    /// Workaround due to `Copy` in [`ConditionallySelectable`] supertrait bounds.
-    pub fn conditional_and_then<C, F>(&self, condition: C, f: F) -> CtOption<Self>
-    where
-        C: Fn(&Self) -> CtOption<Self>,
-        F: Fn(Self) -> CtOption<Self>,
-    {
-        let conditional_val = condition(self);
-        let mut is_some = conditional_val.is_some();
-
-        let placeholder = Self::zero_with_precision(self.bits_precision());
-        let value = Option::<Self>::from(conditional_val).unwrap_or(placeholder);
-        debug_assert_eq!(self.bits_precision(), value.bits_precision());
-
-        let conditional_val = f(value);
-        is_some &= conditional_val.is_some();
-
-        let placeholder = Self::zero_with_precision(self.bits_precision());
-        let value = Option::from(conditional_val).unwrap_or(placeholder);
-        debug_assert_eq!(self.bits_precision(), value.bits_precision());
-
-        CtOption::new(value, is_some)
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::BoxedUint;
-    use subtle::{Choice, CtOption};
+    use crate::ConstantTimeSelect;
+    use subtle::Choice;
 
     #[test]
     fn conditional_select() {
         let a = BoxedUint::zero_with_precision(128);
         let b = BoxedUint::max(128);
 
-        assert_eq!(a, BoxedUint::conditional_select(&a, &b, Choice::from(0)));
-        assert_eq!(b, BoxedUint::conditional_select(&a, &b, Choice::from(1)));
+        assert_eq!(a, BoxedUint::ct_select(&a, &b, Choice::from(0)));
+        assert_eq!(b, BoxedUint::ct_select(&a, &b, Choice::from(1)));
     }
-
-    #[test]
-    fn conditional_map_some() {
-        let n = BoxedUint::one();
-
-        let ret = n
-            .conditional_map(
-                |n| CtOption::new(n.clone(), 1u8.into()),
-                |n| n.wrapping_add(&BoxedUint::one()),
-            )
-            .unwrap();
-
-        assert_eq!(ret, BoxedUint::from(2u8));
-    }
-
-    #[test]
-    fn conditional_map_none() {
-        let n = BoxedUint::one();
-
-        let ret = n.conditional_map(
-            |n| CtOption::new(n.clone(), 0u8.into()),
-            |n| n.wrapping_add(&BoxedUint::one()),
-        );
-
-        assert!(bool::from(ret.is_none()));
-    }
-
-    #[test]
-    fn conditional_and_then_all_some() {
-        let n = BoxedUint::one();
-
-        let ret = n
-            .conditional_and_then(
-                |n| CtOption::new(n.clone(), 1u8.into()),
-                |n| CtOption::new(n.wrapping_add(&BoxedUint::one()), 1u8.into()),
-            )
-            .unwrap();
-
-        assert_eq!(ret, BoxedUint::from(2u8));
-    }
-
-    macro_rules! conditional_and_then_none_test {
-        ($name:ident, $a:expr, $b:expr) => {
-            #[test]
-            fn $name() {
-                let n = BoxedUint::one();
-
-                let ret = n.conditional_and_then(
-                    |n| CtOption::new(n.clone(), $a.into()),
-                    |n| CtOption::new(n.wrapping_add(&BoxedUint::one()), $b.into()),
-                );
-
-                assert!(bool::from(ret.is_none()));
-            }
-        };
-    }
-
-    conditional_and_then_none_test!(conditional_and_then_none_some, 0, 1);
-    conditional_and_then_none_test!(conditional_and_then_some_none, 1, 0);
-    conditional_and_then_none_test!(conditional_and_then_none_none, 0, 0);
 }

--- a/src/uint/boxed/neg.rs
+++ b/src/uint/boxed/neg.rs
@@ -1,12 +1,12 @@
 //! [`BoxedUint`] negation operations.
 
-use crate::{BoxedUint, Limb, WideWord, Word, WrappingNeg};
+use crate::{BoxedUint, ConstantTimeSelect, Limb, WideWord, Word, WrappingNeg};
 use subtle::Choice;
 
 impl BoxedUint {
     /// Negates based on `choice` by wrapping the integer.
     pub(crate) fn conditional_wrapping_neg(&self, choice: Choice) -> BoxedUint {
-        Self::conditional_select(self, &self.wrapping_neg(), choice)
+        Self::ct_select(self, &self.wrapping_neg(), choice)
     }
 
     /// Perform wrapping negation.

--- a/src/uint/boxed/shl.rs
+++ b/src/uint/boxed/shl.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] bitwise left shift operations.
 
-use crate::{BoxedUint, Limb, WrappingShl, Zero};
+use crate::{BoxedUint, ConstantTimeSelect, Limb, WrappingShl, Zero};
 use core::ops::{Shl, ShlAssign};
 use subtle::{Choice, ConstantTimeLess};
 
@@ -49,7 +49,7 @@ impl BoxedUint {
             // Will not overflow by construction
             self.shl_vartime_into(&mut temp, 1 << i)
                 .expect("shift within range");
-            self.conditional_assign(&temp, bit);
+            self.ct_assign(&temp, bit);
         }
 
         #[cfg(feature = "zeroize")]

--- a/src/uint/boxed/shr.rs
+++ b/src/uint/boxed/shr.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] bitwise right shift operations.
 
-use crate::{BoxedUint, Limb, WrappingShr, Zero};
+use crate::{BoxedUint, ConstantTimeSelect, Limb, WrappingShr, Zero};
 use core::ops::{Shr, ShrAssign};
 use subtle::{Choice, ConstantTimeLess};
 
@@ -55,7 +55,7 @@ impl BoxedUint {
             // Will not overflow by construction
             self.shr_vartime_into(&mut temp, 1 << i)
                 .expect("shift within range");
-            self.conditional_assign(&temp, bit);
+            self.ct_assign(&temp, bit);
         }
 
         #[cfg(feature = "zeroize")]


### PR DESCRIPTION
We can't impl `subtle::ConditionallySelectable` for `Boxed*` types due to a bound on `Copy`.

I've proposed various ways to try to fix this upstream, e.g. dalek-cryptography/subtle#118, from which the `ConstantTimeSelect` trait has been extracted. It provides the same API as
`ConditionallySelectable` but without the `Copy` bound.

A blanket impl of `ConstantTimeSelect` for all `ConditionallySelectable` types means that all stack allocated types can continue to use `ConditionallySelectable` and will receive an impl of `ConstantTimeSelect` as well.

A bound on `ConstantTimeSelect` has been added to the `Integer` trait as well, allowing it to be used on all `*Uint` types in this crate with `Integer` as the trait abstraction.