### PR TITLE
Bernstein-Yang: use `ConstCtOption`

### DIFF
--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -1,6 +1,6 @@
 use subtle::{Choice, CtOption};
 
-use crate::{NonZero, Uint, Word};
+use crate::{modular::BernsteinYangInverter, NonZero, Uint, Word};
 
 /// A boolean value returned by constant-time `const fn`s.
 // TODO: should be replaced by `subtle::Choice` or `CtOption`
@@ -288,6 +288,22 @@ impl<const LIMBS: usize> ConstCtOption<NonZero<Uint<LIMBS>>> {
     /// `msg`.
     #[inline]
     pub const fn expect(self, msg: &str) -> NonZero<Uint<LIMBS>> {
+        assert!(self.is_some.is_true_vartime(), "{}", msg);
+        self.value
+    }
+}
+
+impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
+    ConstCtOption<BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>>
+{
+    /// Returns the contained value, consuming the `self` value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is none with a custom panic message provided by
+    /// `msg`.
+    #[inline]
+    pub const fn expect(self, msg: &str) -> BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS> {
         assert!(self.is_some.is_true_vartime(), "{}", msg);
         self.value
     }

--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -20,9 +20,7 @@ macro_rules! impl_precompute_inverter_trait {
 
         impl PrecomputeInverterWithAdjuster for $name {
             fn precompute_inverter_with_adjuster(&self, adjuster: &Self) -> Self::Inverter {
-                let (ret, is_some) = Self::Inverter::new(self, adjuster);
-                assert!(bool::from(is_some), "modulus must be odd");
-                ret
+                Self::Inverter::new(self, adjuster).expect("modulus must be odd")
             }
         }
     };


### PR DESCRIPTION
Replaces previous usages of `(_, ConstChoice)` with `ConstCtOption`.