### PR TITLE
`BoxedResidueInverter` tests and benchmarks

### DIFF
--- a/src/modular/bernstein_yang/boxed.rs
+++ b/src/modular/bernstein_yang/boxed.rs
@@ -12,7 +12,7 @@ use subtle::{Choice, ConstantTimeEq, CtOption};
 #[derive(Clone, Debug)]
 pub struct BoxedBernsteinYangInverter {
     /// Modulus
-    modulus: BoxedUint62L,
+    pub(crate) modulus: BoxedUint62L,
 
     /// Adjusting parameter
     adjuster: BoxedUint62L,
@@ -165,7 +165,9 @@ impl Inverter for BoxedBernsteinYangInverter {
         let antiunit = f.is_minus_one();
         let ret = self.norm(d, antiunit);
         let is_some = Choice::from((f.is_one() || antiunit) as u8);
-        CtOption::new(BoxedUint::from(&ret), is_some)
+
+        let ret = BoxedUint::from(&ret);
+        CtOption::new(ret.shorten(value.bits_precision()), is_some)
     }
 }
 

--- a/src/modular/boxed_residue/inv.rs
+++ b/src/modular/boxed_residue/inv.rs
@@ -1,8 +1,15 @@
 //! Multiplicative inverses of boxed residue.
 
-use super::BoxedResidue;
-use crate::{modular::reduction::montgomery_reduction_boxed_mut, traits::Invert};
+use super::{BoxedResidue, BoxedResidueParams};
+use crate::{
+    modular::{reduction::montgomery_reduction_boxed_mut, BoxedBernsteinYangInverter},
+    Invert, Inverter, PrecomputeInverter, PrecomputeInverterWithAdjuster,
+};
+use core::fmt;
 use subtle::CtOption;
+
+#[cfg(feature = "std")]
+use std::sync::Arc;
 
 impl BoxedResidue {
     /// Computes the residue `self^-1` representing the multiplicative inverse of `self`.
@@ -34,5 +41,109 @@ impl Invert for BoxedResidue {
     type Output = CtOption<Self>;
     fn invert(&self) -> Self::Output {
         self.invert()
+    }
+}
+
+impl PrecomputeInverter for BoxedResidueParams {
+    type Inverter = BoxedResidueInverter;
+    type Output = BoxedResidue;
+
+    fn precompute_inverter(&self) -> BoxedResidueInverter {
+        BoxedResidueInverter {
+            inverter: self.modulus.precompute_inverter_with_adjuster(&self.r2),
+            residue_params: self.clone().into(),
+        }
+    }
+}
+
+/// Bernstein-Yang inverter which inverts [`DynResidue`] types.
+pub struct BoxedResidueInverter {
+    /// Precomputed Bernstein-Yang inverter.
+    inverter: BoxedBernsteinYangInverter,
+
+    /// Residue parameters.
+    #[cfg(not(feature = "std"))]
+    residue_params: BoxedResidueParams,
+
+    /// Residue parameters.
+    // Uses `Arc` when `std` is available.
+    #[cfg(feature = "std")]
+    residue_params: Arc<BoxedResidueParams>,
+}
+
+impl Inverter for BoxedResidueInverter {
+    type Output = BoxedResidue;
+
+    fn invert(&self, value: &BoxedResidue) -> CtOption<Self::Output> {
+        debug_assert_eq!(self.residue_params, value.residue_params);
+
+        let montgomery_form = self.inverter.invert(&value.montgomery_form);
+        let is_some = montgomery_form.is_some();
+        let montgomery_form2 = value.montgomery_form.clone();
+        let ret = BoxedResidue {
+            montgomery_form: Option::from(montgomery_form).unwrap_or(montgomery_form2),
+            residue_params: value.residue_params.clone(),
+        };
+
+        CtOption::new(ret, is_some)
+    }
+}
+
+impl fmt::Debug for BoxedResidueInverter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BoxedResidueInverter")
+            .field("modulus", &self.inverter.modulus)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BoxedResidue, BoxedResidueParams};
+    use crate::{BoxedUint, Inverter, PrecomputeInverter};
+    use hex_literal::hex;
+
+    fn residue_params() -> BoxedResidueParams {
+        BoxedResidueParams::new(
+            BoxedUint::from_be_slice(
+                &hex!("15477BCCEFE197328255BFA79A1217899016D927EF460F4FF404029D24FA4409"),
+                256,
+            )
+            .unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_self_inverse() {
+        let params = residue_params();
+        let x = BoxedUint::from_be_slice(
+            &hex!("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685"),
+            256,
+        )
+        .unwrap();
+        let x_mod = BoxedResidue::new(x, params);
+
+        let inv = x_mod.invert().unwrap();
+        let res = x_mod * inv;
+
+        assert!(bool::from(res.retrieve().is_one()));
+    }
+
+    #[test]
+    fn test_self_inverse_precomuted() {
+        let params = residue_params();
+        let inverter = params.precompute_inverter();
+
+        let x = BoxedUint::from_be_slice(
+            &hex!("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685"),
+            256,
+        )
+        .unwrap();
+        let x_mod = BoxedResidue::new(x, params);
+        let inv = inverter.invert(&x_mod).unwrap();
+        let res = x_mod * inv;
+
+        assert!(bool::from(res.retrieve().is_one()));
     }
 }

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -179,6 +179,7 @@ impl BoxedUint {
     /// Shortens this type's precision to the given number of bits.
     ///
     /// Panics if `at_least_bits_precision` is larger than the current precision.
+    #[must_use]
     pub fn shorten(&self, at_least_bits_precision: u32) -> BoxedUint {
         assert!(at_least_bits_precision <= self.bits_precision());
         let mut ret = BoxedUint::zero_with_precision(at_least_bits_precision);

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -19,6 +19,9 @@ use subtle::CtOption;
 // TODO(tarcieri): change this into a `const fn` when `const_mut_refs` is stable
 macro_rules! impl_schoolbook_multiplication {
     ($lhs:expr, $rhs:expr, $lo:expr, $hi:expr) => {{
+        debug_assert!($lhs.len() == $lo.len());
+        debug_assert!($rhs.len() == $hi.len());
+
         let mut i = 0;
         while i < $lhs.len() {
             let mut j = 0;


### PR DESCRIPTION
Even without any optimization work, it seems significantly faster:

```
Montgomery arithmetic/invert, U256
                        time:   [6.8324 ms 6.8402 ms 6.8482 ms]
```

```
Montgomery arithmetic/Bernstein-Yang invert, U256
                        time:   [342.58 µs 343.71 µs 344.81 µs]
```