### PR TITLE
BoxedBernsteinYangInverter: reduce allocations

### DIFF
--- a/src/modular/bernstein_yang.rs
+++ b/src/modular/bernstein_yang.rs
@@ -173,6 +173,7 @@ impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
             .wrapping_mul(d.lowest() as i64)
             .wrapping_add(t[0][1].wrapping_mul(e.lowest() as i64))
             & mask;
+
         let ce = t[1][0]
             .wrapping_mul(d.lowest() as i64)
             .wrapping_add(t[1][1].wrapping_mul(e.lowest() as i64))


### PR DESCRIPTION
```
Montgomery arithmetic/Bernstein-Yang invert, U256
                        time:   [289.83 µs 290.75 µs 291.70 µs]
                        change: [-17.320% -16.859% -16.379%] (p = 0.00 < 0.05)
```