### PR TITLE
BoxedUint: move `From` impls to module

### DIFF
--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -3,30 +3,31 @@
 mod add;
 mod add_mod;
 mod bit_and;
+mod bit_not;
 mod bit_or;
+mod bit_xor;
 mod bits;
 mod cmp;
 mod ct;
 mod div;
 pub(crate) mod encoding;
+mod from;
 mod inv_mod;
 mod mul;
 mod mul_mod;
 mod neg;
+mod neg_mod;
 mod shl;
 mod shr;
 mod sub;
 mod sub_mod;
 
-mod bit_not;
-mod bit_xor;
-mod neg_mod;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{Integer, Limb, NonZero, Uint, Word, Zero, U128, U64};
+use crate::{Integer, Limb, NonZero, Word, Zero};
 use alloc::{boxed::Box, vec, vec::Vec};
-use core::{fmt, mem};
+use core::fmt;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 #[cfg(feature = "zeroize")]
@@ -278,89 +279,6 @@ impl AsMut<[Limb]> for BoxedUint {
 impl Default for BoxedUint {
     fn default() -> Self {
         Self::zero()
-    }
-}
-
-impl From<u8> for BoxedUint {
-    fn from(n: u8) -> Self {
-        vec![Limb::from(n); 1].into()
-    }
-}
-
-impl From<u16> for BoxedUint {
-    fn from(n: u16) -> Self {
-        vec![Limb::from(n); 1].into()
-    }
-}
-
-impl From<u32> for BoxedUint {
-    fn from(n: u32) -> Self {
-        vec![Limb::from(n); 1].into()
-    }
-}
-
-impl From<u64> for BoxedUint {
-    fn from(n: u64) -> Self {
-        U64::from(n).into()
-    }
-}
-
-impl From<u128> for BoxedUint {
-    fn from(n: u128) -> Self {
-        U128::from(n).into()
-    }
-}
-
-impl From<Limb> for BoxedUint {
-    fn from(limb: Limb) -> Self {
-        vec![limb; 1].into()
-    }
-}
-
-impl From<&[Limb]> for BoxedUint {
-    fn from(limbs: &[Limb]) -> BoxedUint {
-        Self {
-            limbs: limbs.into(),
-        }
-    }
-}
-
-impl From<Box<[Limb]>> for BoxedUint {
-    fn from(limbs: Box<[Limb]>) -> BoxedUint {
-        Vec::from(limbs).into()
-    }
-}
-
-impl From<Vec<Limb>> for BoxedUint {
-    fn from(mut limbs: Vec<Limb>) -> BoxedUint {
-        if limbs.is_empty() {
-            limbs.push(Limb::ZERO);
-        }
-
-        Self {
-            limbs: limbs.into_boxed_slice(),
-        }
-    }
-}
-
-impl From<Vec<Word>> for BoxedUint {
-    fn from(mut words: Vec<Word>) -> BoxedUint {
-        // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
-        #[allow(unsafe_code)]
-        unsafe {
-            let ptr = words.as_mut_ptr() as *mut Limb;
-            let len = words.len();
-            let capacity = words.capacity();
-            mem::forget(words);
-            Vec::<Limb>::from_raw_parts(ptr, len, capacity)
-        }
-        .into()
-    }
-}
-
-impl<const LIMBS: usize> From<Uint<LIMBS>> for BoxedUint {
-    fn from(uint: Uint<LIMBS>) -> BoxedUint {
-        Vec::from(uint.to_limbs()).into()
     }
 }
 

--- a/src/uint/boxed/from.rs
+++ b/src/uint/boxed/from.rs
@@ -1,0 +1,96 @@
+//! `From`-like conversions for [`BoxedUint`].
+
+use crate::{BoxedUint, Limb, Uint, Word, U128, U64};
+use alloc::{boxed::Box, vec::Vec};
+use core::mem;
+
+impl From<u8> for BoxedUint {
+    fn from(n: u8) -> Self {
+        vec![Limb::from(n); 1].into()
+    }
+}
+
+impl From<u16> for BoxedUint {
+    fn from(n: u16) -> Self {
+        vec![Limb::from(n); 1].into()
+    }
+}
+
+impl From<u32> for BoxedUint {
+    fn from(n: u32) -> Self {
+        vec![Limb::from(n); 1].into()
+    }
+}
+
+impl From<u64> for BoxedUint {
+    fn from(n: u64) -> Self {
+        U64::from(n).into()
+    }
+}
+
+impl From<u128> for BoxedUint {
+    fn from(n: u128) -> Self {
+        U128::from(n).into()
+    }
+}
+
+impl From<Limb> for BoxedUint {
+    fn from(limb: Limb) -> Self {
+        vec![limb; 1].into()
+    }
+}
+
+impl From<&[Limb]> for BoxedUint {
+    fn from(limbs: &[Limb]) -> BoxedUint {
+        Self {
+            limbs: limbs.into(),
+        }
+    }
+}
+
+impl From<Box<[Limb]>> for BoxedUint {
+    fn from(limbs: Box<[Limb]>) -> BoxedUint {
+        Vec::from(limbs).into()
+    }
+}
+
+impl From<Vec<Limb>> for BoxedUint {
+    fn from(mut limbs: Vec<Limb>) -> BoxedUint {
+        if limbs.is_empty() {
+            limbs.push(Limb::ZERO);
+        }
+
+        Self {
+            limbs: limbs.into_boxed_slice(),
+        }
+    }
+}
+
+impl From<Vec<Word>> for BoxedUint {
+    fn from(mut words: Vec<Word>) -> BoxedUint {
+        // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
+        #[allow(unsafe_code)]
+        unsafe {
+            let ptr = words.as_mut_ptr() as *mut Limb;
+            let len = words.len();
+            let capacity = words.capacity();
+            mem::forget(words);
+            Vec::<Limb>::from_raw_parts(ptr, len, capacity)
+        }
+        .into()
+    }
+}
+
+impl<const LIMBS: usize> From<Uint<LIMBS>> for BoxedUint {
+    #[inline]
+    fn from(uint: Uint<LIMBS>) -> BoxedUint {
+        Self::from(&uint)
+    }
+}
+
+impl<const LIMBS: usize> From<&Uint<LIMBS>> for BoxedUint {
+    #[inline]
+    fn from(uint: &Uint<LIMBS>) -> BoxedUint {
+        Vec::from(uint.to_limbs()).into()
+    }
+}


### PR DESCRIPTION
More consistent with `Uint`