### PR TITLE
`BoxedBernsteinYangInverter` proptests

### DIFF
--- a/src/modular/boxed_residue.rs
+++ b/src/modular/boxed_residue.rs
@@ -103,6 +103,9 @@ impl BoxedResidueParams {
 
     /// Common functionality of `new` and `new_vartime`.
     fn new_inner(modulus: BoxedUint, r: BoxedUint, r2: BoxedUint) -> CtOption<Self> {
+        debug_assert_eq!(r.bits_precision(), modulus.bits_precision());
+        debug_assert_eq!(r2.bits_precision(), modulus.bits_precision());
+
         // If the inverse exists, it means the modulus is odd.
         let (inv_mod_limb, modulus_is_odd) = modulus.inv_mod2k(Word::BITS);
         let mod_neg_inv = Limb(Word::MIN.wrapping_sub(inv_mod_limb.limbs[0].0));

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -169,6 +169,7 @@ impl BoxedUint {
     /// Widen this type's precision to the given number of bits.
     ///
     /// Panics if `at_least_bits_precision` is smaller than the current precision.
+    #[must_use]
     pub fn widen(&self, at_least_bits_precision: u32) -> BoxedUint {
         assert!(at_least_bits_precision >= self.bits_precision());
 

--- a/tests/bernstein_yang_proptests.rs
+++ b/tests/bernstein_yang_proptests.rs
@@ -6,6 +6,9 @@ use num_integer::Integer;
 use num_traits::One;
 use proptest::prelude::*;
 
+#[cfg(feature = "alloc")]
+use crypto_bigint::{BoxedUint, NonZero};
+
 /// Example prime number (NIST P-256 curve order)
 const P: U256 =
     U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
@@ -14,14 +17,27 @@ fn to_biguint(uint: &U256) -> BigUint {
     BigUint::from_bytes_le(uint.to_le_bytes().as_ref())
 }
 
+#[cfg(feature = "alloc")]
+fn to_biguint_boxed(boxed_uint: &BoxedUint) -> BigUint {
+    BigUint::from_bytes_le(boxed_uint.to_le_bytes().as_ref())
+}
+
 prop_compose! {
     fn uint()(bytes in any::<[u8; 32]>()) -> U256 {
         U256::from_le_slice(&bytes)
     }
 }
+
+#[cfg(feature = "alloc")]
 prop_compose! {
-    fn uint_mod_p(p: U256)(a in uint()) -> U256 {
-        a.wrapping_rem(&p)
+    fn boxed_uint()(byte_vec in any::<Vec<u8>>()) -> BoxedUint {
+        let mut bytes = byte_vec.as_slice();
+
+        if bytes.len() > 32 {
+            bytes = &bytes[..32];
+        }
+
+        BoxedUint::from_le_slice(&bytes, 256).unwrap()
     }
 }
 
@@ -35,10 +51,32 @@ proptest! {
         let inverter = P.precompute_inverter();
         let actual = inverter.invert(&x);
 
-        prop_assert_eq!(expected_is_some, actual.is_some().into());
+        prop_assert_eq!(expected_is_some, bool::from(actual.is_some()));
 
         if let Some(actual) = actual.into() {
             let inv_bi = to_biguint(&actual);
+            let res = (inv_bi * x_bi) % p_bi;
+            prop_assert_eq!(res, BigUint::one());
+        }
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn boxed_inv_mod(x in boxed_uint()) {
+        let p = BoxedUint::from(&P);
+        let x = x.rem_vartime(&NonZero::new(p.clone()).unwrap()).widen(p.bits_precision());
+
+        let x_bi = to_biguint_boxed(&x);
+        let p_bi = to_biguint(&P);
+
+        let expected_is_some = x_bi.gcd(&p_bi) == BigUint::one();
+        let inverter = p.precompute_inverter();
+        let actual = inverter.invert(&x);
+
+        prop_assert_eq!(expected_is_some, bool::from(actual.is_some()));
+
+        if let Some(actual) = actual.into() {
+            let inv_bi = to_biguint_boxed(&actual);
             let res = (inv_bi * x_bi) % p_bi;
             prop_assert_eq!(res, BigUint::one());
         }

--- a/tests/boxed_residue_proptests.rs
+++ b/tests/boxed_residue_proptests.rs
@@ -93,22 +93,6 @@ proptest! {
     }
 
     #[test]
-    fn precomputed_inv(x in uint(), n in modulus()) {
-        let x = reduce(&x, n.clone());
-        let actual = Option::<BoxedResidue>::from(x.invert()).map(|a| a.retrieve());
-
-        let x_bi = retrieve_biguint(&x);
-        let n_bi = to_biguint(n.modulus());
-        let expected = x_bi.mod_inverse(&n_bi);
-
-        match (expected, actual) {
-            (Some(exp), Some(act)) => prop_assert_eq!(exp, to_biguint(&act).into()),
-            (None, None) => (),
-            (_, _) => panic!("disagreement on if modular inverse exists")
-        }
-    }
-
-    #[test]
     fn mul((a, b) in residue_pair()) {
         let p = a.params().modulus();
         let actual = &a * &b;


### PR DESCRIPTION
Adds proptests for the P-256 modulus analogous to the ones we have for `BernsteinYangInverter`.