### PR TITLE
Uint: rename `rem(_wide)` => `rem(_wide)_vartime`

### DIFF
--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -31,6 +31,19 @@ fn bench_division(c: &mut Criterion) {
         )
     });
 
+    group.bench_function("rem_vartime, U256/U128, full size", |b| {
+        b.iter_batched(
+            || {
+                let x = U256::random(&mut OsRng);
+                let y_half = U128::random(&mut OsRng);
+                let y: U256 = (y_half, U128::ZERO).into();
+                (x, NonZero::new(y).unwrap())
+            },
+            |(x, y)| black_box(x.rem_vartime(&y)),
+            BatchSize::SmallInput,
+        )
+    });
+
     group.bench_function("div/rem, U256/Limb, full size", |b| {
         b.iter_batched(
             || {

--- a/src/modular.rs
+++ b/src/modular.rs
@@ -159,7 +159,7 @@ mod tests {
         // Computing xR mod modulus without Montgomery reduction
         let (lo, hi) = x.split_mul(&Modulus2::R);
         let c = hi.concat(&lo);
-        let red = c.rem(&NonZero::new(U256::ZERO.concat(&Modulus2::MODULUS)).unwrap());
+        let red = c.rem_vartime(&NonZero::new(U256::ZERO.concat(&Modulus2::MODULUS)).unwrap());
         let (hi, lo) = red.split();
         assert_eq!(hi, Uint::ZERO);
 

--- a/src/modular/dyn_residue.rs
+++ b/src/modular/dyn_residue.rs
@@ -47,8 +47,8 @@ impl<const LIMBS: usize> DynResidueParams<LIMBS> {
         ))
         .expect("modulus ensured non-zero");
 
-        let r = Uint::MAX.rem(&nz_modulus).wrapping_add(&Uint::ONE);
-        let r2 = Uint::rem_wide(r.square_wide(), &nz_modulus);
+        let r = Uint::MAX.rem_vartime(&nz_modulus).wrapping_add(&Uint::ONE);
+        let r2 = Uint::rem_wide_vartime(r.square_wide(), &nz_modulus);
 
         let maybe_inverse = modulus.inv_mod2k_vartime(Word::BITS);
         // If the inverse exists, it means the modulus is odd.

--- a/src/modular/residue/macros.rs
+++ b/src/modular/residue/macros.rs
@@ -33,9 +33,10 @@ macro_rules! impl_modulus {
             };
 
             const R: $uint_type = $crate::Uint::MAX
-                .rem(&Self::MODULUS)
+                .rem_vartime(&Self::MODULUS)
                 .wrapping_add(&$crate::Uint::ONE);
-            const R2: $uint_type = $crate::Uint::rem_wide(Self::R.square_wide(), &Self::MODULUS);
+            const R2: $uint_type =
+                $crate::Uint::rem_wide_vartime(Self::R.square_wide(), &Self::MODULUS);
             const MOD_NEG_INV: $crate::Limb = $crate::Limb(
                 $crate::Word::MIN.wrapping_sub(
                     Self::MODULUS

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -138,7 +138,7 @@ mod tests {
                             prod.limbs[$size..].clone_from_slice(&hi.limbs);
                             let mut modulus = Uint::ZERO;
                             modulus.limbs[..$size].clone_from_slice(&p.as_ref().limbs);
-                            let reduced = prod.rem(&NonZero::new(modulus).unwrap());
+                            let reduced = prod.rem_vartime(&NonZero::new(modulus).unwrap());
                             let mut expected = Uint::ZERO;
                             expected.limbs[..].clone_from_slice(&reduced.limbs[..$size]);
                             expected

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -140,7 +140,7 @@ mod tests {
                             prod.limbs[$size..].clone_from_slice(&hi.limbs);
                             let mut modulus = Uint::ZERO;
                             modulus.limbs[..$size].clone_from_slice(&p.as_ref().limbs);
-                            let reduced = prod.rem(&NonZero::new(modulus).unwrap());
+                            let reduced = prod.rem_vartime(&NonZero::new(modulus).unwrap());
                             let mut expected = Uint::ZERO;
                             expected.limbs[..].clone_from_slice(&reduced.limbs[..$size]);
                             expected


### PR DESCRIPTION
These functions operate in variable time with respect to the `rhs` parameter.

Renames them to `*_vartime` as is the convention of this crate, and in their place adds an actual constant-time remainder implementation (using `div_rem`)