### PR TITLE
Add `Uint::gcd` using Bernstein-Yang

### DIFF
--- a/src/uint.rs
+++ b/src/uint.rs
@@ -18,6 +18,7 @@ mod div;
 pub(crate) mod div_limb;
 mod encoding;
 mod from;
+mod gcd;
 mod inv_mod;
 pub(crate) mod mul;
 mod mul_mod;
@@ -431,6 +432,7 @@ impl_uint_concat_split_mixed! {
 
 #[cfg(feature = "extra-sizes")]
 mod extra_sizes;
+
 #[cfg(feature = "extra-sizes")]
 pub use extra_sizes::*;
 

--- a/src/uint/gcd.rs
+++ b/src/uint/gcd.rs
@@ -1,0 +1,30 @@
+//! Support for computing greatest common divisor of two `Uint`s.
+
+use super::Uint;
+use crate::{modular::BernsteinYangInverter, PrecomputeInverter};
+
+impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> Uint<SAT_LIMBS>
+where
+    Self: PrecomputeInverter<Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>>,
+{
+    /// Compute the greatest common divisor (GCD) of this number and another.
+    ///
+    /// Panics if `self` is odd.
+    pub fn gcd(&self, rhs: &Self) -> Self {
+        debug_assert!(bool::from(self.is_odd()));
+        <Self as PrecomputeInverter>::Inverter::gcd(self, rhs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::U256;
+
+    #[test]
+    fn gcd() {
+        let f = U256::from(4391633u32);
+        let g = U256::from(2022161u32);
+        let gcd = f.gcd(&g);
+        assert_eq!(gcd, U256::from(1763u32));
+    }
+}

--- a/tests/uint_proptests.proptest-regressions
+++ b/tests/uint_proptests.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 109dd02159bd1afed3bdf3b3a82407df5df8d5949115574175225e7e72d13056 # shrinks to a = Uint(0x0000000000000000000000000000000000000000000000000000000000000006), b = Uint(0x0000000000000000000000000000000000000000000000000000000000000068)

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -2,10 +2,10 @@
 
 use crypto_bigint::{
     modular::{DynResidue, DynResidueParams},
-    Encoding, Limb, NonZero, Word, U256,
+    Encoding, Integer, Limb, NonZero, Word, U256,
 };
 use num_bigint::BigUint;
-use num_integer::Integer;
+use num_integer::Integer as _;
 use num_traits::identities::{One, Zero};
 use proptest::prelude::*;
 use std::mem;
@@ -273,6 +273,21 @@ proptest! {
 
             assert_eq!(expected, actual);
         }
+    }
+
+    #[test]
+    fn gcd(mut f in uint(), g in uint()) {
+        if f.is_even().into() {
+            f = f.wrapping_add(&U256::ONE);
+        }
+
+        let f_bi = to_biguint(&f);
+        let g_bi = to_biguint(&g);
+
+        let expected = to_uint(f_bi.gcd(&g_bi));
+        let actual = f.gcd(&g);
+
+        assert_eq!(expected, actual);
     }
 
     #[test]


### PR DESCRIPTION
Adds support for computing the greatest common divisor of two numbers using the Bernstein-Yang algorithm, which is already impl'd for inversions.