### PR TITLE
Make `Uint::gcd` a `const fn`

### DIFF
--- a/src/modular/bernstein_yang.rs
+++ b/src/modular/bernstein_yang.rs
@@ -99,7 +99,7 @@ impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
     ///
     /// This is defined on this type to piggyback on the definitions for `SAT_LIMBS` and `UNSAT_LIMBS` which are
     /// computed when defining `PrecomputeInverter::Inverter` for various `Uint` limb sizes.
-    pub(crate) fn gcd(f: &Uint<SAT_LIMBS>, g: &Uint<SAT_LIMBS>) -> Uint<SAT_LIMBS> {
+    pub(crate) const fn gcd(f: &Uint<SAT_LIMBS>, g: &Uint<SAT_LIMBS>) -> Uint<SAT_LIMBS> {
         let f_0 = Int62L::from_uint(f);
         let inverse = inv_mod2_62(f.as_words());
 

--- a/src/uint/gcd.rs
+++ b/src/uint/gcd.rs
@@ -10,8 +10,8 @@ where
     /// Compute the greatest common divisor (GCD) of this number and another.
     ///
     /// Panics if `self` is odd.
-    pub fn gcd(&self, rhs: &Self) -> Self {
-        debug_assert!(bool::from(self.is_odd()));
+    pub const fn gcd(&self, rhs: &Self) -> Self {
+        debug_assert!(self.is_odd().is_true_vartime());
         <Self as PrecomputeInverter>::Inverter::gcd(self, rhs)
     }
 }


### PR DESCRIPTION
All the prerequisites are there. It was simply an oversight not making it so in #472.