### PR TITLE
Uint: make GCD fallible

### DIFF
--- a/src/uint/gcd.rs
+++ b/src/uint/gcd.rs
@@ -1,7 +1,7 @@
 //! Support for computing greatest common divisor of two `Uint`s.
 
 use super::Uint;
-use crate::{modular::BernsteinYangInverter, PrecomputeInverter};
+use crate::{modular::BernsteinYangInverter, ConstCtOption, PrecomputeInverter};
 
 impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> Uint<SAT_LIMBS>
 where
@@ -9,10 +9,10 @@ where
 {
     /// Compute the greatest common divisor (GCD) of this number and another.
     ///
-    /// Panics if `self` is odd.
-    pub const fn gcd(&self, rhs: &Self) -> Self {
-        debug_assert!(self.is_odd().is_true_vartime());
-        <Self as PrecomputeInverter>::Inverter::gcd(self, rhs)
+    /// Returns none in the event that `self` is even (i.e. `self` MUST be odd). However, `rhs` may be even.
+    pub const fn gcd(&self, rhs: &Self) -> ConstCtOption<Self> {
+        let ret = <Self as PrecomputeInverter>::Inverter::gcd(self, rhs);
+        ConstCtOption::new(ret, self.is_odd())
     }
 }
 
@@ -25,7 +25,7 @@ mod tests {
         // Two semiprimes with no common factors
         let f = U256::from(59u32 * 67);
         let g = U256::from(61u32 * 71);
-        let gcd = f.gcd(&g);
+        let gcd = f.gcd(&g).unwrap();
         assert_eq!(gcd, U256::ONE);
     }
 
@@ -33,14 +33,20 @@ mod tests {
     fn gcd_nonprime() {
         let f = U256::from(4391633u32);
         let g = U256::from(2022161u32);
-        let gcd = f.gcd(&g);
+        let gcd = f.gcd(&g).unwrap();
         assert_eq!(gcd, U256::from(1763u32));
+    }
+
+    #[test]
+    fn gcd_zero() {
+        let f = U256::ZERO;
+        assert!(f.gcd(&U256::ONE).is_none().is_true_vartime());
     }
 
     #[test]
     fn gcd_one() {
         let f = U256::ONE;
-        assert_eq!(U256::ONE, f.gcd(&U256::ONE));
-        assert_eq!(U256::ONE, f.gcd(&U256::from(2u8)));
+        assert_eq!(U256::ONE, f.gcd(&U256::ONE).unwrap());
+        assert_eq!(U256::ONE, f.gcd(&U256::from(2u8)).unwrap());
     }
 }

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -278,6 +278,7 @@ proptest! {
     #[test]
     fn gcd(mut f in uint(), g in uint()) {
         if f.is_even().into() {
+            // Ensure `f` is always odd (required by Bernstein-Yang)
             f = f.wrapping_add(&U256::ONE);
         }
 
@@ -285,7 +286,7 @@ proptest! {
         let g_bi = to_biguint(&g);
 
         let expected = to_uint(f_bi.gcd(&g_bi));
-        let actual = f.gcd(&g);
+        let actual = f.gcd(&g).unwrap();
 
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
Since Bernstein-Yang relies on `f` being odd, this makes `Uint::gcd` return a `ConstCtOption` rather than panicking in the event that `f` is even.