### PR TITLE
Impl `DynResidue::inv(ert)` using Bernstein-Yang

### DIFF
--- a/benches/dyn_residue.rs
+++ b/benches/dyn_residue.rs
@@ -4,7 +4,7 @@ use criterion::{
 };
 use crypto_bigint::{
     modular::{DynResidue, DynResidueParams},
-    Inverter, PrecomputeInverter, Random, U256,
+    Invert, Inverter, PrecomputeInverter, Random, U256,
 };
 use rand_core::OsRng;
 

--- a/tests/dyn_residue_proptests.rs
+++ b/tests/dyn_residue_proptests.rs
@@ -1,6 +1,6 @@
 //! Equivalence tests between `crypto_bigint::DynResidue` and `num-bigint`.
 
-use crypto_bigint::{Encoding, Integer, Inverter, NonZero, PrecomputeInverter, U256};
+use crypto_bigint::{Encoding, Integer, Invert, Inverter, NonZero, PrecomputeInverter, U256};
 use num_bigint::{BigUint, ModInverse};
 use proptest::prelude::*;
 


### PR DESCRIPTION
This results in a massive performance improvement:

```
Montgomery arithmetic/invert, U256
                        time:   [1.7834 µs 1.7870 µs 1.7913 µs]
                        change: [-99.974% -99.974% -99.974%] (p = 0.00 < 0.05)
```