### PR TITLE
Residue: add proptests

### DIFF
--- a/src/modular/residue.rs
+++ b/src/modular/residue.rs
@@ -64,15 +64,12 @@ pub trait ResidueParams<const LIMBS: usize>:
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// A residue mod `MOD`, represented using `LIMBS` limbs. The modulus of this residue is constant,
 /// so it cannot be set at runtime.
 ///
 /// Internally, the value is stored in Montgomery form (multiplied by MOD::R) until it is retrieved.
-pub struct Residue<MOD, const LIMBS: usize>
-where
-    MOD: ResidueParams<LIMBS>,
-{
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Residue<MOD: ResidueParams<LIMBS>, const LIMBS: usize> {
     montgomery_form: Uint<LIMBS>,
     phantom: PhantomData<MOD>,
 }

--- a/src/modular/residue/inv.rs
+++ b/src/modular/residue/inv.rs
@@ -13,7 +13,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
     /// I.e. `self * self^-1 = 1`.
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
-    pub const fn invert(&self) -> ConstCtOption<Self> {
+    pub const fn inv(&self) -> ConstCtOption<Self> {
         let maybe_inverse = inv_montgomery_form(
             &self.montgomery_form,
             &MOD::MODULUS.0,
@@ -34,7 +34,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Residue<MOD, LIMBS> {
 impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Invert for Residue<MOD, LIMBS> {
     type Output = CtOption<Self>;
     fn invert(&self) -> Self::Output {
-        self.invert().into()
+        self.inv().into()
     }
 }
 
@@ -42,7 +42,7 @@ impl<MOD: ResidueParams<LIMBS>, const LIMBS: usize> Invert for NonZero<Residue<M
     type Output = Self;
     fn invert(&self) -> Self::Output {
         // Always succeeds for a non-zero argument
-        let value = self.as_ref().invert().unwrap();
+        let value = self.as_ref().inv().unwrap();
         // An inverse is necessarily non-zero
         NonZero::new(value).unwrap()
     }
@@ -139,7 +139,7 @@ mod tests {
             U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");
         let x_mod = const_residue!(x, Modulus);
 
-        let inv = x_mod.invert().unwrap();
+        let inv = x_mod.inv().unwrap();
         let res = x_mod * inv;
 
         assert_eq!(res.retrieve(), U256::ONE);

--- a/src/modular/residue/macros.rs
+++ b/src/modular/residue/macros.rs
@@ -14,7 +14,7 @@
 macro_rules! impl_modulus {
     ($name:ident, $uint_type:ty, $value:expr) => {
         #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-        pub struct $name {}
+        pub struct $name;
         impl<const DLIMBS: usize> $crate::modular::ResidueParams<{ <$uint_type>::LIMBS }> for $name
         where
             $uint_type: $crate::ConcatMixed<MixedOutput = $crate::Uint<DLIMBS>>,

--- a/tests/residue.rs
+++ b/tests/residue.rs
@@ -1,0 +1,80 @@
+//! Equivalence tests between `crypto_bigint::Residue` and `num-bigint`.
+
+use crypto_bigint::{impl_modulus, modular::ResidueParams, Encoding, Invert, Inverter, U256};
+use num_bigint::{BigUint, ModInverse};
+use proptest::prelude::*;
+
+impl_modulus!(
+    Modulus,
+    U256,
+    "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"
+);
+
+type Residue = crypto_bigint::modular::Residue<Modulus, { U256::LIMBS }>;
+
+fn to_biguint(uint: &U256) -> BigUint {
+    BigUint::from_bytes_le(uint.to_le_bytes().as_ref())
+}
+
+fn retrieve_biguint(residue: &Residue) -> BigUint {
+    to_biguint(&residue.retrieve())
+}
+
+fn reduce(n: &U256) -> Residue {
+    Residue::new(&n)
+}
+
+prop_compose! {
+    fn uint()(bytes in any::<[u8; 32]>()) -> U256 {
+        U256::from_le_slice(&bytes)
+    }
+}
+prop_compose! {
+    /// Generate a single residue.
+    fn residue()(a in uint()) -> Residue {
+        reduce(&a)
+    }
+}
+
+proptest! {
+    #[test]
+    fn inv(x in uint()) {
+        let x = reduce(&x);
+        let actual = Option::<Residue>::from(x.invert());
+
+        let x_bi = retrieve_biguint(&x);
+        let n_bi = to_biguint(&Modulus::MODULUS);
+        let expected = x_bi.mod_inverse(&n_bi);
+
+        match (expected, actual) {
+            (Some(exp), Some(act)) => {
+                let res = x * act;
+                prop_assert_eq!(res.retrieve(), U256::ONE);
+                prop_assert_eq!(exp, retrieve_biguint(&act).into());
+            }
+            (None, None) => (),
+            (_, _) => panic!("disagreement on if modular inverse exists")
+        }
+    }
+
+    #[test]
+    fn precomputed_inv(x in uint()) {
+        let x = reduce(&x);
+        let inverter = Modulus::precompute_inverter();
+        let actual = Option::<Residue>::from(inverter.invert(&x));
+
+        let x_bi = retrieve_biguint(&x);
+        let n_bi = to_biguint(&Modulus::MODULUS);
+        let expected = x_bi.mod_inverse(&n_bi);
+
+        match (expected, actual) {
+            (Some(exp), Some(act)) => {
+                let res = x * act;
+                prop_assert_eq!(res.retrieve(), U256::ONE);
+                prop_assert_eq!(exp, retrieve_biguint(&act).into());
+            }
+            (None, None) => (),
+            (_, _) => panic!("disagreement on if modular inverse exists")
+        }
+    }
+}


### PR DESCRIPTION
Adds an initial set of proptests which cover inversions, similar to the ones recently added to `DynResidue`.