### PR TITLE
Use `{Limb, Uint}::to_nz` to convert to `NonZero`

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -19,7 +19,7 @@ mod sub;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{Bounded, Constants, ZeroConstant};
+use crate::{Bounded, ConstCtOption, Constants, NonZero, ZeroConstant};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
@@ -91,6 +91,13 @@ impl Limb {
     /// Size of the inner integer in bytes.
     #[cfg(target_pointer_width = "64")]
     pub const BYTES: usize = 8;
+
+    /// Convert to a [`NonZero<Limb>`].
+    ///
+    /// Returns some if the original value is non-zero, and false otherwise.
+    pub const fn to_nz(self) -> ConstCtOption<NonZero<Self>> {
+        ConstCtOption::new(NonZero(self), self.is_nonzero())
+    }
 }
 
 impl Bounded for Limb {

--- a/src/modular/residue/macros.rs
+++ b/src/modular/residue/macros.rs
@@ -28,8 +28,8 @@ macro_rules! impl_modulus {
                     panic!("modulus must be odd");
                 }
 
-                // Can unwrap `NonZero::const_new()` here since `res` was asserted to be odd.
-                $crate::NonZero::<$uint_type>::const_new(res).expect("modulus ensured non-zero")
+                // Can unwrap here since `res` was asserted to be odd.
+                res.to_nz().expect("modulus ensured non-zero")
             };
 
             const R: $uint_type = $crate::Uint::MAX

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -1,6 +1,6 @@
 //! Wrapper type for non-zero integers.
 
-use crate::{Bounded, ConstCtOption, Constants, Encoding, Limb, Uint, Zero};
+use crate::{Bounded, Constants, Encoding, Limb, Uint, Zero};
 use core::{
     fmt,
     num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8},
@@ -24,22 +24,6 @@ use serdect::serde::{
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct NonZero<T>(pub(crate) T);
-
-impl NonZero<Limb> {
-    /// Creates a new non-zero limb in a const context.
-    /// The second return value is `FALSE` if `n` is zero, `TRUE` otherwise.
-    pub const fn const_new(n: Limb) -> ConstCtOption<Self> {
-        ConstCtOption::new(Self(n), n.is_nonzero())
-    }
-}
-
-impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
-    /// Creates a new non-zero integer in a const context.
-    /// The second return value is `FALSE` if `n` is zero, `TRUE` otherwise.
-    pub const fn const_new(n: Uint<LIMBS>) -> ConstCtOption<Self> {
-        ConstCtOption::new(Self(n), n.is_nonzero())
-    }
-}
 
 impl<T> NonZero<T> {
     /// Create a new non-zero integer.

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -40,8 +40,8 @@ pub(crate) mod boxed;
 mod rand;
 
 use crate::{
-    modular::BernsteinYangInverter, Bounded, Constants, Encoding, FixedInteger, Integer, Limb,
-    PrecomputeInverter, PrecomputeInverterWithAdjuster, Word, ZeroConstant,
+    modular::BernsteinYangInverter, Bounded, ConstCtOption, Constants, Encoding, FixedInteger,
+    Integer, Limb, NonZero, PrecomputeInverter, PrecomputeInverterWithAdjuster, Word, ZeroConstant,
 };
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
@@ -168,6 +168,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Convert this [`Uint`] into its inner limbs.
     pub const fn to_limbs(self) -> [Limb; LIMBS] {
         self.limbs
+    }
+
+    /// Convert to a [`NonZero<Limb>`].
+    ///
+    /// Returns some if the original value is non-zero, and false otherwise.
+    pub const fn to_nz(self) -> ConstCtOption<NonZero<Self>> {
+        ConstCtOption::new(NonZero(self), self.is_nonzero())
     }
 }
 

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -204,7 +204,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Panics if `rhs == 0`.
     pub const fn wrapping_rem(&self, rhs: &Self) -> Self {
-        let nz_rhs = NonZero::<Self>::const_new(*rhs).expect("non-zero divisor");
+        let nz_rhs = rhs.to_nz().expect("non-zero divisor");
         self.rem_vartime(&nz_rhs)
     }
 

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -1,8 +1,7 @@
 //! [`Uint`] square root operations.
 
+use crate::Uint;
 use subtle::{ConstantTimeEq, CtOption};
-
-use crate::{NonZero, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes √(`self`) in constant time.
@@ -30,8 +29,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             x_prev = x;
 
             // Calculate `x_{i+1} = floor((x_i + self / x_i) / 2)`
-
-            let maybe_nz_x = NonZero::<Self>::const_new(x);
+            let maybe_nz_x = x.to_nz();
             let (nz_x, is_some) = maybe_nz_x.components_ref();
             let (q, _) = self.div_rem(nz_x);
 
@@ -63,8 +61,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // Stop right away if `x` is zero to avoid divizion by zero.
         while !x.cmp_vartime(&Self::ZERO).is_eq() {
             // Calculate `x_{i+1} = floor((x_i + self / x_i) / 2)`
-            let q = self
-                .wrapping_div_vartime(&NonZero::<Self>::const_new(x).expect("ensured non-zero"));
+            let q = self.wrapping_div_vartime(&x.to_nz().expect("ensured non-zero"));
             let t = x.wrapping_add(&q);
             let next_x = t.shr1();
 


### PR DESCRIPTION
Replaces the previous type-specific `NonZero::const_new` methods with more idiomatic `Limb::to_nz`/`Uint::to_nz` methods which can be called on a value and return `ConstCtChoice<NonZero<_>>`.