### PR TITLE
NonZero: remove `from_uint`; reorganize module

### DIFF
--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -83,6 +83,65 @@ where
     }
 }
 
+impl NonZero<Limb> {
+    /// Create a [`NonZero<Limb>`] from a [`NonZeroU8`] (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<NonZeroU8>` when stable
+    pub const fn from_u8(n: NonZeroU8) -> Self {
+        Self(Limb::from_u8(n.get()))
+    }
+
+    /// Create a [`NonZero<Limb>`] from a [`NonZeroU16`] (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<NonZeroU16>` when stable
+    pub const fn from_u16(n: NonZeroU16) -> Self {
+        Self(Limb::from_u16(n.get()))
+    }
+
+    /// Create a [`NonZero<Limb>`] from a [`NonZeroU32`] (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<NonZeroU32>` when stable
+    pub const fn from_u32(n: NonZeroU32) -> Self {
+        Self(Limb::from_u32(n.get()))
+    }
+
+    /// Create a [`NonZero<Limb>`] from a [`NonZeroU64`] (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<NonZeroU64>` when stable
+    #[cfg(target_pointer_width = "64")]
+    pub const fn from_u64(n: NonZeroU64) -> Self {
+        Self(Limb::from_u64(n.get()))
+    }
+}
+
+impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
+    /// Create a [`NonZero<Uint>`] from a [`NonZeroU8`] (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<NonZeroU8>` when stable
+    pub const fn from_u8(n: NonZeroU8) -> Self {
+        Self(Uint::from_u8(n.get()))
+    }
+
+    /// Create a [`NonZero<Uint>`] from a [`NonZeroU16`] (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<NonZeroU16>` when stable
+    pub const fn from_u16(n: NonZeroU16) -> Self {
+        Self(Uint::from_u16(n.get()))
+    }
+
+    /// Create a [`NonZero<Uint>`] from a [`NonZeroU32`] (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<NonZeroU32>` when stable
+    pub const fn from_u32(n: NonZeroU32) -> Self {
+        Self(Uint::from_u32(n.get()))
+    }
+
+    /// Create a [`NonZero<Uint>`] from a [`NonZeroU64`] (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<NonZeroU64>` when stable
+    pub const fn from_u64(n: NonZeroU64) -> Self {
+        Self(Uint::from_u64(n.get()))
+    }
+
+    /// Create a [`NonZero<Uint>`] from a [`NonZeroU128`] (const-friendly)
+    // TODO(tarcieri): replace with `const impl From<NonZeroU128>` when stable
+    pub const fn from_u128(n: NonZeroU128) -> Self {
+        Self(Uint::from_u128(n.get()))
+    }
+}
+
 #[cfg(feature = "generic-array")]
 impl<T> NonZero<T>
 where
@@ -149,6 +208,61 @@ where
     }
 }
 
+impl From<NonZeroU8> for NonZero<Limb> {
+    fn from(integer: NonZeroU8) -> Self {
+        Self::from_u8(integer)
+    }
+}
+
+impl From<NonZeroU16> for NonZero<Limb> {
+    fn from(integer: NonZeroU16) -> Self {
+        Self::from_u16(integer)
+    }
+}
+
+impl From<NonZeroU32> for NonZero<Limb> {
+    fn from(integer: NonZeroU32) -> Self {
+        Self::from_u32(integer)
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+impl From<NonZeroU64> for NonZero<Limb> {
+    fn from(integer: NonZeroU64) -> Self {
+        Self::from_u64(integer)
+    }
+}
+
+impl<const LIMBS: usize> From<NonZeroU8> for NonZero<Uint<LIMBS>> {
+    fn from(integer: NonZeroU8) -> Self {
+        Self::from_u8(integer)
+    }
+}
+
+impl<const LIMBS: usize> From<NonZeroU16> for NonZero<Uint<LIMBS>> {
+    fn from(integer: NonZeroU16) -> Self {
+        Self::from_u16(integer)
+    }
+}
+
+impl<const LIMBS: usize> From<NonZeroU32> for NonZero<Uint<LIMBS>> {
+    fn from(integer: NonZeroU32) -> Self {
+        Self::from_u32(integer)
+    }
+}
+
+impl<const LIMBS: usize> From<NonZeroU64> for NonZero<Uint<LIMBS>> {
+    fn from(integer: NonZeroU64) -> Self {
+        Self::from_u64(integer)
+    }
+}
+
+impl<const LIMBS: usize> From<NonZeroU128> for NonZero<Uint<LIMBS>> {
+    fn from(integer: NonZeroU128) -> Self {
+        Self::from_u128(integer)
+    }
+}
+
 impl<T> fmt::Display for NonZero<T>
 where
     T: fmt::Display,
@@ -191,134 +305,6 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::UpperHex::fmt(&self.0, f)
-    }
-}
-
-impl NonZero<Limb> {
-    /// Create a [`NonZero<Limb>`] from a [`NonZeroU8`] (const-friendly)
-    // TODO(tarcieri): replace with `const impl From<NonZeroU8>` when stable
-    pub const fn from_u8(n: NonZeroU8) -> Self {
-        Self(Limb::from_u8(n.get()))
-    }
-
-    /// Create a [`NonZero<Limb>`] from a [`NonZeroU16`] (const-friendly)
-    // TODO(tarcieri): replace with `const impl From<NonZeroU16>` when stable
-    pub const fn from_u16(n: NonZeroU16) -> Self {
-        Self(Limb::from_u16(n.get()))
-    }
-
-    /// Create a [`NonZero<Limb>`] from a [`NonZeroU32`] (const-friendly)
-    // TODO(tarcieri): replace with `const impl From<NonZeroU32>` when stable
-    pub const fn from_u32(n: NonZeroU32) -> Self {
-        Self(Limb::from_u32(n.get()))
-    }
-
-    /// Create a [`NonZero<Limb>`] from a [`NonZeroU64`] (const-friendly)
-    // TODO(tarcieri): replace with `const impl From<NonZeroU64>` when stable
-    #[cfg(target_pointer_width = "64")]
-    pub const fn from_u64(n: NonZeroU64) -> Self {
-        Self(Limb::from_u64(n.get()))
-    }
-}
-
-impl From<NonZeroU8> for NonZero<Limb> {
-    fn from(integer: NonZeroU8) -> Self {
-        Self::from_u8(integer)
-    }
-}
-
-impl From<NonZeroU16> for NonZero<Limb> {
-    fn from(integer: NonZeroU16) -> Self {
-        Self::from_u16(integer)
-    }
-}
-
-impl From<NonZeroU32> for NonZero<Limb> {
-    fn from(integer: NonZeroU32) -> Self {
-        Self::from_u32(integer)
-    }
-}
-
-#[cfg(target_pointer_width = "64")]
-impl From<NonZeroU64> for NonZero<Limb> {
-    fn from(integer: NonZeroU64) -> Self {
-        Self::from_u64(integer)
-    }
-}
-
-impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
-    /// Create a [`NonZero<Uint>`] from a [`Uint`] (const-friendly)
-    pub const fn from_uint(n: Uint<LIMBS>) -> Self {
-        let mut i = 0;
-        let mut found_non_zero = false;
-        while i < LIMBS {
-            if n.as_limbs()[i].0 != 0 {
-                found_non_zero = true;
-            }
-            i += 1;
-        }
-        assert!(found_non_zero, "found zero");
-        Self(n)
-    }
-
-    /// Create a [`NonZero<Uint>`] from a [`NonZeroU8`] (const-friendly)
-    // TODO(tarcieri): replace with `const impl From<NonZeroU8>` when stable
-    pub const fn from_u8(n: NonZeroU8) -> Self {
-        Self(Uint::from_u8(n.get()))
-    }
-
-    /// Create a [`NonZero<Uint>`] from a [`NonZeroU16`] (const-friendly)
-    // TODO(tarcieri): replace with `const impl From<NonZeroU16>` when stable
-    pub const fn from_u16(n: NonZeroU16) -> Self {
-        Self(Uint::from_u16(n.get()))
-    }
-
-    /// Create a [`NonZero<Uint>`] from a [`NonZeroU32`] (const-friendly)
-    // TODO(tarcieri): replace with `const impl From<NonZeroU32>` when stable
-    pub const fn from_u32(n: NonZeroU32) -> Self {
-        Self(Uint::from_u32(n.get()))
-    }
-
-    /// Create a [`NonZero<Uint>`] from a [`NonZeroU64`] (const-friendly)
-    // TODO(tarcieri): replace with `const impl From<NonZeroU64>` when stable
-    pub const fn from_u64(n: NonZeroU64) -> Self {
-        Self(Uint::from_u64(n.get()))
-    }
-
-    /// Create a [`NonZero<Uint>`] from a [`NonZeroU128`] (const-friendly)
-    // TODO(tarcieri): replace with `const impl From<NonZeroU128>` when stable
-    pub const fn from_u128(n: NonZeroU128) -> Self {
-        Self(Uint::from_u128(n.get()))
-    }
-}
-
-impl<const LIMBS: usize> From<NonZeroU8> for NonZero<Uint<LIMBS>> {
-    fn from(integer: NonZeroU8) -> Self {
-        Self::from_u8(integer)
-    }
-}
-
-impl<const LIMBS: usize> From<NonZeroU16> for NonZero<Uint<LIMBS>> {
-    fn from(integer: NonZeroU16) -> Self {
-        Self::from_u16(integer)
-    }
-}
-
-impl<const LIMBS: usize> From<NonZeroU32> for NonZero<Uint<LIMBS>> {
-    fn from(integer: NonZeroU32) -> Self {
-        Self::from_u32(integer)
-    }
-}
-
-impl<const LIMBS: usize> From<NonZeroU64> for NonZero<Uint<LIMBS>> {
-    fn from(integer: NonZeroU64) -> Self {
-        Self::from_u64(integer)
-    }
-}
-
-impl<const LIMBS: usize> From<NonZeroU128> for NonZero<Uint<LIMBS>> {
-    fn from(integer: NonZeroU128) -> Self {
-        Self::from_u128(integer)
     }
 }
 


### PR DESCRIPTION
The `NonZero::from_uint` method duplicates the `Uint::to_nz` method, and isn't actually used anywhere in this codebase.

Also reorganizes the module to place all the inherent impls at the top, and the trait impls at the bottom.