### PR TITLE
Add `Odd` newtype

### DIFF
--- a/benches/boxed_monty.rs
+++ b/benches/boxed_monty.rs
@@ -4,7 +4,7 @@ use criterion::{
 };
 use crypto_bigint::{
     modular::{BoxedMontyForm, BoxedMontyParams},
-    BoxedUint, NonZero, RandomMod,
+    BoxedUint, NonZero, Odd, RandomMod,
 };
 use num_bigint::BigUint;
 use rand_core::OsRng;
@@ -17,10 +17,7 @@ fn to_biguint(uint: &BoxedUint) -> BigUint {
 }
 
 fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let params = BoxedMontyParams::new(
-        BoxedUint::random(&mut OsRng, UINT_BITS) | BoxedUint::one_with_precision(UINT_BITS),
-    )
-    .unwrap();
+    let params = BoxedMontyParams::new(Odd::<BoxedUint>::random(&mut OsRng, UINT_BITS));
 
     group.bench_function("invert, U256", |b| {
         b.iter_batched(
@@ -60,8 +57,8 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         )
     });
 
-    let m = BoxedUint::random(&mut OsRng, UINT_BITS) | BoxedUint::one_with_precision(UINT_BITS);
-    let params = BoxedMontyParams::new(m).unwrap();
+    let m = Odd::<BoxedUint>::random(&mut OsRng, UINT_BITS);
+    let params = BoxedMontyParams::new(m);
     group.bench_function("modpow, BoxedUint^BoxedUint", |b| {
         b.iter_batched(
             || {
@@ -96,7 +93,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("BoxedMontyParams::new", |b| {
         b.iter_batched(
-            || BoxedUint::random(&mut OsRng, UINT_BITS) | BoxedUint::one_with_precision(UINT_BITS),
+            || Odd::<BoxedUint>::random(&mut OsRng, UINT_BITS),
             |modulus| black_box(BoxedMontyParams::new(modulus)),
             BatchSize::SmallInput,
         )
@@ -104,16 +101,13 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
 
     group.bench_function("BoxedMontyParams::new_vartime", |b| {
         b.iter_batched(
-            || BoxedUint::random(&mut OsRng, UINT_BITS) | BoxedUint::one_with_precision(UINT_BITS),
+            || Odd::<BoxedUint>::random(&mut OsRng, UINT_BITS),
             |modulus| black_box(BoxedMontyParams::new_vartime(modulus)),
             BatchSize::SmallInput,
         )
     });
 
-    let params = BoxedMontyParams::new(
-        BoxedUint::random(&mut OsRng, UINT_BITS) | BoxedUint::one_with_precision(UINT_BITS),
-    )
-    .unwrap();
+    let params = BoxedMontyParams::new(Odd::<BoxedUint>::random(&mut OsRng, UINT_BITS));
     group.bench_function("BoxedMontyForm::new", |b| {
         b.iter_batched(
             || BoxedUint::random(&mut OsRng, UINT_BITS),
@@ -122,10 +116,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
         )
     });
 
-    let params = BoxedMontyParams::new(
-        BoxedUint::random(&mut OsRng, UINT_BITS) | BoxedUint::one_with_precision(UINT_BITS),
-    )
-    .unwrap();
+    let params = BoxedMontyParams::new(Odd::<BoxedUint>::random(&mut OsRng, UINT_BITS));
     group.bench_function("BoxedMontyForm::retrieve", |b| {
         b.iter_batched(
             || BoxedMontyForm::new(BoxedUint::random(&mut OsRng, UINT_BITS), params.clone()),

--- a/benches/monty.rs
+++ b/benches/monty.rs
@@ -4,7 +4,7 @@ use criterion::{
 };
 use crypto_bigint::{
     modular::{MontyForm, MontyParams},
-    Invert, Inverter, PrecomputeInverter, Random, U256,
+    Invert, Inverter, Odd, PrecomputeInverter, Random, U256,
 };
 use rand_core::OsRng;
 
@@ -14,22 +14,22 @@ use crypto_bigint::MultiExponentiate;
 fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("MontyParams creation", |b| {
         b.iter_batched(
-            || U256::random(&mut OsRng) | U256::ONE,
-            |modulus| black_box(MontyParams::new(&modulus)),
+            || Odd::<U256>::random(&mut OsRng),
+            |modulus| black_box(MontyParams::new(modulus)),
             BatchSize::SmallInput,
         )
     });
 
-    let params = MontyParams::new(&(U256::random(&mut OsRng) | U256::ONE)).unwrap();
+    let params = MontyParams::new(Odd::<U256>::random(&mut OsRng));
     group.bench_function("MontyForm creation", |b| {
         b.iter_batched(
-            || U256::random(&mut OsRng),
+            || Odd::<U256>::random(&mut OsRng),
             |x| black_box(MontyForm::new(&x, params)),
             BatchSize::SmallInput,
         )
     });
 
-    let params = MontyParams::new(&(U256::random(&mut OsRng) | U256::ONE)).unwrap();
+    let params = MontyParams::new(Odd::<U256>::random(&mut OsRng));
     group.bench_function("MontyForm retrieve", |b| {
         b.iter_batched(
             || MontyForm::new(&U256::random(&mut OsRng), params),
@@ -40,7 +40,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
 }
 
 fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let params = MontyParams::new(&(U256::random(&mut OsRng) | U256::ONE)).unwrap();
+    let params = MontyParams::new(Odd::<U256>::random(&mut OsRng));
 
     group.bench_function("invert, U256", |b| {
         b.iter_batched(

--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -1,6 +1,6 @@
 use subtle::{Choice, CtOption};
 
-use crate::{modular::BernsteinYangInverter, NonZero, Uint, Word};
+use crate::{modular::BernsteinYangInverter, NonZero, Odd, Uint, Word};
 
 /// A boolean value returned by constant-time `const fn`s.
 // TODO: should be replaced by `subtle::Choice` or `CtOption`
@@ -300,6 +300,20 @@ impl<const LIMBS: usize> ConstCtOption<NonZero<Uint<LIMBS>>> {
     /// `msg`.
     #[inline]
     pub const fn expect(self, msg: &str) -> NonZero<Uint<LIMBS>> {
+        assert!(self.is_some.is_true_vartime(), "{}", msg);
+        self.value
+    }
+}
+
+impl<const LIMBS: usize> ConstCtOption<Odd<Uint<LIMBS>>> {
+    /// Returns the contained value, consuming the `self` value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is none with a custom panic message provided by
+    /// `msg`.
+    #[inline]
+    pub const fn expect(self, msg: &str) -> Odd<Uint<LIMBS>> {
         assert!(self.is_some.is_true_vartime(), "{}", msg);
         self.value
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,7 @@ mod checked;
 mod const_choice;
 mod limb;
 mod non_zero;
+mod odd;
 mod primitives;
 mod traits;
 mod uint;
@@ -180,6 +181,7 @@ pub use crate::{
     const_choice::{ConstChoice, ConstCtOption},
     limb::{Limb, WideWord, Word},
     non_zero::NonZero,
+    odd::Odd,
     traits::*,
     uint::div_limb::Reciprocal,
     uint::*,

--- a/src/limb/bit_and.rs
+++ b/src/limb/bit_and.rs
@@ -1,7 +1,7 @@
 //! Limb bit and operations.
 
 use super::Limb;
-use core::ops::BitAnd;
+use core::ops::{BitAnd, BitAndAssign};
 
 impl Limb {
     /// Calculates `a & b`.
@@ -17,5 +17,17 @@ impl BitAnd for Limb {
     #[inline(always)]
     fn bitand(self, rhs: Self) -> Self::Output {
         self.bitand(rhs)
+    }
+}
+
+impl BitAndAssign for Limb {
+    fn bitand_assign(&mut self, rhs: Self) {
+        self.0 &= rhs.0;
+    }
+}
+
+impl BitAndAssign<&Limb> for Limb {
+    fn bitand_assign(&mut self, rhs: &Limb) {
+        self.0 &= rhs.0;
     }
 }

--- a/src/limb/bit_xor.rs
+++ b/src/limb/bit_xor.rs
@@ -1,7 +1,7 @@
 //! Limb bit xor operations.
 
 use super::Limb;
-use core::ops::BitXor;
+use core::ops::{BitXor, BitXorAssign};
 
 impl Limb {
     /// Calculates `a ^ b`.
@@ -16,5 +16,11 @@ impl BitXor for Limb {
 
     fn bitxor(self, rhs: Self) -> Self::Output {
         self.bitxor(rhs)
+    }
+}
+
+impl BitXorAssign for Limb {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        self.0 ^= rhs.0;
     }
 }

--- a/src/modular/add.rs
+++ b/src/modular/add.rs
@@ -1,9 +1,9 @@
-use crate::Uint;
+use crate::{Odd, Uint};
 
 pub(crate) const fn add_montgomery_form<const LIMBS: usize>(
     a: &Uint<LIMBS>,
     b: &Uint<LIMBS>,
-    modulus: &Uint<LIMBS>,
+    modulus: &Odd<Uint<LIMBS>>,
 ) -> Uint<LIMBS> {
-    a.add_mod(b, modulus)
+    a.add_mod(b, &modulus.0)
 }

--- a/src/modular/bernstein_yang.rs
+++ b/src/modular/bernstein_yang.rs
@@ -13,7 +13,7 @@
 #[macro_use]
 mod macros;
 
-use crate::{ConstChoice, ConstCtOption, Inverter, Limb, Uint, Word};
+use crate::{ConstChoice, ConstCtOption, Inverter, Limb, Odd, Uint, Word};
 use subtle::CtOption;
 
 /// Modular multiplicative inverter based on the Bernstein-Yang method.
@@ -61,14 +61,12 @@ impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
     /// Creates the inverter for specified modulus and adjusting parameter.
     ///
     /// Modulus must be odd. Returns `None` if it is not.
-    pub const fn new(modulus: &Uint<SAT_LIMBS>, adjuster: &Uint<SAT_LIMBS>) -> ConstCtOption<Self> {
-        let ret = Self {
-            modulus: Int62L::from_uint(modulus),
+    pub const fn new(modulus: &Odd<Uint<SAT_LIMBS>>, adjuster: &Uint<SAT_LIMBS>) -> Self {
+        Self {
+            modulus: Int62L::from_uint(&modulus.0),
             adjuster: Int62L::from_uint(adjuster),
-            inverse: inv_mod2_62(modulus.as_words()),
-        };
-
-        ConstCtOption::new(ret, modulus.is_odd())
+            inverse: inv_mod2_62(modulus.0.as_words()),
+        }
     }
 
     /// Returns either the adjusted modular multiplicative inverse for the argument or `None`

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -50,7 +50,7 @@ impl BoxedMontyParams {
         // `R mod modulus` where `R = 2^BITS`.
         // Represents 1 in Montgomery form.
         let one = BoxedUint::max(bits_precision)
-            .rem(&modulus.as_nz_ref())
+            .rem(modulus.as_nz_ref())
             .wrapping_add(&BoxedUint::one());
 
         // `R^2 mod modulus`, used to convert integers to Montgomery form.
@@ -82,7 +82,7 @@ impl BoxedMontyParams {
             .rem_vartime(&modulus.as_nz_ref().widen(bits_precision * 2))
             .shorten(bits_precision);
 
-        Self::new_inner(modulus, one, r2).into()
+        Self::new_inner(modulus, one, r2)
     }
 
     /// Common functionality of `new` and `new_vartime`.

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -12,7 +12,7 @@ use super::{
     reduction::{montgomery_reduction_boxed, montgomery_reduction_boxed_mut},
     Retrieve,
 };
-use crate::{BoxedUint, ConstantTimeSelect, Integer, Limb, Monty, NonZero, Word};
+use crate::{BoxedUint, Integer, Limb, Monty, Odd, Word};
 use subtle::CtOption;
 
 #[cfg(feature = "std")]
@@ -26,7 +26,7 @@ use zeroize::Zeroize;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BoxedMontyParams {
     /// The constant modulus
-    modulus: BoxedUint,
+    modulus: Odd<BoxedUint>,
     /// Parameter used in Montgomery reduction
     one: BoxedUint,
     /// R^2, used to move into Montgomery form
@@ -44,28 +44,19 @@ impl BoxedMontyParams {
     ///
     /// Returns a `CtOption` that is `None` if the provided modulus is not odd.
     /// TODO(tarcieri): DRY out with `MontyParams::new`?
-    pub fn new(modulus: BoxedUint) -> CtOption<Self> {
+    pub fn new(modulus: Odd<BoxedUint>) -> Self {
         let bits_precision = modulus.bits_precision();
-
-        // Use a surrogate value of `1` in case a modulus of `0` is passed.
-        // This will be rejected by the `is_odd` check above, which will fail and return `None`.
-        let modulus_nz = NonZero::new(BoxedUint::ct_select(
-            &modulus,
-            &BoxedUint::one_with_precision(bits_precision),
-            modulus.is_zero(),
-        ))
-        .expect("modulus ensured non-zero");
 
         // `R mod modulus` where `R = 2^BITS`.
         // Represents 1 in Montgomery form.
         let one = BoxedUint::max(bits_precision)
-            .rem(&modulus_nz)
+            .rem(&modulus.as_nz_ref())
             .wrapping_add(&BoxedUint::one());
 
         // `R^2 mod modulus`, used to convert integers to Montgomery form.
         let r2 = one
             .square()
-            .rem(&modulus_nz.widen(bits_precision * 2))
+            .rem(&modulus.as_nz_ref().widen(bits_precision * 2))
             .shorten(bits_precision);
 
         Self::new_inner(modulus, one, r2)
@@ -76,56 +67,43 @@ impl BoxedMontyParams {
     ///
     /// Returns `None` if the provided modulus is not odd.
     /// TODO(tarcieri): DRY out with `MontyParams::new`?
-    pub fn new_vartime(modulus: BoxedUint) -> Option<Self> {
-        if modulus.is_even().into() {
-            return None;
-        }
-
+    pub fn new_vartime(modulus: Odd<BoxedUint>) -> Self {
         let bits_precision = modulus.bits_precision();
-
-        // Use a surrogate value of `1` in case a modulus of `0` is passed.
-        // This will be rejected by the `is_odd` check above, which will fail and return `None`.
-        let modulus_nz = NonZero::new(BoxedUint::ct_select(
-            &modulus,
-            &BoxedUint::one_with_precision(bits_precision),
-            modulus.is_zero(),
-        ))
-        .expect("modulus ensured non-zero");
 
         // `R mod modulus` where `R = 2^BITS`.
         // Represents 1 in Montgomery form.
         let one = BoxedUint::max(bits_precision)
-            .rem_vartime(&modulus_nz)
+            .rem_vartime(modulus.as_nz_ref())
             .wrapping_add(&BoxedUint::one());
 
         // `R^2 mod modulus`, used to convert integers to Montgomery form.
         let r2 = one
             .square()
-            .rem_vartime(&modulus_nz.widen(bits_precision * 2))
+            .rem_vartime(&modulus.as_nz_ref().widen(bits_precision * 2))
             .shorten(bits_precision);
 
         Self::new_inner(modulus, one, r2).into()
     }
 
     /// Common functionality of `new` and `new_vartime`.
-    fn new_inner(modulus: BoxedUint, one: BoxedUint, r2: BoxedUint) -> CtOption<Self> {
+    fn new_inner(modulus: Odd<BoxedUint>, one: BoxedUint, r2: BoxedUint) -> Self {
         debug_assert_eq!(one.bits_precision(), modulus.bits_precision());
         debug_assert_eq!(r2.bits_precision(), modulus.bits_precision());
 
         // If the inverse exists, it means the modulus is odd.
         let (inv_mod_limb, modulus_is_odd) = modulus.inv_mod2k(Word::BITS);
+        debug_assert!(bool::from(modulus_is_odd));
+
         let mod_neg_inv = Limb(Word::MIN.wrapping_sub(inv_mod_limb.limbs[0].0));
         let r3 = montgomery_reduction_boxed(&mut r2.square(), &modulus, mod_neg_inv);
 
-        let params = Self {
+        Self {
             modulus,
             one,
             r2,
             r3,
             mod_neg_inv,
-        };
-
-        CtOption::new(params, modulus_is_odd)
+        }
     }
 
     /// Modulus value.
@@ -256,7 +234,11 @@ impl Monty for BoxedMontyForm {
     type Params = BoxedMontyParams;
 
     fn new_params(modulus: Self::Integer) -> CtOption<Self::Params> {
-        BoxedMontyParams::new(modulus)
+        let is_odd = modulus.is_odd();
+
+        // Note: instantiates a potentially invalid `Odd`, but guards with `CtOption`.
+        let params = BoxedMontyParams::new(Odd(modulus));
+        CtOption::new(params, is_odd)
     }
 
     fn new(value: Self::Integer, params: Self::Params) -> Self {
@@ -280,25 +262,4 @@ fn convert_to_montgomery(integer: &mut BoxedUint, params: &BoxedMontyParams) {
 
     #[cfg(feature = "zeroize")]
     product.zeroize();
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{BoxedMontyParams, BoxedUint};
-
-    #[test]
-    fn new_params_with_invalid_modulus() {
-        // 0
-        let ret = BoxedMontyParams::new(BoxedUint::zero());
-        assert!(bool::from(ret.is_none()));
-
-        // 2
-        let ret = BoxedMontyParams::new(BoxedUint::from(2u8));
-        assert!(bool::from(ret.is_none()));
-    }
-
-    #[test]
-    fn new_params_with_valid_modulus() {
-        BoxedMontyParams::new(BoxedUint::from(3u8)).unwrap();
-    }
 }

--- a/src/modular/boxed_monty_form/add.rs
+++ b/src/modular/boxed_monty_form/add.rs
@@ -72,14 +72,12 @@ mod tests {
 
     #[test]
     fn add_overflow() {
-        let params = BoxedMontyParams::new(
-            BoxedUint::from_be_slice(
-                &hex!("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"),
-                256,
-            )
-            .unwrap(),
+        let modulus = BoxedUint::from_be_slice(
+            &hex!("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"),
+            256,
         )
         .unwrap();
+        let params = BoxedMontyParams::new(modulus.to_odd().unwrap());
 
         let x = BoxedUint::from_be_slice(
             &hex!("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56"),

--- a/src/modular/boxed_monty_form/inv.rs
+++ b/src/modular/boxed_monty_form/inv.rs
@@ -49,9 +49,10 @@ mod tests {
                 &hex!("15477BCCEFE197328255BFA79A1217899016D927EF460F4FF404029D24FA4409"),
                 256,
             )
+            .unwrap()
+            .to_odd()
             .unwrap(),
         )
-        .unwrap()
     }
 
     #[test]

--- a/src/modular/boxed_monty_form/mul.rs
+++ b/src/modular/boxed_monty_form/mul.rs
@@ -321,7 +321,7 @@ mod tests {
         let modulus = 0xB44677037A7DBDE04814256570DCBD8Du128;
 
         let boxed_modulus = BoxedUint::from(modulus);
-        let boxed_params = BoxedMontyParams::new(boxed_modulus).unwrap();
+        let boxed_params = BoxedMontyParams::new(boxed_modulus.to_odd().unwrap());
         let boxed_monty = BoxedMontyForm::new(BoxedUint::from(x), boxed_params);
         let boxed_square = boxed_monty.square();
 

--- a/src/modular/boxed_monty_form/sub.rs
+++ b/src/modular/boxed_monty_form/sub.rs
@@ -73,14 +73,12 @@ mod tests {
 
     #[test]
     fn sub_overflow() {
-        let params = BoxedMontyParams::new(
-            BoxedUint::from_be_slice(
-                &hex!("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"),
-                256,
-            )
-            .unwrap(),
+        let modulus = BoxedUint::from_be_slice(
+            &hex!("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"),
+            256,
         )
         .unwrap();
+        let params = BoxedMontyParams::new(modulus.to_odd().unwrap());
 
         let x = BoxedUint::from_be_slice(
             &hex!("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56"),

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -98,7 +98,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     const fn from_integer(integer: &Uint<LIMBS>) -> Self {
         let product = integer.split_mul(&MOD::R2);
         let montgomery_form =
-            montgomery_reduction::<LIMBS>(&product, &MOD::MODULUS.0, MOD::MOD_NEG_INV);
+            montgomery_reduction::<LIMBS>(&product, &MOD::MODULUS, MOD::MOD_NEG_INV);
 
         Self {
             montgomery_form,
@@ -115,7 +115,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     pub const fn retrieve(&self) -> Uint<LIMBS> {
         montgomery_reduction::<LIMBS>(
             &(self.montgomery_form, Uint::ZERO),
-            &MOD::MODULUS.0,
+            &MOD::MODULUS,
             MOD::MOD_NEG_INV,
         )
     }

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -9,7 +9,7 @@ mod sub;
 
 use self::inv::ConstMontyFormInverter;
 use super::{div_by_2::div_by_2, reduction::montgomery_reduction, BernsteinYangInverter, Retrieve};
-use crate::{Limb, NonZero, PrecomputeInverter, Uint, ZeroConstant};
+use crate::{Limb, Odd, PrecomputeInverter, Uint, ZeroConstant};
 use core::{fmt::Debug, marker::PhantomData};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
@@ -39,7 +39,7 @@ pub trait ConstMontyParams<const LIMBS: usize>:
     const LIMBS: usize;
 
     /// The constant modulus
-    const MODULUS: NonZero<Uint<LIMBS>>;
+    const MODULUS: Odd<Uint<LIMBS>>;
     /// 1 in Montgomery form
     const ONE: Uint<LIMBS>;
     /// `R^2 mod MODULUS`, used to move into Montgomery form
@@ -196,7 +196,7 @@ where
 {
     #[inline]
     fn random(rng: &mut impl CryptoRngCore) -> Self {
-        Self::new(&Uint::random_mod(rng, &MOD::MODULUS))
+        Self::new(&Uint::random_mod(rng, MOD::MODULUS.as_nz_ref()))
     }
 }
 

--- a/src/modular/const_monty_form/add.rs
+++ b/src/modular/const_monty_form/add.rs
@@ -11,7 +11,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
             montgomery_form: add_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
-                &MOD::MODULUS.0,
+                &MOD::MODULUS,
             ),
             phantom: core::marker::PhantomData,
         }

--- a/src/modular/const_monty_form/inv.rs
+++ b/src/modular/const_monty_form/inv.rs
@@ -21,8 +21,7 @@ where
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
     pub const fn inv(&self) -> ConstCtOption<Self> {
         let inverter =
-            <Uint<SAT_LIMBS> as PrecomputeInverter>::Inverter::new(&MOD::MODULUS.0, &MOD::R2)
-                .expect("modulus should be valid");
+            <Uint<SAT_LIMBS> as PrecomputeInverter>::Inverter::new(&MOD::MODULUS, &MOD::R2);
 
         let maybe_inverse = inverter.inv(&self.montgomery_form);
         let (inverse, inverse_is_some) = maybe_inverse.components_ref();
@@ -69,8 +68,7 @@ where
 {
     /// Create a new [`ConstMontyFormInverter`] for the given [`ConstMontyParams`].
     pub const fn new() -> Self {
-        let inverter =
-            BernsteinYangInverter::new(&MOD::MODULUS.0, &MOD::R2).expect("modulus should be valid");
+        let inverter = BernsteinYangInverter::new(&MOD::MODULUS, &MOD::R2);
 
         Self {
             inverter,

--- a/src/modular/const_monty_form/macros.rs
+++ b/src/modular/const_monty_form/macros.rs
@@ -46,7 +46,7 @@ macro_rules! impl_modulus {
 
             const R3: $uint_type = $crate::modular::montgomery_reduction(
                 &Self::R2.square_wide(),
-                Self::MODULUS.as_ref(),
+                &Self::MODULUS,
                 Self::MOD_NEG_INV,
             );
         }

--- a/src/modular/const_monty_form/macros.rs
+++ b/src/modular/const_monty_form/macros.rs
@@ -21,27 +21,20 @@ macro_rules! impl_modulus {
             $uint_type: $crate::ConcatMixed<MixedOutput = $crate::Uint<DLIMBS>>,
         {
             const LIMBS: usize = <$uint_type>::LIMBS;
-            const MODULUS: $crate::NonZero<$uint_type> = {
+            const MODULUS: $crate::Odd<$uint_type> = {
                 let res = <$uint_type>::from_be_hex($value);
-
-                // Check that the modulus is odd
-                if res.as_limbs()[0].0 & 1 == 0 {
-                    panic!("modulus must be odd");
-                }
-
-                // Can unwrap here since `res` was asserted to be odd.
-                res.to_nz().expect("modulus ensured non-zero")
+                res.to_odd().expect("modulus ensured non-zero")
             };
 
             // `R mod MODULUS` where `R = 2^BITS`.
             // Represents 1 in Montgomery form.
             const ONE: $uint_type = $crate::Uint::MAX
-                .rem_vartime(&Self::MODULUS)
+                .rem_vartime(Self::MODULUS.as_nz_ref())
                 .wrapping_add(&$crate::Uint::ONE);
 
             // `R^2 mod MODULUS`, used to convert integers to Montgomery form.
             const R2: $uint_type =
-                $crate::Uint::rem_wide_vartime(Self::ONE.square_wide(), &Self::MODULUS);
+                $crate::Uint::rem_wide_vartime(Self::ONE.square_wide(), Self::MODULUS.as_nz_ref());
 
             const MOD_NEG_INV: $crate::Limb = $crate::Limb(
                 $crate::Word::MIN.wrapping_sub(

--- a/src/modular/const_monty_form/macros.rs
+++ b/src/modular/const_monty_form/macros.rs
@@ -23,7 +23,7 @@ macro_rules! impl_modulus {
             const LIMBS: usize = <$uint_type>::LIMBS;
             const MODULUS: $crate::Odd<$uint_type> = {
                 let res = <$uint_type>::from_be_hex($value);
-                res.to_odd().expect("modulus ensured non-zero")
+                res.to_odd().expect("modulus must be odd")
             };
 
             // `R mod MODULUS` where `R = 2^BITS`.

--- a/src/modular/const_monty_form/macros.rs
+++ b/src/modular/const_monty_form/macros.rs
@@ -21,10 +21,7 @@ macro_rules! impl_modulus {
             $uint_type: $crate::ConcatMixed<MixedOutput = $crate::Uint<DLIMBS>>,
         {
             const LIMBS: usize = <$uint_type>::LIMBS;
-            const MODULUS: $crate::Odd<$uint_type> = {
-                let res = <$uint_type>::from_be_hex($value);
-                res.to_odd().expect("modulus must be odd")
-            };
+            const MODULUS: $crate::Odd<$uint_type> = $crate::Odd::<$uint_type>::from_be_hex($value);
 
             // `R mod MODULUS` where `R = 2^BITS`.
             // Represents 1 in Montgomery form.

--- a/src/modular/const_monty_form/mul.rs
+++ b/src/modular/const_monty_form/mul.rs
@@ -19,7 +19,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
             montgomery_form: mul_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
-                &MOD::MODULUS.0,
+                &MOD::MODULUS,
                 MOD::MOD_NEG_INV,
             ),
             phantom: PhantomData,
@@ -31,7 +31,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
         Self {
             montgomery_form: square_montgomery_form(
                 &self.montgomery_form,
-                &MOD::MODULUS.0,
+                &MOD::MODULUS,
                 MOD::MOD_NEG_INV,
             ),
             phantom: PhantomData,

--- a/src/modular/const_monty_form/pow.rs
+++ b/src/modular/const_monty_form/pow.rs
@@ -33,7 +33,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
                 &self.montgomery_form,
                 exponent,
                 exponent_bits,
-                &MOD::MODULUS.0,
+                &MOD::MODULUS,
                 &MOD::ONE,
                 MOD::MOD_NEG_INV,
             ),

--- a/src/modular/const_monty_form/sub.rs
+++ b/src/modular/const_monty_form/sub.rs
@@ -11,7 +11,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
             montgomery_form: sub_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
-                &MOD::MODULUS.0,
+                &MOD::MODULUS,
             ),
             phantom: core::marker::PhantomData,
         }

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -54,7 +54,7 @@ impl<const LIMBS: usize> MontyParams<LIMBS> {
         let mod_neg_inv = Limb(Word::MIN.wrapping_sub(inv_mod.limbs[0].0));
 
         // `R^3 mod modulus`, used for inversion in Montgomery form.
-        let r3 = montgomery_reduction(&r2.square_wide(), &modulus.0, mod_neg_inv);
+        let r3 = montgomery_reduction(&r2.square_wide(), &modulus, mod_neg_inv);
 
         Self {
             modulus,
@@ -119,7 +119,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Instantiates a new `MontyForm` that represents this `integer` mod `MOD`.
     pub const fn new(integer: &Uint<LIMBS>, params: MontyParams<LIMBS>) -> Self {
         let product = integer.split_mul(&params.r2);
-        let montgomery_form = montgomery_reduction(&product, &params.modulus.0, params.mod_neg_inv);
+        let montgomery_form = montgomery_reduction(&product, &params.modulus, params.mod_neg_inv);
 
         Self {
             montgomery_form,
@@ -131,7 +131,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     pub const fn retrieve(&self) -> Uint<LIMBS> {
         montgomery_reduction(
             &(self.montgomery_form, Uint::ZERO),
-            &self.params.modulus.0,
+            &self.params.modulus,
             self.params.mod_neg_inv,
         )
     }

--- a/src/modular/monty_form/add.rs
+++ b/src/modular/monty_form/add.rs
@@ -11,7 +11,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
             montgomery_form: add_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
-                &self.params.modulus,
+                &self.params.modulus.0,
             ),
             params: self.params,
         }

--- a/src/modular/monty_form/add.rs
+++ b/src/modular/monty_form/add.rs
@@ -64,16 +64,15 @@ impl<const LIMBS: usize> AddAssign<MontyForm<LIMBS>> for MontyForm<LIMBS> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        modular::monty_form::{MontyForm, MontyParams},
-        U256,
+        modular::{MontyForm, MontyParams},
+        Odd, U256,
     };
 
     #[test]
     fn add_overflow() {
-        let params = MontyParams::new(&U256::from_be_hex(
+        let params = MontyParams::new(Odd::<U256>::from_be_hex(
             "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-        ))
-        .unwrap();
+        ));
 
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");

--- a/src/modular/monty_form/add.rs
+++ b/src/modular/monty_form/add.rs
@@ -11,7 +11,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
             montgomery_form: add_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
-                &self.params.modulus.0,
+                &self.params.modulus,
             ),
             params: self.params,
         }

--- a/src/modular/monty_form/inv.rs
+++ b/src/modular/monty_form/inv.rs
@@ -110,13 +110,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::{MontyForm, MontyParams};
-    use crate::{Invert, Inverter, PrecomputeInverter, U256};
+    use crate::{Invert, Inverter, Odd, PrecomputeInverter, U256};
 
     fn params() -> MontyParams<{ U256::LIMBS }> {
-        MontyParams::new(&U256::from_be_hex(
+        MontyParams::new(Odd::<U256>::from_be_hex(
             "15477BCCEFE197328255BFA79A1217899016D927EF460F4FF404029D24FA4409",
         ))
-        .unwrap()
     }
 
     #[test]

--- a/src/modular/monty_form/inv.rs
+++ b/src/modular/monty_form/inv.rs
@@ -23,8 +23,7 @@ where
         let inverter = <Uint<SAT_LIMBS> as PrecomputeInverter>::Inverter::new(
             &self.params.modulus,
             &self.params.r2,
-        )
-        .expect("modulus should be valid");
+        );
 
         let maybe_inverse = inverter.inv(&self.montgomery_form);
         let (inverse, inverse_is_some) = maybe_inverse.components_ref();

--- a/src/modular/monty_form/mul.rs
+++ b/src/modular/monty_form/mul.rs
@@ -14,7 +14,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
             montgomery_form: mul_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
-                &self.params.modulus,
+                &self.params.modulus.0,
                 self.params.mod_neg_inv,
             ),
             params: self.params,
@@ -26,7 +26,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
         Self {
             montgomery_form: square_montgomery_form(
                 &self.montgomery_form,
-                &self.params.modulus,
+                &self.params.modulus.0,
                 self.params.mod_neg_inv,
             ),
             params: self.params,

--- a/src/modular/monty_form/mul.rs
+++ b/src/modular/monty_form/mul.rs
@@ -14,7 +14,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
             montgomery_form: mul_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
-                &self.params.modulus.0,
+                &self.params.modulus,
                 self.params.mod_neg_inv,
             ),
             params: self.params,
@@ -26,7 +26,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
         Self {
             montgomery_form: square_montgomery_form(
                 &self.montgomery_form,
-                &self.params.modulus.0,
+                &self.params.modulus,
                 self.params.mod_neg_inv,
             ),
             params: self.params,

--- a/src/modular/monty_form/pow.rs
+++ b/src/modular/monty_form/pow.rs
@@ -33,7 +33,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
                 &self.montgomery_form,
                 exponent,
                 exponent_bits,
-                &self.params.modulus.0,
+                &self.params.modulus,
                 &self.params.one,
                 self.params.mod_neg_inv,
             ),

--- a/src/modular/monty_form/pow.rs
+++ b/src/modular/monty_form/pow.rs
@@ -33,7 +33,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
                 &self.montgomery_form,
                 exponent,
                 exponent_bits,
-                &self.params.modulus,
+                &self.params.modulus.0,
                 &self.params.one,
                 self.params.mod_neg_inv,
             ),

--- a/src/modular/monty_form/sub.rs
+++ b/src/modular/monty_form/sub.rs
@@ -11,7 +11,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
             montgomery_form: sub_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
-                &self.params.modulus.0,
+                &self.params.modulus,
             ),
             params: self.params,
         }

--- a/src/modular/monty_form/sub.rs
+++ b/src/modular/monty_form/sub.rs
@@ -64,16 +64,15 @@ impl<const LIMBS: usize> SubAssign<MontyForm<LIMBS>> for MontyForm<LIMBS> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        modular::monty_form::{MontyForm, MontyParams},
-        U256,
+        modular::{MontyForm, MontyParams},
+        Odd, U256,
     };
 
     #[test]
     fn sub_overflow() {
-        let params = MontyParams::new(&U256::from_be_hex(
+        let params = MontyParams::new(Odd::<U256>::from_be_hex(
             "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-        ))
-        .unwrap();
+        ));
 
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");

--- a/src/modular/monty_form/sub.rs
+++ b/src/modular/monty_form/sub.rs
@@ -11,7 +11,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
             montgomery_form: sub_montgomery_form(
                 &self.montgomery_form,
                 &rhs.montgomery_form,
-                &self.params.modulus,
+                &self.params.modulus.0,
             ),
             params: self.params,
         }

--- a/src/modular/mul.rs
+++ b/src/modular/mul.rs
@@ -1,11 +1,10 @@
-use crate::{Limb, Uint};
-
 use super::reduction::montgomery_reduction;
+use crate::{Limb, Odd, Uint};
 
 pub(crate) const fn mul_montgomery_form<const LIMBS: usize>(
     a: &Uint<LIMBS>,
     b: &Uint<LIMBS>,
-    modulus: &Uint<LIMBS>,
+    modulus: &Odd<Uint<LIMBS>>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {
     let product = a.split_mul(b);
@@ -14,7 +13,7 @@ pub(crate) const fn mul_montgomery_form<const LIMBS: usize>(
 
 pub(crate) const fn square_montgomery_form<const LIMBS: usize>(
     a: &Uint<LIMBS>,
-    modulus: &Uint<LIMBS>,
+    modulus: &Odd<Uint<LIMBS>>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {
     let product = a.square_wide();

--- a/src/modular/pow.rs
+++ b/src/modular/pow.rs
@@ -1,6 +1,5 @@
-use crate::{ConstChoice, Limb, Uint, Word};
-
 use super::mul::{mul_montgomery_form, square_montgomery_form};
+use crate::{ConstChoice, Limb, Odd, Uint, Word};
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -16,7 +15,7 @@ pub const fn pow_montgomery_form<const LIMBS: usize, const RHS_LIMBS: usize>(
     x: &Uint<LIMBS>,
     exponent: &Uint<RHS_LIMBS>,
     exponent_bits: u32,
-    modulus: &Uint<LIMBS>,
+    modulus: &Odd<Uint<LIMBS>>,
     one: &Uint<LIMBS>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {
@@ -36,7 +35,7 @@ pub const fn multi_exponentiate_montgomery_form_array<
 >(
     bases_and_exponents: &[(Uint<LIMBS>, Uint<RHS_LIMBS>); N],
     exponent_bits: u32,
-    modulus: &Uint<LIMBS>,
+    modulus: &Odd<Uint<LIMBS>>,
     one: &Uint<LIMBS>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {
@@ -73,7 +72,7 @@ pub const fn multi_exponentiate_montgomery_form_array<
 pub fn multi_exponentiate_montgomery_form_slice<const LIMBS: usize, const RHS_LIMBS: usize>(
     bases_and_exponents: &[(Uint<LIMBS>, Uint<RHS_LIMBS>)],
     exponent_bits: u32,
-    modulus: &Uint<LIMBS>,
+    modulus: &Odd<Uint<LIMBS>>,
     one: &Uint<LIMBS>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {
@@ -98,7 +97,7 @@ pub fn multi_exponentiate_montgomery_form_slice<const LIMBS: usize, const RHS_LI
 
 const fn compute_powers<const LIMBS: usize>(
     x: &Uint<LIMBS>,
-    modulus: &Uint<LIMBS>,
+    modulus: &Odd<Uint<LIMBS>>,
     one: &Uint<LIMBS>,
     mod_neg_inv: Limb,
 ) -> [Uint<LIMBS>; 1 << WINDOW] {
@@ -118,7 +117,7 @@ const fn compute_powers<const LIMBS: usize>(
 const fn multi_exponentiate_montgomery_form_internal<const LIMBS: usize, const RHS_LIMBS: usize>(
     powers_and_exponents: &[([Uint<LIMBS>; 1 << WINDOW], Uint<RHS_LIMBS>)],
     exponent_bits: u32,
-    modulus: &Uint<LIMBS>,
+    modulus: &Odd<Uint<LIMBS>>,
     one: &Uint<LIMBS>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {

--- a/src/modular/reduction.rs
+++ b/src/modular/reduction.rs
@@ -1,6 +1,6 @@
 //! Modular reduction implementation.
 
-use crate::{Limb, Uint};
+use crate::{Limb, Odd, Uint};
 
 #[cfg(feature = "alloc")]
 use {crate::BoxedUint, subtle::Choice};
@@ -47,17 +47,22 @@ macro_rules! impl_montgomery_reduction {
 /// Algorithm 14.32 in Handbook of Applied Cryptography <https://cacr.uwaterloo.ca/hac/about/chap14.pdf>
 pub const fn montgomery_reduction<const LIMBS: usize>(
     lower_upper: &(Uint<LIMBS>, Uint<LIMBS>),
-    modulus: &Uint<LIMBS>,
+    modulus: &Odd<Uint<LIMBS>>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {
     let (mut lower, mut upper) = *lower_upper;
-    let meta_carry =
-        impl_montgomery_reduction!(upper.limbs, lower.limbs, &modulus.limbs, mod_neg_inv, LIMBS);
+    let meta_carry = impl_montgomery_reduction!(
+        upper.limbs,
+        lower.limbs,
+        &modulus.0.limbs,
+        mod_neg_inv,
+        LIMBS
+    );
 
     // Division is simply taking the upper half of the limbs
     // Final reduction (at this point, the value is at most 2 * modulus,
     // so `meta_carry` is either 0 or 1)
-    upper.sub_mod_with_carry(meta_carry, modulus, modulus)
+    upper.sub_mod_with_carry(meta_carry, &modulus.0, &modulus.0)
 }
 
 /// Algorithm 14.32 in Handbook of Applied Cryptography <https://cacr.uwaterloo.ca/hac/about/chap14.pdf>

--- a/src/modular/sub.rs
+++ b/src/modular/sub.rs
@@ -1,9 +1,9 @@
-use crate::Uint;
+use crate::{Odd, Uint};
 
 pub(crate) const fn sub_montgomery_form<const LIMBS: usize>(
     a: &Uint<LIMBS>,
     b: &Uint<LIMBS>,
-    modulus: &Uint<LIMBS>,
+    modulus: &Odd<Uint<LIMBS>>,
 ) -> Uint<LIMBS> {
-    a.sub_mod(b, modulus)
+    a.sub_mod(b, &modulus.0)
 }

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -4,6 +4,9 @@ use crate::{Integer, NonZero, Uint};
 use core::{cmp::Ordering, ops::Deref};
 use subtle::{Choice, ConditionallySelectable, CtOption};
 
+#[cfg(feature = "alloc")]
+use crate::BoxedUint;
+
 #[cfg(feature = "rand_core")]
 use {crate::Random, rand_core::CryptoRngCore};
 
@@ -100,6 +103,20 @@ impl<const LIMBS: usize> PartialEq<Odd<Uint<LIMBS>>> for Uint<LIMBS> {
 
 impl<const LIMBS: usize> PartialOrd<Odd<Uint<LIMBS>>> for Uint<LIMBS> {
     fn partial_cmp(&self, other: &Odd<Uint<LIMBS>>) -> Option<Ordering> {
+        Some(self.cmp(&other.0))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl PartialEq<Odd<BoxedUint>> for BoxedUint {
+    fn eq(&self, other: &Odd<BoxedUint>) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl PartialOrd<Odd<BoxedUint>> for BoxedUint {
+    fn partial_cmp(&self, other: &Odd<BoxedUint>) -> Option<Ordering> {
         Some(self.cmp(&other.0))
     }
 }

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -1,6 +1,6 @@
 //! Wrapper type for non-zero integers.
 
-use crate::{Integer, NonZero};
+use crate::{Integer, NonZero, Uint};
 use core::ops::Deref;
 use subtle::{Choice, ConditionallySelectable, CtOption};
 
@@ -37,6 +37,26 @@ impl<T> Odd<T> {
     /// Returns the inner value.
     pub fn get(self) -> T {
         self.0
+    }
+}
+
+impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
+    /// Create a new [`Odd<Uint<LIMBS>>`] from the provided big endian hex string.
+    ///
+    /// Panics if the hex is malformed or not zero-padded accordingly for the size, or if the value is even.
+    pub const fn from_be_hex(hex: &str) -> Self {
+        let uint = Uint::<LIMBS>::from_be_hex(hex);
+        assert!(uint.is_odd().is_true_vartime(), "number must be odd");
+        Odd(uint)
+    }
+
+    /// Create a new [`Odd<Uint<LIMBS>>`] from the provided little endian hex string.
+    ///
+    /// Panics if the hex is malformed or not zero-padded accordingly for the size, or if the value is even.
+    pub const fn from_le_hex(hex: &str) -> Self {
+        let uint = Uint::<LIMBS>::from_be_hex(hex);
+        assert!(uint.is_odd().is_true_vartime(), "number must be odd");
+        Odd(uint)
     }
 }
 

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -1,7 +1,7 @@
 //! Wrapper type for non-zero integers.
 
 use crate::{Integer, NonZero, Uint};
-use core::ops::Deref;
+use core::{cmp::Ordering, ops::Deref};
 use subtle::{Choice, ConditionallySelectable, CtOption};
 
 #[cfg(feature = "rand_core")]
@@ -89,6 +89,18 @@ impl<T> Deref for Odd<T> {
 
     fn deref(&self) -> &T {
         &self.0
+    }
+}
+
+impl<const LIMBS: usize> PartialEq<Odd<Uint<LIMBS>>> for Uint<LIMBS> {
+    fn eq(&self, other: &Odd<Uint<LIMBS>>) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl<const LIMBS: usize> PartialOrd<Odd<Uint<LIMBS>>> for Uint<LIMBS> {
+    fn partial_cmp(&self, other: &Odd<Uint<LIMBS>>) -> Option<Ordering> {
+        Some(self.cmp(&other.0))
     }
 }
 

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -4,6 +4,9 @@ use crate::{Integer, NonZero, Uint};
 use core::ops::Deref;
 use subtle::{Choice, ConditionallySelectable, CtOption};
 
+#[cfg(feature = "rand_core")]
+use {crate::Random, rand_core::CryptoRngCore};
+
 /// Wrapper type for odd integers.
 ///
 /// These are frequently used in cryptography, e.g. as a modulus.
@@ -86,5 +89,13 @@ impl<T> Deref for Odd<T> {
 
     fn deref(&self) -> &T {
         &self.0
+    }
+}
+
+#[cfg(feature = "rand_core")]
+impl<const LIMBS: usize> Random for Odd<Uint<LIMBS>> {
+    /// Generate a random `NonZero<Uint<T>>`.
+    fn random(rng: &mut impl CryptoRngCore) -> Self {
+        Odd(Uint::random(rng) | Uint::ONE)
     }
 }

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -1,0 +1,70 @@
+//! Wrapper type for non-zero integers.
+
+use crate::{Integer, NonZero};
+use core::ops::Deref;
+use subtle::{Choice, ConditionallySelectable, CtOption};
+
+/// Wrapper type for odd integers.
+///
+/// These are frequently used in cryptography, e.g. as a modulus.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Odd<T>(pub(crate) T);
+
+impl<T> Odd<T> {
+    /// Create a new odd integer.
+    pub fn new(n: T) -> CtOption<Self>
+    where
+        T: Integer,
+    {
+        let is_odd = n.is_odd();
+        CtOption::new(Self(n), is_odd)
+    }
+
+    /// Provides access to the contents of [`Odd`] in a `const` context.
+    pub const fn as_ref(&self) -> &T {
+        &self.0
+    }
+
+    /// All odd integers are definitionally non-zero, so we can also obtain a reference to [`NonZero`].
+    pub const fn as_nz_ref(&self) -> &NonZero<T> {
+        #[allow(trivial_casts, unsafe_code)]
+        unsafe {
+            &*(&self.0 as *const T as *const NonZero<T>)
+        }
+    }
+
+    /// Returns the inner value.
+    pub fn get(self) -> T {
+        self.0
+    }
+}
+
+impl<T> AsRef<T> for Odd<T> {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> AsRef<NonZero<T>> for Odd<T> {
+    fn as_ref(&self) -> &NonZero<T> {
+        self.as_nz_ref()
+    }
+}
+
+impl<T> ConditionallySelectable for Odd<T>
+where
+    T: ConditionallySelectable,
+{
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        Self(T::conditional_select(&a.0, &b.0, choice))
+    }
+}
+
+impl<T> Deref for Odd<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -8,7 +8,10 @@ use subtle::{Choice, ConditionallySelectable, CtOption};
 use crate::BoxedUint;
 
 #[cfg(feature = "rand_core")]
-use {crate::Random, rand_core::CryptoRngCore};
+use {
+    crate::{Limb, Random},
+    rand_core::CryptoRngCore,
+};
 
 /// Wrapper type for odd integers.
 ///
@@ -125,6 +128,18 @@ impl PartialOrd<Odd<BoxedUint>> for BoxedUint {
 impl<const LIMBS: usize> Random for Odd<Uint<LIMBS>> {
     /// Generate a random `NonZero<Uint<T>>`.
     fn random(rng: &mut impl CryptoRngCore) -> Self {
-        Odd(Uint::random(rng) | Uint::ONE)
+        let mut ret = Uint::random(rng);
+        ret.limbs[0] &= Limb::ONE;
+        Odd(ret)
+    }
+}
+
+#[cfg(all(feature = "alloc", feature = "rand_core"))]
+impl Odd<BoxedUint> {
+    /// Generate a random `NonZero<Uint<T>>`.
+    pub fn random(rng: &mut impl CryptoRngCore, bits_precision: u32) -> Self {
+        let mut ret = BoxedUint::random(rng, bits_precision);
+        ret.limbs[0] &= Limb::ONE;
+        Odd(ret)
     }
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -41,7 +41,7 @@ mod rand;
 
 use crate::{
     modular::{BernsteinYangInverter, MontyForm},
-    Bounded, ConstCtOption, Constants, Encoding, FixedInteger, Integer, Limb, NonZero,
+    Bounded, ConstCtOption, Constants, Encoding, FixedInteger, Integer, Limb, NonZero, Odd,
     PrecomputeInverter, PrecomputeInverterWithAdjuster, Word, ZeroConstant,
 };
 use core::fmt;
@@ -171,11 +171,18 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         self.limbs
     }
 
-    /// Convert to a [`NonZero<Limb>`].
+    /// Convert to a [`NonZero<Uint<LIMBS>>`].
     ///
     /// Returns some if the original value is non-zero, and false otherwise.
     pub const fn to_nz(self) -> ConstCtOption<NonZero<Self>> {
         ConstCtOption::new(NonZero(self), self.is_nonzero())
+    }
+
+    /// Convert to a [`Odd<Uint<LIMBS>>`].
+    ///
+    /// Returns some if the original value is odd, and false otherwise.
+    pub const fn to_odd(self) -> ConstCtOption<Odd<Self>> {
+        ConstCtOption::new(Odd(self), self.is_odd())
     }
 }
 

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -25,10 +25,10 @@ mod sub_mod;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{modular::BoxedMontyForm, Integer, Limb, NonZero, Word, Zero};
+use crate::{modular::BoxedMontyForm, Integer, Limb, NonZero, Odd, Word, Zero};
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::fmt;
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -164,6 +164,12 @@ impl BoxedUint {
     /// Get the number of limbs in this [`BoxedUint`].
     pub fn nlimbs(&self) -> usize {
         self.limbs.len()
+    }
+
+    /// Convert into an [`Odd`].
+    pub fn to_odd(self) -> CtOption<Odd<Self>> {
+        let is_odd = self.is_odd();
+        CtOption::new(Odd(self), is_odd)
     }
 
     /// Widen this type's precision to the given number of bits.

--- a/src/uint/boxed/inv_mod.rs
+++ b/src/uint/boxed/inv_mod.rs
@@ -38,8 +38,8 @@ impl BoxedUint {
     /// Computes 1/`self` mod `2^k`.
     ///
     /// If the inverse does not exist (`k > 0` and `self` is even),
-    /// returns `ConstChoice::FALSE` as the second element of the tuple,
-    /// otherwise returns `ConstChoice::TRUE`.
+    /// returns `Choice::FALSE` as the second element of the tuple,
+    /// otherwise returns `Choice::TRUE`.
     pub(crate) fn inv_mod2k(&self, k: u32) -> (Self, Choice) {
         let mut x = Self::zero_with_precision(self.bits_precision()); // keeps `x` during iterations
         let mut b = Self::one_with_precision(self.bits_precision()); // keeps `b_i` during iterations

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -3,7 +3,7 @@
 use crate::{
     modular::{BoxedMontyForm, BoxedMontyParams},
     primitives::mul_rem,
-    BoxedUint, Limb, MulMod, WideWord, Word,
+    BoxedUint, Limb, MulMod, Odd, WideWord, Word,
 };
 
 impl BoxedUint {
@@ -18,8 +18,9 @@ impl BoxedUint {
         // Barrett reduction instead.
         //
         // It's worth potentially exploring other approaches to improve efficiency.
-        match Option::<BoxedMontyParams>::from(BoxedMontyParams::new(p.clone())) {
-            Some(params) => {
+        match Odd::new(p.clone()).into() {
+            Some(p) => {
+                let params = BoxedMontyParams::new(p);
                 let lhs = BoxedMontyForm::new(self.clone(), params.clone());
                 let rhs = BoxedMontyForm::new(rhs.clone(), params);
                 let ret = lhs * rhs;

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -38,6 +38,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Create a new [`Uint`] from the provided big endian hex string.
+    ///
+    /// Panics if the hex is malformed or not zero-padded accordingly for the size.
     pub const fn from_be_hex(hex: &str) -> Self {
         let bytes = hex.as_bytes();
 
@@ -94,6 +96,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Create a new [`Uint`] from the provided little endian hex string.
+    ///
+    /// Panics if the hex is malformed or not zero-padded accordingly for the size.
     pub const fn from_le_hex(hex: &str) -> Self {
         let bytes = hex.as_bytes();
 

--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -20,7 +20,8 @@ macro_rules! impl_precompute_inverter_trait {
 
         impl PrecomputeInverterWithAdjuster for $name {
             fn precompute_inverter_with_adjuster(&self, adjuster: &Self) -> Self::Inverter {
-                Self::Inverter::new(self, adjuster).expect("modulus must be odd")
+                let modulus = self.to_odd().expect("modulus must be odd");
+                Self::Inverter::new(&modulus, adjuster)
             }
         }
     };

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -18,8 +18,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // Barrett reduction instead.
         //
         // It's worth potentially exploring other approaches to improve efficiency.
-        match MontyParams::new(p).into() {
-            Some(params) => {
+        match p.to_odd().into() {
+            Some(odd_p) => {
+                let params = MontyParams::new(odd_p);
                 let lhs = MontyForm::new(self, params);
                 let rhs = MontyForm::new(rhs, params);
                 let ret = lhs * rhs;

--- a/tests/boxed_monty_form.rs
+++ b/tests/boxed_monty_form.rs
@@ -4,7 +4,7 @@
 
 use crypto_bigint::{
     modular::{BoxedMontyForm, BoxedMontyParams},
-    BoxedUint, Integer, Limb, NonZero,
+    BoxedUint, Integer, Limb, NonZero, Odd,
 };
 use num_bigint::{BigUint, ModInverse};
 use proptest::prelude::*;
@@ -48,7 +48,7 @@ prop_compose! {
             n = n.wrapping_add(&BoxedUint::one());
         }
 
-        BoxedMontyParams::new(n).expect("modulus should be valid")
+        BoxedMontyParams::new(Odd::new(n).expect("modulus should be odd"))
     }
 }
 prop_compose! {
@@ -71,8 +71,9 @@ proptest! {
             n = n.wrapping_add(&BoxedUint::one());
         }
 
-        let params1 = BoxedMontyParams::new(n.clone()).unwrap();
-        let params2 = BoxedMontyParams::new_vartime(n).unwrap();
+        let n = Odd::new(n).expect("ensured odd");
+        let params1 = BoxedMontyParams::new(n.clone());
+        let params2 = BoxedMontyParams::new_vartime(n);
         prop_assert_eq!(params1, params2);
     }
 

--- a/tests/monty_form.rs
+++ b/tests/monty_form.rs
@@ -1,6 +1,6 @@
 //! Equivalence tests between `crypto_bigint::MontyForm` and `num-bigint`.
 
-use crypto_bigint::{Encoding, Integer, Invert, Inverter, NonZero, PrecomputeInverter, U256};
+use crypto_bigint::{Encoding, Integer, Invert, Inverter, NonZero, Odd, PrecomputeInverter, U256};
 use num_bigint::{BigUint, ModInverse};
 use proptest::prelude::*;
 
@@ -33,7 +33,7 @@ prop_compose! {
             n = n.wrapping_add(&U256::one());
         }
 
-        MontyParams::new(&n).expect("modulus should be valid")
+        MontyParams::new(Odd::new(n).expect("modulus ensured odd"))
     }
 }
 

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -2,7 +2,7 @@
 
 use crypto_bigint::{
     modular::{MontyForm, MontyParams},
-    Encoding, Integer, Limb, NonZero, Word, U256,
+    Encoding, Integer, Limb, NonZero, Odd, Word, U256,
 };
 use num_bigint::BigUint;
 use num_integer::Integer as _;
@@ -11,8 +11,8 @@ use proptest::prelude::*;
 use std::mem;
 
 /// Example prime number (NIST P-256 curve order)
-const P: U256 =
-    U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
+const P: Odd<U256> =
+    Odd::<U256>::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
 
 fn to_biguint(uint: &U256) -> BigUint {
     BigUint::from_bytes_le(uint.to_le_bytes().as_ref())
@@ -33,7 +33,7 @@ prop_compose! {
     }
 }
 prop_compose! {
-    fn uint_mod_p(p: U256)(a in uint()) -> U256 {
+    fn uint_mod_p(p: Odd<U256>)(a in uint()) -> U256 {
         a.wrapping_rem(&p)
     }
 }
@@ -141,8 +141,8 @@ proptest! {
 
     #[test]
     fn add_mod_nist_p256(a in uint_mod_p(P), b in uint_mod_p(P)) {
-        assert!(a < P);
-        assert!(b < P);
+        assert!(a < *P);
+        assert!(b < *P);
 
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);
@@ -151,8 +151,8 @@ proptest! {
         let expected = to_uint((a_bi + b_bi) % p_bi);
         let actual = a.add_mod(&b, &P);
 
-        assert!(expected < P);
-        assert!(actual < P);
+        assert!(expected < *P);
+        assert!(actual < *P);
 
         assert_eq!(expected, actual);
     }
@@ -163,8 +163,8 @@ proptest! {
             mem::swap(&mut a, &mut b);
         }
 
-        assert!(a < P);
-        assert!(b < P);
+        assert!(a < *P);
+        assert!(b < *P);
 
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);
@@ -173,16 +173,16 @@ proptest! {
         let expected = to_uint((a_bi - b_bi) % p_bi);
         let actual = a.sub_mod(&b, &P);
 
-        assert!(expected < P);
-        assert!(actual < P);
+        assert!(expected < *P);
+        assert!(actual < *P);
 
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn mul_mod_nist_p256(a in uint_mod_p(P), b in uint_mod_p(P)) {
-        assert!(a < P);
-        assert!(b < P);
+        assert!(a < *P);
+        assert!(b < *P);
 
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);
@@ -191,8 +191,8 @@ proptest! {
         let expected = to_uint((a_bi * b_bi) % p_bi);
         let actual = a.mul_mod(&b, &P);
 
-        assert!(expected < P);
-        assert!(actual < P);
+        assert!(expected < *P);
+        assert!(actual < *P);
 
         assert_eq!(expected, actual);
     }
@@ -404,7 +404,7 @@ proptest! {
 
         let expected = to_uint(a_bi.modpow(&b_bi, &p_bi));
 
-        let params = MontyParams::new(&P).unwrap();
+        let params = MontyParams::new(P);
         let a_m = MontyForm::new(&a, params);
         let actual = a_m.pow(&b).retrieve();
 
@@ -421,7 +421,7 @@ proptest! {
 
         let expected = to_uint(a_bi.modpow(&b_bi, &p_bi));
 
-        let params = MontyParams::new(&P).unwrap();
+        let params = MontyParams::new(P);
         let a_m = MontyForm::new(&a, params);
         let actual = a_m.pow_bounded_exp(&b, exponent_bits.into()).retrieve();
 
@@ -442,7 +442,7 @@ proptest! {
         };
         let expected = to_uint(expected);
 
-        let params = MontyParams::new(&P).unwrap();
+        let params = MontyParams::new(P);
         let a_m = MontyForm::new(&a, params);
         let actual = a_m.div_by_2().retrieve();
 

--- a/tests/uint_proptests.rs
+++ b/tests/uint_proptests.rs
@@ -141,8 +141,8 @@ proptest! {
 
     #[test]
     fn add_mod_nist_p256(a in uint_mod_p(P), b in uint_mod_p(P)) {
-        assert!(a < *P);
-        assert!(b < *P);
+        assert!(a < P);
+        assert!(b < P);
 
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);
@@ -151,8 +151,8 @@ proptest! {
         let expected = to_uint((a_bi + b_bi) % p_bi);
         let actual = a.add_mod(&b, &P);
 
-        assert!(expected < *P);
-        assert!(actual < *P);
+        assert!(expected < P);
+        assert!(actual < P);
 
         assert_eq!(expected, actual);
     }
@@ -163,8 +163,8 @@ proptest! {
             mem::swap(&mut a, &mut b);
         }
 
-        assert!(a < *P);
-        assert!(b < *P);
+        assert!(a < P);
+        assert!(b < P);
 
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);
@@ -173,16 +173,16 @@ proptest! {
         let expected = to_uint((a_bi - b_bi) % p_bi);
         let actual = a.sub_mod(&b, &P);
 
-        assert!(expected < *P);
-        assert!(actual < *P);
+        assert!(expected < P);
+        assert!(actual < P);
 
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn mul_mod_nist_p256(a in uint_mod_p(P), b in uint_mod_p(P)) {
-        assert!(a < *P);
-        assert!(b < *P);
+        assert!(a < P);
+        assert!(b < P);
 
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);
@@ -191,8 +191,8 @@ proptest! {
         let expected = to_uint((a_bi * b_bi) % p_bi);
         let actual = a.mul_mod(&b, &P);
 
-        assert!(expected < *P);
-        assert!(actual < *P);
+        assert!(expected < P);
+        assert!(actual < P);
 
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
Adds a newtype similar to `NonZero` which identifies odd integers at the type level.

This can be used for infallible conversions for moduli, i.e. reusing a `*MontParams` modulus as a Bernstein-Yang modulus infallibly.

Closes #479 