### PR TITLE
Add `Gcd` trait

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -197,6 +197,27 @@ pub trait FixedInteger: Bounded + ConditionallySelectable + Constants + Copy + I
     const LIMBS: usize;
 }
 
+/// Compute greatest common divisor of two integers.
+pub trait Gcd<Rhs = Self>: Sized {
+    /// Output type.
+    type Output;
+
+    /// Compute greatest common divisor of `self` and `rhs`.
+    ///
+    /// Returns none unless `self` is odd (`rhs` may be even or odd)`.
+    fn gcd(&self, rhs: &Rhs) -> Self::Output;
+}
+
+/// Trait impl'd by precomputed modular inverters obtained via the [`PrecomputeInverter`] trait.
+pub trait Inverter {
+    /// Output of an inversion.
+    type Output;
+
+    /// Compute a modular inversion, returning `None` if the result is undefined (i.e. if `value` is zero or isn't
+    /// prime relative to the modulus).
+    fn invert(&self, value: &Self::Output) -> CtOption<Self::Output>;
+}
+
 /// Obtain a precomputed inverter for efficiently computing modular inversions for a given modulus.
 pub trait PrecomputeInverter {
     /// Inverter type for integers of this size.
@@ -209,16 +230,6 @@ pub trait PrecomputeInverter {
     ///
     /// Returns `None` if `self` is even.
     fn precompute_inverter(&self) -> Self::Inverter;
-}
-
-/// Trait impl'd by precomputed modular inverters.
-pub trait Inverter {
-    /// Output of an inversion.
-    type Output;
-
-    /// Compute a modular inversion, returning `None` if the result is undefined (i.e. if `value` is zero or isn't
-    /// prime relative to the modulus).
-    fn invert(&self, value: &Self::Output) -> CtOption<Self::Output>;
 }
 
 /// Zero values.

--- a/src/uint/boxed/gcd.rs
+++ b/src/uint/boxed/gcd.rs
@@ -1,18 +1,29 @@
 //! Support for computing greatest common divisor of two `BoxedUint`s.
 
 use super::BoxedUint;
-use crate::{modular::bernstein_yang, Odd};
+use crate::{modular::bernstein_yang, Gcd, Integer, Odd};
+use subtle::CtOption;
 
-impl Odd<BoxedUint> {
-    /// Compute the greatest common divisor (GCD) of this number and another.
-    pub fn gcd(&self, rhs: &BoxedUint) -> BoxedUint {
+impl Gcd for BoxedUint {
+    type Output = CtOption<Self>;
+
+    fn gcd(&self, rhs: &Self) -> CtOption<Self> {
+        let ret = bernstein_yang::boxed::gcd(self, rhs);
+        CtOption::new(ret, self.is_odd())
+    }
+}
+
+impl Gcd<BoxedUint> for Odd<BoxedUint> {
+    type Output = BoxedUint;
+
+    fn gcd(&self, rhs: &BoxedUint) -> BoxedUint {
         bernstein_yang::boxed::gcd(self, rhs)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::BoxedUint;
+    use crate::{BoxedUint, Gcd};
 
     #[test]
     fn gcd_relatively_prime() {

--- a/src/uint/gcd.rs
+++ b/src/uint/gcd.rs
@@ -1,7 +1,7 @@
 //! Support for computing greatest common divisor of two `Uint`s.
 
-use super::Uint;
-use crate::{modular::BernsteinYangInverter, ConstCtOption, PrecomputeInverter};
+use crate::{modular::BernsteinYangInverter, ConstCtOption, Gcd, Odd, PrecomputeInverter, Uint};
+use subtle::CtOption;
 
 impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> Uint<SAT_LIMBS>
 where
@@ -13,6 +13,28 @@ where
     pub const fn gcd(&self, rhs: &Self) -> ConstCtOption<Self> {
         let ret = <Self as PrecomputeInverter>::Inverter::gcd(self, rhs);
         ConstCtOption::new(ret, self.is_odd())
+    }
+}
+
+impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> Gcd for Uint<SAT_LIMBS>
+where
+    Self: PrecomputeInverter<Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>>,
+{
+    type Output = CtOption<Uint<SAT_LIMBS>>;
+
+    fn gcd(&self, rhs: &Self) -> CtOption<Self> {
+        self.gcd(rhs).into()
+    }
+}
+
+impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> Gcd<Uint<SAT_LIMBS>> for Odd<Uint<SAT_LIMBS>>
+where
+    Self: PrecomputeInverter<Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>>,
+{
+    type Output = Uint<SAT_LIMBS>;
+
+    fn gcd(&self, rhs: &Uint<SAT_LIMBS>) -> Uint<SAT_LIMBS> {
+        <Self as PrecomputeInverter>::Inverter::gcd(self, rhs)
     }
 }
 

--- a/tests/boxed_uint_proptests.rs
+++ b/tests/boxed_uint_proptests.rs
@@ -3,7 +3,7 @@
 #![cfg(feature = "alloc")]
 
 use core::cmp::Ordering;
-use crypto_bigint::{BoxedUint, CheckedAdd, Integer, Limb, NonZero};
+use crypto_bigint::{BoxedUint, CheckedAdd, Gcd, Integer, Limb, NonZero};
 use num_bigint::{BigUint, ModInverse};
 use num_integer::Integer as _;
 use num_traits::identities::One;


### PR DESCRIPTION
Adds a trait for computing the greatest common divisor of two numbers.

Uses a fallible impl for the `*Uint` types, and an infallible one for `Odd<*Uint>`.