### PR TITLE
Impl `PrecomputeInterver(WithAdjuster)` on `Odd`

### DIFF
--- a/src/modular/boxed_monty_form/inv.rs
+++ b/src/modular/boxed_monty_form/inv.rs
@@ -33,7 +33,7 @@ impl PrecomputeInverter for BoxedMontyParams {
 
     fn precompute_inverter(&self) -> BoxedMontyFormInverter {
         BoxedMontyFormInverter {
-            inverter: self.modulus.0.precompute_inverter_with_adjuster(&self.r2),
+            inverter: self.modulus.precompute_inverter_with_adjuster(&self.r2),
             params: self.clone().into(),
         }
     }

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -55,7 +55,7 @@ pub trait ConstMontyParams<const LIMBS: usize>:
     /// Use [`ConstMontyFormInverter::new`] if you need `const fn` access.
     fn precompute_inverter<const UNSAT_LIMBS: usize>() -> ConstMontyFormInverter<Self, LIMBS>
     where
-        Uint<LIMBS>: PrecomputeInverter<
+        Odd<Uint<LIMBS>>: PrecomputeInverter<
             Inverter = BernsteinYangInverter<LIMBS, UNSAT_LIMBS>,
             Output = Uint<LIMBS>,
         >,

--- a/src/modular/const_monty_form/inv.rs
+++ b/src/modular/const_monty_form/inv.rs
@@ -2,7 +2,7 @@
 
 use super::{ConstMontyForm, ConstMontyParams};
 use crate::{
-    modular::BernsteinYangInverter, ConstCtOption, Invert, Inverter, PrecomputeInverter, Uint,
+    modular::BernsteinYangInverter, ConstCtOption, Invert, Inverter, Odd, PrecomputeInverter, Uint,
 };
 use core::{fmt, marker::PhantomData};
 use subtle::CtOption;
@@ -10,7 +10,7 @@ use subtle::CtOption;
 impl<MOD: ConstMontyParams<SAT_LIMBS>, const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
     ConstMontyForm<MOD, SAT_LIMBS>
 where
-    Uint<SAT_LIMBS>: PrecomputeInverter<
+    Odd<Uint<SAT_LIMBS>>: PrecomputeInverter<
         Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>,
         Output = Uint<SAT_LIMBS>,
     >,
@@ -21,7 +21,7 @@ where
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
     pub const fn inv(&self) -> ConstCtOption<Self> {
         let inverter =
-            <Uint<SAT_LIMBS> as PrecomputeInverter>::Inverter::new(&MOD::MODULUS, &MOD::R2);
+            <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(&MOD::MODULUS, &MOD::R2);
 
         let maybe_inverse = inverter.inv(&self.montgomery_form);
         let (inverse, inverse_is_some) = maybe_inverse.components_ref();
@@ -38,7 +38,7 @@ where
 impl<MOD: ConstMontyParams<SAT_LIMBS>, const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> Invert
     for ConstMontyForm<MOD, SAT_LIMBS>
 where
-    Uint<SAT_LIMBS>: PrecomputeInverter<
+    Odd<Uint<SAT_LIMBS>>: PrecomputeInverter<
         Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>,
         Output = Uint<SAT_LIMBS>,
     >,
@@ -52,16 +52,16 @@ where
 /// Bernstein-Yang inverter which inverts [`ConstMontyForm`] types.
 pub struct ConstMontyFormInverter<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize>
 where
-    Uint<LIMBS>: PrecomputeInverter<Output = Uint<LIMBS>>,
+    Odd<Uint<LIMBS>>: PrecomputeInverter<Output = Uint<LIMBS>>,
 {
-    inverter: <Uint<LIMBS> as PrecomputeInverter>::Inverter,
+    inverter: <Odd<Uint<LIMBS>> as PrecomputeInverter>::Inverter,
     phantom: PhantomData<MOD>,
 }
 
 impl<MOD: ConstMontyParams<SAT_LIMBS>, const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
     ConstMontyFormInverter<MOD, SAT_LIMBS>
 where
-    Uint<SAT_LIMBS>: PrecomputeInverter<
+    Odd<Uint<SAT_LIMBS>>: PrecomputeInverter<
         Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>,
         Output = Uint<SAT_LIMBS>,
     >,
@@ -95,7 +95,7 @@ where
 impl<MOD: ConstMontyParams<SAT_LIMBS>, const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> Inverter
     for ConstMontyFormInverter<MOD, SAT_LIMBS>
 where
-    Uint<SAT_LIMBS>: PrecomputeInverter<
+    Odd<Uint<SAT_LIMBS>>: PrecomputeInverter<
         Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>,
         Output = Uint<SAT_LIMBS>,
     >,
@@ -110,7 +110,7 @@ where
 impl<MOD: ConstMontyParams<SAT_LIMBS>, const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> fmt::Debug
     for ConstMontyFormInverter<MOD, SAT_LIMBS>
 where
-    Uint<SAT_LIMBS>: PrecomputeInverter<
+    Odd<Uint<SAT_LIMBS>>: PrecomputeInverter<
         Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>,
         Output = Uint<SAT_LIMBS>,
     >,

--- a/src/modular/monty_form/inv.rs
+++ b/src/modular/monty_form/inv.rs
@@ -2,15 +2,15 @@
 
 use super::{MontyForm, MontyParams};
 use crate::{
-    modular::BernsteinYangInverter, traits::Invert, ConstCtOption, Inverter, PrecomputeInverter,
-    PrecomputeInverterWithAdjuster, Uint,
+    modular::BernsteinYangInverter, traits::Invert, ConstCtOption, Inverter, Odd,
+    PrecomputeInverter, PrecomputeInverterWithAdjuster, Uint,
 };
 use core::fmt;
 use subtle::CtOption;
 
 impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> MontyForm<SAT_LIMBS>
 where
-    Uint<SAT_LIMBS>: PrecomputeInverter<
+    Odd<Uint<SAT_LIMBS>>: PrecomputeInverter<
         Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>,
         Output = Uint<SAT_LIMBS>,
     >,
@@ -20,7 +20,7 @@ where
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
     pub const fn inv(&self) -> ConstCtOption<Self> {
-        let inverter = <Uint<SAT_LIMBS> as PrecomputeInverter>::Inverter::new(
+        let inverter = <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(
             &self.params.modulus,
             &self.params.r2,
         );
@@ -39,7 +39,7 @@ where
 
 impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> Invert for MontyForm<SAT_LIMBS>
 where
-    Uint<SAT_LIMBS>: PrecomputeInverter<
+    Odd<Uint<SAT_LIMBS>>: PrecomputeInverter<
         Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>,
         Output = Uint<SAT_LIMBS>,
     >,
@@ -53,7 +53,8 @@ where
 
 impl<const LIMBS: usize> PrecomputeInverter for MontyParams<LIMBS>
 where
-    Uint<LIMBS>: PrecomputeInverter<Output = Uint<LIMBS>> + PrecomputeInverterWithAdjuster,
+    Odd<Uint<LIMBS>>:
+        PrecomputeInverter<Output = Uint<LIMBS>> + PrecomputeInverterWithAdjuster<Uint<LIMBS>>,
 {
     type Inverter = MontyFormInverter<LIMBS>;
     type Output = MontyForm<LIMBS>;
@@ -69,15 +70,15 @@ where
 /// Bernstein-Yang inverter which inverts [`MontyForm`] types.
 pub struct MontyFormInverter<const LIMBS: usize>
 where
-    Uint<LIMBS>: PrecomputeInverter<Output = Uint<LIMBS>>,
+    Odd<Uint<LIMBS>>: PrecomputeInverter<Output = Uint<LIMBS>>,
 {
-    inverter: <Uint<LIMBS> as PrecomputeInverter>::Inverter,
+    inverter: <Odd<Uint<LIMBS>> as PrecomputeInverter>::Inverter,
     params: MontyParams<LIMBS>,
 }
 
 impl<const LIMBS: usize> Inverter for MontyFormInverter<LIMBS>
 where
-    Uint<LIMBS>: PrecomputeInverter<Output = Uint<LIMBS>>,
+    Odd<Uint<LIMBS>>: PrecomputeInverter<Output = Uint<LIMBS>>,
 {
     type Output = MontyForm<LIMBS>;
 
@@ -95,7 +96,7 @@ where
 
 impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> fmt::Debug for MontyFormInverter<SAT_LIMBS>
 where
-    Uint<SAT_LIMBS>: PrecomputeInverter<
+    Odd<Uint<SAT_LIMBS>>: PrecomputeInverter<
         Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>,
         Output = Uint<SAT_LIMBS>,
     >,

--- a/src/traits/sealed.rs
+++ b/src/traits/sealed.rs
@@ -3,8 +3,8 @@
 use super::PrecomputeInverter;
 
 /// Obtain a precomputed inverter which applies the given adjustment factor, i.e. for Montgomery form.
-pub trait PrecomputeInverterWithAdjuster: PrecomputeInverter {
+pub trait PrecomputeInverterWithAdjuster<Adjuster>: PrecomputeInverter {
     /// Obtain a precomputed inverter for `&self` as the modulus, supplying a custom adjusting parameter (e.g. R^2 for
     /// when computing inversions in Montgomery form).
-    fn precompute_inverter_with_adjuster(&self, adjuster: &Self) -> Self::Inverter;
+    fn precompute_inverter_with_adjuster(&self, adjuster: &Adjuster) -> Self::Inverter;
 }

--- a/src/uint/boxed/from.rs
+++ b/src/uint/boxed/from.rs
@@ -1,6 +1,6 @@
 //! `From`-like conversions for [`BoxedUint`].
 
-use crate::{BoxedUint, Limb, Uint, Word, U128, U64};
+use crate::{BoxedUint, Limb, Odd, Uint, Word, U128, U64};
 use alloc::{boxed::Box, vec::Vec};
 use core::mem;
 
@@ -92,5 +92,33 @@ impl<const LIMBS: usize> From<&Uint<LIMBS>> for BoxedUint {
     #[inline]
     fn from(uint: &Uint<LIMBS>) -> BoxedUint {
         Vec::from(uint.to_limbs()).into()
+    }
+}
+
+impl<const LIMBS: usize> From<Odd<Uint<LIMBS>>> for BoxedUint {
+    #[inline]
+    fn from(uint: Odd<Uint<LIMBS>>) -> BoxedUint {
+        Self::from(&uint.0)
+    }
+}
+
+impl<const LIMBS: usize> From<&Odd<Uint<LIMBS>>> for BoxedUint {
+    #[inline]
+    fn from(uint: &Odd<Uint<LIMBS>>) -> BoxedUint {
+        Self::from(&uint.0)
+    }
+}
+
+impl<const LIMBS: usize> From<Odd<Uint<LIMBS>>> for Odd<BoxedUint> {
+    #[inline]
+    fn from(uint: Odd<Uint<LIMBS>>) -> Odd<BoxedUint> {
+        Odd(BoxedUint::from(&uint.0))
+    }
+}
+
+impl<const LIMBS: usize> From<&Odd<Uint<LIMBS>>> for Odd<BoxedUint> {
+    #[inline]
+    fn from(uint: &Odd<Uint<LIMBS>>) -> Odd<BoxedUint> {
+        Odd(BoxedUint::from(&uint.0))
     }
 }

--- a/src/uint/boxed/inv_mod.rs
+++ b/src/uint/boxed/inv_mod.rs
@@ -1,7 +1,7 @@
 //! [`BoxedUint`] modular inverse (i.e. reciprocal) operations.
 
 use crate::{
-    modular::BoxedBernsteinYangInverter, BoxedUint, ConstantTimeSelect, Integer,
+    modular::BoxedBernsteinYangInverter, BoxedUint, ConstantTimeSelect, Integer, Odd,
     PrecomputeInverter, PrecomputeInverterWithAdjuster,
 };
 use subtle::{Choice, ConstantTimeEq, ConstantTimeLess, CtOption};
@@ -146,22 +146,22 @@ impl BoxedUint {
 }
 
 /// Precompute a Bernstein-Yang inverter using `self` as the modulus.
-///
-/// Panics if called on an even number!
-impl PrecomputeInverter for BoxedUint {
+impl PrecomputeInverter for Odd<BoxedUint> {
     type Inverter = BoxedBernsteinYangInverter;
-    type Output = Self;
+    type Output = BoxedUint;
 
     fn precompute_inverter(&self) -> BoxedBernsteinYangInverter {
-        Self::precompute_inverter_with_adjuster(self, &Self::one())
+        Self::precompute_inverter_with_adjuster(self, &BoxedUint::one())
     }
 }
 
-// TODO(tarcieri): only impl these traits for `Odd`?
-impl PrecomputeInverterWithAdjuster for BoxedUint {
-    fn precompute_inverter_with_adjuster(&self, adjuster: &Self) -> BoxedBernsteinYangInverter {
-        let modulus = self.to_odd().expect("modulus must be odd");
-        BoxedBernsteinYangInverter::new(&modulus, adjuster)
+/// Precompute a Bernstein-Yang inverter using `self` as the modulus.
+impl PrecomputeInverterWithAdjuster<BoxedUint> for Odd<BoxedUint> {
+    fn precompute_inverter_with_adjuster(
+        &self,
+        adjuster: &BoxedUint,
+    ) -> BoxedBernsteinYangInverter {
+        BoxedBernsteinYangInverter::new(self, adjuster)
     }
 }
 

--- a/src/uint/gcd.rs
+++ b/src/uint/gcd.rs
@@ -5,20 +5,20 @@ use subtle::CtOption;
 
 impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> Uint<SAT_LIMBS>
 where
-    Self: PrecomputeInverter<Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>>,
+    Odd<Self>: PrecomputeInverter<Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>>,
 {
     /// Compute the greatest common divisor (GCD) of this number and another.
     ///
     /// Returns none in the event that `self` is even (i.e. `self` MUST be odd). However, `rhs` may be even.
     pub const fn gcd(&self, rhs: &Self) -> ConstCtOption<Self> {
-        let ret = <Self as PrecomputeInverter>::Inverter::gcd(self, rhs);
+        let ret = <Odd<Self> as PrecomputeInverter>::Inverter::gcd(self, rhs);
         ConstCtOption::new(ret, self.is_odd())
     }
 }
 
 impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> Gcd for Uint<SAT_LIMBS>
 where
-    Self: PrecomputeInverter<Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>>,
+    Odd<Self>: PrecomputeInverter<Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>>,
 {
     type Output = CtOption<Uint<SAT_LIMBS>>;
 
@@ -29,12 +29,12 @@ where
 
 impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> Gcd<Uint<SAT_LIMBS>> for Odd<Uint<SAT_LIMBS>>
 where
-    Self: PrecomputeInverter<Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>>,
+    Odd<Self>: PrecomputeInverter<Inverter = BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS>>,
 {
     type Output = Uint<SAT_LIMBS>;
 
     fn gcd(&self, rhs: &Uint<SAT_LIMBS>) -> Uint<SAT_LIMBS> {
-        <Self as PrecomputeInverter>::Inverter::gcd(self, rhs)
+        <Odd<Self> as PrecomputeInverter>::Inverter::gcd(self, rhs)
     }
 }
 

--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -3,8 +3,8 @@
 /// Impl the `Inverter` trait, where we need to compute the number of unsaturated limbs for a given number of bits.
 macro_rules! impl_precompute_inverter_trait {
     ($name:ident, $bits:expr) => {
-        /// Precompute a Bernstein-Yang inverter using `self` as the modulus. Panics if called on an even number!
-        impl PrecomputeInverter for $name {
+        /// Precompute a Bernstein-Yang inverter using `self` as the modulus.
+        impl PrecomputeInverter for Odd<$name> {
             #[allow(trivial_numeric_casts)]
             type Inverter = BernsteinYangInverter<
                 { nlimbs!($bits) },
@@ -14,15 +14,14 @@ macro_rules! impl_precompute_inverter_trait {
             type Output = $name;
 
             fn precompute_inverter(&self) -> Self::Inverter {
-                Self::precompute_inverter_with_adjuster(self, &Self::ONE)
+                Self::precompute_inverter_with_adjuster(self, &Uint::ONE)
             }
         }
 
-        // TODO(tarcieri): only impl these traits for `Odd`?
-        impl PrecomputeInverterWithAdjuster for $name {
-            fn precompute_inverter_with_adjuster(&self, adjuster: &Self) -> Self::Inverter {
-                let modulus = self.to_odd().expect("modulus must be odd");
-                Self::Inverter::new(&modulus, adjuster)
+        /// Precompute a Bernstein-Yang inverter using `self` as the modulus.
+        impl PrecomputeInverterWithAdjuster<$name> for Odd<$name> {
+            fn precompute_inverter_with_adjuster(&self, adjuster: &$name) -> Self::Inverter {
+                Self::Inverter::new(self, adjuster)
             }
         }
     };

--- a/tests/bernstein_yang_proptests.rs
+++ b/tests/bernstein_yang_proptests.rs
@@ -1,17 +1,17 @@
 //! Equivalence tests for Bernstein-Yang inversions.
 
-use crypto_bigint::{Encoding, Inverter, PrecomputeInverter, U256};
+use crypto_bigint::{Encoding, Inverter, Odd, PrecomputeInverter, U256};
 use num_bigint::BigUint;
 use num_integer::Integer;
 use num_traits::One;
 use proptest::prelude::*;
 
 #[cfg(feature = "alloc")]
-use crypto_bigint::{BoxedUint, NonZero};
+use crypto_bigint::BoxedUint;
 
 /// Example prime number (NIST P-256 curve order)
-const P: U256 =
-    U256::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
+const P: Odd<U256> =
+    Odd::<U256>::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
 
 fn to_biguint(uint: &U256) -> BigUint {
     BigUint::from_bytes_le(uint.to_le_bytes().as_ref())
@@ -63,8 +63,8 @@ proptest! {
     #[cfg(feature = "alloc")]
     #[test]
     fn boxed_inv_mod(x in boxed_uint()) {
-        let p = BoxedUint::from(&P);
-        let x = x.rem_vartime(&NonZero::new(p.clone()).unwrap()).widen(p.bits_precision());
+        let p = Odd::<BoxedUint>::from(&P);
+        let x = x.rem_vartime(p.as_nz_ref()).widen(p.bits_precision());
 
         let x_bi = to_biguint_boxed(&x);
         let p_bi = to_biguint(&P);


### PR DESCRIPTION
Moves all of the impls for these traits to `Odd<Uint<_>>`/`Odd<BoxedUint>`.

They infallibly return an inverter, but previously panicked if called on even numbers.

This commit replaces the panic condition with type safety instead.