### PR TITLE
Boxed Bernstein-Yang: reduce allocations

### DIFF
--- a/benches/boxed_monty.rs
+++ b/benches/boxed_monty.rs
@@ -19,7 +19,7 @@ fn to_biguint(uint: &BoxedUint) -> BigUint {
 fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let params = BoxedMontyParams::new(Odd::<BoxedUint>::random(&mut OsRng, UINT_BITS));
 
-    group.bench_function("invert, U256", |b| {
+    group.bench_function("invert, 4096-bit", |b| {
         b.iter_batched(
             || {
                 let modulus = NonZero::new(params.modulus().clone()).unwrap();


### PR DESCRIPTION
Performs more operations in-place

```
Boxed Montgomery arithmetic/invert, 4096-bit
                        time:   [208.34 µs 208.70 µs 209.08 µs]
                        change: [-23.092% -22.837% -22.579%] (p = 0.00 < 0.05)
                        Performance has improved.
```