### PR TITLE
tests: extract `common` module

### DIFF
--- a/src/odd.rs
+++ b/src/odd.rs
@@ -1,6 +1,6 @@
 //! Wrapper type for non-zero integers.
 
-use crate::{Integer, NonZero, Uint};
+use crate::{Integer, Limb, NonZero, Uint};
 use core::{cmp::Ordering, ops::Deref};
 use subtle::{Choice, ConditionallySelectable, CtOption};
 
@@ -8,10 +8,7 @@ use subtle::{Choice, ConditionallySelectable, CtOption};
 use crate::BoxedUint;
 
 #[cfg(feature = "rand_core")]
-use {
-    crate::{Limb, Random},
-    rand_core::CryptoRngCore,
-};
+use {crate::Random, rand_core::CryptoRngCore};
 
 /// Wrapper type for odd integers.
 ///
@@ -72,6 +69,15 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
 impl<T> AsRef<T> for Odd<T> {
     fn as_ref(&self) -> &T {
         &self.0
+    }
+}
+
+impl<T> AsRef<[Limb]> for Odd<T>
+where
+    T: AsRef<[Limb]>,
+{
+    fn as_ref(&self) -> &[Limb] {
+        self.0.as_ref()
     }
 }
 

--- a/tests/boxed_monty_form.rs
+++ b/tests/boxed_monty_form.rs
@@ -2,6 +2,9 @@
 
 #![cfg(feature = "alloc")]
 
+mod common;
+
+use common::to_biguint;
 use crypto_bigint::{
     modular::{BoxedMontyForm, BoxedMontyParams},
     BoxedUint, Integer, Inverter, Limb, NonZero, Odd, PrecomputeInverter,
@@ -10,10 +13,6 @@ use num_bigint::BigUint;
 use num_modular::ModularUnaryOps;
 use proptest::prelude::*;
 use std::cmp::Ordering;
-
-fn to_biguint(uint: &BoxedUint) -> BigUint {
-    BigUint::from_bytes_be(&uint.to_be_bytes())
-}
 
 fn retrieve_biguint(monty_form: &BoxedMontyForm) -> BigUint {
     to_biguint(&monty_form.retrieve())

--- a/tests/boxed_uint.rs
+++ b/tests/boxed_uint.rs
@@ -2,6 +2,9 @@
 
 #![cfg(feature = "alloc")]
 
+mod common;
+
+use common::to_biguint;
 use core::cmp::Ordering;
 use crypto_bigint::{BoxedUint, CheckedAdd, Gcd, Integer, Limb, NonZero};
 use num_bigint::BigUint;
@@ -9,10 +12,6 @@ use num_integer::Integer as _;
 use num_modular::ModularUnaryOps;
 use num_traits::identities::One;
 use proptest::prelude::*;
-
-fn to_biguint(uint: &BoxedUint) -> BigUint {
-    BigUint::from_bytes_be(&uint.to_be_bytes())
-}
 
 fn to_uint(big_uint: BigUint) -> BoxedUint {
     let bytes = big_uint.to_bytes_be();
@@ -170,7 +169,7 @@ proptest! {
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);
         let expected = a_bi.invm(&b_bi);
-        let actual = Option::from(a.inv_odd_mod(&b));
+        let actual = Option::<BoxedUint>::from(a.inv_odd_mod(&b));
 
         match (expected, actual) {
             (Some(exp), Some(act)) => prop_assert_eq!(exp, to_biguint(&act).into()),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,21 @@
+//! Common functionality shared between tests.
+
+// Different tests may use only a subset of the available functionality
+#![allow(dead_code)]
+
+use crypto_bigint::{Encoding, Limb};
+use num_bigint::BigUint;
+
+/// `Uint` to `num_bigint::BigUint`
+pub fn to_biguint<T>(uint: &T) -> BigUint
+where
+    T: AsRef<[Limb]>,
+{
+    let mut bytes = Vec::with_capacity(uint.as_ref().len() * Limb::BYTES);
+
+    for limb in uint.as_ref() {
+        bytes.extend_from_slice(&limb.to_le_bytes());
+    }
+
+    BigUint::from_bytes_le(&bytes)
+}

--- a/tests/const_monty_form.rs
+++ b/tests/const_monty_form.rs
@@ -1,6 +1,9 @@
 //! Equivalence tests between `crypto_bigint::ConstMontyForm` and `num-bigint`.
 
-use crypto_bigint::{impl_modulus, modular::ConstMontyParams, Encoding, Invert, Inverter, U256};
+mod common;
+
+use common::to_biguint;
+use crypto_bigint::{impl_modulus, modular::ConstMontyParams, Invert, Inverter, U256};
 use num_bigint::BigUint;
 use num_modular::ModularUnaryOps;
 use proptest::prelude::*;
@@ -12,10 +15,6 @@ impl_modulus!(
 );
 
 type ConstMontyForm = crypto_bigint::modular::ConstMontyForm<Modulus, { U256::LIMBS }>;
-
-fn to_biguint(uint: &U256) -> BigUint {
-    BigUint::from_bytes_le(uint.to_le_bytes().as_ref())
-}
 
 fn retrieve_biguint(monty_form: &ConstMontyForm) -> BigUint {
     to_biguint(&monty_form.retrieve())

--- a/tests/monty_form.rs
+++ b/tests/monty_form.rs
@@ -1,16 +1,15 @@
 //! Equivalence tests between `crypto_bigint::MontyForm` and `num-bigint`.
 
-use crypto_bigint::{Encoding, Integer, Invert, Inverter, NonZero, Odd, PrecomputeInverter, U256};
+mod common;
+
+use common::to_biguint;
+use crypto_bigint::{Integer, Invert, Inverter, NonZero, Odd, PrecomputeInverter, U256};
 use num_bigint::BigUint;
 use num_modular::ModularUnaryOps;
 use proptest::prelude::*;
 
 type MontyForm = crypto_bigint::modular::MontyForm<{ U256::LIMBS }>;
 type MontyParams = crypto_bigint::modular::MontyParams<{ U256::LIMBS }>;
-
-fn to_biguint(uint: &U256) -> BigUint {
-    BigUint::from_bytes_le(uint.to_le_bytes().as_ref())
-}
 
 fn retrieve_biguint(monty_form: &MontyForm) -> BigUint {
     to_biguint(&monty_form.retrieve())

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -1,5 +1,8 @@
 //! Equivalence tests between `crypto_bigint::Uint` and `num_bigint::BigUint`.
 
+mod common;
+
+use common::to_biguint;
 use crypto_bigint::{
     modular::{MontyForm, MontyParams},
     Encoding, Integer, Limb, NonZero, Odd, Word, U256,
@@ -13,10 +16,6 @@ use std::mem;
 /// Example prime number (NIST P-256 curve order)
 const P: Odd<U256> =
     Odd::<U256>::from_be_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
-
-fn to_biguint(uint: &U256) -> BigUint {
-    BigUint::from_bytes_le(uint.to_le_bytes().as_ref())
-}
 
 fn to_uint(big_uint: BigUint) -> U256 {
     let mut input = [0u8; U256::BYTES];


### PR DESCRIPTION
Extracts a module containing shared functionality which can be reused between various tests.

Currently it just contains `to_biguint` (which has been adapted to work with both `Uint` and `BoxedUint`)