### PR TITLE
Add `RandomBits` trait

### DIFF
--- a/benches/boxed_uint.rs
+++ b/benches/boxed_uint.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
-use crypto_bigint::BoxedUint;
+use crypto_bigint::{BoxedUint, RandomBits};
 use rand_core::OsRng;
 
 /// Size of `BoxedUint` to use in benchmark.
@@ -10,7 +10,7 @@ fn bench_shifts(c: &mut Criterion) {
 
     group.bench_function("shl_vartime", |b| {
         b.iter_batched(
-            || BoxedUint::random(&mut OsRng, UINT_BITS),
+            || BoxedUint::random_bits(&mut OsRng, UINT_BITS),
             |x| black_box(x.shl_vartime(UINT_BITS / 2 + 10)),
             BatchSize::SmallInput,
         )
@@ -18,7 +18,7 @@ fn bench_shifts(c: &mut Criterion) {
 
     group.bench_function("shl", |b| {
         b.iter_batched(
-            || BoxedUint::random(&mut OsRng, UINT_BITS),
+            || BoxedUint::random_bits(&mut OsRng, UINT_BITS),
             |x| x.overflowing_shl(UINT_BITS / 2 + 10),
             BatchSize::SmallInput,
         )
@@ -26,7 +26,7 @@ fn bench_shifts(c: &mut Criterion) {
 
     group.bench_function("shr_vartime", |b| {
         b.iter_batched(
-            || BoxedUint::random(&mut OsRng, UINT_BITS),
+            || BoxedUint::random_bits(&mut OsRng, UINT_BITS),
             |x| black_box(x.shr_vartime(UINT_BITS / 2 + 10)),
             BatchSize::SmallInput,
         )
@@ -34,7 +34,7 @@ fn bench_shifts(c: &mut Criterion) {
 
     group.bench_function("shr", |b| {
         b.iter_batched(
-            || BoxedUint::random(&mut OsRng, UINT_BITS),
+            || BoxedUint::random_bits(&mut OsRng, UINT_BITS),
             |x| x.overflowing_shr(UINT_BITS / 2 + 10),
             BatchSize::SmallInput,
         )

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -10,6 +10,9 @@ use crate::BoxedUint;
 #[cfg(feature = "rand_core")]
 use {crate::Random, rand_core::CryptoRngCore};
 
+#[cfg(all(feature = "alloc", feature = "rand_core"))]
+use crate::RandomBits;
+
 /// Wrapper type for odd integers.
 ///
 /// These are frequently used in cryptography, e.g. as a modulus.
@@ -143,8 +146,8 @@ impl<const LIMBS: usize> Random for Odd<Uint<LIMBS>> {
 #[cfg(all(feature = "alloc", feature = "rand_core"))]
 impl Odd<BoxedUint> {
     /// Generate a random `Odd<Uint<T>>`.
-    pub fn random(rng: &mut impl CryptoRngCore, bits_precision: u32) -> Self {
-        let mut ret = BoxedUint::random(rng, bits_precision);
+    pub fn random(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
+        let mut ret = BoxedUint::random_bits(rng, bit_length);
         ret.limbs[0] |= Limb::ONE;
         Odd(ret)
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -335,17 +335,23 @@ impl std::error::Error for RandomBitsError {}
 #[cfg(feature = "rand_core")]
 pub trait RandomBits: Sized {
     /// Generate a cryptographically secure random value in range `[0, 2^bit_length)`.
+    ///
+    /// A wrapper for [`RandomBits::try_random_bits`] that panics on error.
     fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
         Self::try_random_bits(rng, bit_length).expect("try_random_bits() failed")
     }
 
     /// Generate a cryptographically secure random value in range `[0, 2^bit_length)`.
+    ///
+    /// This method is variable time wrt `bit_length`.
     fn try_random_bits(
         rng: &mut impl CryptoRngCore,
         bit_length: u32,
     ) -> Result<Self, RandomBitsError>;
 
-    /// Generate a cryptographically secure random value.
+    /// Generate a cryptographically secure random value in range `[0, 2^bit_length)`,
+    /// returning an integer with the closest available size to `bits_precision`
+    /// (if the implementing type supports runtime sizing).
     ///
     /// A wrapper for [`RandomBits::try_random_bits_with_precision`] that panics on error.
     fn random_bits_with_precision(
@@ -360,6 +366,8 @@ pub trait RandomBits: Sized {
     /// Generate a cryptographically secure random value in range `[0, 2^bit_length)`,
     /// returning an integer with the closest available size to `bits_precision`
     /// (if the implementing type supports runtime sizing).
+    ///
+    /// This method is variable time wrt `bit_length`.
     fn try_random_bits_with_precision(
         rng: &mut impl CryptoRngCore,
         bit_length: u32,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -22,6 +22,9 @@ use subtle::{
 #[cfg(feature = "rand_core")]
 use rand_core::CryptoRngCore;
 
+#[cfg(feature = "rand_core")]
+use core::fmt;
+
 /// Integers whose representation takes a bounded amount of space.
 pub trait Bounded {
     /// Size of this integer in bits.
@@ -274,7 +277,7 @@ pub trait Random: Sized {
     fn random(rng: &mut impl CryptoRngCore) -> Self;
 }
 
-/// Possible errors of [`RandomBits::try_random_bits`].
+/// Possible errors of the methods in [`RandomBits`] trait.
 #[cfg(feature = "rand_core")]
 #[derive(Debug)]
 pub enum RandomBitsError {
@@ -296,6 +299,37 @@ pub enum RandomBitsError {
         bits_precision: u32,
     },
 }
+
+#[cfg(feature = "rand_core")]
+impl fmt::Display for RandomBitsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RandCore(err) => write!(f, "{}", err),
+            Self::BitsPrecisionMismatch {
+                bits_precision,
+                integer_bits,
+            } => write!(
+                f,
+                concat![
+                    "The requested `bits_precision` ({}) does not match ",
+                    "the size of the integer corresponding to the type ({})"
+                ],
+                bits_precision, integer_bits
+            ),
+            Self::BitLengthTooLarge {
+                bit_length,
+                bits_precision,
+            } => write!(
+                f,
+                "The requested `bit_length` ({}) is larger than `bits_precision` ({}).",
+                bit_length, bits_precision
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for RandomBitsError {}
 
 /// Random bits generation support.
 #[cfg(feature = "rand_core")]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -274,6 +274,13 @@ pub trait Random: Sized {
     fn random(rng: &mut impl CryptoRngCore) -> Self;
 }
 
+/// Random number generation support.
+#[cfg(feature = "rand_core")]
+pub trait RandomBits: Sized {
+    /// Generate a cryptographically secure random value.
+    fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32, bits_precision: u32) -> Self;
+}
+
 /// Modular random number generation support.
 #[cfg(feature = "rand_core")]
 pub trait RandomMod: Sized + Zero {

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -137,7 +137,7 @@ mod tests {
 
     #[cfg(feature = "rand")]
     use {
-        crate::CheckedMul,
+        crate::{CheckedMul, RandomBits},
         rand_chacha::ChaChaRng,
         rand_core::{RngCore, SeedableRng},
     };
@@ -303,7 +303,7 @@ mod tests {
         }
 
         for _ in 0..50 {
-            let s = BoxedUint::random(&mut rng, 512);
+            let s = BoxedUint::random_bits(&mut rng, 512);
             let mut s2 = BoxedUint::zero_with_precision(512);
             s2.limbs[..s.limbs.len()].copy_from_slice(&s.limbs);
             assert_eq!(s.square().sqrt(), s2);

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -1,7 +1,7 @@
 //! Random number generator support
 
 use super::Uint;
-use crate::{Encoding, Limb, NonZero, Random, RandomMod, Zero};
+use crate::{Encoding, Limb, NonZero, Random, RandomBits, RandomMod, Zero};
 use rand_core::CryptoRngCore;
 use subtle::ConstantTimeLess;
 
@@ -15,6 +15,20 @@ impl<const LIMBS: usize> Random for Uint<LIMBS> {
         }
 
         limbs.into()
+    }
+}
+
+impl<const LIMBS: usize> RandomBits for Uint<LIMBS> {
+    fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32, bits_precision: u32) -> Self {
+        if bits_precision != Self::BITS {
+            panic!("The requested precision ({bits_precision}) does not match the Uint size");
+        }
+        if bit_length > Self::BITS {
+            panic!("The requested bit length ({bit_length}) is larger than the chosen Uint size");
+        }
+        let random = Self::random(rng);
+
+        random >> (Self::BITS - bit_length)
     }
 }
 

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -1,7 +1,7 @@
 //! Random number generator support
 
-use super::Uint;
-use crate::{Encoding, Limb, NonZero, Random, RandomBits, RandomMod, Zero};
+use super::{Uint, Word};
+use crate::{Encoding, Limb, NonZero, Random, RandomBits, RandomBitsError, RandomMod, Zero};
 use rand_core::CryptoRngCore;
 use subtle::ConstantTimeLess;
 
@@ -18,17 +18,59 @@ impl<const LIMBS: usize> Random for Uint<LIMBS> {
     }
 }
 
+pub(crate) fn random_bits_core(
+    rng: &mut impl CryptoRngCore,
+    limbs: &mut [Limb],
+    bit_length: u32,
+) -> Result<(), RandomBitsError> {
+    let buffer: Word = 0;
+    let mut buffer = buffer.to_be_bytes();
+
+    let nonzero_limbs = ((bit_length + Limb::BITS - 1) / Limb::BITS) as usize;
+    let partial_limb = bit_length % Limb::BITS;
+    let mask = Word::MAX >> ((Word::BITS - partial_limb) % Word::BITS);
+
+    for i in 0..nonzero_limbs - 1 {
+        rng.try_fill_bytes(&mut buffer)
+            .map_err(RandomBitsError::RandCore)?;
+        limbs[i] = Limb(Word::from_be_bytes(buffer));
+    }
+
+    rng.try_fill_bytes(&mut buffer)
+        .map_err(RandomBitsError::RandCore)?;
+    limbs[nonzero_limbs - 1] = Limb(Word::from_be_bytes(buffer) & mask);
+
+    Ok(())
+}
+
 impl<const LIMBS: usize> RandomBits for Uint<LIMBS> {
-    fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32, bits_precision: u32) -> Self {
+    fn try_random_bits(
+        rng: &mut impl CryptoRngCore,
+        bit_length: u32,
+    ) -> Result<Self, RandomBitsError> {
+        Self::try_random_bits_with_precision(rng, bit_length, Self::BITS)
+    }
+
+    fn try_random_bits_with_precision(
+        rng: &mut impl CryptoRngCore,
+        bit_length: u32,
+        bits_precision: u32,
+    ) -> Result<Self, RandomBitsError> {
         if bits_precision != Self::BITS {
-            panic!("The requested precision ({bits_precision}) does not match the Uint size");
+            return Err(RandomBitsError::BitsPrecisionMismatch {
+                bits_precision,
+                integer_bits: Self::BITS,
+            });
         }
         if bit_length > Self::BITS {
-            panic!("The requested bit length ({bit_length}) is larger than the chosen Uint size");
+            return Err(RandomBitsError::BitLengthTooLarge {
+                bit_length,
+                bits_precision,
+            });
         }
-        let random = Self::random(rng);
-
-        random >> (Self::BITS - bit_length)
+        let mut limbs = [Limb::ZERO; LIMBS];
+        random_bits_core(rng, &mut limbs, bit_length)?;
+        Ok(Self::from(limbs))
     }
 }
 
@@ -89,7 +131,7 @@ pub(super) fn random_mod_core<T>(
 
 #[cfg(test)]
 mod tests {
-    use crate::{NonZero, RandomMod, U256};
+    use crate::{Limb, NonZero, RandomBits, RandomMod, U256};
     use rand_core::SeedableRng;
 
     #[test]
@@ -110,5 +152,43 @@ mod tests {
 
         // Check that the value is in range
         assert!(res < U256::from(0x10000000000000001u128));
+    }
+
+    #[test]
+    fn random_bits() {
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+
+        let lower_bound = 16;
+
+        // Full length of the integer
+        let bit_length = U256::BITS;
+        for _ in 0..10 {
+            let res = U256::random_bits(&mut rng, bit_length);
+            assert!(res > (U256::ONE << (bit_length - lower_bound)));
+        }
+
+        // A multiple of limb size
+        let bit_length = U256::BITS - Limb::BITS;
+        for _ in 0..10 {
+            let res = U256::random_bits(&mut rng, bit_length);
+            assert!(res > (U256::ONE << (bit_length - lower_bound)));
+            assert!(res < (U256::ONE << bit_length));
+        }
+
+        // A multiple of 8
+        let bit_length = U256::BITS - Limb::BITS - 8;
+        for _ in 0..10 {
+            let res = U256::random_bits(&mut rng, bit_length);
+            assert!(res > (U256::ONE << (bit_length - lower_bound)));
+            assert!(res < (U256::ONE << bit_length));
+        }
+
+        // Not a multiple of 8
+        let bit_length = U256::BITS - Limb::BITS - 8 - 3;
+        for _ in 0..10 {
+            let res = U256::random_bits(&mut rng, bit_length);
+            assert!(res > (U256::ONE << (bit_length - lower_bound)));
+            assert!(res < (U256::ONE << bit_length));
+        }
     }
 }


### PR DESCRIPTION
Adds a trait for generating a random number of a given bit size.

Can be improved by using masking instead of shift.

- Is there a better way to express this API?
- Should it be constant-time in `bit_length`? 
- Should the inherent `BoxedUint::random()` take `bits_precision` as well?
