### PR TITLE
Variable-time division improvements

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -66,8 +66,18 @@ pub(crate) const fn mac(a: Word, b: Word, c: Word, carry: Word) -> (Word, Word) 
     (ret as Word, (ret >> Word::BITS) as Word)
 }
 
-/// Computes `(a * b) % d`.
+/// Computes `(a * b) % d`. Not constant time in `d`.
 #[inline(always)]
-pub(crate) const fn mul_rem(a: Word, b: Word, d: Word) -> Word {
+pub(crate) const fn mul_rem_vartime(a: Word, b: Word, d: Word) -> Word {
     ((a as WideWord * b as WideWord) % (d as WideWord)) as Word
+}
+
+/// Returns `(hi * 2^Word::BITS + lo) / d`.
+/// Not constant-time in `d`.
+/// Assumes that the result fits in `Word`.
+#[inline(always)]
+pub(crate) const fn div_wide_vartime(hi: Word, lo: Word, d: Word) -> Word {
+    let q = (((hi as WideWord) << Word::BITS) + (lo as WideWord)) / (d as WideWord);
+    debug_assert!(q <= Word::MAX as WideWord);
+    q as Word
 }

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     modular::{BoxedMontyForm, BoxedMontyParams},
-    primitives::mul_rem,
+    primitives::mul_rem_vartime,
     BoxedUint, Limb, MulMod, Odd, WideWord, Word,
 };
 
@@ -42,7 +42,7 @@ impl BoxedUint {
         // We implicitly assume `LIMBS > 0`, because `Uint<0>` doesn't compile.
         // Still the case `LIMBS == 1` needs special handling.
         if self.nlimbs() == 1 {
-            let reduced = mul_rem(self.limbs[0].0, rhs.limbs[0].0, Word::MIN.wrapping_sub(c.0));
+            let reduced = mul_rem_vartime(self.limbs[0].0, rhs.limbs[0].0, Word::MIN.wrapping_sub(c.0));
             return Self::from(reduced);
         }
 

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -54,6 +54,18 @@ macro_rules! impl_schoolbook_multiplication {
 }
 
 impl<const LIMBS: usize> Uint<LIMBS> {
+    pub(crate) fn mul_limb_vartime(&self, rhs: Limb) -> (Self, Limb) {
+        let mut carry = Limb::ZERO;
+        let mut result = Self::ZERO;
+        let limbs = ((self.bits_vartime() + Limb::BITS - 1) / Limb::BITS) as usize;
+        for i in 0..limbs {
+            let (x, new_carry) = self.limbs[i].mul_wide(rhs);
+            result.limbs[i] = x + carry;
+            carry = new_carry;
+        }
+        (result, carry)
+    }
+
     /// Multiply `self` by `rhs`, returning a concatenated "wide" result.
     pub fn widening_mul<const RHS_LIMBS: usize>(
         &self,

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     modular::{MontyForm, MontyParams},
-    primitives::mul_rem,
+    primitives::mul_rem_vartime,
     Limb, MulMod, Uint, WideWord, Word,
 };
 
@@ -40,7 +40,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // We implicitly assume `LIMBS > 0`, because `Uint<0>` doesn't compile.
         // Still the case `LIMBS == 1` needs special handling.
         if LIMBS == 1 {
-            let reduced = mul_rem(self.limbs[0].0, rhs.limbs[0].0, Word::MIN.wrapping_sub(c.0));
+            let reduced = mul_rem_vartime(self.limbs[0].0, rhs.limbs[0].0, Word::MIN.wrapping_sub(c.0));
             return Self::from_word(reduced);
         }
 

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -49,7 +49,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes √(`self`)
     ///
     /// Callers can check if `self` is a square by squaring the result
-    pub const fn sqrt_vartime(&self) -> Self {
+    pub fn sqrt_vartime(&self) -> Self {
         // Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.13
 
         // The initial guess: `x_0 = 2^ceil(b/2)`, where `2^(b-1) <= self < b`.
@@ -92,7 +92,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Wrapped sqrt is just normal √(`self`)
     /// There’s no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations.
-    pub const fn wrapping_sqrt_vartime(&self) -> Self {
+    pub fn wrapping_sqrt_vartime(&self) -> Self {
         self.sqrt_vartime()
     }
 


### PR DESCRIPTION
- Implement the variable-time division algorithm from "Handbook of Applied Cryptography"

TODO:
- The divisor should be normalized first so that the MSB is set (see the notes in the Handbook). But that might put the dividend out of bounds of `Uint`.
- (tangential) `mul_mod_special()` is variable time in `c` - need to either change the name, or to make a constant-time equivalent of `mul_rem_vartime` that it uses. 
- (also tangential) the algorithm in `mul_mod_special()` is not actually the one from "Handbook of Applied Cryptography"; there are some modifications made, and I'm trying to understand why they work. It needs comments.
- The division-by-limb methods can have variable-time equivalents, but we need to see if they are actually faster. The variable time algorithms can be introduced at `div_rem_limb_with_reciprocal()`, `short_div()`, and possibly `div2by1()` (although the latter mostly has additions and multiplications, and only a few constant-time comparisons)