### PR TITLE
Rename `MontyParams::new` => `::new_vartime`

### DIFF
--- a/benches/monty.rs
+++ b/benches/monty.rs
@@ -15,12 +15,12 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
     group.bench_function("MontyParams creation", |b| {
         b.iter_batched(
             || Odd::<U256>::random(&mut OsRng),
-            |modulus| black_box(MontyParams::new(modulus)),
+            |modulus| black_box(MontyParams::new_vartime(modulus)),
             BatchSize::SmallInput,
         )
     });
 
-    let params = MontyParams::new(Odd::<U256>::random(&mut OsRng));
+    let params = MontyParams::new_vartime(Odd::<U256>::random(&mut OsRng));
     group.bench_function("MontyForm creation", |b| {
         b.iter_batched(
             || Odd::<U256>::random(&mut OsRng),
@@ -29,7 +29,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
         )
     });
 
-    let params = MontyParams::new(Odd::<U256>::random(&mut OsRng));
+    let params = MontyParams::new_vartime(Odd::<U256>::random(&mut OsRng));
     group.bench_function("MontyForm retrieve", |b| {
         b.iter_batched(
             || MontyForm::new(&U256::random(&mut OsRng), params),
@@ -40,7 +40,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
 }
 
 fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let params = MontyParams::new(Odd::<U256>::random(&mut OsRng));
+    let params = MontyParams::new_vartime(Odd::<U256>::random(&mut OsRng));
 
     group.bench_function("invert, U256", |b| {
         b.iter_batched(

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -33,10 +33,8 @@ pub struct MontyParams<const LIMBS: usize> {
 }
 
 impl<const LIMBS: usize> MontyParams<LIMBS> {
-    /// Instantiates a new set of `MontyParams` representing the given `modulus` if it is odd.
-    ///
-    /// Returns `None` if the provided modulus is not odd.
-    pub fn new(modulus: Odd<Uint<LIMBS>>) -> Self {
+    /// Instantiates a new set of `MontyParams` representing the given odd `modulus`.
+    pub fn new_vartime(modulus: Odd<Uint<LIMBS>>) -> Self {
         // `R mod modulus` where `R = 2^BITS`.
         // Represents 1 in Montgomery form.
         let one = Uint::MAX
@@ -201,7 +199,7 @@ impl<const LIMBS: usize> Monty for MontyForm<LIMBS> {
     type Params = MontyParams<LIMBS>;
 
     fn new_params(modulus: Odd<Self::Integer>) -> Self::Params {
-        MontyParams::new(modulus)
+        MontyParams::new_vartime(modulus)
     }
 
     fn new(value: Self::Integer, params: Self::Params) -> Self {

--- a/src/modular/monty_form/add.rs
+++ b/src/modular/monty_form/add.rs
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn add_overflow() {
-        let params = MontyParams::new(Odd::<U256>::from_be_hex(
+        let params = MontyParams::new_vartime(Odd::<U256>::from_be_hex(
             "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
         ));
 

--- a/src/modular/monty_form/inv.rs
+++ b/src/modular/monty_form/inv.rs
@@ -114,7 +114,7 @@ mod tests {
     use crate::{Invert, Inverter, Odd, PrecomputeInverter, U256};
 
     fn params() -> MontyParams<{ U256::LIMBS }> {
-        MontyParams::new(Odd::<U256>::from_be_hex(
+        MontyParams::new_vartime(Odd::<U256>::from_be_hex(
             "15477BCCEFE197328255BFA79A1217899016D927EF460F4FF404029D24FA4409",
         ))
     }

--- a/src/modular/monty_form/sub.rs
+++ b/src/modular/monty_form/sub.rs
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn sub_overflow() {
-        let params = MontyParams::new(Odd::<U256>::from_be_hex(
+        let params = MontyParams::new_vartime(Odd::<U256>::from_be_hex(
             "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
         ));
 

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -20,7 +20,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // It's worth potentially exploring other approaches to improve efficiency.
         match p.to_odd().into() {
             Some(odd_p) => {
-                let params = MontyParams::new(odd_p);
+                let params = MontyParams::new_vartime(odd_p);
                 let lhs = MontyForm::new(self, params);
                 let rhs = MontyForm::new(rhs, params);
                 let ret = lhs * rhs;

--- a/tests/monty_form.rs
+++ b/tests/monty_form.rs
@@ -33,7 +33,7 @@ prop_compose! {
             n = n.wrapping_add(&U256::one());
         }
 
-        MontyParams::new(Odd::new(n).expect("modulus ensured odd"))
+        MontyParams::new_vartime(Odd::new(n).expect("modulus ensured odd"))
     }
 }
 

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -402,7 +402,7 @@ proptest! {
 
         let expected = to_uint(a_bi.modpow(&b_bi, &p_bi));
 
-        let params = MontyParams::new(P);
+        let params = MontyParams::new_vartime(P);
         let a_m = MontyForm::new(&a, params);
         let actual = a_m.pow(&b).retrieve();
 
@@ -419,7 +419,7 @@ proptest! {
 
         let expected = to_uint(a_bi.modpow(&b_bi, &p_bi));
 
-        let params = MontyParams::new(P);
+        let params = MontyParams::new_vartime(P);
         let a_m = MontyForm::new(&a, params);
         let actual = a_m.pow_bounded_exp(&b, exponent_bits.into()).retrieve();
 
@@ -440,7 +440,7 @@ proptest! {
         };
         let expected = to_uint(expected);
 
-        let params = MontyParams::new(P);
+        let params = MontyParams::new_vartime(P);
         let a_m = MontyForm::new(&a, params);
         let actual = a_m.div_by_2().retrieve();
 


### PR DESCRIPTION
For consistency with `BoxedMontyParams::new_vartime` and our general labeling strategy.