### PR TITLE
Have `(Boxed)MontyParams::modulus` return `&Odd<_>`

### DIFF
--- a/benches/boxed_monty.rs
+++ b/benches/boxed_monty.rs
@@ -4,7 +4,7 @@ use criterion::{
 };
 use crypto_bigint::{
     modular::{BoxedMontyForm, BoxedMontyParams},
-    BoxedUint, NonZero, Odd, RandomMod,
+    BoxedUint, Odd, RandomMod,
 };
 use num_bigint::BigUint;
 use rand_core::OsRng;
@@ -22,8 +22,10 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("invert, 4096-bit", |b| {
         b.iter_batched(
             || {
-                let modulus = NonZero::new(params.modulus().clone()).unwrap();
-                BoxedMontyForm::new(BoxedUint::random_mod(&mut OsRng, &modulus), params.clone())
+                BoxedMontyForm::new(
+                    BoxedUint::random_mod(&mut OsRng, params.modulus().as_nz_ref()),
+                    params.clone(),
+                )
             },
             |x| black_box(x).invert(),
             BatchSize::SmallInput,

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -106,7 +106,7 @@ impl BoxedMontyParams {
     }
 
     /// Modulus value.
-    pub fn modulus(&self) -> &BoxedUint {
+    pub fn modulus(&self) -> &Odd<BoxedUint> {
         &self.modulus
     }
 

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -64,8 +64,8 @@ impl<const LIMBS: usize> MontyParams<LIMBS> {
     }
 
     /// Returns the modulus which was used to initialize these parameters.
-    pub const fn modulus(&self) -> &Uint<LIMBS> {
-        &self.modulus.0
+    pub const fn modulus(&self) -> &Odd<Uint<LIMBS>> {
+        &self.modulus
     }
 
     /// Create `MontyParams` corresponding to a `ConstMontyParams`.

--- a/tests/boxed_monty_form.rs
+++ b/tests/boxed_monty_form.rs
@@ -7,7 +7,7 @@ mod common;
 use common::to_biguint;
 use crypto_bigint::{
     modular::{BoxedMontyForm, BoxedMontyParams},
-    BoxedUint, Integer, Inverter, Limb, NonZero, Odd, PrecomputeInverter,
+    BoxedUint, Integer, Inverter, Limb, Odd, PrecomputeInverter,
 };
 use num_bigint::BigUint;
 use num_modular::ModularUnaryOps;
@@ -20,7 +20,6 @@ fn retrieve_biguint(monty_form: &BoxedMontyForm) -> BigUint {
 
 fn reduce(n: &BoxedUint, p: BoxedMontyParams) -> BoxedMontyForm {
     let bits_precision = p.modulus().bits_precision();
-    let modulus = NonZero::new(p.modulus().clone()).unwrap();
 
     let n = match n.bits_precision().cmp(&bits_precision) {
         Ordering::Less => n.widen(bits_precision),
@@ -28,7 +27,10 @@ fn reduce(n: &BoxedUint, p: BoxedMontyParams) -> BoxedMontyForm {
         Ordering::Greater => n.shorten(bits_precision),
     };
 
-    let n_reduced = n.rem_vartime(&modulus).widen(p.bits_precision());
+    let n_reduced = n
+        .rem_vartime(p.modulus().as_nz_ref())
+        .widen(p.bits_precision());
+
     BoxedMontyForm::new(n_reduced, p)
 }
 

--- a/tests/monty_form.rs
+++ b/tests/monty_form.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use common::to_biguint;
-use crypto_bigint::{Integer, Invert, Inverter, NonZero, Odd, PrecomputeInverter, U256};
+use crypto_bigint::{Integer, Invert, Inverter, Odd, PrecomputeInverter, U256};
 use num_bigint::BigUint;
 use num_modular::ModularUnaryOps;
 use proptest::prelude::*;
@@ -16,8 +16,7 @@ fn retrieve_biguint(monty_form: &MontyForm) -> BigUint {
 }
 
 fn reduce(n: &U256, p: MontyParams) -> MontyForm {
-    let modulus = NonZero::new(p.modulus().clone()).unwrap();
-    let n_reduced = n.rem_vartime(&modulus);
+    let n_reduced = n.rem_vartime(p.modulus().as_nz_ref());
     MontyForm::new(&n_reduced, p)
 }
 


### PR DESCRIPTION
Notably `Odd` permits a simple reference conversion to `NonZero` which makes it possible to clean up some tests.