### PR TITLE
Handle even `s` in `Uint::inv_mod`

### DIFF
--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -186,7 +186,7 @@ impl PartialEq for ConstChoice {
 #[derive(Debug, Clone)]
 pub struct ConstCtOption<T> {
     value: T,
-    pub(crate) is_some: ConstChoice,
+    is_some: ConstChoice,
 }
 
 impl<T> ConstCtOption<T> {

--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -243,7 +243,7 @@ impl<T> ConstCtOption<T> {
 
     /// Apply an additional [`ConstChoice`] requirement to `is_some`.
     #[inline]
-    pub const fn and_choice(mut self, is_some: ConstChoice) -> Self {
+    pub(crate) const fn and_choice(mut self, is_some: ConstChoice) -> Self {
         self.is_some = self.is_some.and(is_some);
         self
     }

--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -186,7 +186,7 @@ impl PartialEq for ConstChoice {
 #[derive(Debug, Clone)]
 pub struct ConstCtOption<T> {
     value: T,
-    is_some: ConstChoice,
+    pub(crate) is_some: ConstChoice,
 }
 
 impl<T> ConstCtOption<T> {

--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -240,6 +240,13 @@ impl<T> ConstCtOption<T> {
         assert!(self.is_some.is_true_vartime());
         self.value
     }
+
+    /// Apply an additional [`ConstChoice`] requirement to `is_some`.
+    #[inline]
+    pub const fn and_choice(mut self, is_some: ConstChoice) -> Self {
+        self.is_some = self.is_some.and(is_some);
+        self
+    }
 }
 
 impl<T> From<ConstCtOption<T>> for CtOption<T> {

--- a/src/uint/inv_mod.rs
+++ b/src/uint/inv_mod.rs
@@ -107,8 +107,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // Decompose `self` into RNS with moduli `2^k` and `s` and calculate the inverses.
         // Using the fact that `(z^{-1} mod (m1 * m2)) mod m1 == z^{-1} mod m1`
         let s_is_odd = s.is_odd();
-        let mut maybe_a = self.inv_odd_mod(&Odd(s));
-        maybe_a.is_some = maybe_a.is_some.and(s_is_odd);
+        let maybe_a = self.inv_odd_mod(&Odd(s)).and_choice(s_is_odd);
 
         let maybe_b = self.inv_mod2k(k);
         let is_some = maybe_a.is_some().and(maybe_b.is_some());

--- a/src/uint/inv_mod.rs
+++ b/src/uint/inv_mod.rs
@@ -106,7 +106,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         // Decompose `self` into RNS with moduli `2^k` and `s` and calculate the inverses.
         // Using the fact that `(z^{-1} mod (m1 * m2)) mod m1 == z^{-1} mod m1`
-        let maybe_a = self.inv_odd_mod(&Odd(s));
+        let s_is_odd = s.is_odd();
+        let mut maybe_a = self.inv_odd_mod(&Odd(s));
+        maybe_a.is_some = maybe_a.is_some.and(s_is_odd);
+
         let maybe_b = self.inv_mod2k(k);
         let is_some = maybe_a.is_some().and(maybe_b.is_some());
 


### PR DESCRIPTION
This is an oversight from #501 which switched to using Bernstein-Yang inversions for `Uint::inv_odd_mod`.

The new implementation in #501 assumes `s` is always `Odd` but didn't actually check for that and set the `ConstCtOption` to be "none" accordingly. This PR fixes that.