### PR TITLE
Add "vartime" suffix to Monty::new_params()

### DIFF
--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -240,8 +240,8 @@ impl Monty for BoxedMontyForm {
     type Integer = BoxedUint;
     type Params = BoxedMontyParams;
 
-    fn new_params(modulus: Odd<Self::Integer>) -> Self::Params {
-        BoxedMontyParams::new(modulus)
+    fn new_params_vartime(modulus: Odd<Self::Integer>) -> Self::Params {
+        BoxedMontyParams::new_vartime(modulus)
     }
 
     fn new(value: Self::Integer, params: Self::Params) -> Self {

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -234,7 +234,7 @@ impl<const LIMBS: usize> Monty for MontyForm<LIMBS> {
     type Integer = Uint<LIMBS>;
     type Params = MontyParams<LIMBS>;
 
-    fn new_params(modulus: Odd<Self::Integer>) -> Self::Params {
+    fn new_params_vartime(modulus: Odd<Self::Integer>) -> Self::Params {
         MontyParams::new_vartime(modulus)
     }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -778,8 +778,9 @@ pub trait Monty:
     /// The precomputed data needed for this representation.
     type Params: 'static + Clone + Debug + Eq + Sized + Send + Sync;
 
-    /// Create the precomputed data for Montgomery representation of integers modulo `modulus`.
-    fn new_params(modulus: Odd<Self::Integer>) -> Self::Params;
+    /// Create the precomputed data for Montgomery representation of integers modulo `modulus`,
+    /// variable time in `modulus`.
+    fn new_params_vartime(modulus: Odd<Self::Integer>) -> Self::Params;
 
     /// Convert the value into the representation using precomputed data.
     fn new(value: Self::Integer, params: Self::Params) -> Self;


### PR DESCRIPTION
The implementation for `Uint` was already vartime. The `BoxedUint` one wasn't, changed to vartime.

It would be logical to have `new_params()` for the constant-time implementation, but implementing it for `Uint` requires additional bounds with `Split`/`Concat` which have to be propagated everywhere. Not sure what the best course of action here is.

One possibility is perhaps splitting out the "convertible to Montgomery" in a separate trait.