### PR TITLE
Additional methods for `Integer` and `Monty`

### DIFF
--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -256,6 +256,14 @@ impl Monty for BoxedMontyForm {
         BoxedMontyForm::one(params)
     }
 
+    fn params(&self) -> &Self::Params {
+        &self.params
+    }
+
+    fn as_montgomery(&self) -> &Self::Integer {
+        &self.montgomery_form
+    }
+
     fn div_by_2(&self) -> Self {
         BoxedMontyForm::div_by_2(self)
     }

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -250,6 +250,14 @@ impl<const LIMBS: usize> Monty for MontyForm<LIMBS> {
         MontyForm::one(params)
     }
 
+    fn params(&self) -> &Self::Params {
+        &self.params
+    }
+
+    fn as_montgomery(&self) -> &Self::Integer {
+        &self.montgomery_form
+    }
+
     fn div_by_2(&self) -> Self {
         MontyForm::div_by_2(self)
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -800,6 +800,12 @@ pub trait Monty:
     /// Returns one in this representation.
     fn one(params: Self::Params) -> Self;
 
+    /// Returns the parameter struct used to initialize this object.
+    fn params(&self) -> &Self::Params;
+
+    /// Access the value in Montgomery form.
+    fn as_montgomery(&self) -> &Self::Integer;
+
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
     fn div_by_2(&self) -> Self;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -158,11 +158,6 @@ pub trait Integer:
     /// The value `1`.
     fn one() -> Self;
 
-    /// The value `0` with the same precision as `other`.
-    fn zero_like(other: &Self) -> Self {
-        Self::from_limb_like(Limb::ZERO, other)
-    }
-
     /// The value `1` with the same precision as `other`.
     fn one_like(other: &Self) -> Self {
         Self::from_limb_like(Limb::ONE, other)
@@ -256,6 +251,16 @@ pub trait Zero: ConstantTimeEq + Sized {
     #[inline]
     fn set_zero(&mut self) {
         *self = Zero::zero();
+    }
+
+    /// Return the value `0` with the same precision as `other`.
+    fn zero_like(other: &Self) -> Self
+    where
+        Self: Clone,
+    {
+        let mut ret = other.clone();
+        ret.set_zero();
+        ret
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -158,6 +158,19 @@ pub trait Integer:
     /// The value `1`.
     fn one() -> Self;
 
+    /// The value `0` with the same precision as `other`.
+    fn zero_like(other: &Self) -> Self {
+        Self::from_limb_like(Limb::ZERO, other)
+    }
+
+    /// The value `1` with the same precision as `other`.
+    fn one_like(other: &Self) -> Self {
+        Self::from_limb_like(Limb::ONE, other)
+    }
+
+    /// Returns an integer with the first limb set to `limb`, and the same precision as `other`.
+    fn from_limb_like(limb: Limb, other: &Self) -> Self;
+
     /// Number of limbs in this integer.
     fn nlimbs(&self) -> usize;
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -249,6 +249,10 @@ impl<const LIMBS: usize> Integer for Uint<LIMBS> {
         Self::ONE
     }
 
+    fn from_limb_like(limb: Limb, _other: &Self) -> Self {
+        Self::from(limb)
+    }
+
     fn nlimbs(&self) -> usize {
         Self::LIMBS
     }

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -307,6 +307,12 @@ impl Integer for BoxedUint {
         Self::one()
     }
 
+    fn from_limb_like(limb: Limb, other: &Self) -> Self {
+        let mut ret = Self::zero_with_precision(other.bits_precision());
+        ret.limbs[0] = limb;
+        ret
+    }
+
     fn nlimbs(&self) -> usize {
         self.nlimbs()
     }


### PR DESCRIPTION
- Add `Integer::from_limb_like()`, `one_like()`, and `Zero::zero_like()`. This is needed in [#39](https://github.com/entropyxyz/crypto-primes/pull/39)
- Add `Monty::params()` and `as_montgomery()` 

I do not entirely like `from_limb_like`, but that's all I could come up with.