### PR TITLE
Use explicit types in pointer casts

### DIFF
--- a/src/uint.rs
+++ b/src/uint.rs
@@ -143,7 +143,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
         #[allow(trivial_casts, unsafe_code)]
         unsafe {
-            &*((&self.limbs as *const _) as *const [Word; LIMBS])
+            &*((&self.limbs as *const [Limb; LIMBS]) as *const [Word; LIMBS])
         }
     }
 
@@ -152,7 +152,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
         #[allow(trivial_casts, unsafe_code)]
         unsafe {
-            &mut *((&mut self.limbs as *mut _) as *mut [Word; LIMBS])
+            &mut *((&mut self.limbs as *mut [Limb; LIMBS]) as *mut [Word; LIMBS])
         }
     }
 

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -139,7 +139,7 @@ impl BoxedUint {
         // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
         #[allow(trivial_casts, unsafe_code)]
         unsafe {
-            &*((&*self.limbs as *const _) as *const [Word])
+            &*((&*self.limbs as *const [Limb]) as *const [Word])
         }
     }
 
@@ -148,7 +148,7 @@ impl BoxedUint {
         // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
         #[allow(trivial_casts, unsafe_code)]
         unsafe {
-            &mut *((&mut *self.limbs as *mut _) as *mut [Word])
+            &mut *((&mut *self.limbs as *mut [Limb]) as *mut [Word])
         }
     }
 


### PR DESCRIPTION
It's safer to use explicit types than to let the compiler infer them in these situations