### PR TITLE
docs: a few usage examples for div

### DIFF
--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -159,7 +159,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes `self` % 2^k. Faster than reduce since its a power of 2.
     /// Limited to 2^16-1 since Uint doesn't support higher.
-    /// TODO: this is not constant-time.
     ///
     /// ### Usage:
     /// ```
@@ -167,12 +166,12 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// let a = U448::from(10_u64);
     /// let k = 3; // 2^3 = 8
-    /// let remainder = a.rem2k(k);
+    /// let remainder = a.rem2k_vartime(k);
     ///
     /// // As 10 % 8 = 2
     /// assert_eq!(remainder, U448::from(2_u64));
     /// ```
-    pub const fn rem2k(&self, k: u32) -> Self {
+    pub const fn rem2k_vartime(&self, k: u32) -> Self {
         let highest = (LIMBS - 1) as u32;
         let index = k / Limb::BITS;
         let le = ConstChoice::from_u32_le(index, highest);
@@ -268,7 +267,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// let remainder_option = NonZero::new(U448::from(3_u64))
     ///     .map(|b| a.rem(&b));
     ///
-    /// assert!(bool::from(remainder_option.is_some()), "Reduction by zero");
+    /// assert!(bool::from(remainder_option.is_some()));
     ///
     /// // Check reduction by zero
     /// let zero = U448::from(0_u64);
@@ -796,7 +795,7 @@ mod tests {
             let k = rng.next_u32() % 256;
             let den = U256::ONE.overflowing_shl_vartime(k).unwrap();
 
-            let a = num.rem2k(k);
+            let a = num.rem2k_vartime(k);
             let e = num.wrapping_rem_vartime(&den);
             assert_eq!(a, e);
         }

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -230,8 +230,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// // Check division by zero
     /// let zero = U448::from(0_u64);
-    /// assert!(<Choice as Into<bool>>::into(a.checked_div(&zero).is_none()), "Should be None for division by zero");
-    /// 
+    /// assert!(bool::from(a.checked_div(&zero).is_none()), "Should be None for division by zero");
     /// ```
     pub fn checked_div(&self, rhs: &Self) -> CtOption<Self> {
         NonZero::new(*rhs).map(|rhs| {
@@ -241,7 +240,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// This function exists, so that all operations are accounted for in the wrapping operations.
-    /// It is variable-time.
     /// Panics if `rhs == 0`.
     ///
     /// ### Usage:
@@ -254,7 +252,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// assert_eq!(remainder, U448::from(1_u64));
     /// ```
-    pub const fn wrapping_rem(&self, rhs: &Self) -> Self {
+    pub const fn wrapping_rem_vartime(&self, rhs: &Self) -> Self {
         let nz_rhs = rhs.to_nz().expect("non-zero divisor");
         self.rem_vartime(&nz_rhs)
     }
@@ -270,11 +268,12 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// let remainder_option = NonZero::new(U448::from(3_u64))
     ///     .map(|b| a.rem(&b));
     ///
-    /// assert!(<Choice as Into<bool>>::into(remainder_option.is_some()), "Reduction by zero");
+    /// assert!(bool::from(remainder_option.is_some()), "Reduction by zero");
     ///
     /// // Check reduction by zero
     /// let zero = U448::from(0_u64);
-    /// assert!(<Choice as Into<bool>>::into(a.checked_rem(&zero).is_none()), "Should be None for reduction by zero");
+    /// 
+    /// assert!(bool::from(a.checked_rem(&zero).is_none()), "Should be None for reduction by zero");
     /// ```
     pub fn checked_rem(&self, rhs: &Self) -> CtOption<Self> {
         NonZero::new(*rhs).map(|rhs| self.rem(&rhs))
@@ -780,11 +779,11 @@ mod tests {
         let mut a = U256::ZERO;
         let mut b = U256::ZERO;
         b.limbs[b.limbs.len() - 1] = Limb(Word::MAX);
-        let r = a.wrapping_rem(&b);
+        let r = a.wrapping_rem_vartime(&b);
         assert_eq!(r, Uint::ZERO);
         a.limbs[a.limbs.len() - 1] = Limb(1 << (Limb::HI_BIT - 7));
         b.limbs[b.limbs.len() - 1] = Limb(0x82 << (Limb::HI_BIT - 7));
-        let r = a.wrapping_rem(&b);
+        let r = a.wrapping_rem_vartime(&b);
         assert_eq!(r, a);
     }
 
@@ -798,7 +797,7 @@ mod tests {
             let den = U256::ONE.overflowing_shl_vartime(k).unwrap();
 
             let a = num.rem2k(k);
-            let e = num.wrapping_rem(&den);
+            let e = num.wrapping_rem_vartime(&den);
             assert_eq!(a, e);
         }
     }

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -272,7 +272,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// // Check reduction by zero
     /// let zero = U448::from(0_u64);
-    /// 
+    ///
     /// assert!(bool::from(a.checked_rem(&zero).is_none()), "Should be None for reduction by zero");
     /// ```
     pub fn checked_rem(&self, rhs: &Self) -> CtOption<Self> {

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -248,7 +248,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// let a = U448::from(10_u64);
     /// let b = U448::from(3_u64);
-    /// let remainder = a.wrapping_rem(&b);
+    /// let remainder = a.wrapping_rem_vartime(&b);
     ///
     /// assert_eq!(remainder, U448::from(1_u64));
     /// ```

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -33,7 +33,7 @@ prop_compose! {
 }
 prop_compose! {
     fn uint_mod_p(p: Odd<U256>)(a in uint()) -> U256 {
-        a.wrapping_rem(&p)
+        a.wrapping_rem_vartime(&p)
     }
 }
 prop_compose! {
@@ -268,7 +268,7 @@ proptest! {
 
         if !b_bi.is_zero() {
             let expected = to_uint(a_bi % b_bi);
-            let actual = a.wrapping_rem(&b);
+            let actual = a.wrapping_rem_vartime(&b);
 
             assert_eq!(expected, actual);
         }


### PR DESCRIPTION
Adds a few usage examples for div operations. ref issue #283.

Additionally modifies:

```rust
pub const fn wrapping_rem
```

into:
```rust
pub const fn wrapping_rem_vartime
```

since it uses ```rem_vartime``` internally.