### PR TITLE
Boxed sqrt reduce cloning

### DIFF
--- a/benches/boxed_uint.rs
+++ b/benches/boxed_uint.rs
@@ -43,6 +43,26 @@ fn bench_shifts(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_shifts);
+fn bench_boxed_sqrt(c: &mut Criterion) {
+    let mut group = c.benchmark_group("boxed_sqrt");
+    group.bench_function("boxed_sqrt, 4096", |b| {
+        b.iter_batched(
+            || BoxedUint::random_bits(&mut OsRng, UINT_BITS),
+            |x| x.sqrt(),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("boxed_sqrt_vartime, 4096", |b| {
+        b.iter_batched(
+            || BoxedUint::random_bits(&mut OsRng, UINT_BITS),
+            |x| x.sqrt_vartime(),
+            BatchSize::SmallInput,
+        )
+    });
+
+}
+
+criterion_group!(benches, bench_shifts, bench_boxed_sqrt);
 
 criterion_main!(benches);

--- a/benches/boxed_uint.rs
+++ b/benches/boxed_uint.rs
@@ -60,7 +60,6 @@ fn bench_boxed_sqrt(c: &mut Criterion) {
             BatchSize::SmallInput,
         )
     });
-
 }
 
 criterion_group!(benches, bench_shifts, bench_boxed_sqrt);

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -22,12 +22,13 @@ impl BoxedUint {
 
         // Repeat enough times to guarantee result has stabilized.
         let mut i = 0;
-        // TODO: avoid this clone
         let mut x_prev = x.clone(); // keep the previous iteration in case we need to roll back.
 
         // TODO (#378): the tests indicate that just `Self::LOG2_BITS` may be enough.
         while i < self.log2_bits() + 2 {
-            x_prev = x.clone(); // TODO: can we avoid this clone?
+            // Use clone_from to avoid allocation
+            // TODO: check if `x_prev.clone_from(&x)` does the same thing
+            x_prev.limbs.clone_from(&x.limbs);
 
             // Calculate `x_{i+1} = floor((x_i + self / x_i) / 2)`
 

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -28,7 +28,7 @@ impl BoxedUint {
         while i < self.log2_bits() + 2 {
             // Use clone_from to avoid allocation
             // TODO: check if `x_prev.clone_from(&x)` does the same thing
-            x_prev.limbs.clone_from(&x.limbs);
+            x_prev.limbs.clone_from_slice(&x.limbs);
 
             // Calculate `x_{i+1} = floor((x_i + self / x_i) / 2)`
 

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -26,8 +26,6 @@ impl BoxedUint {
 
         // TODO (#378): the tests indicate that just `Self::LOG2_BITS` may be enough.
         while i < self.log2_bits() + 2 {
-            // Use clone_from to avoid allocation
-            // TODO: check if `x_prev.clone_from(&x)` does the same thing
             x_prev.limbs.clone_from_slice(&x.limbs);
 
             // Calculate `x_{i+1} = floor((x_i + self / x_i) / 2)`


### PR DESCRIPTION
Removed one of the inline TODO's for reducing allocation. Also added some benchmarks.

I am not sure if it's more appropriate to use `.clone_from` on `BoxedUint` or the limbs; it seems like alloc-free cloning is done on the limbs elsewhere. Reviewer please advise.

Interestingly the benchmarks did not show statistically significant improvements between the code change. I am not aware of benchmarking on memory usage, either.