### PR TITLE
Migrate from `generic-array` to `hybrid-array`

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -34,12 +34,12 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features der
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features generic-array
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features hybrid-array
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rand_core
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rlp
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features zeroize
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,der,generic-array,rand_core,rlp,serde,zeroize
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,der,hybrid-array,rand_core,rlp,serde,zeroize
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,8 +223,8 @@ dependencies = [
  "bincode",
  "criterion",
  "der",
- "generic-array",
  "hex-literal",
+ "hybrid-array",
  "num-bigint",
  "num-integer",
  "num-modular",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0-pre.0"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b489fd2221710c1dd46637d66b984161fb66134f81437a8489800306bcc2ecea"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 
 [[package]]
 name = "either"
@@ -273,16 +273,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +300,15 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27fbaf242418fe980caf09ed348d5a6aeabe71fc1bd8bebad641f4591ae0a46d"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "is-terminal"
@@ -715,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.3.0-pre.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791ef964bfaba6be28a5c3f0c56836e17cb711ac009ca1074b9c735a3ebf240a"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
@@ -780,12 +779,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ rust-version = "1.73"
 subtle = { version = "2.5", default-features = false }
 
 # optional dependencies
-der = { version = "=0.8.0-pre.0", optional = true, default-features = false }
-generic-array = { version = "0.14", optional = true }
+der = { version = "0.7", optional = true, default-features = false }
+hybrid-array = { version = "=0.2.0-pre.8", optional = true }
 num-traits = { version = "0.2", default-features = false }
 rand_core = { version = "0.6.4", optional = true }
 rlp = { version = "0.5", optional = true, default-features = false }
-serdect = { version = "=0.3.0-pre.0", optional = true, default-features = false }
+serdect = { version = "0.2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true,  default-features = false }
 
 [dev-dependencies]

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,16 +1,16 @@
-//! Interop support for `generic-array`
+//! Interop support for `hybrid-array`
 
 use crate::{Encoding, Integer};
 use core::ops::Add;
-use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
+use hybrid_array::{typenum::Unsigned, Array, ArraySize};
 
 /// Alias for a byte array whose size is defined by [`ArrayEncoding::ByteSize`].
-pub type ByteArray<T> = GenericArray<u8, <T as ArrayEncoding>::ByteSize>;
+pub type ByteArray<T> = Array<u8, <T as ArrayEncoding>::ByteSize>;
 
-/// Support for encoding a big integer as a `GenericArray`.
+/// Support for encoding a big integer as a `Array`.
 pub trait ArrayEncoding: Encoding {
     /// Size of a byte array which encodes a big integer.
-    type ByteSize: ArrayLength<u8> + Add + Eq + Ord + Unsigned;
+    type ByteSize: ArraySize + Add + Eq + Ord + Unsigned;
 
     /// Deserialize from a big-endian byte array.
     fn from_be_byte_array(bytes: ByteArray<Self>) -> Self;
@@ -25,14 +25,14 @@ pub trait ArrayEncoding: Encoding {
     fn to_le_byte_array(&self) -> ByteArray<Self>;
 }
 
-/// Support for decoding a `GenericArray` as a big integer.
+/// Support for decoding a `Array` as a big integer.
 pub trait ArrayDecoding {
-    /// Big integer which decodes a `GenericArray`.
+    /// Big integer which decodes a `Array`.
     type Output: ArrayEncoding + Integer;
 
-    /// Deserialize from a big-endian `GenericArray`.
+    /// Deserialize from a big-endian `Array`.
     fn into_uint_be(self) -> Self::Output;
 
-    /// Deserialize from a little-endian `GenericArray`.
+    /// Deserialize from a little-endian `Array`.
     fn into_uint_le(self) -> Self::Output;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ mod macros;
 
 pub mod modular;
 
-#[cfg(feature = "generic-array")]
+#[cfg(feature = "hybrid-array")]
 mod array;
 mod checked;
 mod const_choice;
@@ -191,10 +191,10 @@ pub use subtle;
 #[cfg(feature = "alloc")]
 pub use crate::uint::boxed::{encoding::DecodeError, BoxedUint};
 
-#[cfg(feature = "generic-array")]
+#[cfg(feature = "hybrid-array")]
 pub use {
     crate::array::{ArrayDecoding, ArrayEncoding, ByteArray},
-    generic_array::{self, typenum::consts},
+    hybrid_array::{self, typenum::consts},
 };
 
 #[cfg(feature = "rand_core")]
@@ -210,7 +210,7 @@ pub use zeroize;
 pub mod prelude {
     pub use crate::traits::*;
 
-    #[cfg(feature = "generic-array")]
+    #[cfg(feature = "hybrid-array")]
     pub use crate::array::{ArrayDecoding, ArrayEncoding};
 }
 

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -8,7 +8,7 @@ use core::{
 };
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
-#[cfg(feature = "generic-array")]
+#[cfg(feature = "hybrid-array")]
 use crate::{ArrayEncoding, ByteArray};
 
 #[cfg(feature = "rand_core")]
@@ -142,7 +142,7 @@ impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
     }
 }
 
-#[cfg(feature = "generic-array")]
+#[cfg(feature = "hybrid-array")]
 impl<T> NonZero<T>
 where
     T: ArrayEncoding + Zero,

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -32,7 +32,7 @@ mod sqrt;
 mod sub;
 mod sub_mod;
 
-#[cfg(feature = "generic-array")]
+#[cfg(feature = "hybrid-array")]
 mod array;
 #[cfg(feature = "alloc")]
 pub(crate) mod boxed;
@@ -63,9 +63,9 @@ use zeroize::DefaultIsZeroes;
 /// encoding functions that can be used with [`Uint`] constants.
 ///
 /// Optional crate features for encoding (off-by-default):
-/// - `generic-array`: enables [`ArrayEncoding`][`crate::ArrayEncoding`] trait which can be used to
-///   [`Uint`] as `GenericArray<u8, N>` and a [`ArrayDecoding`][`crate::ArrayDecoding`] trait which
-///   can be used to `GenericArray<u8, N>` as [`Uint`].
+/// - `hybrid-array`: enables [`ArrayEncoding`][`crate::ArrayEncoding`] trait which can be used to
+///   [`Uint`] as `Array<u8, N>` and a [`ArrayDecoding`][`crate::ArrayDecoding`] trait which
+///   can be used to `Array<u8, N>` as [`Uint`].
 /// - `rlp`: support for [Recursive Length Prefix (RLP)][RLP] encoding.
 ///
 /// [RLP]: https://eth.wiki/fundamentals/rlp

--- a/src/uint/array.rs
+++ b/src/uint/array.rs
@@ -1,8 +1,8 @@
-//! `generic-array` integration with `Uint`.
-// TODO(tarcieri): completely phase out `generic-array` when const generics are powerful enough
+//! `hybrid-array` integration with `Uint`.
+// TODO(tarcieri): completely phase out `hybrid-array` when const generics are powerful enough
 
 use crate::{ArrayDecoding, ArrayEncoding, ByteArray};
-use generic_array::{typenum, GenericArray};
+use hybrid_array::{typenum, Array};
 
 macro_rules! impl_uint_array_encoding {
     ($(($uint:ident, $bytes:path)),+) => {
@@ -22,20 +22,20 @@ macro_rules! impl_uint_array_encoding {
 
                 #[inline]
                 fn to_be_byte_array(&self) -> ByteArray<Self> {
-                    let mut result = GenericArray::default();
+                    let mut result = Array::default();
                     self.write_be_bytes(&mut result);
                     result
                 }
 
                 #[inline]
                 fn to_le_byte_array(&self) -> ByteArray<Self> {
-                    let mut result = GenericArray::default();
+                    let mut result = Array::default();
                     self.write_le_bytes(&mut result);
                     result
                 }
             }
 
-            impl ArrayDecoding for GenericArray<u8, $bytes> {
+            impl ArrayDecoding for Array<u8, $bytes> {
                 type Output = super::$uint;
 
                 fn into_uint_be(self) -> Self::Output {

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -1,6 +1,6 @@
 //! Const-friendly decoding/encoding operations for [`Uint`].
 
-#[cfg(all(feature = "der", feature = "generic-array"))]
+#[cfg(all(feature = "der", feature = "hybrid-array"))]
 mod der;
 
 #[cfg(feature = "rlp")]
@@ -9,7 +9,7 @@ mod rlp;
 use super::Uint;
 use crate::{Limb, Word};
 
-#[cfg(feature = "generic-array")]
+#[cfg(feature = "hybrid-array")]
 use crate::Encoding;
 
 impl<const LIMBS: usize> Uint<LIMBS> {
@@ -131,7 +131,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Serialize this [`Uint`] as big-endian, writing it into the provided
     /// byte slice.
-    #[cfg(feature = "generic-array")]
+    #[cfg(feature = "hybrid-array")]
     #[inline]
     pub(crate) fn write_be_bytes(&self, out: &mut [u8]) {
         debug_assert_eq!(out.len(), Limb::BYTES * LIMBS);
@@ -149,7 +149,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Serialize this [`Uint`] as little-endian, writing it into the provided
     /// byte slice.
-    #[cfg(feature = "generic-array")]
+    #[cfg(feature = "hybrid-array")]
     #[inline]
     pub(crate) fn write_le_bytes(&self, out: &mut [u8]) {
         debug_assert_eq!(out.len(), Limb::BYTES * LIMBS);

--- a/src/uint/encoding/der.rs
+++ b/src/uint/encoding/der.rs
@@ -1,6 +1,6 @@
 //! Support for decoding/encoding [`Uint`] as an ASN.1 DER `INTEGER`.
 
-use crate::{generic_array::GenericArray, ArrayEncoding, Uint};
+use crate::{hybrid_array::Array, ArrayEncoding, Uint};
 use ::der::{
     asn1::{AnyRef, UintRef},
     DecodeValue, EncodeValue, FixedTag, Length, Tag,
@@ -24,7 +24,7 @@ where
     type Error = der::Error;
 
     fn try_from(bytes: UintRef<'a>) -> der::Result<Uint<LIMBS>> {
-        let mut array = GenericArray::default();
+        let mut array = Array::default();
         let offset = array.len().saturating_sub(bytes.len().try_into()?);
         array[offset..].copy_from_slice(bytes.as_bytes());
         Ok(Uint::from_be_byte_array(array))


### PR DESCRIPTION
This commit replaces the optional `generic-array` feature with `hybrid-array`, which adds support for (de)serializing `Uint`s as `hybrid_array::Array<u8, _>`.

The `hybrid_array` crate notably has significantly less unsafe code than `generic-array`, which it accomplishes by being built on const generic core arrays, which are the public inner type of `Array`.