### PR TITLE
Rename `ZeroConstant` => `ConstZero`

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -19,7 +19,7 @@ mod sub;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{Bounded, ConstCtOption, Constants, NonZero, ZeroConstant};
+use crate::{Bounded, ConstCtOption, ConstZero, Constants, NonZero};
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
@@ -120,7 +120,7 @@ impl ConditionallySelectable for Limb {
     }
 }
 
-impl ZeroConstant for Limb {
+impl ConstZero for Limb {
     const ZERO: Self = Self::ZERO;
 }
 

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -9,7 +9,7 @@ mod sub;
 
 use self::inv::ConstMontyFormInverter;
 use super::{div_by_2::div_by_2, reduction::montgomery_reduction, BernsteinYangInverter, Retrieve};
-use crate::{Limb, Odd, PrecomputeInverter, Uint, ZeroConstant};
+use crate::{ConstZero, Limb, Odd, PrecomputeInverter, Uint};
 use core::{fmt::Debug, marker::PhantomData};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
@@ -181,7 +181,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> Default for ConstMontyFor
     }
 }
 
-impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ZeroConstant for ConstMontyForm<MOD, LIMBS> {
+impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstZero for ConstMontyForm<MOD, LIMBS> {
     const ZERO: Self = Self::ZERO;
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -267,12 +267,12 @@ pub trait Zero: ConstantTimeEq + Sized {
 /// Trait for associating a constant representing zero.
 ///
 /// Types which impl this trait automatically receive a blanket impl of [`Zero`].
-pub trait ZeroConstant: Zero {
+pub trait ConstZero: Zero {
     /// The value `0`.
     const ZERO: Self;
 }
 
-impl<T: ZeroConstant> Zero for T {
+impl<T: ConstZero> Zero for T {
     #[inline(always)]
     fn zero() -> T {
         Self::ZERO
@@ -280,7 +280,7 @@ impl<T: ZeroConstant> Zero for T {
 }
 
 /// Trait for associating constant values with a type.
-pub trait Constants: ZeroConstant {
+pub trait Constants: ConstZero {
     /// The value `1`.
     const ONE: Self;
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -41,8 +41,8 @@ mod rand;
 
 use crate::{
     modular::{BernsteinYangInverter, MontyForm},
-    Bounded, ConstCtOption, Constants, Encoding, FixedInteger, Integer, Limb, NonZero, Odd,
-    PrecomputeInverter, PrecomputeInverterWithAdjuster, Word, ZeroConstant,
+    Bounded, ConstCtOption, ConstZero, Constants, Encoding, FixedInteger, Integer, Limb, NonZero,
+    Odd, PrecomputeInverter, PrecomputeInverterWithAdjuster, Word,
 };
 use core::fmt;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
@@ -258,7 +258,7 @@ impl<const LIMBS: usize> Integer for Uint<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> ZeroConstant for Uint<LIMBS> {
+impl<const LIMBS: usize> ConstZero for Uint<LIMBS> {
     const ZERO: Self = Self::ZERO;
 }
 


### PR DESCRIPTION
Renames the trait to match the prospective name it might potentially receive upstream in `num-traits`: rust-num/num-traits#303