### PR TITLE
Fix `Uint::shr(_vartime)` and `Uint::shl(_vartime)`

### DIFF
--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -117,18 +117,16 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
     }
 
-    /// Computes `self << shift` in a panic-free manner, masking off bits of `shift` which would cause the shift to
-    /// exceed the type's width.
+    /// Computes `self << shift` in a panic-free manner, returning zero if the shift exceeds the
+    /// precision.
     pub const fn wrapping_shl(&self, shift: u32) -> Self {
-        self.overflowing_shl(shift % Self::BITS)
-            .expect("shift within range")
+        self.overflowing_shl(shift).unwrap_or(Self::ZERO)
     }
 
-    /// Computes `self << shift` in variable-time in a panic-free manner, masking off bits of `shift` which would cause
-    /// the shift to exceed the type's width.
+    /// Computes `self << shift` in variable-time in a panic-free manner, returning zero if the
+    /// shift exceeds the precision.
     pub const fn wrapping_shl_vartime(&self, shift: u32) -> Self {
-        self.overflowing_shl_vartime(shift % Self::BITS)
-            .expect("shift within range")
+        self.overflowing_shl_vartime(shift).unwrap_or(Self::ZERO)
     }
 
     /// Computes `self << shift` where `0 <= shift < Limb::BITS`,

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -116,18 +116,16 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
     }
 
-    /// Computes `self >> shift` in a panic-free manner, masking off bits of `shift` which would cause the shift to
-    /// exceed the type's width.
+    /// Computes `self >> shift` in a panic-free manner, returning zero if the shift exceeds the
+    /// precision.
     pub const fn wrapping_shr(&self, shift: u32) -> Self {
-        self.overflowing_shr(shift % Self::BITS)
-            .expect("shift within range")
+        self.overflowing_shr(shift).unwrap_or(Self::ZERO)
     }
 
-    /// Computes `self >> shift` in variable-time in a panic-free manner, masking off bits of `shift` which would cause
-    /// the shift to exceed the type's width.
+    /// Computes `self >> shift` in variable-time in a panic-free manner, returning zero if the
+    /// shift exceeds the precision.
     pub const fn wrapping_shr_vartime(&self, shift: u32) -> Self {
-        self.overflowing_shr_vartime(shift % Self::BITS)
-            .expect("shift within range")
+        self.overflowing_shr_vartime(shift).unwrap_or(Self::ZERO)
     }
 
     /// Computes `self >> 1` in constant-time.

--- a/tests/uint.proptest-regressions
+++ b/tests/uint.proptest-regressions
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 109dd02159bd1afed3bdf3b3a82407df5df8d5949115574175225e7e72d13056 # shrinks to a = Uint(0x0000000000000000000000000000000000000000000000000000000000000006), b = Uint(0x0000000000000000000000000000000000000000000000000000000000000068)

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -371,6 +371,35 @@ proptest! {
     }
 
     #[test]
+    fn wrapping_shl(n in uint(), shift in any::<u32>()) {
+        let n_bi = to_biguint(&n);
+
+        let expected = if shift < U256::BITS {
+            to_uint(n_bi << shift)
+        } else {
+            U256::ZERO
+        };
+
+        let actual_ct = n.wrapping_shl(shift);
+        assert_eq!(expected, actual_ct);
+
+        let actual_vartime = n.wrapping_shl_vartime(shift);
+        assert_eq!(expected, actual_vartime);
+    }
+
+    #[test]
+    fn wrapping_shr(n in uint(), shift in any::<u32>()) {
+        let n_bi = to_biguint(&n);
+        let expected = to_uint(n_bi >> shift);
+
+        let actual_ct = n.wrapping_shr(shift);
+        assert_eq!(expected, actual_ct);
+
+        let actual_vartime = n.wrapping_shr_vartime(shift);
+        assert_eq!(expected, actual_vartime);
+    }
+
+    #[test]
     fn encoding(a in uint()) {
         assert_eq!(a, U256::from_be_bytes(a.to_be_bytes()));
         assert_eq!(a, U256::from_le_bytes(a.to_le_bytes()));


### PR DESCRIPTION
The amount to shift was being miscomputed. It should've been a saturating-like operation, where any shift larger than the precision returns zero, but instead a modulus (which isn't constant time) was being applied instead.

This also adds proptests to ensure correct behavior.