### PR TITLE
Add `Uint::{shl_vartime, shr_vartime}`

### DIFF
--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -13,6 +13,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             .expect("`shift` within the bit size of the integer")
     }
 
+    /// Computes `self << shift` in variable time.
+    ///
+    /// Panics if `shift >= Self::BITS`.
+    pub const fn shl_vartime(&self, shift: u32) -> Self {
+        self.overflowing_shl_vartime(shift)
+            .expect("`shift` within the bit size of the integer")
+    }
+
     /// Computes `self << shift`.
     ///
     /// Returns `None` if `shift >= Self::BITS`.

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -13,6 +13,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             .expect("`shift` within the bit size of the integer")
     }
 
+    /// Computes `self >> shift` in variable time.
+    ///
+    /// Panics if `shift >= Self::BITS`.
+    pub const fn shr_vartime(&self, shift: u32) -> Self {
+        self.overflowing_shr_vartime(shift)
+            .expect("`shift` within the bit size of the integer")
+    }
+
     /// Computes `self >> shift`.
     ///
     /// Returns `None` if `shift >= Self::BITS`.


### PR DESCRIPTION
Adds panicking wrappers for `overflowing_sh*_vartime` which panic-on-overflow.