### PR TITLE
CI: move `dudect` into its own workflow

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -107,21 +107,6 @@ jobs:
       - run: cargo update -Z minimal-versions
       - run: cargo +stable build --release --all-features
 
-  # dudect benchmarks: check for constant-time operation
-  dudect:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-      - run: cargo build --release
-        working-directory: dudect
-      - run: cargo run --release
-          | tee /dev/stderr
-          | perl -n -e '/max t = [+-](\d*\.?\d*)/; if ($1 >= 100) { exit 1 }'
-        working-directory: dudect
-
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dudect.yml
+++ b/.github/workflows/dudect.yml
@@ -1,0 +1,23 @@
+# dudect benchmarks: check for constant-time operation
+name: dudect
+
+on:
+  push:
+    branches: master
+    paths-ignore:
+      - README.md
+
+jobs:
+  dudect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - run: cargo build --release
+        working-directory: dudect
+      - run: cargo run --release
+          | tee /dev/stderr
+          | perl -n -e '/max t = [+-](\d*\.?\d*)/; if ($1 >= 100) { exit 1 }'
+        working-directory: dudect


### PR DESCRIPTION
It takes awhile to run, especially if we expand it.

If it's in its own workflow we can skip running it on PRs, but still run it on merges, which should retroactively detect any regressions.