### PR TITLE
Uint: change `split_mixed` to accept `self`; make `pub`

### DIFF
--- a/src/uint/from.rs
+++ b/src/uint/from.rs
@@ -1,6 +1,6 @@
 //! `From`-like conversions for [`Uint`].
 
-use crate::{ConcatMixed, Limb, Uint, WideWord, Word, U128, U64};
+use crate::{ConcatMixed, Limb, SplitMixed, Uint, WideWord, Word, U128, U64};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a [`Uint`] from a `u8` (const-friendly)
@@ -214,9 +214,12 @@ where
     }
 }
 
-impl<const L: usize, const H: usize, const LIMBS: usize> From<Uint<LIMBS>> for (Uint<L>, Uint<H>) {
+impl<const L: usize, const H: usize, const LIMBS: usize> From<Uint<LIMBS>> for (Uint<L>, Uint<H>)
+where
+    Uint<LIMBS>: SplitMixed<Uint<L>, Uint<H>>,
+{
     fn from(num: Uint<LIMBS>) -> (Uint<L>, Uint<H>) {
-        crate::uint::split::split_mixed(&num)
+        num.split_mixed()
     }
 }
 

--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -90,7 +90,7 @@ macro_rules! impl_uint_concat_split_mixed {
         impl $crate::traits::SplitMixed<Uint<{ U64::LIMBS * $size }>, Uint<{ <$name>::LIMBS - U64::LIMBS * $size }>> for $name
         {
             fn split_mixed(&self) -> (Uint<{ U64::LIMBS * $size }>, Uint<{ <$name>::LIMBS - U64::LIMBS * $size }>) {
-                $crate::uint::split::split_mixed(self)
+                self.split_mixed()
             }
         }
     };
@@ -128,7 +128,7 @@ macro_rules! impl_uint_concat_split_even {
         impl $crate::traits::SplitMixed<Uint<{ <$name>::LIMBS / 2 }>, Uint<{ <$name>::LIMBS / 2 }>> for $name
         {
             fn split_mixed(&self) -> (Uint<{ <$name>::LIMBS / 2 }>, Uint<{ <$name>::LIMBS / 2 }>) {
-                $crate::uint::split::split_mixed(self)
+                self.split_mixed()
             }
         }
 
@@ -140,7 +140,7 @@ macro_rules! impl_uint_concat_split_even {
         impl $name {
             /// Split this number in half, returning its low and high components respectively.
             pub const fn split(&self) -> (Uint<{ <$name>::LIMBS / 2 }>, Uint<{ <$name>::LIMBS / 2 }>) {
-                $crate::uint::split::split_mixed(self)
+                self.split_mixed()
             }
         }
     };

--- a/src/uint/split.rs
+++ b/src/uint/split.rs
@@ -1,26 +1,29 @@
-use crate::{Limb, Uint};
+use crate::{Limb, SplitMixed, Uint};
 
-/// Split this number in half, returning its low and high components respectively.
-#[inline]
-pub(crate) const fn split_mixed<const L: usize, const H: usize, const O: usize>(
-    n: &Uint<O>,
-) -> (Uint<L>, Uint<H>) {
-    let top = L + H;
-    let top = if top < O { top } else { O };
-    let mut lo = [Limb::ZERO; L];
-    let mut hi = [Limb::ZERO; H];
-    let mut i = 0;
+impl<const I: usize> Uint<I> {
+    /// Split this number into low and high components respectively.
+    #[inline]
+    pub const fn split_mixed<const L: usize, const H: usize>(&self) -> (Uint<L>, Uint<H>)
+    where
+        Self: SplitMixed<Uint<L>, Uint<H>>,
+    {
+        let top = L + H;
+        let top = if top < I { top } else { I };
+        let mut lo = [Limb::ZERO; L];
+        let mut hi = [Limb::ZERO; H];
+        let mut i = 0;
 
-    while i < top {
-        if i < L {
-            lo[i] = n.limbs[i];
-        } else {
-            hi[i - L] = n.limbs[i];
+        while i < top {
+            if i < L {
+                lo[i] = self.limbs[i];
+            } else {
+                hi[i - L] = self.limbs[i];
+            }
+            i += 1;
         }
-        i += 1;
-    }
 
-    (Uint { limbs: lo }, Uint { limbs: hi })
+        (Uint { limbs: lo }, Uint { limbs: hi })
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The `split_mixed` method provides a `const fn`-friendly way to split numbers.

This refactors it to be a method that accepts `self` as an argument so it can be called as `uint.split_mixed()` and also exposes it as `pub`, allowing downstream users to use it in `const fn` contexts.

A newly added `SplitMixed` bound typechecks the sizes of the outputs to ensure that they're a valid combination, which is the best we can do absent something like `generic_const_exprs`.