### PR TITLE
Make `Uint::split` const generic over inputs

### DIFF
--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -136,13 +136,6 @@ macro_rules! impl_uint_concat_split_even {
         {
             type Output = Uint<{ <$name>::LIMBS / 2 }>;
         }
-
-        impl $name {
-            /// Split this number in half, returning its low and high components respectively.
-            pub const fn split(&self) -> (Uint<{ <$name>::LIMBS / 2 }>, Uint<{ <$name>::LIMBS / 2 }>) {
-                self.split_mixed()
-            }
-        }
     };
     ($($name:ident,)+) => {
         $(

--- a/src/uint/split.rs
+++ b/src/uint/split.rs
@@ -1,6 +1,14 @@
-use crate::{Limb, SplitMixed, Uint};
+use crate::{Limb, Split, SplitMixed, Uint};
 
 impl<const I: usize> Uint<I> {
+    /// Split this number in half into low and high components.
+    pub const fn split<const O: usize>(&self) -> (Uint<O>, Uint<O>)
+    where
+        Self: Split<Output = Uint<O>>,
+    {
+        self.split_mixed()
+    }
+
     /// Split this number into low and high components respectively.
     #[inline]
     pub const fn split_mixed<const L: usize, const H: usize>(&self) -> (Uint<L>, Uint<H>)


### PR DESCRIPTION
This allows a `const fn` to be written which is bounded on the `Split` trait, and generic over a number of input limbs.

It replaces the previous macro-defined version.