### PR TITLE
Refactor `Uint::{concat, concat_mixed}`

### DIFF
--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -83,7 +83,7 @@ macro_rules! impl_uint_concat_split_mixed {
             type MixedOutput = $name;
 
             fn concat_mixed(&self, hi: &Uint<{ U64::LIMBS * $size }>) -> Self::MixedOutput {
-                $crate::uint::concat::concat_mixed(self, hi)
+                Uint::concat_mixed(self, hi)
             }
         }
 
@@ -113,15 +113,7 @@ macro_rules! impl_uint_concat_split_even {
             type MixedOutput = $name;
 
             fn concat_mixed(&self, hi: &Uint<{ <$name>::LIMBS / 2 }>) -> Self::MixedOutput {
-                $crate::uint::concat::concat_mixed(self, hi)
-            }
-        }
-
-        impl Uint<{ <$name>::LIMBS / 2 }> {
-            /// Concatenate the two values, with `self` as least significant and `hi` as the most
-            /// significant.
-            pub const fn concat(&self, hi: &Uint<{ <$name>::LIMBS / 2 }>) -> $name {
-                $crate::uint::concat::concat_mixed(self, hi)
+                Uint::concat_mixed(self, hi)
             }
         }
 

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -2,7 +2,6 @@
 
 // TODO(tarcieri): use Karatsuba for better performance
 
-use super::concat::concat_mixed;
 use crate::{
     Checked, CheckedMul, Concat, ConcatMixed, Limb, Uint, WideningMul, Wrapping, WrappingMul, Zero,
 };
@@ -61,10 +60,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         rhs: &Uint<RHS_LIMBS>,
     ) -> Uint<WIDE_LIMBS>
     where
-        Uint<RHS_LIMBS>: ConcatMixed<Self, MixedOutput = Uint<WIDE_LIMBS>>,
+        Self: ConcatMixed<Uint<RHS_LIMBS>, MixedOutput = Uint<WIDE_LIMBS>>,
     {
         let (lo, hi) = self.split_mul(rhs);
-        concat_mixed(&lo, &hi)
+        Uint::concat_mixed(&lo, &hi)
     }
 
     /// Compute "wide" multiplication as a 2-tuple containing the `(lo, hi)` components of the product, whose sizes
@@ -172,7 +171,7 @@ where
     /// Square self, returning a concatenated "wide" result.
     pub const fn square(&self) -> Uint<WIDE_LIMBS> {
         let (lo, hi) = self.square_wide();
-        concat_mixed(&lo, &hi)
+        lo.concat(&hi)
     }
 }
 
@@ -244,9 +243,9 @@ impl<const LIMBS: usize> MulAssign<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS
 impl<const LIMBS: usize, const RHS_LIMBS: usize, const WIDE_LIMBS: usize>
     WideningMul<Uint<RHS_LIMBS>> for Uint<LIMBS>
 where
-    Uint<RHS_LIMBS>: ConcatMixed<Self, MixedOutput = Uint<WIDE_LIMBS>>,
+    Self: ConcatMixed<Uint<RHS_LIMBS>, MixedOutput = Uint<WIDE_LIMBS>>,
 {
-    type Output = <Uint<RHS_LIMBS> as ConcatMixed<Self>>::MixedOutput;
+    type Output = <Self as ConcatMixed<Uint<RHS_LIMBS>>>::MixedOutput;
 
     #[inline]
     fn widening_mul(&self, rhs: Uint<RHS_LIMBS>) -> Self::Output {
@@ -257,9 +256,9 @@ where
 impl<const LIMBS: usize, const RHS_LIMBS: usize, const WIDE_LIMBS: usize>
     WideningMul<&Uint<RHS_LIMBS>> for Uint<LIMBS>
 where
-    Uint<RHS_LIMBS>: ConcatMixed<Self, MixedOutput = Uint<WIDE_LIMBS>>,
+    Self: ConcatMixed<Uint<RHS_LIMBS>, MixedOutput = Uint<WIDE_LIMBS>>,
 {
-    type Output = <Uint<RHS_LIMBS> as ConcatMixed<Self>>::MixedOutput;
+    type Output = <Self as ConcatMixed<Uint<RHS_LIMBS>>>::MixedOutput;
 
     #[inline]
     fn widening_mul(&self, rhs: &Uint<RHS_LIMBS>) -> Self::Output {


### PR DESCRIPTION
Does a similar treatment to what #556 and #557 did for `split*` methods, moving `concat_mixed` to be a method on `Uint` that accepts `&self`, making the method public, and redefining `Uint::concat` generically with bounds on `Self: Concat`.