### PR TITLE
CI: test with `cargo-careful`

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -107,6 +107,14 @@ jobs:
       - run: cargo update -Z minimal-versions
       - run: cargo +stable build --release --all-features
 
+  careful:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo install cargo-careful
+      - run: cargo careful test --all-features
+
   clippy:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
`cargo careful` is a tool to run your Rust code extra carefully -- opting into a bunch of nightly-only extra checks that help detect Undefined Behavior, and using a standard library with debug assertions.

https://github.com/RalfJung/cargo-careful