### PR TITLE
Bump `hybrid-array` to v0.2.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,9 +303,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c5517ac29f08e88170b9647d85cc5f21c2596de177b4867232e20b214b8da1"
+checksum = "7b700a69c9d992339e82b6cda619873ee17768be06e80ed5ef07c50c50d499ab"
 dependencies = [
  "typenum",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ subtle = { version = "2.5", default-features = false }
 
 # optional dependencies
 der = { version = "0.7", optional = true, default-features = false }
-hybrid-array = { version = "0.2.0-rc.0", optional = true }
+hybrid-array = { version = "0.2.0-rc.1", optional = true }
 num-traits = { version = "0.2", default-features = false }
 rand_core = { version = "0.6.4", optional = true }
 rlp = { version = "0.5", optional = true, default-features = false }

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -126,8 +126,8 @@ pub(super) fn random_mod_core<T>(
         }
 
         // Generate the high limb which may need to only be filled partially.
-        bytes.as_mut().fill(0);
-        rng.fill_bytes(&mut (bytes.as_mut()[0..hi_bytes]));
+        bytes = Limb::ZERO.to_le_bytes();
+        rng.fill_bytes(&mut bytes[..hi_bytes]);
         n.as_mut()[n_limbs - 1] = Limb::from_le_bytes(bytes);
 
         if n.ct_lt(modulus).into() {


### PR DESCRIPTION
This was supposed to be a "backwards compatible" release but it did wind up adding some trait impls which break inference in certain cases.

This bumps the dependency and fixes the ambiguities.