### PR TITLE
In-place cloning of Montgomery form

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.6.0-pre.11"
+version = "0.6.0-pre.12"
 dependencies = [
  "bincode",
  "criterion",

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -220,6 +220,14 @@ impl BoxedMontyForm {
         self.montgomery_form.clone()
     }
 
+    /// Directly clone from another boxed monty. This method assumes that other has the same
+    /// parameter as self and will not check
+    pub fn clone_from_montgomery(&mut self, other: &Self) {
+        self.montgomery_form
+            .limbs
+            .copy_from_slice(other.montgomery_form.as_limbs())
+    }
+
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
     pub fn div_by_2(&self) -> Self {
         Self {
@@ -264,6 +272,10 @@ impl Monty for BoxedMontyForm {
         &self.montgomery_form
     }
 
+    fn clone_from_montgomery(&mut self, other: &Self) {
+        self.clone_from_montgomery(other)
+    }
+
     fn div_by_2(&self) -> Self {
         BoxedMontyForm::div_by_2(self)
     }
@@ -299,5 +311,17 @@ mod tests {
 
         assert_eq!(zero.div_by_2(), zero);
         assert_eq!(one.div_by_2().mul(&two), one);
+    }
+
+    #[test]
+    fn inplace_cloning() {
+        let modulus = Odd::new(BoxedUint::from(9u8)).unwrap();
+        let params = BoxedMontyParams::new(modulus);
+        let zero = BoxedMontyForm::zero(params.clone());
+        let mut target = BoxedMontyForm::one(params.clone());
+
+        assert_ne!(target, zero);
+        target.clone_from_montgomery(&zero);
+        assert_eq!(target, zero);
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -811,6 +811,9 @@ pub trait Monty:
     /// Access the value in Montgomery form.
     fn as_montgomery(&self) -> &Self::Integer;
 
+    /// In-place cloning of Montgomery form, assuming tha parameters are equal
+    fn clone_from_montgomery(&mut self, other: &Self);
+
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
     fn div_by_2(&self) -> Self;
 }


### PR DESCRIPTION
Originally meant to allow boxed Monty to be cloned without additional allocation. Also includes a change to the `Monty` trait to expose `clone_from_montgomery` to generics