### PR TITLE
Enable `clippy::must_use_candidate` lint + autofix

### DIFF
--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -274,6 +274,7 @@ impl<T> From<ConstCtOption<T>> for Option<T> {
 impl<const LIMBS: usize> ConstCtOption<Uint<LIMBS>> {
     /// This returns the underlying value if it is `Some` or the provided value otherwise.
     #[inline]
+    #[must_use]
     pub const fn unwrap_or(self, def: Uint<LIMBS>) -> Uint<LIMBS> {
         Uint::select(&def, &self.value, self.is_some)
     }
@@ -285,6 +286,7 @@ impl<const LIMBS: usize> ConstCtOption<Uint<LIMBS>> {
     /// Panics if the value is none with a custom panic message provided by
     /// `msg`.
     #[inline]
+    #[must_use]
     pub const fn expect(self, msg: &str) -> Uint<LIMBS> {
         assert!(self.is_some.is_true_vartime(), "{}", msg);
         self.value
@@ -299,6 +301,7 @@ impl<const LIMBS: usize> ConstCtOption<(Uint<LIMBS>, Uint<LIMBS>)> {
     /// Panics if the value is none with a custom panic message provided by
     /// `msg`.
     #[inline]
+    #[must_use]
     pub const fn expect(self, msg: &str) -> (Uint<LIMBS>, Uint<LIMBS>) {
         assert!(self.is_some.is_true_vartime(), "{}", msg);
         self.value
@@ -313,6 +316,7 @@ impl<const LIMBS: usize> ConstCtOption<NonZero<Uint<LIMBS>>> {
     /// Panics if the value is none with a custom panic message provided by
     /// `msg`.
     #[inline]
+    #[must_use]
     pub const fn expect(self, msg: &str) -> NonZero<Uint<LIMBS>> {
         assert!(self.is_some.is_true_vartime(), "{}", msg);
         self.value
@@ -327,6 +331,7 @@ impl<const LIMBS: usize> ConstCtOption<Odd<Uint<LIMBS>>> {
     /// Panics if the value is none with a custom panic message provided by
     /// `msg`.
     #[inline]
+    #[must_use]
     pub const fn expect(self, msg: &str) -> Odd<Uint<LIMBS>> {
         assert!(self.is_some.is_true_vartime(), "{}", msg);
         self.value
@@ -341,6 +346,7 @@ impl ConstCtOption<NonZero<Limb>> {
     /// Panics if the value is none with a custom panic message provided by
     /// `msg`.
     #[inline]
+    #[must_use]
     pub const fn expect(self, msg: &str) -> NonZero<Limb> {
         assert!(self.is_some.is_true_vartime(), "{}", msg);
         self.value
@@ -357,6 +363,7 @@ impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
     /// Panics if the value is none with a custom panic message provided by
     /// `msg`.
     #[inline]
+    #[must_use]
     pub const fn expect(self, msg: &str) -> BernsteinYangInverter<SAT_LIMBS, UNSAT_LIMBS> {
         assert!(self.is_some.is_true_vartime(), "{}", msg);
         self.value

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 #![deny(unsafe_code)]
 #![warn(
     clippy::mod_module_files,
+    clippy::must_use_candidate,
     clippy::unwrap_used,
     missing_docs,
     missing_debug_implementations,

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -98,6 +98,7 @@ impl Limb {
     /// Convert to a [`NonZero<Limb>`].
     ///
     /// Returns some if the original value is non-zero, and false otherwise.
+    #[must_use]
     pub const fn to_nz(self) -> ConstCtOption<NonZero<Self>> {
         ConstCtOption::new(NonZero(self), self.is_nonzero())
     }

--- a/src/limb/add.rs
+++ b/src/limb/add.rs
@@ -10,6 +10,7 @@ use subtle::CtOption;
 impl Limb {
     /// Computes `self + rhs`, returning the result along with the carry.
     #[inline(always)]
+    #[must_use]
     pub const fn overflowing_add(self, rhs: Limb) -> (Limb, Limb) {
         let (res, carry) = overflowing_add(self.0, rhs.0);
         (Limb(res), Limb(carry))
@@ -17,6 +18,7 @@ impl Limb {
 
     /// Computes `self + rhs + carry`, returning the result along with the new carry.
     #[inline(always)]
+    #[must_use]
     pub const fn adc(self, rhs: Limb, carry: Limb) -> (Limb, Limb) {
         let (res, carry) = adc(self.0, rhs.0, carry.0);
         (Limb(res), Limb(carry))
@@ -24,12 +26,14 @@ impl Limb {
 
     /// Perform saturating addition.
     #[inline]
+    #[must_use]
     pub const fn saturating_add(&self, rhs: Self) -> Self {
         Limb(self.0.saturating_add(rhs.0))
     }
 
     /// Perform wrapping addition, discarding overflow.
     #[inline(always)]
+    #[must_use]
     pub const fn wrapping_add(&self, rhs: Self) -> Self {
         Limb(self.0.wrapping_add(rhs.0))
     }

--- a/src/limb/bit_and.rs
+++ b/src/limb/bit_and.rs
@@ -6,6 +6,7 @@ use core::ops::{BitAnd, BitAndAssign};
 impl Limb {
     /// Calculates `a & b`.
     #[inline(always)]
+    #[must_use]
     pub const fn bitand(self, rhs: Self) -> Self {
         Limb(self.0 & rhs.0)
     }

--- a/src/limb/bit_not.rs
+++ b/src/limb/bit_not.rs
@@ -6,6 +6,7 @@ use core::ops::Not;
 impl Limb {
     /// Calculates `!a`.
     #[inline(always)]
+    #[must_use]
     pub const fn not(self) -> Self {
         Limb(!self.0)
     }

--- a/src/limb/bit_or.rs
+++ b/src/limb/bit_or.rs
@@ -6,6 +6,7 @@ use core::ops::{BitOr, BitOrAssign};
 impl Limb {
     /// Calculates `a | b`.
     #[inline(always)]
+    #[must_use]
     pub const fn bitor(self, rhs: Self) -> Self {
         Limb(self.0 | rhs.0)
     }

--- a/src/limb/bit_xor.rs
+++ b/src/limb/bit_xor.rs
@@ -6,6 +6,7 @@ use core::ops::{BitXor, BitXorAssign};
 impl Limb {
     /// Calculates `a ^ b`.
     #[inline(always)]
+    #[must_use]
     pub const fn bitxor(self, rhs: Self) -> Self {
         Limb(self.0 ^ rhs.0)
     }

--- a/src/limb/bits.rs
+++ b/src/limb/bits.rs
@@ -3,24 +3,28 @@ use super::Limb;
 impl Limb {
     /// Calculate the number of bits needed to represent this number.
     #[inline(always)]
+    #[must_use]
     pub const fn bits(self) -> u32 {
         Limb::BITS - self.0.leading_zeros()
     }
 
     /// Calculate the number of leading zeros in the binary representation of this number.
     #[inline(always)]
+    #[must_use]
     pub const fn leading_zeros(self) -> u32 {
         self.0.leading_zeros()
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number.
     #[inline(always)]
+    #[must_use]
     pub const fn trailing_zeros(self) -> u32 {
         self.0.trailing_zeros()
     }
 
     /// Calculate the number of trailing ones the binary representation of this number.
     #[inline(always)]
+    #[must_use]
     pub const fn trailing_ones(self) -> u32 {
         self.0.trailing_ones()
     }

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -9,6 +9,7 @@ use subtle::{
 impl Limb {
     /// Is this limb an odd number?
     #[inline]
+    #[must_use]
     pub fn is_odd(&self) -> Choice {
         Choice::from(self.0 as u8 & 1)
     }
@@ -17,11 +18,13 @@ impl Limb {
     ///
     /// Note that the [`PartialOrd`] and [`Ord`] impls wrap constant-time
     /// comparisons using the `subtle` crate.
+    #[must_use]
     pub fn cmp_vartime(&self, other: &Self) -> Ordering {
         self.0.cmp(&other.0)
     }
 
     /// Performs an equality check in variable-time.
+    #[must_use]
     pub const fn eq_vartime(&self, other: &Self) -> bool {
         self.0 == other.0
     }

--- a/src/limb/from.rs
+++ b/src/limb/from.rs
@@ -5,18 +5,21 @@ use super::{Limb, WideWord, Word};
 impl Limb {
     /// Create a [`Limb`] from a `u8` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u8>` when stable
+    #[must_use]
     pub const fn from_u8(n: u8) -> Self {
         Limb(n as Word)
     }
 
     /// Create a [`Limb`] from a `u16` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u16>` when stable
+    #[must_use]
     pub const fn from_u16(n: u16) -> Self {
         Limb(n as Word)
     }
 
     /// Create a [`Limb`] from a `u32` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u32>` when stable
+    #[must_use]
     pub const fn from_u32(n: u32) -> Self {
         #[allow(trivial_numeric_casts)]
         Limb(n as Word)
@@ -25,6 +28,7 @@ impl Limb {
     /// Create a [`Limb`] from a `u64` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u64>` when stable
     #[cfg(target_pointer_width = "64")]
+    #[must_use]
     pub const fn from_u64(n: u64) -> Self {
         Limb(n)
     }

--- a/src/limb/mul.rs
+++ b/src/limb/mul.rs
@@ -11,6 +11,7 @@ use subtle::CtOption;
 impl Limb {
     /// Computes `self + (b * c) + carry`, returning the result along with the new carry.
     #[inline(always)]
+    #[must_use]
     pub const fn mac(self, b: Limb, c: Limb, carry: Limb) -> (Limb, Limb) {
         let (res, carry) = mac(self.0, b.0, c.0, carry.0);
         (Limb(res), Limb(carry))
@@ -18,12 +19,14 @@ impl Limb {
 
     /// Perform saturating multiplication.
     #[inline(always)]
+    #[must_use]
     pub const fn saturating_mul(&self, rhs: Self) -> Self {
         Limb(self.0.saturating_mul(rhs.0))
     }
 
     /// Perform wrapping multiplication, discarding overflow.
     #[inline(always)]
+    #[must_use]
     pub const fn wrapping_mul(&self, rhs: Self) -> Self {
         Limb(self.0.wrapping_mul(rhs.0))
     }

--- a/src/limb/neg.rs
+++ b/src/limb/neg.rs
@@ -6,6 +6,7 @@ use num_traits::WrappingNeg;
 impl Limb {
     /// Perform wrapping negation.
     #[inline(always)]
+    #[must_use]
     pub const fn wrapping_neg(self) -> Self {
         Limb(self.0.wrapping_neg())
     }

--- a/src/limb/shl.rs
+++ b/src/limb/shl.rs
@@ -8,6 +8,7 @@ impl Limb {
     /// Computes `self << shift`.
     /// Panics if `shift` overflows `Limb::BITS`.
     #[inline(always)]
+    #[must_use]
     pub const fn shl(self, shift: u32) -> Self {
         Limb(self.0 << shift)
     }

--- a/src/limb/shr.rs
+++ b/src/limb/shr.rs
@@ -7,6 +7,7 @@ impl Limb {
     /// Computes `self >> shift`.
     /// Panics if `shift` overflows `Limb::BITS`.
     #[inline(always)]
+    #[must_use]
     pub const fn shr(self, shift: u32) -> Self {
         Limb(self.0 >> shift)
     }

--- a/src/limb/sub.rs
+++ b/src/limb/sub.rs
@@ -7,6 +7,7 @@ use subtle::CtOption;
 impl Limb {
     /// Computes `self - (rhs + borrow)`, returning the result along with the new borrow.
     #[inline(always)]
+    #[must_use]
     pub const fn sbb(self, rhs: Limb, borrow: Limb) -> (Limb, Limb) {
         let (res, borrow) = sbb(self.0, rhs.0, borrow.0);
         (Limb(res), Limb(borrow))
@@ -14,6 +15,7 @@ impl Limb {
 
     /// Perform saturating subtraction.
     #[inline]
+    #[must_use]
     pub const fn saturating_sub(&self, rhs: Self) -> Self {
         Limb(self.0.saturating_sub(rhs.0))
     }
@@ -21,6 +23,7 @@ impl Limb {
     /// Perform wrapping subtraction, discarding underflow and wrapping around
     /// the boundary of the type.
     #[inline(always)]
+    #[must_use]
     pub const fn wrapping_sub(&self, rhs: Self) -> Self {
         Limb(self.0.wrapping_sub(rhs.0))
     }

--- a/src/modular/bernstein_yang.rs
+++ b/src/modular/bernstein_yang.rs
@@ -64,6 +64,7 @@ impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
     /// Creates the inverter for specified modulus and adjusting parameter.
     ///
     /// Modulus must be odd. Returns `None` if it is not.
+    #[must_use]
     pub const fn new(modulus: &Odd<Uint<SAT_LIMBS>>, adjuster: &Uint<SAT_LIMBS>) -> Self {
         Self {
             modulus: Int62L::from_uint(&modulus.0),
@@ -74,6 +75,7 @@ impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
 
     /// Returns either the adjusted modular multiplicative inverse for the argument or `None`
     /// depending on invertibility of the argument, i.e. its coprimality with the modulus
+    #[must_use]
     pub const fn inv(&self, value: &Uint<SAT_LIMBS>) -> ConstCtOption<Uint<SAT_LIMBS>> {
         let (d, f) = divsteps(
             self.adjuster,

--- a/src/modular/bernstein_yang/boxed.rs
+++ b/src/modular/bernstein_yang/boxed.rs
@@ -28,6 +28,7 @@ impl BoxedBernsteinYangInverter {
     /// Creates the inverter for specified modulus and adjusting parameter.
     ///
     /// Modulus must be odd. Returns `None` if it is not.
+    #[must_use]
     pub fn new(modulus: &Odd<BoxedUint>, adjuster: &BoxedUint) -> Self {
         Self {
             modulus: BoxedInt62L::from(&modulus.0),

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -43,6 +43,7 @@ impl BoxedMontyParams {
     ///
     /// Returns a `CtOption` that is `None` if the provided modulus is not odd.
     /// TODO(tarcieri): DRY out with `MontyParams::new`?
+    #[must_use]
     pub fn new(modulus: Odd<BoxedUint>) -> Self {
         let bits_precision = modulus.bits_precision();
 
@@ -66,6 +67,7 @@ impl BoxedMontyParams {
     ///
     /// Returns `None` if the provided modulus is not odd.
     /// TODO(tarcieri): DRY out with `MontyParams::new`?
+    #[must_use]
     pub fn new_vartime(modulus: Odd<BoxedUint>) -> Self {
         let bits_precision = modulus.bits_precision();
 
@@ -106,11 +108,13 @@ impl BoxedMontyParams {
     }
 
     /// Modulus value.
+    #[must_use]
     pub fn modulus(&self) -> &Odd<BoxedUint> {
         &self.modulus
     }
 
     /// Bits of precision in the modulus.
+    #[must_use]
     pub fn bits_precision(&self) -> u32 {
         self.modulus.bits_precision()
     }
@@ -134,6 +138,7 @@ pub struct BoxedMontyForm {
 
 impl BoxedMontyForm {
     /// Instantiates a new [`BoxedMontyForm`] that represents an integer modulo the provided params.
+    #[must_use]
     pub fn new(mut integer: BoxedUint, params: BoxedMontyParams) -> Self {
         debug_assert_eq!(integer.bits_precision(), params.bits_precision());
         convert_to_montgomery(&mut integer, &params);
@@ -147,6 +152,7 @@ impl BoxedMontyForm {
 
     /// Instantiates a new [`BoxedMontyForm`] that represents an integer modulo the provided params.
     #[cfg(feature = "std")]
+    #[must_use]
     pub fn new_with_arc(mut integer: BoxedUint, params: Arc<BoxedMontyParams>) -> Self {
         debug_assert_eq!(integer.bits_precision(), params.bits_precision());
         convert_to_montgomery(&mut integer, &params);
@@ -157,11 +163,13 @@ impl BoxedMontyForm {
     }
 
     /// Bits of precision in the modulus.
+    #[must_use]
     pub fn bits_precision(&self) -> u32 {
         self.params.bits_precision()
     }
 
     /// Retrieves the integer currently encoded in this [`BoxedMontyForm`], guaranteed to be reduced.
+    #[must_use]
     pub fn retrieve(&self) -> BoxedUint {
         let mut montgomery_form = self.montgomery_form.widen(self.bits_precision() * 2);
 
@@ -179,6 +187,7 @@ impl BoxedMontyForm {
     }
 
     /// Instantiates a new `ConstMontyForm` that represents zero.
+    #[must_use]
     pub fn zero(params: BoxedMontyParams) -> Self {
         Self {
             montgomery_form: BoxedUint::zero_with_precision(params.bits_precision()),
@@ -187,6 +196,7 @@ impl BoxedMontyForm {
     }
 
     /// Instantiates a new `ConstMontyForm` that represents 1.
+    #[must_use]
     pub fn one(params: BoxedMontyParams) -> Self {
         Self {
             montgomery_form: params.one.clone(),
@@ -195,17 +205,20 @@ impl BoxedMontyForm {
     }
 
     /// Returns the parameter struct used to initialize this object.
+    #[must_use]
     pub fn params(&self) -> &BoxedMontyParams {
         &self.params
     }
 
     /// Access the [`BoxedMontyForm`] value in Montgomery form.
+    #[must_use]
     pub fn as_montgomery(&self) -> &BoxedUint {
         debug_assert!(self.montgomery_form < self.params.modulus);
         &self.montgomery_form
     }
 
     /// Create a [`BoxedMontyForm`] from a value in Montgomery form.
+    #[must_use]
     pub fn from_montgomery(integer: BoxedUint, params: BoxedMontyParams) -> Self {
         debug_assert_eq!(integer.bits_precision(), params.bits_precision());
         Self {
@@ -215,12 +228,14 @@ impl BoxedMontyForm {
     }
 
     /// Extract the value from the [`BoxedMontyForm`] in Montgomery form.
+    #[must_use]
     pub fn to_montgomery(&self) -> BoxedUint {
         debug_assert!(self.montgomery_form < self.params.modulus);
         self.montgomery_form.clone()
     }
 
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
+    #[must_use]
     pub fn div_by_2(&self) -> Self {
         Self {
             montgomery_form: div_by_2::div_by_2_boxed(&self.montgomery_form, &self.params.modulus),
@@ -286,7 +301,7 @@ mod tests {
     #[test]
     fn new_params_with_valid_modulus() {
         let modulus = Odd::new(BoxedUint::from(3u8)).unwrap();
-        BoxedMontyParams::new(modulus);
+        let _ = BoxedMontyParams::new(modulus);
     }
 
     #[test]

--- a/src/modular/boxed_monty_form/add.rs
+++ b/src/modular/boxed_monty_form/add.rs
@@ -5,6 +5,7 @@ use core::ops::{Add, AddAssign};
 
 impl BoxedMontyForm {
     /// Adds `rhs`.
+    #[must_use]
     pub fn add(&self, rhs: &Self) -> Self {
         debug_assert_eq!(self.params, rhs.params);
 

--- a/src/modular/boxed_monty_form/inv.rs
+++ b/src/modular/boxed_monty_form/inv.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 impl BoxedMontyForm {
     /// Computes `self^-1` representing the multiplicative inverse of `self`.
     /// I.e. `self * self^-1 = 1`.
+    #[must_use]
     pub fn invert(&self) -> CtOption<Self> {
         let inverter = self.params.precompute_inverter();
         inverter.invert(self)

--- a/src/modular/boxed_monty_form/mul.rs
+++ b/src/modular/boxed_monty_form/mul.rs
@@ -21,6 +21,7 @@ use zeroize::Zeroize;
 
 impl BoxedMontyForm {
     /// Multiplies by `rhs`.
+    #[must_use]
     pub fn mul(&self, rhs: &Self) -> Self {
         debug_assert_eq!(&self.params, &rhs.params);
         let montgomery_form = MontyMultiplier::from(self.params.borrow())
@@ -33,6 +34,7 @@ impl BoxedMontyForm {
     }
 
     /// Computes the (reduced) square.
+    #[must_use]
     pub fn square(&self) -> Self {
         let montgomery_form =
             MontyMultiplier::from(self.params.borrow()).square(&self.montgomery_form);

--- a/src/modular/boxed_monty_form/neg.rs
+++ b/src/modular/boxed_monty_form/neg.rs
@@ -6,6 +6,7 @@ use core::ops::Neg;
 
 impl BoxedMontyForm {
     /// Negates the number.
+    #[must_use]
     pub fn neg(&self) -> Self {
         let zero = Self {
             montgomery_form: BoxedUint::zero_with_precision(self.params.bits_precision()),

--- a/src/modular/boxed_monty_form/pow.rs
+++ b/src/modular/boxed_monty_form/pow.rs
@@ -7,6 +7,7 @@ use subtle::{ConstantTimeEq, ConstantTimeLess};
 
 impl BoxedMontyForm {
     /// Raises to the `exponent` power.
+    #[must_use]
     pub fn pow(&self, exponent: &BoxedUint) -> Self {
         self.pow_bounded_exp(exponent, exponent.bits_precision())
     }
@@ -16,6 +17,7 @@ impl BoxedMontyForm {
     /// to take into account for the exponent.
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
+    #[must_use]
     pub fn pow_bounded_exp(&self, exponent: &BoxedUint, exponent_bits: u32) -> Self {
         let ret = Self {
             montgomery_form: pow_montgomery_form(

--- a/src/modular/boxed_monty_form/sub.rs
+++ b/src/modular/boxed_monty_form/sub.rs
@@ -5,6 +5,7 @@ use core::ops::{Sub, SubAssign};
 
 impl BoxedMontyForm {
     /// Subtracts `rhs`.
+    #[must_use]
     pub fn sub(&self, rhs: &Self) -> Self {
         debug_assert_eq!(self.params, rhs.params);
 

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -53,6 +53,7 @@ pub trait ConstMontyParams<const LIMBS: usize>:
     /// Precompute a Bernstein-Yang inverter for this modulus.
     ///
     /// Use [`ConstMontyFormInverter::new`] if you need `const fn` access.
+    #[must_use]
     fn precompute_inverter<const UNSAT_LIMBS: usize>() -> ConstMontyFormInverter<Self, LIMBS>
     where
         Odd<Uint<LIMBS>>: PrecomputeInverter<
@@ -107,11 +108,13 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     }
 
     /// Instantiates a new [`ConstMontyForm`] that represents this `integer` mod `MOD`.
+    #[must_use]
     pub const fn new(integer: &Uint<LIMBS>) -> Self {
         Self::from_integer(integer)
     }
 
     /// Retrieves the integer currently encoded in this [`ConstMontyForm`], guaranteed to be reduced.
+    #[must_use]
     pub const fn retrieve(&self) -> Uint<LIMBS> {
         montgomery_reduction::<LIMBS>(
             &(self.montgomery_form, Uint::ZERO),
@@ -121,6 +124,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     }
 
     /// Access the `ConstMontyForm` value in Montgomery form.
+    #[must_use]
     pub const fn as_montgomery(&self) -> &Uint<LIMBS> {
         &self.montgomery_form
     }
@@ -131,6 +135,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     }
 
     /// Create a `ConstMontyForm` from a value in Montgomery form.
+    #[must_use]
     pub const fn from_montgomery(integer: Uint<LIMBS>) -> Self {
         Self {
             montgomery_form: integer,
@@ -139,11 +144,13 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     }
 
     /// Extract the value from the `ConstMontyForm` in Montgomery form.
+    #[must_use]
     pub const fn to_montgomery(&self) -> Uint<LIMBS> {
         self.montgomery_form
     }
 
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
+    #[must_use]
     pub const fn div_by_2(&self) -> Self {
         Self {
             montgomery_form: div_by_2(&self.montgomery_form, &MOD::MODULUS),

--- a/src/modular/const_monty_form/add.rs
+++ b/src/modular/const_monty_form/add.rs
@@ -6,6 +6,7 @@ use core::ops::{Add, AddAssign};
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Adds `rhs`.
+    #[must_use]
     pub const fn add(&self, rhs: &ConstMontyForm<MOD, LIMBS>) -> Self {
         Self {
             montgomery_form: add_montgomery_form(

--- a/src/modular/const_monty_form/inv.rs
+++ b/src/modular/const_monty_form/inv.rs
@@ -19,6 +19,7 @@ where
     /// I.e. `self * self^-1 = 1`.
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
+    #[must_use]
     pub const fn inv(&self) -> ConstCtOption<Self> {
         let inverter =
             <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(&MOD::MODULUS, &MOD::R2);
@@ -67,6 +68,7 @@ where
     >,
 {
     /// Create a new [`ConstMontyFormInverter`] for the given [`ConstMontyParams`].
+    #[must_use]
     pub const fn new() -> Self {
         let inverter = BernsteinYangInverter::new(&MOD::MODULUS, &MOD::R2);
 
@@ -78,6 +80,7 @@ where
 
     /// Returns either the adjusted modular multiplicative inverse for the argument or None
     /// depending on invertibility of the argument, i.e. its coprimality with the modulus.
+    #[must_use]
     pub const fn inv(
         &self,
         value: &ConstMontyForm<MOD, SAT_LIMBS>,

--- a/src/modular/const_monty_form/mul.rs
+++ b/src/modular/const_monty_form/mul.rs
@@ -14,6 +14,7 @@ use super::{ConstMontyForm, ConstMontyParams};
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Multiplies by `rhs`.
+    #[must_use]
     pub const fn mul(&self, rhs: &Self) -> Self {
         Self {
             montgomery_form: mul_montgomery_form(
@@ -27,6 +28,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     }
 
     /// Computes the (reduced) square.
+    #[must_use]
     pub const fn square(&self) -> Self {
         Self {
             montgomery_form: square_montgomery_form(

--- a/src/modular/const_monty_form/neg.rs
+++ b/src/modular/const_monty_form/neg.rs
@@ -5,6 +5,7 @@ use core::ops::Neg;
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Negates the number.
+    #[must_use]
     pub const fn neg(&self) -> Self {
         Self::ZERO.sub(self)
     }

--- a/src/modular/const_monty_form/pow.rs
+++ b/src/modular/const_monty_form/pow.rs
@@ -11,6 +11,7 @@ use {crate::modular::pow::multi_exponentiate_montgomery_form_slice, alloc::vec::
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Raises to the `exponent` power.
+    #[must_use]
     pub const fn pow<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,
@@ -23,6 +24,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     /// to take into account for the exponent.
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
+    #[must_use]
     pub const fn pow_bounded_exp<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,

--- a/src/modular/const_monty_form/sub.rs
+++ b/src/modular/const_monty_form/sub.rs
@@ -6,6 +6,7 @@ use core::ops::{Sub, SubAssign};
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Subtracts `rhs`.
+    #[must_use]
     pub const fn sub(&self, rhs: &Self) -> Self {
         Self {
             montgomery_form: sub_montgomery_form(

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -38,6 +38,7 @@ where
     Uint<WIDE_LIMBS>: Split<Output = Uint<LIMBS>>,
 {
     /// Instantiates a new set of `MontyParams` representing the given odd `modulus`.
+    #[must_use]
     pub fn new(modulus: Odd<Uint<LIMBS>>) -> Self {
         // `R mod modulus` where `R = 2^BITS`.
         // Represents 1 in Montgomery form.
@@ -72,6 +73,7 @@ where
 
 impl<const LIMBS: usize> MontyParams<LIMBS> {
     /// Instantiates a new set of `MontyParams` representing the given odd `modulus`.
+    #[must_use]
     pub fn new_vartime(modulus: Odd<Uint<LIMBS>>) -> Self {
         // `R mod modulus` where `R = 2^BITS`.
         // Represents 1 in Montgomery form.
@@ -102,11 +104,13 @@ impl<const LIMBS: usize> MontyParams<LIMBS> {
     }
 
     /// Returns the modulus which was used to initialize these parameters.
+    #[must_use]
     pub const fn modulus(&self) -> &Odd<Uint<LIMBS>> {
         &self.modulus
     }
 
     /// Create `MontyParams` corresponding to a `ConstMontyParams`.
+    #[must_use]
     pub const fn from_const_params<P>() -> Self
     where
         P: ConstMontyParams<LIMBS>,
@@ -153,6 +157,7 @@ pub struct MontyForm<const LIMBS: usize> {
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Instantiates a new `MontyForm` that represents this `integer` mod `MOD`.
+    #[must_use]
     pub const fn new(integer: &Uint<LIMBS>, params: MontyParams<LIMBS>) -> Self {
         let product = integer.split_mul(&params.r2);
         let montgomery_form = montgomery_reduction(&product, &params.modulus, params.mod_neg_inv);
@@ -164,6 +169,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Retrieves the integer currently encoded in this `MontyForm`, guaranteed to be reduced.
+    #[must_use]
     pub const fn retrieve(&self) -> Uint<LIMBS> {
         montgomery_reduction(
             &(self.montgomery_form, Uint::ZERO),
@@ -173,6 +179,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Instantiates a new `MontyForm` that represents zero.
+    #[must_use]
     pub const fn zero(params: MontyParams<LIMBS>) -> Self {
         Self {
             montgomery_form: Uint::<LIMBS>::ZERO,
@@ -181,6 +188,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Instantiates a new `MontyForm` that represents 1.
+    #[must_use]
     pub const fn one(params: MontyParams<LIMBS>) -> Self {
         Self {
             montgomery_form: params.one,
@@ -189,11 +197,13 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Returns the parameter struct used to initialize this object.
+    #[must_use]
     pub const fn params(&self) -> &MontyParams<LIMBS> {
         &self.params
     }
 
     /// Access the `MontyForm` value in Montgomery form.
+    #[must_use]
     pub const fn as_montgomery(&self) -> &Uint<LIMBS> {
         &self.montgomery_form
     }
@@ -204,6 +214,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Create a `MontyForm` from a value in Montgomery form.
+    #[must_use]
     pub const fn from_montgomery(integer: Uint<LIMBS>, params: MontyParams<LIMBS>) -> Self {
         Self {
             montgomery_form: integer,
@@ -212,11 +223,13 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Extract the value from the `MontyForm` in Montgomery form.
+    #[must_use]
     pub const fn to_montgomery(&self) -> Uint<LIMBS> {
         self.montgomery_form
     }
 
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
+    #[must_use]
     pub const fn div_by_2(&self) -> Self {
         Self {
             montgomery_form: div_by_2(&self.montgomery_form, &self.params.modulus),

--- a/src/modular/monty_form/add.rs
+++ b/src/modular/monty_form/add.rs
@@ -6,6 +6,7 @@ use core::ops::{Add, AddAssign};
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Adds `rhs`.
+    #[must_use]
     pub const fn add(&self, rhs: &Self) -> Self {
         Self {
             montgomery_form: add_montgomery_form(

--- a/src/modular/monty_form/inv.rs
+++ b/src/modular/monty_form/inv.rs
@@ -19,6 +19,7 @@ where
     /// I.e. `self * self^-1 = 1`.
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
+    #[must_use]
     pub const fn inv(&self) -> ConstCtOption<Self> {
         let inverter = <Odd<Uint<SAT_LIMBS>> as PrecomputeInverter>::Inverter::new(
             &self.params.modulus,

--- a/src/modular/monty_form/mul.rs
+++ b/src/modular/monty_form/mul.rs
@@ -9,6 +9,7 @@ use core::ops::{Mul, MulAssign};
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Multiplies by `rhs`.
+    #[must_use]
     pub const fn mul(&self, rhs: &Self) -> Self {
         Self {
             montgomery_form: mul_montgomery_form(
@@ -22,6 +23,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Computes the (reduced) square.
+    #[must_use]
     pub const fn square(&self) -> Self {
         Self {
             montgomery_form: square_montgomery_form(

--- a/src/modular/monty_form/neg.rs
+++ b/src/modular/monty_form/neg.rs
@@ -5,6 +5,7 @@ use core::ops::Neg;
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Negates the number.
+    #[must_use]
     pub const fn neg(&self) -> Self {
         Self::zero(self.params).sub(self)
     }

--- a/src/modular/monty_form/pow.rs
+++ b/src/modular/monty_form/pow.rs
@@ -11,6 +11,7 @@ use {crate::modular::pow::multi_exponentiate_montgomery_form_slice, alloc::vec::
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Raises to the `exponent` power.
+    #[must_use]
     pub const fn pow<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,
@@ -23,6 +24,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// to take into account for the exponent.
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
+    #[must_use]
     pub const fn pow_bounded_exp<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,

--- a/src/modular/monty_form/sub.rs
+++ b/src/modular/monty_form/sub.rs
@@ -6,6 +6,7 @@ use core::ops::{Sub, SubAssign};
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Subtracts `rhs`.
+    #[must_use]
     pub const fn sub(&self, rhs: &Self) -> Self {
         Self {
             montgomery_form: sub_montgomery_form(

--- a/src/modular/reduction.rs
+++ b/src/modular/reduction.rs
@@ -45,6 +45,7 @@ macro_rules! impl_montgomery_reduction {
 }
 
 /// Algorithm 14.32 in Handbook of Applied Cryptography <https://cacr.uwaterloo.ca/hac/about/chap14.pdf>
+#[must_use]
 pub const fn montgomery_reduction<const LIMBS: usize>(
     lower_upper: &(Uint<LIMBS>, Uint<LIMBS>),
     modulus: &Odd<Uint<LIMBS>>,

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -86,18 +86,21 @@ where
 impl NonZero<Limb> {
     /// Create a [`NonZero<Limb>`] from a [`NonZeroU8`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU8>` when stable
+    #[must_use]
     pub const fn from_u8(n: NonZeroU8) -> Self {
         Self(Limb::from_u8(n.get()))
     }
 
     /// Create a [`NonZero<Limb>`] from a [`NonZeroU16`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU16>` when stable
+    #[must_use]
     pub const fn from_u16(n: NonZeroU16) -> Self {
         Self(Limb::from_u16(n.get()))
     }
 
     /// Create a [`NonZero<Limb>`] from a [`NonZeroU32`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU32>` when stable
+    #[must_use]
     pub const fn from_u32(n: NonZeroU32) -> Self {
         Self(Limb::from_u32(n.get()))
     }
@@ -105,6 +108,7 @@ impl NonZero<Limb> {
     /// Create a [`NonZero<Limb>`] from a [`NonZeroU64`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU64>` when stable
     #[cfg(target_pointer_width = "64")]
+    #[must_use]
     pub const fn from_u64(n: NonZeroU64) -> Self {
         Self(Limb::from_u64(n.get()))
     }
@@ -113,30 +117,35 @@ impl NonZero<Limb> {
 impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
     /// Create a [`NonZero<Uint>`] from a [`NonZeroU8`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU8>` when stable
+    #[must_use]
     pub const fn from_u8(n: NonZeroU8) -> Self {
         Self(Uint::from_u8(n.get()))
     }
 
     /// Create a [`NonZero<Uint>`] from a [`NonZeroU16`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU16>` when stable
+    #[must_use]
     pub const fn from_u16(n: NonZeroU16) -> Self {
         Self(Uint::from_u16(n.get()))
     }
 
     /// Create a [`NonZero<Uint>`] from a [`NonZeroU32`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU32>` when stable
+    #[must_use]
     pub const fn from_u32(n: NonZeroU32) -> Self {
         Self(Uint::from_u32(n.get()))
     }
 
     /// Create a [`NonZero<Uint>`] from a [`NonZeroU64`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU64>` when stable
+    #[must_use]
     pub const fn from_u64(n: NonZeroU64) -> Self {
         Self(Uint::from_u64(n.get()))
     }
 
     /// Create a [`NonZero<Uint>`] from a [`NonZeroU128`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU128>` when stable
+    #[must_use]
     pub const fn from_u128(n: NonZeroU128) -> Self {
         Self(Uint::from_u128(n.get()))
     }

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -53,6 +53,7 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
     /// Create a new [`Odd<Uint<LIMBS>>`] from the provided big endian hex string.
     ///
     /// Panics if the hex is malformed or not zero-padded accordingly for the size, or if the value is even.
+    #[must_use]
     pub const fn from_be_hex(hex: &str) -> Self {
         let uint = Uint::<LIMBS>::from_be_hex(hex);
         assert!(uint.is_odd().is_true_vartime(), "number must be odd");
@@ -62,6 +63,7 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
     /// Create a new [`Odd<Uint<LIMBS>>`] from the provided little endian hex string.
     ///
     /// Panics if the hex is malformed or not zero-padded accordingly for the size, or if the value is even.
+    #[must_use]
     pub const fn from_le_hex(hex: &str) -> Self {
         let uint = Uint::<LIMBS>::from_be_hex(hex);
         assert!(uint.is_odd().is_true_vartime(), "number must be odd");

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -104,6 +104,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     pub const LIMBS: usize = LIMBS;
 
     /// Const-friendly [`Uint`] constructor.
+    #[must_use]
     pub const fn new(limbs: [Limb; LIMBS]) -> Self {
         Self { limbs }
     }
@@ -111,6 +112,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a [`Uint`] from an array of [`Word`]s (i.e. word-sized unsigned
     /// integers).
     #[inline]
+    #[must_use]
     pub const fn from_words(arr: [Word; LIMBS]) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;
@@ -126,6 +128,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create an array of [`Word`]s (i.e. word-sized unsigned integers) from
     /// a [`Uint`].
     #[inline]
+    #[must_use]
     pub const fn to_words(self) -> [Word; LIMBS] {
         let mut arr = [0; LIMBS];
         let mut i = 0;
@@ -139,6 +142,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Borrow the inner limbs as an array of [`Word`]s.
+    #[must_use]
     pub const fn as_words(&self) -> &[Word; LIMBS] {
         // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
         #[allow(unsafe_code)]
@@ -157,6 +161,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Borrow the limbs of this [`Uint`].
+    #[must_use]
     pub const fn as_limbs(&self) -> &[Limb; LIMBS] {
         &self.limbs
     }
@@ -167,6 +172,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Convert this [`Uint`] into its inner limbs.
+    #[must_use]
     pub const fn to_limbs(self) -> [Limb; LIMBS] {
         self.limbs
     }
@@ -174,6 +180,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Convert to a [`NonZero<Uint<LIMBS>>`].
     ///
     /// Returns some if the original value is non-zero, and false otherwise.
+    #[must_use]
     pub const fn to_nz(self) -> ConstCtOption<NonZero<Self>> {
         ConstCtOption::new(NonZero(self), self.is_nonzero())
     }
@@ -181,6 +188,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Convert to a [`Odd<Uint<LIMBS>>`].
     ///
     /// Returns some if the original value is odd, and false otherwise.
+    #[must_use]
     pub const fn to_odd(self) -> ConstCtOption<Odd<Self>> {
         ConstCtOption::new(Odd(self), self.is_odd())
     }

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -7,6 +7,7 @@ use subtle::CtOption;
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `a + b + carry`, returning the result along with the new carry.
     #[inline(always)]
+    #[must_use]
     pub const fn adc(&self, rhs: &Self, mut carry: Limb) -> (Self, Limb) {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;
@@ -22,12 +23,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Perform saturating addition, returning `MAX` on overflow.
+    #[must_use]
     pub const fn saturating_add(&self, rhs: &Self) -> Self {
         let (res, overflow) = self.adc(rhs, Limb::ZERO);
         Self::select(&res, &Self::MAX, ConstChoice::from_word_lsb(overflow.0))
     }
 
     /// Perform wrapping addition, discarding overflow.
+    #[must_use]
     pub const fn wrapping_add(&self, rhs: &Self) -> Self {
         self.adc(rhs, Limb::ZERO).0
     }

--- a/src/uint/add_mod.rs
+++ b/src/uint/add_mod.rs
@@ -6,6 +6,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self + rhs mod p`.
     ///
     /// Assumes `self + rhs` as unbounded integer is `< 2p`.
+    #[must_use]
     pub const fn add_mod(&self, rhs: &Self, p: &Self) -> Self {
         let (w, carry) = self.adc(rhs, Limb::ZERO);
 
@@ -23,6 +24,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
     ///
     /// Assumes `self + rhs` as unbounded integer is `< 2p`.
+    #[must_use]
     pub const fn add_mod_special(&self, rhs: &Self, c: Limb) -> Self {
         // `Uint::adc` also works with a carry greater than 1.
         let (out, carry) = self.adc(rhs, c);

--- a/src/uint/bit_and.rs
+++ b/src/uint/bit_and.rs
@@ -8,6 +8,7 @@ use subtle::{Choice, CtOption};
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `a & b`.
     #[inline(always)]
+    #[must_use]
     pub const fn bitand(&self, rhs: &Self) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;
@@ -22,6 +23,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Perform bitwise `AND` between `self` and the given [`Limb`], performing the `AND` operation
     /// on every limb of `self`.
+    #[must_use]
     pub const fn bitand_limb(&self, rhs: Limb) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;
@@ -38,11 +40,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub const fn wrapping_and(&self, rhs: &Self) -> Self {
         self.bitand(rhs)
     }
 
     /// Perform checked bitwise `AND`, returning a [`CtOption`] which `is_some` always
+    #[must_use]
     pub fn checked_and(&self, rhs: &Self) -> CtOption<Self> {
         let result = self.bitand(rhs);
         CtOption::new(result, Choice::from(1))

--- a/src/uint/bit_not.rs
+++ b/src/uint/bit_not.rs
@@ -7,6 +7,7 @@ use core::ops::Not;
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `!a`.
     #[inline(always)]
+    #[must_use]
     pub const fn not(&self) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;

--- a/src/uint/bit_or.rs
+++ b/src/uint/bit_or.rs
@@ -8,6 +8,7 @@ use subtle::{Choice, CtOption};
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `a & b`.
     #[inline(always)]
+    #[must_use]
     pub const fn bitor(&self, rhs: &Self) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;
@@ -24,11 +25,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub const fn wrapping_or(&self, rhs: &Self) -> Self {
         self.bitor(rhs)
     }
 
     /// Perform checked bitwise `OR`, returning a [`CtOption`] which `is_some` always
+    #[must_use]
     pub fn checked_or(&self, rhs: &Self) -> CtOption<Self> {
         let result = self.bitor(rhs);
         CtOption::new(result, Choice::from(1))

--- a/src/uint/bit_xor.rs
+++ b/src/uint/bit_xor.rs
@@ -8,6 +8,7 @@ use subtle::{Choice, CtOption};
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `a ^ b`.
     #[inline(always)]
+    #[must_use]
     pub const fn bitxor(&self, rhs: &Self) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;
@@ -24,11 +25,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub const fn wrapping_xor(&self, rhs: &Self) -> Self {
         self.bitxor(rhs)
     }
 
     /// Perform checked bitwise `XOR`, returning a [`CtOption`] which `is_some` always
+    #[must_use]
     pub fn checked_xor(&self, rhs: &Self) -> CtOption<Self> {
         let result = self.bitxor(rhs);
         CtOption::new(result, Choice::from(1))

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -130,6 +130,7 @@ pub(crate) const fn trailing_ones_vartime(limbs: &[Limb]) -> u32 {
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Get the value of the bit at position `index`, as a truthy or falsy `ConstChoice`.
     /// Returns the falsy value for indices out of range.
+    #[must_use]
     pub const fn bit(&self, index: u32) -> ConstChoice {
         bit(&self.limbs, index)
     }
@@ -139,51 +140,60 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// # Remarks
     /// This operation is variable time with respect to `index` only.
     #[inline(always)]
+    #[must_use]
     pub const fn bit_vartime(&self, index: u32) -> bool {
         bit_vartime(&self.limbs, index)
     }
 
     /// Calculate the number of bits needed to represent this number.
     #[inline]
+    #[must_use]
     pub const fn bits(&self) -> u32 {
         Self::BITS - self.leading_zeros()
     }
 
     /// Calculate the number of bits needed to represent this number in variable-time with respect
     /// to `self`.
+    #[must_use]
     pub const fn bits_vartime(&self) -> u32 {
         bits_vartime(&self.limbs)
     }
 
     /// Calculate the number of leading zeros in the binary representation of this number.
+    #[must_use]
     pub const fn leading_zeros(&self) -> u32 {
         leading_zeros(&self.limbs)
     }
 
     /// Calculate the number of leading zeros in the binary representation of this number in
     /// variable-time with respect to `self`.
+    #[must_use]
     pub const fn leading_zeros_vartime(&self) -> u32 {
         Self::BITS - self.bits_vartime()
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number.
+    #[must_use]
     pub const fn trailing_zeros(&self) -> u32 {
         trailing_zeros(&self.limbs)
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number in
     /// variable-time with respect to `self`.
+    #[must_use]
     pub const fn trailing_zeros_vartime(&self) -> u32 {
         trailing_zeros_vartime(&self.limbs)
     }
 
     /// Calculate the number of trailing ones in the binary representation of this number.
+    #[must_use]
     pub const fn trailing_ones(&self) -> u32 {
         trailing_ones(&self.limbs)
     }
 
     /// Calculate the number of trailing ones in the binary representation of this number,
     /// variable time in `self`.
+    #[must_use]
     pub const fn trailing_ones_vartime(&self) -> u32 {
         trailing_ones_vartime(&self.limbs)
     }

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -59,6 +59,7 @@ impl BoxedUint {
     }
 
     /// Get the value `0` represented as succinctly as possible.
+    #[must_use]
     pub fn zero() -> Self {
         Self {
             limbs: vec![Limb::ZERO; 1].into(),
@@ -68,11 +69,13 @@ impl BoxedUint {
     /// Get the value `0` with the given number of bits of precision.
     ///
     /// `at_least_bits_precision` is rounded up to a multiple of [`Limb::BITS`].
+    #[must_use]
     pub fn zero_with_precision(at_least_bits_precision: u32) -> Self {
         vec![Limb::ZERO; Self::limbs_for_precision(at_least_bits_precision)].into()
     }
 
     /// Get the value `1`, represented as succinctly as possible.
+    #[must_use]
     pub fn one() -> Self {
         Self {
             limbs: vec![Limb::ONE; 1].into(),
@@ -82,6 +85,7 @@ impl BoxedUint {
     /// Get the value `1` with the given number of bits of precision.
     ///
     /// `at_least_bits_precision` is rounded up to a multiple of [`Limb::BITS`].
+    #[must_use]
     pub fn one_with_precision(at_least_bits_precision: u32) -> Self {
         let mut ret = Self::zero_with_precision(at_least_bits_precision);
         ret.limbs[0] = Limb::ONE;
@@ -89,6 +93,7 @@ impl BoxedUint {
     }
 
     /// Is this [`BoxedUint`] equal to zero?
+    #[must_use]
     pub fn is_zero(&self) -> Choice {
         self.limbs
             .iter()
@@ -97,11 +102,13 @@ impl BoxedUint {
 
     /// Is this [`BoxedUint`] *NOT* equal to zero?
     #[inline]
+    #[must_use]
     pub fn is_nonzero(&self) -> Choice {
         !self.is_zero()
     }
 
     /// Is this [`BoxedUint`] equal to one?
+    #[must_use]
     pub fn is_one(&self) -> Choice {
         let mut iter = self.limbs.iter();
         let choice = iter.next().copied().unwrap_or(Limb::ZERO).ct_eq(&Limb::ONE);
@@ -112,6 +119,7 @@ impl BoxedUint {
     /// precision bits requested.
     ///
     /// That is, returns the value `2^self.bits_precision() - 1`.
+    #[must_use]
     pub fn max(at_least_bits_precision: u32) -> Self {
         vec![Limb::MAX; Self::limbs_for_precision(at_least_bits_precision)].into()
     }
@@ -133,6 +141,7 @@ impl BoxedUint {
     }
 
     /// Borrow the inner limbs as a slice of [`Word`]s.
+    #[must_use]
     pub fn as_words(&self) -> &[Word] {
         // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
         #[allow(trivial_casts, unsafe_code)]
@@ -151,6 +160,7 @@ impl BoxedUint {
     }
 
     /// Borrow the limbs of this [`BoxedUint`].
+    #[must_use]
     pub fn as_limbs(&self) -> &[Limb] {
         self.limbs.as_ref()
     }
@@ -161,21 +171,25 @@ impl BoxedUint {
     }
 
     /// Convert this [`BoxedUint`] into its inner limbs.
+    #[must_use]
     pub fn to_limbs(&self) -> Box<[Limb]> {
         self.limbs.clone()
     }
 
     /// Convert this [`BoxedUint`] into its inner limbs.
+    #[must_use]
     pub fn into_limbs(self) -> Box<[Limb]> {
         self.limbs
     }
 
     /// Get the number of limbs in this [`BoxedUint`].
+    #[must_use]
     pub fn nlimbs(&self) -> usize {
         self.limbs.len()
     }
 
     /// Convert into an [`Odd`].
+    #[must_use]
     pub fn to_odd(&self) -> CtOption<Odd<Self>> {
         let is_odd = self.is_odd();
         CtOption::new(Odd(self.clone()), is_odd)
@@ -263,6 +277,7 @@ impl NonZero<BoxedUint> {
     /// Widen this type's precision to the given number of bits.
     ///
     /// See [`BoxedUint::widen`] for more information, including panic conditions.
+    #[must_use]
     pub fn widen(&self, bits_precision: u32) -> Self {
         NonZero(self.0.widen(bits_precision))
     }

--- a/src/uint/boxed/add.rs
+++ b/src/uint/boxed/add.rs
@@ -7,6 +7,7 @@ use subtle::{Choice, ConditionallySelectable, CtOption};
 impl BoxedUint {
     /// Computes `a + b + carry`, returning the result along with the new carry.
     #[inline(always)]
+    #[must_use]
     pub fn adc(&self, rhs: &Self, carry: Limb) -> (Self, Limb) {
         Self::fold_limbs(self, rhs, carry, |a, b, c| a.adc(b, c))
     }
@@ -28,6 +29,7 @@ impl BoxedUint {
     }
 
     /// Perform wrapping addition, discarding overflow.
+    #[must_use]
     pub fn wrapping_add(&self, rhs: &Self) -> Self {
         self.adc(rhs, Limb::ZERO).0
     }

--- a/src/uint/boxed/add_mod.rs
+++ b/src/uint/boxed/add_mod.rs
@@ -6,6 +6,7 @@ impl BoxedUint {
     /// Computes `self + rhs mod p`.
     ///
     /// Assumes `self + rhs` as unbounded integer is `< 2p`.
+    #[must_use]
     pub fn add_mod(&self, rhs: &Self, p: &Self) -> Self {
         debug_assert_eq!(self.bits_precision(), p.bits_precision());
         debug_assert_eq!(rhs.bits_precision(), p.bits_precision());

--- a/src/uint/boxed/bit_and.rs
+++ b/src/uint/boxed/bit_and.rs
@@ -8,12 +8,14 @@ use subtle::{Choice, CtOption};
 impl BoxedUint {
     /// Computes bitwise `a & b`.
     #[inline(always)]
+    #[must_use]
     pub fn bitand(&self, rhs: &Self) -> Self {
         Self::map_limbs(self, rhs, |a, b| a.bitand(b))
     }
 
     /// Perform bitwise `AND` between `self` and the given [`Limb`], performing the `AND` operation
     /// on every limb of `self`.
+    #[must_use]
     pub fn bitand_limb(&self, rhs: Limb) -> Self {
         Self {
             limbs: self.limbs.iter().map(|limb| limb.bitand(rhs)).collect(),
@@ -24,11 +26,13 @@ impl BoxedUint {
     ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub fn wrapping_and(&self, rhs: &Self) -> Self {
         self.bitand(rhs)
     }
 
     /// Perform checked bitwise `AND`, returning a [`CtOption`] which `is_some` always
+    #[must_use]
     pub fn checked_and(&self, rhs: &Self) -> CtOption<Self> {
         let result = self.bitand(rhs);
         CtOption::new(result, Choice::from(1))

--- a/src/uint/boxed/bit_not.rs
+++ b/src/uint/boxed/bit_not.rs
@@ -6,6 +6,7 @@ use core::ops::Not;
 
 impl BoxedUint {
     /// Computes bitwise `!a`.
+    #[must_use]
     pub fn not(&self) -> Self {
         let mut limbs = vec![Limb::ZERO; self.nlimbs()];
 

--- a/src/uint/boxed/bit_or.rs
+++ b/src/uint/boxed/bit_or.rs
@@ -7,6 +7,7 @@ use subtle::{Choice, CtOption};
 impl BoxedUint {
     /// Computes bitwise `a & b`.
     #[inline(always)]
+    #[must_use]
     pub fn bitor(&self, rhs: &Self) -> Self {
         Self::map_limbs(self, rhs, |a, b| a.bitor(b))
     }
@@ -15,11 +16,13 @@ impl BoxedUint {
     ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub fn wrapping_or(&self, rhs: &Self) -> Self {
         self.bitor(rhs)
     }
 
     /// Perform checked bitwise `OR`, returning a [`CtOption`] which `is_some` always
+    #[must_use]
     pub fn checked_or(&self, rhs: &Self) -> CtOption<Self> {
         let result = self.bitor(rhs);
         CtOption::new(result, Choice::from(1))

--- a/src/uint/boxed/bit_xor.rs
+++ b/src/uint/boxed/bit_xor.rs
@@ -8,6 +8,7 @@ use subtle::{Choice, CtOption};
 impl BoxedUint {
     /// Computes bitwise `a ^ b`.
     #[inline(always)]
+    #[must_use]
     pub fn bitxor(&self, rhs: &Self) -> Self {
         Self::map_limbs(self, rhs, |a, b| a.bitxor(b))
     }
@@ -16,11 +17,13 @@ impl BoxedUint {
     ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub fn wrapping_xor(&self, rhs: &Self) -> Self {
         self.bitxor(rhs)
     }
 
     /// Perform checked bitwise `XOR`, returning a [`CtOption`] which `is_some` always
+    #[must_use]
     pub fn checked_xor(&self, rhs: &Self) -> CtOption<Self> {
         let result = self.bitxor(rhs);
         CtOption::new(result, Choice::from(1))

--- a/src/uint/boxed/bits.rs
+++ b/src/uint/boxed/bits.rs
@@ -12,6 +12,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 impl BoxedUint {
     /// Get the value of the bit at position `index`, as a truthy or falsy `Choice`.
     /// Returns the falsy value for indices out of range.
+    #[must_use]
     pub fn bit(&self, index: u32) -> Choice {
         bit(&self.limbs, index).into()
     }
@@ -21,6 +22,7 @@ impl BoxedUint {
     /// # Remarks
     /// This operation is variable time with respect to `index` only.
     #[inline(always)]
+    #[must_use]
     pub const fn bit_vartime(&self, index: u32) -> bool {
         bit_vartime(&self.limbs, index)
     }
@@ -29,44 +31,52 @@ impl BoxedUint {
     /// set bit.
     ///
     /// Use [`BoxedUint::bits_precision`] to get the total capacity of this integer.
+    #[must_use]
     pub fn bits(&self) -> u32 {
         self.bits_precision() - self.leading_zeros()
     }
 
     /// Calculate the number of bits needed to represent this number in variable-time with respect
     /// to `self`.
+    #[must_use]
     pub fn bits_vartime(&self) -> u32 {
         bits_vartime(&self.limbs)
     }
 
     /// Calculate the number of leading zeros in the binary representation of this number.
+    #[must_use]
     pub const fn leading_zeros(&self) -> u32 {
         leading_zeros(&self.limbs)
     }
 
     /// Get the precision of this [`BoxedUint`] in bits.
+    #[must_use]
     pub fn bits_precision(&self) -> u32 {
         self.limbs.len() as u32 * Limb::BITS
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number.
+    #[must_use]
     pub fn trailing_zeros(&self) -> u32 {
         trailing_zeros(&self.limbs)
     }
 
     /// Calculate the number of trailing ones in the binary representation of this number.
+    #[must_use]
     pub fn trailing_ones(&self) -> u32 {
         trailing_ones(&self.limbs)
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number in
     /// variable-time with respect to `self`.
+    #[must_use]
     pub fn trailing_zeros_vartime(&self) -> u32 {
         trailing_zeros_vartime(&self.limbs)
     }
 
     /// Calculate the number of trailing ones in the binary representation of this number,
     /// variable time in `self`.
+    #[must_use]
     pub fn trailing_ones_vartime(&self) -> u32 {
         trailing_ones_vartime(&self.limbs)
     }

--- a/src/uint/boxed/cmp.rs
+++ b/src/uint/boxed/cmp.rs
@@ -12,6 +12,7 @@ use subtle::{
 
 impl BoxedUint {
     /// Returns the Ordering between `self` and `rhs` in variable time.
+    #[must_use]
     pub fn cmp_vartime(&self, rhs: &Self) -> Ordering {
         debug_assert_eq!(self.limbs.len(), rhs.limbs.len());
         let mut i = self.limbs.len() - 1;

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -10,34 +10,40 @@ use subtle::{Choice, ConstantTimeEq, ConstantTimeLess, CtOption};
 impl BoxedUint {
     /// Computes `self / rhs` using a pre-made reciprocal,
     /// returns the quotient (q) and remainder (r).
+    #[must_use]
     pub fn div_rem_limb_with_reciprocal(&self, reciprocal: &Reciprocal) -> (Self, Limb) {
         boxed::div_limb::div_rem_limb_with_reciprocal(self, reciprocal)
     }
 
     /// Computes `self / rhs`, returns the quotient (q) and remainder (r).
+    #[must_use]
     pub fn div_rem_limb(&self, rhs: NonZero<Limb>) -> (Self, Limb) {
         boxed::div_limb::div_rem_limb_with_reciprocal(self, &Reciprocal::new(rhs))
     }
 
     /// Computes `self % rhs` using a pre-made reciprocal.
     #[inline(always)]
+    #[must_use]
     pub fn rem_limb_with_reciprocal(&self, reciprocal: &Reciprocal) -> Limb {
         boxed::div_limb::rem_limb_with_reciprocal(self, reciprocal)
     }
 
     /// Computes `self % rhs`.
     #[inline(always)]
+    #[must_use]
     pub fn rem_limb(&self, rhs: NonZero<Limb>) -> Limb {
         boxed::div_limb::rem_limb_with_reciprocal(self, &Reciprocal::new(rhs))
     }
 
     /// Computes self / rhs, returns the quotient, remainder.
+    #[must_use]
     pub fn div_rem(&self, rhs: &NonZero<Self>) -> (Self, Self) {
         // Since `rhs` is nonzero, this should always hold.
         self.div_rem_unchecked(rhs.as_ref())
     }
 
     /// Computes self % rhs, returns the remainder.
+    #[must_use]
     pub fn rem(&self, rhs: &NonZero<Self>) -> Self {
         self.div_rem(rhs).1
     }
@@ -45,6 +51,7 @@ impl BoxedUint {
     /// Computes self / rhs, returns the quotient, remainder.
     ///
     /// Variable-time with respect to `rhs`
+    #[must_use]
     pub fn div_rem_vartime(&self, rhs: &NonZero<Self>) -> (Self, Self) {
         // Since `rhs` is nonzero, this should always hold.
         self.div_rem_vartime_unchecked(rhs.as_ref())
@@ -58,6 +65,7 @@ impl BoxedUint {
     ///
     /// Panics if `self` and `rhs` have different precisions.
     // TODO(tarcieri): handle different precisions without panicking
+    #[must_use]
     pub fn rem_vartime(&self, rhs: &NonZero<Self>) -> Self {
         debug_assert_eq!(self.bits_precision(), rhs.bits_precision());
         let mb = rhs.bits();
@@ -83,6 +91,7 @@ impl BoxedUint {
     /// This function exists, so that all operations are accounted for in the wrapping operations.
     ///
     /// Panics if `rhs == 0`.
+    #[must_use]
     pub fn wrapping_div(&self, rhs: &NonZero<Self>) -> Self {
         self.div_rem(rhs).0
     }
@@ -91,12 +100,14 @@ impl BoxedUint {
     ///
     /// There’s no way wrapping could ever happen.
     /// This function exists, so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub fn wrapping_div_vartime(&self, rhs: &NonZero<Self>) -> Self {
         self.div_rem_vartime(rhs).0
     }
 
     /// Perform checked division, returning a [`CtOption`] which `is_some`
     /// only if the rhs != 0
+    #[must_use]
     pub fn checked_div(&self, rhs: &Self) -> CtOption<Self> {
         let q = self.div_rem_unchecked(rhs).0;
         CtOption::new(q, !rhs.is_zero())

--- a/src/uint/boxed/encoding.rs
+++ b/src/uint/boxed/encoding.rs
@@ -100,6 +100,7 @@ impl BoxedUint {
 
     /// Serialize this [`BoxedUint`] as big-endian.
     #[inline]
+    #[must_use]
     pub fn to_be_bytes(&self) -> Box<[u8]> {
         let mut out = vec![0u8; self.limbs.len() * Limb::BYTES];
 
@@ -118,6 +119,7 @@ impl BoxedUint {
 
     /// Serialize this [`BoxedUint`] as little-endian.
     #[inline]
+    #[must_use]
     pub fn to_le_bytes(&self) -> Box<[u8]> {
         let mut out = vec![0u8; self.limbs.len() * Limb::BYTES];
 
@@ -134,6 +136,7 @@ impl BoxedUint {
     }
 
     /// Create a new [`BoxedUint`] from the provided big endian hex string.
+    #[must_use]
     pub fn from_be_hex(hex: &str, bits_precision: u32) -> CtOption<Self> {
         let nlimbs = (bits_precision / Limb::BITS) as usize;
         let bytes = hex.as_bytes();

--- a/src/uint/boxed/inv_mod.rs
+++ b/src/uint/boxed/inv_mod.rs
@@ -8,6 +8,7 @@ use subtle::{Choice, ConstantTimeEq, ConstantTimeLess, CtOption};
 
 impl BoxedUint {
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
+    #[must_use]
     pub fn inv_odd_mod(&self, modulus: &Odd<Self>) -> CtOption<Self> {
         modulus.precompute_inverter().invert(self)
     }

--- a/src/uint/boxed/mul.rs
+++ b/src/uint/boxed/mul.rs
@@ -10,6 +10,7 @@ impl BoxedUint {
     /// Multiply `self` by `rhs`.
     ///
     /// Returns a widened output with a limb count equal to the sums of the input limb counts.
+    #[must_use]
     pub fn mul(&self, rhs: &Self) -> Self {
         let mut limbs = vec![Limb::ZERO; self.nlimbs() + rhs.nlimbs()];
         mul_limbs(&self.limbs, &rhs.limbs, &mut limbs);
@@ -17,11 +18,13 @@ impl BoxedUint {
     }
 
     /// Perform wrapping multiplication, wrapping to the width of `self`.
+    #[must_use]
     pub fn wrapping_mul(&self, rhs: &Self) -> Self {
         self.mul(rhs).shorten(self.bits_precision())
     }
 
     /// Multiply `self` by itself.
+    #[must_use]
     pub fn square(&self) -> Self {
         // TODO(tarcieri): more optimized implementation (shared with `Uint`?)
         self.mul(self)

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -11,6 +11,7 @@ impl BoxedUint {
     ///
     /// Panics if `p` is even.
     // TODO(tarcieri): support for even `p`?
+    #[must_use]
     pub fn mul_mod(&self, rhs: &BoxedUint, p: &BoxedUint) -> BoxedUint {
         // NOTE: the overhead of converting to Montgomery form to perform this operation and then
         // immediately converting out of Montgomery form after just a single operation is likely to
@@ -36,6 +37,7 @@ impl BoxedUint {
     /// For the modulus reduction, this function implements Algorithm 14.47 from
     /// the "Handbook of Applied Cryptography", by A. Menezes, P. van Oorschot,
     /// and S. Vanstone, CRC Press, 1996.
+    #[must_use]
     pub fn mul_mod_special(&self, rhs: &Self, c: Limb) -> Self {
         debug_assert_eq!(self.bits_precision(), rhs.bits_precision());
 

--- a/src/uint/boxed/neg.rs
+++ b/src/uint/boxed/neg.rs
@@ -4,6 +4,7 @@ use crate::{BoxedUint, Limb, WideWord, Word, WrappingNeg};
 
 impl BoxedUint {
     /// Perform wrapping negation.
+    #[must_use]
     pub fn wrapping_neg(&self) -> Self {
         let mut ret = vec![Limb::ZERO; self.nlimbs()];
         let mut carry = 1;

--- a/src/uint/boxed/neg_mod.rs
+++ b/src/uint/boxed/neg_mod.rs
@@ -6,6 +6,7 @@ use subtle::ConditionallySelectable;
 impl BoxedUint {
     /// Computes `-a mod p`.
     /// Assumes `self` is in `[0, p)`.
+    #[must_use]
     pub fn neg_mod(&self, p: &Self) -> Self {
         debug_assert_eq!(self.bits_precision(), p.bits_precision());
         let is_zero = self.is_zero();
@@ -22,6 +23,7 @@ impl BoxedUint {
 
     /// Computes `-a mod p` for the special modulus
     /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
+    #[must_use]
     pub fn neg_mod_special(&self, c: Limb) -> Self {
         Self::zero_with_precision(self.bits_precision()).sub_mod_special(self, c)
     }

--- a/src/uint/boxed/shl.rs
+++ b/src/uint/boxed/shl.rs
@@ -10,6 +10,7 @@ impl BoxedUint {
     /// Computes `self << shift`.
     ///
     /// Panics if `shift >= Self::BITS`.
+    #[must_use]
     pub fn shl(&self, shift: u32) -> BoxedUint {
         let (result, overflow) = self.overflowing_shl(shift);
         assert!(!bool::from(overflow), "attempt to shift left with overflow");
@@ -28,6 +29,7 @@ impl BoxedUint {
     ///
     /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
     /// or the result and a falsy `Choice` otherwise.
+    #[must_use]
     pub fn overflowing_shl(&self, shift: u32) -> (Self, Choice) {
         let mut result = self.clone();
         let overflow = result.overflowing_shl_assign(shift);
@@ -63,12 +65,14 @@ impl BoxedUint {
 
     /// Computes `self << shift` in a panic-free manner, masking off bits of `shift` which would cause the shift to
     /// exceed the type's width.
+    #[must_use]
     pub fn wrapping_shl(&self, shift: u32) -> Self {
         self.overflowing_shl(shift).0
     }
 
     /// Computes `self << shift` in variable-time in a panic-free manner, masking off bits of `shift` which would cause
     /// the shift to exceed the type's width.
+    #[must_use]
     pub fn wrapping_shl_vartime(&self, shift: u32) -> Self {
         let mut result = Self::zero_with_precision(self.bits_precision());
         let _ = self.shl_vartime_into(&mut result, shift);
@@ -120,6 +124,7 @@ impl BoxedUint {
     ///
     /// When used with a fixed `shift`, this function is constant-time with respect to `self`.
     #[inline(always)]
+    #[must_use]
     pub fn shl_vartime(&self, shift: u32) -> Option<Self> {
         let mut result = Self::zero_with_precision(self.bits_precision());
         let success = self.shl_vartime_into(&mut result, shift);

--- a/src/uint/boxed/shr.rs
+++ b/src/uint/boxed/shr.rs
@@ -8,6 +8,7 @@ impl BoxedUint {
     /// Computes `self >> shift`.
     ///
     /// Panics if `shift >= Self::BITS`.
+    #[must_use]
     pub fn shr(&self, shift: u32) -> BoxedUint {
         let (result, overflow) = self.overflowing_shr(shift);
         assert!(
@@ -32,6 +33,7 @@ impl BoxedUint {
     ///
     /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
     /// or the result and a falsy `Choice` otherwise.
+    #[must_use]
     pub fn overflowing_shr(&self, shift: u32) -> (Self, Choice) {
         let mut result = self.clone();
         let overflow = result.overflowing_shr_assign(shift);
@@ -67,12 +69,14 @@ impl BoxedUint {
 
     /// Computes `self >> shift` in a panic-free manner, masking off bits of `shift` which would cause the shift to
     /// exceed the type's width.
+    #[must_use]
     pub fn wrapping_shr(&self, shift: u32) -> Self {
         self.overflowing_shr(shift).0
     }
 
     /// Computes `self >> shift` in variable-time in a panic-free manner, masking off bits of `shift` which would cause
     /// the shift to exceed the type's width.
+    #[must_use]
     pub fn wrapping_shr_vartime(&self, shift: u32) -> Self {
         let mut result = Self::zero_with_precision(self.bits_precision());
         let _ = self.shr_vartime_into(&mut result, shift);
@@ -122,6 +126,7 @@ impl BoxedUint {
     ///
     /// When used with a fixed `shift`, this function is constant-time with respect to `self`.
     #[inline(always)]
+    #[must_use]
     pub fn shr_vartime(&self, shift: u32) -> Option<Self> {
         let mut result = Self::zero_with_precision(self.bits_precision());
         let success = self.shr_vartime_into(&mut result, shift);

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -8,6 +8,7 @@ impl BoxedUint {
     /// Computes √(`self`) in constant time.
     ///
     /// Callers can check if `self` is a square by squaring the result
+    #[must_use]
     pub fn sqrt(&self) -> Self {
         // Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.13.
         //
@@ -53,6 +54,7 @@ impl BoxedUint {
     /// Computes √(`self`)
     ///
     /// Callers can check if `self` is a square by squaring the result
+    #[must_use]
     pub fn sqrt_vartime(&self) -> Self {
         // Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.13
 
@@ -92,6 +94,7 @@ impl BoxedUint {
     /// Wrapped sqrt is just normal √(`self`)
     /// There’s no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations.
+    #[must_use]
     pub fn wrapping_sqrt(&self) -> Self {
         self.sqrt()
     }
@@ -99,12 +102,14 @@ impl BoxedUint {
     /// Wrapped sqrt is just normal √(`self`)
     /// There’s no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations.
+    #[must_use]
     pub fn wrapping_sqrt_vartime(&self) -> Self {
         self.sqrt_vartime()
     }
 
     /// Perform checked sqrt, returning a [`CtOption`] which `is_some`
     /// only if the √(`self`)² == self
+    #[must_use]
     pub fn checked_sqrt(&self) -> CtOption<Self> {
         let r = self.sqrt();
         let s = r.wrapping_mul(&r);
@@ -113,6 +118,7 @@ impl BoxedUint {
 
     /// Perform checked sqrt, returning a [`CtOption`] which `is_some`
     /// only if the √(`self`)² == self
+    #[must_use]
     pub fn checked_sqrt_vartime(&self) -> CtOption<Self> {
         let r = self.sqrt_vartime();
         let s = r.wrapping_mul(&r);

--- a/src/uint/boxed/sub.rs
+++ b/src/uint/boxed/sub.rs
@@ -7,6 +7,7 @@ use subtle::{Choice, ConditionallySelectable, CtOption};
 impl BoxedUint {
     /// Computes `a - (b + borrow)`, returning the result along with the new borrow.
     #[inline(always)]
+    #[must_use]
     pub fn sbb(&self, rhs: &Self, borrow: Limb) -> (Self, Limb) {
         Self::fold_limbs(self, rhs, borrow, |a, b, c| a.sbb(b, c))
     }
@@ -28,6 +29,7 @@ impl BoxedUint {
     }
 
     /// Perform wrapping subtraction, discarding overflow.
+    #[must_use]
     pub fn wrapping_sub(&self, rhs: &Self) -> Self {
         self.sbb(rhs, Limb::ZERO).0
     }

--- a/src/uint/boxed/sub_mod.rs
+++ b/src/uint/boxed/sub_mod.rs
@@ -6,6 +6,7 @@ impl BoxedUint {
     /// Computes `self - rhs mod p`.
     ///
     /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
+    #[must_use]
     pub fn sub_mod(&self, rhs: &Self, p: &Self) -> Self {
         debug_assert_eq!(self.bits_precision(), p.bits_precision());
         debug_assert_eq!(rhs.bits_precision(), p.bits_precision());
@@ -23,6 +24,7 @@ impl BoxedUint {
     /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
     ///
     /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
+    #[must_use]
     pub fn sub_mod_special(&self, rhs: &Self, c: Limb) -> Self {
         let (out, borrow) = self.sbb(rhs, Limb::ZERO);
 

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -93,6 +93,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Returns the Ordering between `self` and `rhs` in variable time.
+    #[must_use]
     pub const fn cmp_vartime(&self, rhs: &Self) -> Ordering {
         let mut i = LIMBS - 1;
         loop {

--- a/src/uint/concat.rs
+++ b/src/uint/concat.rs
@@ -3,6 +3,7 @@ use crate::{Concat, ConcatMixed, Limb, Uint};
 impl<const L: usize> Uint<L> {
     /// Concatenate the two values, with `self` as least significant and `hi` as the most
     /// significant.
+    #[must_use]
     pub const fn concat<const O: usize>(&self, hi: &Self) -> Uint<O>
     where
         Self: Concat<Output = Uint<O>>,
@@ -13,6 +14,7 @@ impl<const L: usize> Uint<L> {
     /// Concatenate the two values, with `lo` as least significant and `hi`
     /// as the most significant.
     #[inline]
+    #[must_use]
     pub const fn concat_mixed<const H: usize, const O: usize>(lo: &Uint<L>, hi: &Uint<H>) -> Uint<O>
     where
         Self: ConcatMixed<Uint<H>, MixedOutput = Uint<O>>,

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -9,24 +9,28 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self / rhs` using a pre-made reciprocal,
     /// returns the quotient (q) and remainder (r).
     #[inline(always)]
+    #[must_use]
     pub const fn div_rem_limb_with_reciprocal(&self, reciprocal: &Reciprocal) -> (Self, Limb) {
         div_rem_limb_with_reciprocal(self, reciprocal)
     }
 
     /// Computes `self / rhs`, returns the quotient (q) and remainder (r).
     #[inline(always)]
+    #[must_use]
     pub const fn div_rem_limb(&self, rhs: NonZero<Limb>) -> (Self, Limb) {
         div_rem_limb_with_reciprocal(self, &Reciprocal::new(rhs))
     }
 
     /// Computes `self % rhs` using a pre-made reciprocal.
     #[inline(always)]
+    #[must_use]
     pub const fn rem_limb_with_reciprocal(&self, reciprocal: &Reciprocal) -> Limb {
         rem_limb_with_reciprocal(self, reciprocal)
     }
 
     /// Computes `self % rhs`.
     #[inline(always)]
+    #[must_use]
     pub const fn rem_limb(&self, rhs: NonZero<Limb>) -> Limb {
         rem_limb_with_reciprocal(self, &Reciprocal::new(rhs))
     }
@@ -35,6 +39,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// This function is constant-time with respect to both `self` and `rhs`.
     #[allow(trivial_numeric_casts)]
+    #[must_use]
     pub const fn div_rem(&self, rhs: &NonZero<Self>) -> (Self, Self) {
         let mb = rhs.0.bits();
         let mut rem = *self;
@@ -70,6 +75,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
     #[allow(trivial_numeric_casts)]
+    #[must_use]
     pub const fn div_rem_vartime(&self, rhs: &NonZero<Self>) -> (Self, Self) {
         let mb = rhs.0.bits_vartime();
         let mut bd = Self::BITS - mb;
@@ -95,6 +101,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Computes `self` % `rhs`, returns the remainder.
+    #[must_use]
     pub const fn rem(&self, rhs: &NonZero<Self>) -> Self {
         self.div_rem(rhs).1
     }
@@ -103,6 +110,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
+    #[must_use]
     pub const fn rem_vartime(&self, rhs: &NonZero<Self>) -> Self {
         let mb = rhs.0.bits_vartime();
         let mut bd = Self::BITS - mb;
@@ -128,6 +136,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
+    #[must_use]
     pub const fn rem_wide_vartime(lower_upper: (Self, Self), rhs: &NonZero<Self>) -> Self {
         let mb = rhs.0.bits_vartime();
 
@@ -171,6 +180,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// // As 10 % 8 = 2
     /// assert_eq!(remainder, U448::from(2_u64));
     /// ```
+    #[must_use]
     pub const fn rem2k_vartime(&self, k: u32) -> Self {
         let highest = (LIMBS - 1) as u32;
         let index = k / Limb::BITS;
@@ -199,6 +209,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// There’s no way wrapping could ever happen.
     /// This function exists, so that all operations are accounted for in the wrapping operations.
+    #[must_use]
     pub const fn wrapping_div(&self, rhs: &NonZero<Self>) -> Self {
         let (q, _) = self.div_rem(rhs);
         q
@@ -208,6 +219,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// There’s no way wrapping could ever happen.
     /// This function exists, so that all operations are accounted for in the wrapping operations.
+    #[must_use]
     pub const fn wrapping_div_vartime(&self, rhs: &NonZero<Self>) -> Self {
         let (q, _) = self.div_rem_vartime(rhs);
         q
@@ -231,6 +243,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// let zero = U448::from(0_u64);
     /// assert!(bool::from(a.checked_div(&zero).is_none()), "Should be None for division by zero");
     /// ```
+    #[must_use]
     pub fn checked_div(&self, rhs: &Self) -> CtOption<Self> {
         NonZero::new(*rhs).map(|rhs| {
             let (q, _r) = self.div_rem(&rhs);
@@ -251,6 +264,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// assert_eq!(remainder, U448::from(1_u64));
     /// ```
+    #[must_use]
     pub const fn wrapping_rem_vartime(&self, rhs: &Self) -> Self {
         let nz_rhs = rhs.to_nz().expect("non-zero divisor");
         self.rem_vartime(&nz_rhs)
@@ -274,6 +288,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// assert!(bool::from(a.checked_rem(&zero).is_none()), "Should be None for reduction by zero");
     /// ```
+    #[must_use]
     pub fn checked_rem(&self, rhs: &Self) -> CtOption<Self> {
         NonZero::new(*rhs).map(|rhs| self.rem(&rhs))
     }

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -156,6 +156,7 @@ pub struct Reciprocal {
 impl Reciprocal {
     /// Pre-calculates a reciprocal for a known divisor,
     /// to be used in the single-limb division later.
+    #[must_use]
     pub const fn new(divisor: NonZero<Limb>) -> Self {
         let divisor = divisor.0;
 
@@ -177,6 +178,7 @@ impl Reciprocal {
     ///
     /// NOTE: intended for using it as a placeholder during compile-time array generation,
     /// don't rely on the contents.
+    #[must_use]
     pub const fn default() -> Self {
         Self {
             divisor_normalized: Word::MAX,
@@ -188,6 +190,7 @@ impl Reciprocal {
     }
 
     /// Get the shift value
+    #[must_use]
     pub const fn shift(&self) -> u32 {
         self.shift
     }

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -14,6 +14,7 @@ use crate::Encoding;
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a new [`Uint`] from the provided big endian bytes.
+    #[must_use]
     pub const fn from_be_slice(bytes: &[u8]) -> Self {
         assert!(
             bytes.len() == Limb::BYTES * LIMBS,
@@ -40,6 +41,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a new [`Uint`] from the provided big endian hex string.
     ///
     /// Panics if the hex is malformed or not zero-padded accordingly for the size.
+    #[must_use]
     pub const fn from_be_hex(hex: &str) -> Self {
         let bytes = hex.as_bytes();
 
@@ -72,6 +74,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Create a new [`Uint`] from the provided little endian bytes.
+    #[must_use]
     pub const fn from_le_slice(bytes: &[u8]) -> Self {
         assert!(
             bytes.len() == Limb::BYTES * LIMBS,
@@ -98,6 +101,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a new [`Uint`] from the provided little endian hex string.
     ///
     /// Panics if the hex is malformed or not zero-padded accordingly for the size.
+    #[must_use]
     pub const fn from_le_hex(hex: &str) -> Self {
         let bytes = hex.as_bytes();
 

--- a/src/uint/from.rs
+++ b/src/uint/from.rs
@@ -5,6 +5,7 @@ use crate::{ConcatMixed, Limb, SplitMixed, Uint, WideWord, Word, U128, U64};
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a [`Uint`] from a `u8` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u8>` when stable
+    #[must_use]
     pub const fn from_u8(n: u8) -> Self {
         assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
@@ -14,6 +15,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Create a [`Uint`] from a `u16` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u16>` when stable
+    #[must_use]
     pub const fn from_u16(n: u16) -> Self {
         assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
@@ -24,6 +26,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a [`Uint`] from a `u32` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u32>` when stable
     #[allow(trivial_numeric_casts)]
+    #[must_use]
     pub const fn from_u32(n: u32) -> Self {
         assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
@@ -45,6 +48,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a [`Uint`] from a `u64` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u64>` when stable
     #[cfg(target_pointer_width = "64")]
+    #[must_use]
     pub const fn from_u64(n: u64) -> Self {
         assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
@@ -54,6 +58,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Create a [`Uint`] from a `u128` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u128>` when stable
+    #[must_use]
     pub const fn from_u128(n: u128) -> Self {
         assert!(
             LIMBS >= 16 / Limb::BYTES,
@@ -82,6 +87,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Create a [`Uint`] from a `Word` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<Word>` when stable
+    #[must_use]
     pub const fn from_word(n: Word) -> Self {
         assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
@@ -91,6 +97,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Create a [`Uint`] from a `WideWord` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<WideWord>` when stable
+    #[must_use]
     pub const fn from_wide_word(n: WideWord) -> Self {
         assert!(LIMBS >= 2, "number of limbs must be two or greater");
         let mut limbs = [Limb::ZERO; LIMBS];

--- a/src/uint/gcd.rs
+++ b/src/uint/gcd.rs
@@ -10,6 +10,7 @@ where
     /// Compute the greatest common divisor (GCD) of this number and another.
     ///
     /// Returns none in the event that `self` is even (i.e. `self` MUST be odd). However, `rhs` may be even.
+    #[must_use]
     pub const fn gcd(&self, rhs: &Self) -> ConstCtOption<Self> {
         let ret = <Odd<Self> as PrecomputeInverter>::Inverter::gcd(self, rhs);
         ConstCtOption::new(ret, self.is_odd())

--- a/src/uint/inv_mod.rs
+++ b/src/uint/inv_mod.rs
@@ -11,6 +11,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// If the inverse does not exist (`k > 0` and `self` is even),
     /// returns `ConstChoice::FALSE` as the second element of the tuple,
     /// otherwise returns `ConstChoice::TRUE`.
+    #[must_use]
     pub const fn inv_mod2k_vartime(&self, k: u32) -> ConstCtOption<Self> {
         // Using the Algorithm 3 from "A Secure Algorithm for Inversion Modulo 2k"
         // by Sadiel de la Fe and Carles Ferrer.
@@ -49,6 +50,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// If the inverse does not exist (`k > 0` and `self` is even),
     /// returns `ConstChoice::FALSE` as the second element of the tuple,
     /// otherwise returns `ConstChoice::TRUE`.
+    #[must_use]
     pub const fn inv_mod2k(&self, k: u32) -> ConstCtOption<Self> {
         // This is the same algorithm as in `inv_mod2k_vartime()`,
         // but made constant-time w.r.t `k` as well.
@@ -88,6 +90,7 @@ where
     Odd<Self>: PrecomputeInverter<Inverter = BernsteinYangInverter<LIMBS, UNSAT_LIMBS>>,
 {
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
+    #[must_use]
     pub const fn inv_odd_mod(&self, modulus: &Odd<Self>) -> ConstCtOption<Self> {
         BernsteinYangInverter::<LIMBS, UNSAT_LIMBS>::new(modulus, &Uint::ONE).inv(self)
     }
@@ -95,6 +98,7 @@ where
     /// Computes the multiplicative inverse of `self` mod `modulus`.
     ///
     /// Returns some if an inverse exists, otherwise none.
+    #[must_use]
     pub const fn inv_mod(&self, modulus: &Self) -> ConstCtOption<Self> {
         // Decompose `modulus = s * 2^k` where `s` is odd
         let k = modulus.trailing_zeros();

--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -37,12 +37,12 @@ macro_rules! impl_uint_aliases {
 
             impl $name {
                 /// Serialize as big endian bytes.
-                pub const fn to_be_bytes(&self) -> [u8; $bits / 8] {
+                #[must_use] pub const fn to_be_bytes(&self) -> [u8; $bits / 8] {
                     encoding::uint_to_be_bytes::<{ nlimbs!($bits) }, { $bits / 8 }>(self)
                 }
 
                 /// Serialize as little endian bytes.
-                pub const fn to_le_bytes(&self) -> [u8; $bits / 8] {
+                #[must_use] pub const fn to_le_bytes(&self) -> [u8; $bits / 8] {
                     encoding::uint_to_le_bytes::<{ nlimbs!($bits) }, { $bits / 8 }>(self)
                 }
             }

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -55,6 +55,7 @@ macro_rules! impl_schoolbook_multiplication {
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Multiply `self` by `rhs`, returning a concatenated "wide" result.
+    #[must_use]
     pub const fn widening_mul<const RHS_LIMBS: usize, const WIDE_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
@@ -68,6 +69,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Compute "wide" multiplication as a 2-tuple containing the `(lo, hi)` components of the product, whose sizes
     /// correspond to the sizes of the operands.
+    #[must_use]
     pub const fn split_mul<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
@@ -79,17 +81,20 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Perform wrapping multiplication, discarding overflow.
+    #[must_use]
     pub const fn wrapping_mul<const H: usize>(&self, rhs: &Uint<H>) -> Self {
         self.split_mul(rhs).0
     }
 
     /// Perform saturating multiplication, returning `MAX` on overflow.
+    #[must_use]
     pub const fn saturating_mul<const RHS_LIMBS: usize>(&self, rhs: &Uint<RHS_LIMBS>) -> Self {
         let (res, overflow) = self.split_mul(rhs);
         Self::select(&res, &Self::MAX, overflow.is_nonzero())
     }
 
     /// Square self, returning a "wide" result in two parts as (lo, hi).
+    #[must_use]
     pub const fn square_wide(&self) -> (Self, Self) {
         // Translated from https://github.com/ucbrise/jedi-pairing/blob/c4bf151/include/core/bigint.hpp#L410
         //
@@ -169,6 +174,7 @@ where
     Self: Concat<Output = Uint<WIDE_LIMBS>>,
 {
     /// Square self, returning a concatenated "wide" result.
+    #[must_use]
     pub const fn square(&self) -> Uint<WIDE_LIMBS> {
         let (lo, hi) = self.square_wide();
         lo.concat(&hi)

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -11,6 +11,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Panics if `p` is even.
     // TODO(tarcieri): support for even `p`?
+    #[must_use]
     pub fn mul_mod(&self, rhs: &Uint<LIMBS>, p: &Uint<LIMBS>) -> Uint<LIMBS> {
         // NOTE: the overhead of converting to Montgomery form to perform this operation and then
         // immediately converting out of Montgomery form after just a single operation is likely to
@@ -36,6 +37,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// For the modulus reduction, this function implements Algorithm 14.47 from
     /// the "Handbook of Applied Cryptography", by A. Menezes, P. van Oorschot,
     /// and S. Vanstone, CRC Press, 1996.
+    #[must_use]
     pub const fn mul_mod_special(&self, rhs: &Self, c: Limb) -> Self {
         // We implicitly assume `LIMBS > 0`, because `Uint<0>` doesn't compile.
         // Still the case `LIMBS == 1` needs special handling.

--- a/src/uint/neg.rs
+++ b/src/uint/neg.rs
@@ -2,6 +2,7 @@ use crate::{Limb, Uint, WideWord, Word, WrappingNeg};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Perform wrapping negation.
+    #[must_use]
     pub const fn wrapping_neg(&self) -> Self {
         let mut ret = [Limb::ZERO; LIMBS];
         let mut carry = 1;

--- a/src/uint/neg_mod.rs
+++ b/src/uint/neg_mod.rs
@@ -5,6 +5,7 @@ use crate::{Limb, NegMod, Uint};
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `-a mod p`.
     /// Assumes `self` is in `[0, p)`.
+    #[must_use]
     pub const fn neg_mod(&self, p: &Self) -> Self {
         let z = self.is_nonzero();
         let mut ret = p.sbb(self, Limb::ZERO).0;
@@ -20,6 +21,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes `-a mod p` for the special modulus
     /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
+    #[must_use]
     pub const fn neg_mod_special(&self, c: Limb) -> Self {
         Self::ZERO.sub_mod_special(self, c)
     }

--- a/src/uint/resize.rs
+++ b/src/uint/resize.rs
@@ -5,6 +5,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// truncating the upper bits if the value is too large to be
     /// represented.
     #[inline(always)]
+    #[must_use]
     pub const fn resize<const T: usize>(&self) -> Uint<T> {
         let mut res = Uint::ZERO;
         let mut i = 0;

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -8,6 +8,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self << shift`.
     ///
     /// Panics if `shift >= Self::BITS`.
+    #[must_use]
     pub const fn shl(&self, shift: u32) -> Self {
         self.overflowing_shl(shift)
             .expect("`shift` within the bit size of the integer")
@@ -16,6 +17,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self << shift` in variable time.
     ///
     /// Panics if `shift >= Self::BITS`.
+    #[must_use]
     pub const fn shl_vartime(&self, shift: u32) -> Self {
         self.overflowing_shl_vartime(shift)
             .expect("`shift` within the bit size of the integer")
@@ -24,6 +26,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self << shift`.
     ///
     /// Returns `None` if `shift >= Self::BITS`.
+    #[must_use]
     pub const fn overflowing_shl(&self, shift: u32) -> ConstCtOption<Self> {
         // `floor(log2(BITS - 1))` is the number of bits in the representation of `shift`
         // (which lies in range `0 <= shift < BITS`).
@@ -56,6 +59,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// When used with a fixed `shift`, this function is constant-time with respect
     /// to `self`.
     #[inline(always)]
+    #[must_use]
     pub const fn overflowing_shl_vartime(&self, shift: u32) -> ConstCtOption<Self> {
         let mut limbs = [Limb::ZERO; LIMBS];
 
@@ -99,6 +103,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// When used with a fixed `shift`, this function is constant-time with respect
     /// to `self`.
     #[inline(always)]
+    #[must_use]
     pub const fn overflowing_shl_vartime_wide(
         lower_upper: (Self, Self),
         shift: u32,
@@ -127,12 +132,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes `self << shift` in a panic-free manner, returning zero if the shift exceeds the
     /// precision.
+    #[must_use]
     pub const fn wrapping_shl(&self, shift: u32) -> Self {
         self.overflowing_shl(shift).unwrap_or(Self::ZERO)
     }
 
     /// Computes `self << shift` in variable-time in a panic-free manner, returning zero if the
     /// shift exceeds the precision.
+    #[must_use]
     pub const fn wrapping_shl_vartime(&self, shift: u32) -> Self {
         self.overflowing_shl_vartime(shift).unwrap_or(Self::ZERO)
     }

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -8,6 +8,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self >> shift`.
     ///
     /// Panics if `shift >= Self::BITS`.
+    #[must_use]
     pub const fn shr(&self, shift: u32) -> Self {
         self.overflowing_shr(shift)
             .expect("`shift` within the bit size of the integer")
@@ -16,6 +17,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self >> shift` in variable time.
     ///
     /// Panics if `shift >= Self::BITS`.
+    #[must_use]
     pub const fn shr_vartime(&self, shift: u32) -> Self {
         self.overflowing_shr_vartime(shift)
             .expect("`shift` within the bit size of the integer")
@@ -24,6 +26,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self >> shift`.
     ///
     /// Returns `None` if `shift >= Self::BITS`.
+    #[must_use]
     pub const fn overflowing_shr(&self, shift: u32) -> ConstCtOption<Self> {
         // `floor(log2(BITS - 1))` is the number of bits in the representation of `shift`
         // (which lies in range `0 <= shift < BITS`).
@@ -56,6 +59,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// When used with a fixed `shift`, this function is constant-time with respect
     /// to `self`.
     #[inline(always)]
+    #[must_use]
     pub const fn overflowing_shr_vartime(&self, shift: u32) -> ConstCtOption<Self> {
         let mut limbs = [Limb::ZERO; LIMBS];
 
@@ -98,6 +102,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// When used with a fixed `shift`, this function is constant-time with respect
     /// to `self`.
     #[inline(always)]
+    #[must_use]
     pub const fn overflowing_shr_vartime_wide(
         lower_upper: (Self, Self),
         shift: u32,
@@ -126,12 +131,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes `self >> shift` in a panic-free manner, returning zero if the shift exceeds the
     /// precision.
+    #[must_use]
     pub const fn wrapping_shr(&self, shift: u32) -> Self {
         self.overflowing_shr(shift).unwrap_or(Self::ZERO)
     }
 
     /// Computes `self >> shift` in variable-time in a panic-free manner, returning zero if the
     /// shift exceeds the precision.
+    #[must_use]
     pub const fn wrapping_shr_vartime(&self, shift: u32) -> Self {
         self.overflowing_shr_vartime(shift).unwrap_or(Self::ZERO)
     }

--- a/src/uint/split.rs
+++ b/src/uint/split.rs
@@ -2,6 +2,7 @@ use crate::{Limb, Split, SplitMixed, Uint};
 
 impl<const I: usize> Uint<I> {
     /// Split this number in half into low and high components.
+    #[must_use]
     pub const fn split<const O: usize>(&self) -> (Uint<O>, Uint<O>)
     where
         Self: Split<Output = Uint<O>>,
@@ -11,6 +12,7 @@ impl<const I: usize> Uint<I> {
 
     /// Split this number into low and high components respectively.
     #[inline]
+    #[must_use]
     pub const fn split_mixed<const L: usize, const H: usize>(&self) -> (Uint<L>, Uint<H>)
     where
         Self: SplitMixed<Uint<L>, Uint<H>>,

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -7,6 +7,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes √(`self`) in constant time.
     ///
     /// Callers can check if `self` is a square by squaring the result
+    #[must_use]
     pub const fn sqrt(&self) -> Self {
         // Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.13.
         //
@@ -49,6 +50,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes √(`self`)
     ///
     /// Callers can check if `self` is a square by squaring the result
+    #[must_use]
     pub const fn sqrt_vartime(&self) -> Self {
         // Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.13
 
@@ -85,6 +87,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Wrapped sqrt is just normal √(`self`)
     /// There’s no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations.
+    #[must_use]
     pub const fn wrapping_sqrt(&self) -> Self {
         self.sqrt()
     }
@@ -92,12 +95,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Wrapped sqrt is just normal √(`self`)
     /// There’s no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations.
+    #[must_use]
     pub const fn wrapping_sqrt_vartime(&self) -> Self {
         self.sqrt_vartime()
     }
 
     /// Perform checked sqrt, returning a [`CtOption`] which `is_some`
     /// only if the √(`self`)² == self
+    #[must_use]
     pub fn checked_sqrt(&self) -> CtOption<Self> {
         let r = self.sqrt();
         let s = r.wrapping_mul(&r);
@@ -106,6 +111,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Perform checked sqrt, returning a [`CtOption`] which `is_some`
     /// only if the √(`self`)² == self
+    #[must_use]
     pub fn checked_sqrt_vartime(&self) -> CtOption<Self> {
         let r = self.sqrt_vartime();
         let s = r.wrapping_mul(&r);

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -8,6 +8,7 @@ use subtle::CtOption;
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `a - (b + borrow)`, returning the result along with the new borrow.
     #[inline(always)]
+    #[must_use]
     pub const fn sbb(&self, rhs: &Self, mut borrow: Limb) -> (Self, Limb) {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;
@@ -23,6 +24,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Perform saturating subtraction, returning `ZERO` on underflow.
+    #[must_use]
     pub const fn saturating_sub(&self, rhs: &Self) -> Self {
         let (res, underflow) = self.sbb(rhs, Limb::ZERO);
         Self::select(&res, &Self::ZERO, ConstChoice::from_word_mask(underflow.0))
@@ -30,6 +32,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Perform wrapping subtraction, discarding underflow and wrapping around
     /// the boundary of the type.
+    #[must_use]
     pub const fn wrapping_sub(&self, rhs: &Self) -> Self {
         self.sbb(rhs, Limb::ZERO).0
     }

--- a/src/uint/sub_mod.rs
+++ b/src/uint/sub_mod.rs
@@ -6,6 +6,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self - rhs mod p`.
     ///
     /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
+    #[must_use]
     pub const fn sub_mod(&self, rhs: &Self, p: &Self) -> Self {
         let (out, mask) = self.sbb(rhs, Limb::ZERO);
 
@@ -34,6 +35,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
     ///
     /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
+    #[must_use]
     pub const fn sub_mod_special(&self, rhs: &Self, c: Limb) -> Self {
         let (out, borrow) = self.sbb(rhs, Limb::ZERO);
 


### PR DESCRIPTION
Many of the computations we perform have results where failure to use them likely constitutes a bug.

`clippy` can autodetect these cases, and `clippy fix` can auto-apply them.