### PR TITLE
Single-limb `u64` conversion

### DIFF
--- a/src/uint.rs
+++ b/src/uint.rs
@@ -184,6 +184,20 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     pub const fn to_odd(self) -> ConstCtOption<Odd<Self>> {
         ConstCtOption::new(Odd(self), self.is_odd())
     }
+
+    /// Convert a single-limb `Uint` to a `u64` (const-friendly)
+    #[cfg(target_pointer_width = "32")]
+    pub const fn to_u64(self) -> u64 {
+        assert!(LIMBS == 1, "number of limbs must be 1");
+        self.as_words()[0] as u64
+    }
+
+    /// Convert a single-limb `Uint` to a `u64` (const-friendly)
+    #[cfg(target_pointer_width = "64")]
+    pub const fn to_u64(self) -> u64 {
+        assert!(LIMBS == 1, "number of limbs must be 1");
+        self.as_words()[0]
+    }
 }
 
 impl<const LIMBS: usize> AsRef<[Word; LIMBS]> for Uint<LIMBS> {


### PR DESCRIPTION
It may be useful to perform constant-time arithmetic on primitive unsigned integers. While it might be ideal to keep all such operations within this library's `Uint` type, this seems unlikely in practice. I came across this exact situation while solving a problem requiring simple constant-time arithmetic on unsigned integers that eventually needed to be used in contexts that couldn't use `Uint` directly.

This PR adds `to_u64` to `Uint` in the style of the existing `from_u64` functionality. It requires a single limb, and simply extracts the underlying word as a `u64` (depending on the target).