### PR TITLE
Small refactoring in mul mod

### DIFF
--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -21,10 +21,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         match p.to_odd().into() {
             Some(odd_p) => {
                 let params = MontyParams::new_vartime(odd_p);
-                let lhs = MontyForm::new(self, params);
-                let rhs = MontyForm::new(rhs, params);
-                let ret = lhs * rhs;
-                ret.retrieve()
+                (MontyForm::new(self, params) * MontyForm::new(rhs, params)).retrieve()
             }
             None => todo!("even moduli are currently unsupported"),
         }
@@ -83,9 +80,7 @@ const fn mac_by_limb<const LIMBS: usize>(
     let mut carry = carry;
 
     while i < LIMBS {
-        let (n, c) = a.limbs[i].mac(b.limbs[i], c, carry);
-        a.limbs[i] = n;
-        carry = c;
+        (a.limbs[i], carry) = a.limbs[i].mac(b.limbs[i], c, carry);
         i += 1;
     }
 


### PR DESCRIPTION
This pull request implements a small refactoring in the `mac_by_limb` function to streamline the multiplication and accumulation operations (`mul_mod`) by avoiding unnecessary intermediate variable declarations within the `while` loop.
