### PR TITLE
Remove vestigial sidefuzz support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,10 +213,3 @@ pub mod prelude {
     #[cfg(feature = "hybrid-array")]
     pub use crate::array::{ArrayDecoding, ArrayEncoding};
 }
-
-#[cfg(sidefuzz)]
-#[no_mangle]
-pub extern "C" fn fuzz() {
-    let input = sidefuzz::fetch_input(32); // 32 bytes of of fuzzing input as a &[u8]
-    sidefuzz::black_box(my_hopefully_constant_fn(input));
-}


### PR DESCRIPTION
Originally added in #119 along with dudect support, however it was incomplete.

This is now triggering warnings on the latest nightly versions.