### PR TITLE
Make the `Monty::new` borrow the `Uint`

### DIFF
--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -244,8 +244,8 @@ impl Monty for BoxedMontyForm {
         BoxedMontyParams::new_vartime(modulus)
     }
 
-    fn new(value: Self::Integer, params: Self::Params) -> Self {
-        BoxedMontyForm::new(value, params)
+    fn new(value: &Self::Integer, params: Self::Params) -> Self {
+        BoxedMontyForm::new(value.clone(), params)
     }
 
     fn zero(params: Self::Params) -> Self {

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -240,8 +240,8 @@ impl<const LIMBS: usize> Monty for MontyForm<LIMBS> {
         MontyParams::new_vartime(modulus)
     }
 
-    fn new(value: Self::Integer, params: Self::Params) -> Self {
-        MontyForm::new(&value, params)
+    fn new(value: &Self::Integer, params: Self::Params) -> Self {
+        MontyForm::new(value, params)
     }
 
     fn zero(params: Self::Params) -> Self {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -789,7 +789,7 @@ pub trait Monty:
     fn new_params_vartime(modulus: Odd<Self::Integer>) -> Self::Params;
 
     /// Convert the value into the representation using precomputed data.
-    fn new(value: Self::Integer, params: Self::Params) -> Self;
+    fn new(value: &Self::Integer, params: Self::Params) -> Self;
 
     /// Returns zero in this representation.
     fn zero(params: Self::Params) -> Self;


### PR DESCRIPTION
Change the `Monty` trait's `new` method to take a ref to the `Integer` instead of ownership.

Fixes #599
