### PR TITLE
Add impls for fmt::Binary

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -157,6 +157,13 @@ impl fmt::Display for Limb {
     }
 }
 
+impl fmt::Binary for Limb {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:0width$b}", &self.0, width = Self::BITS as usize)
+    }
+}
+
 impl fmt::LowerHex for Limb {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -288,6 +288,15 @@ impl<const LIMBS: usize> fmt::Debug for Uint<LIMBS> {
     }
 }
 
+impl<const LIMBS: usize> fmt::Binary for Uint<LIMBS> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for limb in self.limbs.iter().rev() {
+            fmt::Binary::fmt(limb, f)?;
+        }
+        Ok(())
+    }
+}
+
 impl<const LIMBS: usize> fmt::Display for Uint<LIMBS> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::UpperHex::fmt(self, f)

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -369,6 +369,19 @@ impl fmt::Display for BoxedUint {
     }
 }
 
+impl fmt::Binary for BoxedUint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.limbs.is_empty() {
+            return fmt::Binary::fmt(&Limb::ZERO, f);
+        }
+
+        for limb in self.limbs.iter().rev() {
+            fmt::Binary::fmt(limb, f)?;
+        }
+        Ok(())
+    }
+}
+
 impl fmt::LowerHex for BoxedUint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.limbs.is_empty() {

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -350,4 +350,15 @@ mod tests {
         let n = U128::from_be_hex(hex);
         assert_eq!(hex, format!("{:x}", n));
     }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn fmt_binary() {
+        let hex = "AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD";
+        let n = U128::from_be_hex(hex);
+        let expect = "\
+            1010101010101010101010101010101010111011101110111011101110111011\
+            1100110011001100110011001100110011011101110111011101110111011101";
+        assert_eq!(expect, format!("{:b}", n));
+    }
 }


### PR DESCRIPTION
This was only implemented for `Wrapping<T>` and `NonZero<T>` (where T: Binary).