### PR TITLE
Implement `from_str_radix_vartime` for `Uint`, `BoxedUint`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,7 @@ pub use crate::{
 pub use subtle;
 
 #[cfg(feature = "alloc")]
-pub use crate::uint::boxed::{encoding::DecodeError, BoxedUint};
+pub use crate::uint::boxed::BoxedUint;
 
 #[cfg(feature = "hybrid-array")]
 pub use {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -9,7 +9,7 @@ pub use num_traits::{
 pub(crate) use sealed::PrecomputeInverterWithAdjuster;
 
 use crate::{Limb, NonZero, Odd, Reciprocal};
-use core::fmt::Debug;
+use core::fmt::{self, Debug};
 use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
     Mul, MulAssign, Neg, Not, Rem, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
@@ -21,9 +21,6 @@ use subtle::{
 
 #[cfg(feature = "rand_core")]
 use rand_core::CryptoRngCore;
-
-#[cfg(feature = "rand_core")]
-use core::fmt;
 
 /// Integers whose representation takes a bounded amount of space.
 pub trait Bounded {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -541,6 +541,41 @@ pub trait Encoding: Sized {
     fn to_le_bytes(&self) -> Self::Repr;
 }
 
+/// Possible errors in variable-time integer decoding methods.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DecodeError {
+    /// The input value was empty.
+    Empty,
+
+    /// The input was not consistent with the format restrictions.
+    InvalidDigit,
+
+    /// Input size is too small to fit in the given precision.
+    InputSize,
+
+    /// The deserialized number is larger than the given precision.
+    Precision,
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "empty value provided"),
+            Self::InvalidDigit => {
+                write!(f, "invalid digit character")
+            }
+            Self::InputSize => write!(f, "input size is too small to fit in the given precision"),
+            Self::Precision => write!(
+                f,
+                "the deserialized number is larger than the given precision"
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DecodeError {}
+
 /// Support for optimized squaring
 pub trait Square {
     /// Computes the same as `self * self`, but may be more efficient.


### PR DESCRIPTION
This adds fallible parsing for binary, decimal, and hex integers (and any base from 2 to 36).

The format of these numbers generally matches the `from_str_radix` methods of the standard library. One exception is that underscores may used as spacers, as in `+1_000_000` for example. This is consistent with the `num_bigint` crate.

The `DecodeError` enum is promoted from the uint.boxed module and reused.