### PR TITLE
Implement serde for `Odd`

### DIFF
--- a/src/odd.rs
+++ b/src/odd.rs
@@ -268,7 +268,8 @@ mod tests {
         // @reviewers: I expected an error when deserializing an Odd<U128> into an Odd<U64>, instead I get a truncated number. Is this a big or known limitation?
         #[test]
         fn silently_coerces_bigger_type_into_smaller_type() {
-            let three = Odd::new(U128::from_u128(0x33333333333333333333333333333333)).unwrap();
+            let three = Odd::new(U128::from_u128(0x77777777777777773333333333333333)).unwrap();
+
             let three_ser = bincode::serialize(&three).unwrap();
 
             // This doesn't fail, which is unexpected

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -171,15 +171,10 @@ impl<'de, T: Deserialize<'de> + Integer + Zero> Deserialize<'de> for Odd<T> {
 
         if bool::from(value.is_odd()) {
             Ok(Self(value))
-        } else if bool::from(value.is_zero()) {
-            Err(D::Error::invalid_value(
-                Unexpected::Other("zero"),
-                &"a non-zero odd value",
-            ))
         } else {
             Err(D::Error::invalid_value(
                 Unexpected::Other("even"),
-                &"an odd value",
+                &"a non-zero odd value",
             ))
         }
     }
@@ -239,7 +234,7 @@ mod tests {
             let two_ser = bincode::serialize(&two).unwrap();
             assert!(matches!(
                 *bincode::deserialize::<Odd<U128>>(&two_ser).unwrap_err(),
-                ErrorKind::Custom(mess) if mess == "invalid value: even, expected an odd value"
+                ErrorKind::Custom(mess) if mess == "invalid value: even, expected a non-zero odd value"
             ))
         }
 
@@ -250,7 +245,7 @@ mod tests {
 
             assert!(matches!(
                 *bincode::deserialize::<Odd<U64>>(&zero_ser).unwrap_err(),
-                ErrorKind::Custom(mess) if mess == "invalid value: zero, expected a non-zero odd value"
+                ErrorKind::Custom(mess) if mess == "invalid value: even, expected a non-zero odd value"
             ))
         }
 

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -168,9 +168,9 @@ impl<'de, T: Deserialize<'de> + Integer + Zero> Deserialize<'de> for Odd<T> {
         D: Deserializer<'de>,
     {
         let value: T = T::deserialize(deserializer)?;
-
-        if bool::from(value.is_odd()) {
-            Ok(Self(value))
+        let odd = Self::new(value);
+        if bool::from(odd.is_some()) {
+            Ok(odd.unwrap())
         } else {
             Err(D::Error::invalid_value(
                 Unexpected::Other("even"),

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -13,6 +13,14 @@ use {crate::Random, rand_core::CryptoRngCore};
 #[cfg(all(feature = "alloc", feature = "rand_core"))]
 use crate::RandomBits;
 
+#[cfg(feature = "serde")]
+use crate::Zero;
+#[cfg(feature = "serde")]
+use serdect::serde::{
+    de::{Error, Unexpected},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
 /// Wrapper type for odd integers.
 ///
 /// These are frequently used in cryptography, e.g. as a modulus.
@@ -153,6 +161,40 @@ impl Odd<BoxedUint> {
     }
 }
 
+#[cfg(feature = "serde")]
+impl<'de, T: Deserialize<'de> + Integer + Zero> Deserialize<'de> for Odd<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value: T = T::deserialize(deserializer)?;
+
+        if bool::from(value.is_odd()) {
+            Ok(Self(value))
+        } else if bool::from(value.is_zero()) {
+            Err(D::Error::invalid_value(
+                Unexpected::Other("zero"),
+                &"a non-zero odd value",
+            ))
+        } else {
+            Err(D::Error::invalid_value(
+                Unexpected::Other("even"),
+                &"an odd value",
+            ))
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T: Serialize + Zero> Serialize for Odd<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "alloc")]
@@ -174,5 +216,68 @@ mod tests {
         assert!(bool::from(zero.is_none()));
         let two = Odd::new(BoxedUint::from(2u8));
         assert!(bool::from(two.is_none()));
+    }
+
+    #[cfg(feature = "serde")]
+    mod serde_tests {
+        use crate::{Odd, U128, U64};
+        use alloc::string::ToString;
+        use bincode::ErrorKind;
+
+        #[test]
+        fn roundtrip() {
+            let uint = Odd::new(U64::from_u64(0x00123)).unwrap();
+            let ser = bincode::serialize(&uint).unwrap();
+            let deser = bincode::deserialize::<Odd<U64>>(&ser).unwrap();
+
+            assert_eq!(uint, deser);
+        }
+
+        #[test]
+        fn even_values_do_not_deserialize() {
+            let two = U128::from_u64(0x2);
+            let two_ser = bincode::serialize(&two).unwrap();
+            assert!(matches!(
+                *bincode::deserialize::<Odd<U128>>(&two_ser).unwrap_err(),
+                ErrorKind::Custom(mess) if mess == "invalid value: even, expected an odd value"
+            ))
+        }
+
+        #[test]
+        fn zero_does_not_deserialize() {
+            let zero = U64::ZERO;
+            let zero_ser = bincode::serialize(&zero).unwrap();
+
+            assert!(matches!(
+                *bincode::deserialize::<Odd<U64>>(&zero_ser).unwrap_err(),
+                ErrorKind::Custom(mess) if mess == "invalid value: zero, expected a non-zero odd value"
+            ))
+        }
+
+        #[test]
+        fn cannot_deserialize_into_bigger_type() {
+            let three = Odd::new(U64::from_u64(0x3)).unwrap();
+            let three_ser = bincode::serialize(&three).unwrap();
+            let error_message = bincode::deserialize::<Odd<U128>>(&three_ser)
+                .unwrap_err()
+                .to_string();
+
+            assert_eq!(&error_message, "io error: unexpected end of file");
+        }
+
+        // @reviewers: I expected an error when deserializing an Odd<U128> into an Odd<U64>, instead I get a truncated number. Is this a big or known limitation?
+        #[test]
+        fn silently_coerces_bigger_type_into_smaller_type() {
+            let three = Odd::new(U128::from_u128(0x33333333333333333333333333333333)).unwrap();
+            let three_ser = bincode::serialize(&three).unwrap();
+
+            // This doesn't fail, which is unexpected
+            let smaller = bincode::deserialize::<Odd<U64>>(&three_ser).unwrap();
+
+            assert_eq!(
+                smaller,
+                Odd::new(U64::from_u64(0x3333333333333333)).unwrap()
+            );
+        }
     }
 }

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -168,15 +168,10 @@ impl<'de, T: Deserialize<'de> + Integer + Zero> Deserialize<'de> for Odd<T> {
         D: Deserializer<'de>,
     {
         let value: T = T::deserialize(deserializer)?;
-        let odd = Self::new(value);
-        if bool::from(odd.is_some()) {
-            Ok(odd.unwrap())
-        } else {
-            Err(D::Error::invalid_value(
-                Unexpected::Other("even"),
-                &"a non-zero odd value",
-            ))
-        }
+        Option::<Self>::from(Self::new(value)).ok_or(D::Error::invalid_value(
+            Unexpected::Other("even"),
+            &"a non-zero odd value",
+        ))
     }
 }
 


### PR DESCRIPTION
Most other wrapper types implement serde, e.g. `NonZero` and `Wrapping`. This PR implements it for `Odd` as well.

One oddity I noticed when writing the tests was that deserializing a bigger `Uint` into a smaller one does not return an error. Instead the original value seems to be truncated to fit the smaller type. Is that the expected behaviour?
 
