### PR TITLE
Fix `bernstein_yang_nlimbs!` calculation

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,10 +11,16 @@ macro_rules! nlimbs {
 
 /// Calculate the number of 62-bit unsaturated limbs required to represent the given number of bits when performing
 /// Bernstein-Yang inversions.
+///
+/// We need to ensure that:
+///
+/// ```text
+/// $bits <= (bernstein_yang_nlimbs($bits) * 62) - 64
+/// ```
 // TODO(tarcieri): replace with `generic_const_exprs` (rust-lang/rust#76560) when stable
 macro_rules! bernstein_yang_nlimbs {
     ($bits:expr) => {
-        (($bits / 64) + (($bits / 64) * 2).div_ceil(64) + 1)
+        ($bits + 64).div_ceil(62)
     };
 }
 

--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -24,6 +24,10 @@ macro_rules! impl_precompute_inverter_trait {
                 Self::Inverter::new(self, adjuster)
             }
         }
+
+        #[cfg(debug_assertions)]
+        #[allow(trivial_numeric_casts)]
+        const _: () = assert!((bernstein_yang_nlimbs!($bits as usize) * 62) - 64 >= $bits);
     };
 }
 

--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -25,6 +25,8 @@ macro_rules! impl_precompute_inverter_trait {
             }
         }
 
+        /// Const assertion that the unsaturated integer is sufficiently sized to hold the maximum
+        /// value represented by a saturated `$bits`-sized integer.
         #[cfg(debug_assertions)]
         #[allow(trivial_numeric_casts)]
         const _: () = assert!((bernstein_yang_nlimbs!($bits as usize) * 62) - 64 >= $bits);


### PR DESCRIPTION
The previous calculation of the number of unsaturated 62-bit limbs needed to represent an integer of a given size was incorrect, leading to miscomputed results as seen in #606.

This commit switches to a much simpler calculation based on `div_ceiling(62)`, and also adds a const assertion that the computed number of limbs is sufficient to hold a `$bits`-sized integer.