### PR TITLE
Add support for computing `Uint::gcd` with even modulus

### DIFF
--- a/src/uint/gcd.rs
+++ b/src/uint/gcd.rs
@@ -87,4 +87,14 @@ mod tests {
         assert_eq!(U256::ONE, f.gcd(&U256::ONE).unwrap());
         assert_eq!(U256::ONE, f.gcd(&U256::from(2u8)).unwrap());
     }
+
+    #[test]
+    fn gcd_two() {
+        let f = U256::from_u8(2);
+        assert_eq!(f, f.gcd(&f).unwrap());
+
+        let g = U256::from_u8(4);
+        assert_eq!(f, f.gcd(&g).unwrap());
+        assert_eq!(f, g.gcd(&f).unwrap());
+    }
 }

--- a/src/uint/gcd.rs
+++ b/src/uint/gcd.rs
@@ -77,8 +77,9 @@ mod tests {
 
     #[test]
     fn gcd_zero() {
-        let f = U256::ZERO;
-        assert!(f.gcd(&U256::ONE).is_none().is_true_vartime());
+        assert!(U256::ZERO.gcd(&U256::ZERO).is_none().is_true_vartime());
+        assert!(U256::ZERO.gcd(&U256::ONE).is_none().is_true_vartime());
+        assert!(U256::ONE.gcd(&U256::ZERO).is_none().is_true_vartime());
     }
 
     #[test]

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -5,7 +5,7 @@ mod common;
 use common::to_biguint;
 use crypto_bigint::{
     modular::{MontyForm, MontyParams},
-    Encoding, Integer, Limb, NonZero, Odd, Word, U256,
+    Encoding, Limb, NonZero, Odd, Word, U256,
 };
 use num_bigint::BigUint;
 use num_integer::Integer as _;
@@ -275,12 +275,7 @@ proptest! {
     }
 
     #[test]
-    fn gcd(mut f in uint(), g in uint()) {
-        if f.is_even().into() {
-            // Ensure `f` is always odd (required by Bernstein-Yang)
-            f = f.wrapping_add(&U256::ONE);
-        }
-
+    fn gcd(f in uint(), g in uint()) {
         let f_bi = to_biguint(&f);
         let g_bi = to_biguint(&g);
 


### PR DESCRIPTION
Uses a similar method to `Uint::inv_mod` for extending `Uint::gcd` with support for an even modulus, first dividing out `2^k` from both operands where this operation will ensure at least one value is odd, and then applying Bernstein-Yang to the odd modulus, multiplying the result by `2^k`.