### PR TITLE
Make `Uint::gcd` calculation infallible

### DIFF
--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -280,7 +280,7 @@ proptest! {
         let g_bi = to_biguint(&g);
 
         let expected = to_uint(f_bi.gcd(&g_bi));
-        let actual = f.gcd(&g).unwrap();
+        let actual = f.gcd(&g);
         assert_eq!(expected, actual);
     }
 


### PR DESCRIPTION
See also: #618

The computation was previously fallible because even values were unsupported.

Now that they're supported, the computation no longer needs to be fallible.

We can eventually remove `type Output` from the `Gcd` trait after a similar treatment is applied to `BoxedUint` (see #618).