### PR TITLE
Split `Uint::mul_mod` and `Uint::mul_mod_vartime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "bincode",
  "criterion",

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -188,7 +188,7 @@ proptest! {
         let p_bi = to_biguint(&P);
 
         let expected = to_uint((a_bi * b_bi) % p_bi);
-        let actual = a.mul_mod_vartime(&b, &P);
+        let actual = a.mul_mod_vartime(&b, P.as_nz_ref());
 
         assert!(expected < P);
         assert!(actual < P);

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -188,7 +188,7 @@ proptest! {
         let p_bi = to_biguint(&P);
 
         let expected = to_uint((a_bi * b_bi) % p_bi);
-        let actual = a.mul_mod(&b, &P);
+        let actual = a.mul_mod_vartime(&b, &P);
 
         assert!(expected < P);
         assert!(actual < P);


### PR DESCRIPTION
The previous `mul_mod` was variable-time with respect to the modulus. This adds a proper constant-time version.

It also changes the `p` argument to be `NonZero<Self>`