### PR TITLE
Faster vartime division for BoxedUint

### DIFF
--- a/src/uint/boxed/div_limb.rs
+++ b/src/uint/boxed/div_limb.rs
@@ -1,7 +1,7 @@
 //! Implementation of constant-time division via reciprocal precomputation, as described in
 //! "Improved Division by Invariant Integers" by Niels Möller and Torbjorn Granlund
 //! (DOI: 10.1109/TC.2010.143, <https://gmplib.org/~tege/division-paper.pdf>).
-use crate::{uint::div_limb::div2by1, BoxedUint, Limb, Reciprocal};
+use crate::{uint::div_limb::div2by1, BoxedUint, ConstChoice, Limb, Reciprocal};
 
 /// Divides `u` by the divisor encoded in the `reciprocal`, and returns
 /// the quotient and the remainder.
@@ -10,31 +10,34 @@ pub(crate) fn div_rem_limb_with_reciprocal(
     u: &BoxedUint,
     reciprocal: &Reciprocal,
 ) -> (BoxedUint, Limb) {
-    let (u_shifted, u_hi) = u.shl_limb(reciprocal.shift());
-    let mut r = u_hi.0;
-    let mut q = vec![Limb::ZERO; u.limbs.len()];
-
+    let (mut q, mut r) = u.shl_limb(reciprocal.shift());
     let mut j = u.limbs.len();
     while j > 0 {
         j -= 1;
-        let (qj, rj) = div2by1(r, u_shifted.as_limbs()[j].0, reciprocal);
-        q[j] = Limb(qj);
-        r = rj;
+        (q.limbs[j].0, r.0) = div2by1(r.0, q.limbs[j].0, reciprocal);
     }
-    (BoxedUint { limbs: q.into() }, Limb(r >> reciprocal.shift()))
+    (q, r >> reciprocal.shift())
 }
 
 /// Divides `u` by the divisor encoded in the `reciprocal`, and returns the remainder.
 #[inline(always)]
 pub(crate) fn rem_limb_with_reciprocal(u: &BoxedUint, reciprocal: &Reciprocal) -> Limb {
-    let (u_shifted, u_hi) = u.shl_limb(reciprocal.shift());
-    let mut r = u_hi.0;
-
+    let lshift = reciprocal.shift();
+    let nz = ConstChoice::from_u32_nonzero(lshift);
+    let rshift = nz.if_true_u32(Limb::BITS - lshift);
+    let mut hi = nz.if_true_word(
+        u.limbs[u.limbs.len() - 1]
+            .0
+            .wrapping_shr(Limb::BITS - lshift),
+    );
+    let mut lo;
     let mut j = u.limbs.len();
-    while j > 0 {
+    while j > 1 {
         j -= 1;
-        let (_, rj) = div2by1(r, u_shifted.as_limbs()[j].0, reciprocal);
-        r = rj;
+        lo = u.limbs[j].0 << lshift;
+        lo |= nz.if_true_word(u.limbs[j - 1].0 >> rshift);
+        (_, hi) = div2by1(hi, lo, reciprocal);
     }
-    Limb(r >> reciprocal.shift())
+    (_, hi) = div2by1(hi, u.limbs[0].0 << lshift, reciprocal);
+    Limb(hi >> reciprocal.shift())
 }


### PR DESCRIPTION
This implements the division algorithm from #608 for `BoxedUint`. It includes some adjustments to `div_rem_limb_with_reciprocal` and `rem_limb_with_reciprocal` to reduce allocations.

The main body of the division is implemented as a helper method `div_rem_vartime_in_place`. This is partly to allow internal reuse in implementing `to_str_radix_vartime`.