### PR TITLE
Uint: constant-time Bernstein-Yang `is_negative`

### DIFF
--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -22,10 +22,15 @@ impl ConstChoice {
     }
 
     #[inline]
-    #[allow(trivial_numeric_casts)]
-    #[allow(clippy::unnecessary_cast)]
+    #[cfg(target_pointer_width = "32")]
     pub(crate) const fn as_u64_mask(&self) -> u64 {
-        self.0 as u64
+        ((self.0 as u64) << 32) | (self.0 as u64)
+    }
+
+    #[inline]
+    #[cfg(target_pointer_width = "64")]
+    pub(crate) const fn as_u64_mask(&self) -> u64 {
+        self.0
     }
 
     /// Returns the truthy value if `value == Word::MAX`, and the falsy value if `value == 0`.
@@ -55,7 +60,7 @@ impl ConstChoice {
     pub(crate) const fn from_u64_lsb(value: u64) -> Self {
         debug_assert!(value == 0 || value == 1);
         #[allow(trivial_numeric_casts)]
-        Self(value.wrapping_neg())
+        Self((value as Word).wrapping_neg())
     }
 
     /// Returns the truthy value if `value != 0`, and the falsy value otherwise.

--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -196,7 +196,7 @@ impl ConstChoice {
 
     /// WARNING: this method should only be used in contexts that aren't constant-time critical!
     #[inline]
-    pub(crate) const fn to_bool(self) -> bool {
+    pub(crate) const fn to_bool_vartime(self) -> bool {
         self.to_u8() != 0
     }
 }

--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -55,7 +55,7 @@ impl ConstChoice {
     pub(crate) const fn from_u64_lsb(value: u64) -> Self {
         debug_assert!(value == 0 || value == 1);
         #[allow(trivial_numeric_casts)]
-        Self((value as Word).wrapping_neg())
+        Self(value.wrapping_neg())
     }
 
     /// Returns the truthy value if `value != 0`, and the falsy value otherwise.
@@ -407,6 +407,12 @@ impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
 mod tests {
     use super::ConstChoice;
     use crate::Word;
+
+    #[test]
+    fn from_u64_lsb() {
+        assert_eq!(ConstChoice::from_u64_lsb(0), ConstChoice::FALSE);
+        assert_eq!(ConstChoice::from_u64_lsb(1), ConstChoice::TRUE);
+    }
 
     #[test]
     fn from_word_lt() {

--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -21,6 +21,13 @@ impl ConstChoice {
         self.0 as u32
     }
 
+    #[inline]
+    #[allow(trivial_numeric_casts)]
+    #[allow(clippy::unnecessary_cast)]
+    pub(crate) const fn as_u64_mask(&self) -> u64 {
+        self.0 as u64
+    }
+
     /// Returns the truthy value if `value == Word::MAX`, and the falsy value if `value == 0`.
     /// Panics for other values.
     #[inline]
@@ -39,6 +46,13 @@ impl ConstChoice {
 
     #[inline]
     pub(crate) const fn from_u32_lsb(value: u32) -> Self {
+        debug_assert!(value == 0 || value == 1);
+        #[allow(trivial_numeric_casts)]
+        Self((value as Word).wrapping_neg())
+    }
+
+    #[inline]
+    pub(crate) const fn from_u64_lsb(value: u64) -> Self {
         debug_assert!(value == 0 || value == 1);
         #[allow(trivial_numeric_casts)]
         Self((value as Word).wrapping_neg())
@@ -106,6 +120,20 @@ impl ConstChoice {
         Self::from_u32_lsb(bit)
     }
 
+    /// Returns the truthy value if `x < y`, and the falsy value otherwise.
+    #[inline]
+    pub(crate) const fn from_u64_lt(x: u64, y: u64) -> Self {
+        // See "Hacker's Delight" 2nd ed, section 2-12 (Comparison predicates)
+        let bit = (((!x) & y) | (((!x) | y) & (x.wrapping_sub(y)))) >> (u64::BITS - 1);
+        Self::from_u64_lsb(bit)
+    }
+
+    /// Returns the truthy value if `x > y`, and the falsy value otherwise.
+    #[inline]
+    pub(crate) const fn from_u64_gt(x: u64, y: u64) -> Self {
+        Self::from_u64_lt(y, x)
+    }
+
     #[inline]
     pub(crate) const fn not(&self) -> Self {
         Self(!self.0)
@@ -133,6 +161,12 @@ impl ConstChoice {
         a ^ (self.as_u32_mask() & (a ^ b))
     }
 
+    /// Return `b` if `self` is truthy, otherwise return `a`.
+    #[inline]
+    pub(crate) const fn select_u64(&self, a: u64, b: u64) -> u64 {
+        a ^ (self.as_u64_mask() & (a ^ b))
+    }
+
     /// Return `x` if `self` is truthy, otherwise return 0.
     #[inline]
     pub(crate) const fn if_true_word(&self, x: Word) -> Word {
@@ -153,6 +187,12 @@ impl ConstChoice {
     #[inline]
     pub(crate) const fn to_u8(self) -> u8 {
         (self.0 as u8) & 1
+    }
+
+    /// WARNING: this method should only be used in contexts that aren't constant-time critical!
+    #[inline]
+    pub(crate) const fn to_bool(self) -> bool {
+        self.to_u8() != 0
     }
 }
 
@@ -383,7 +423,23 @@ mod tests {
     }
 
     #[test]
-    fn select() {
+    fn select_u32() {
+        let a: u32 = 1;
+        let b: u32 = 2;
+        assert_eq!(ConstChoice::TRUE.select_u32(a, b), b);
+        assert_eq!(ConstChoice::FALSE.select_u32(a, b), a);
+    }
+
+    #[test]
+    fn select_u64() {
+        let a: u64 = 1;
+        let b: u64 = 2;
+        assert_eq!(ConstChoice::TRUE.select_u64(a, b), b);
+        assert_eq!(ConstChoice::FALSE.select_u64(a, b), a);
+    }
+
+    #[test]
+    fn select_word() {
         let a: Word = 1;
         let b: Word = 2;
         assert_eq!(ConstChoice::TRUE.select_word(a, b), b);

--- a/src/modular/bernstein_yang.rs
+++ b/src/modular/bernstein_yang.rs
@@ -260,9 +260,9 @@ const fn de<const LIMBS: usize>(
 ) -> (Int62L<LIMBS>, Int62L<LIMBS>) {
     let mask = Int62L::<LIMBS>::MASK as i64;
     let mut md =
-        t[0][0] * d.is_negative().to_u8() as i64 + t[0][1] * e.is_negative().to_bool() as i64;
+        t[0][0] * d.is_negative().to_u8() as i64 + t[0][1] * e.is_negative().to_u8() as i64;
     let mut me =
-        t[1][0] * d.is_negative().to_u8() as i64 + t[1][1] * e.is_negative().to_bool() as i64;
+        t[1][0] * d.is_negative().to_u8() as i64 + t[1][1] * e.is_negative().to_u8() as i64;
 
     let cd = t[0][0]
         .wrapping_mul(d.lowest() as i64)
@@ -339,7 +339,7 @@ impl<const LIMBS: usize> Int62L<LIMBS> {
     #[allow(trivial_numeric_casts, clippy::wrong_self_convention)]
     pub const fn to_uint<const SAT_LIMBS: usize>(&self) -> Uint<SAT_LIMBS> {
         debug_assert!(
-            !self.is_negative().to_bool(),
+            !self.is_negative().to_bool_vartime(),
             "can't convert negative number to Uint"
         );
 
@@ -522,9 +522,9 @@ mod tests {
 
     #[test]
     fn int62l_is_negative() {
-        assert!(!Int62L::ZERO.is_negative().to_bool());
-        assert!(!Int62L::ONE.is_negative().to_bool());
-        assert!(Int62L::MINUS_ONE.is_negative().to_bool());
+        assert!(!Int62L::ZERO.is_negative().to_bool_vartime());
+        assert!(!Int62L::ONE.is_negative().to_bool_vartime());
+        assert!(Int62L::MINUS_ONE.is_negative().to_bool_vartime());
     }
 
     #[test]

--- a/src/modular/bernstein_yang.rs
+++ b/src/modular/bernstein_yang.rs
@@ -86,7 +86,7 @@ impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
         // integer to be inverted and the modulus the inverter was created for.
         // Thus, if "f" is neither 1 nor -1, then the sought inverse does not exist.
         let antiunit = f.eq(&Int62L::MINUS_ONE);
-        let ret = self.norm(d, antiunit);
+        let ret = self.norm(d, ConstChoice::from_word_lsb(antiunit as Word));
         let is_some = ConstChoice::from_word_lsb((f.eq(&Int62L::ONE) || antiunit) as Word);
         ConstCtOption::new(ret.to_uint(), is_some)
     }
@@ -102,30 +102,21 @@ impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
         let f = Int62L::from_uint(f);
         let g = Int62L::from_uint(g);
         let (_, mut f) = divsteps(e, f, g, inverse);
-
-        if f.is_negative() {
-            f = f.neg();
-        }
-
+        f = Int62L::select(&f, &f.neg(), f.is_negative());
         f.to_uint()
     }
 
     /// Returns either "value (mod M)" or "-value (mod M)", where M is the modulus the inverter
     /// was created for, depending on "negate", which determines the presence of "-" in the used
     /// formula. The input integer lies in the interval (-2 * M, M).
-    const fn norm(&self, mut value: Int62L<UNSAT_LIMBS>, negate: bool) -> Int62L<UNSAT_LIMBS> {
-        if value.is_negative() {
-            value = value.add(&self.modulus);
-        }
-
-        if negate {
-            value = value.neg();
-        }
-
-        if value.is_negative() {
-            value = value.add(&self.modulus);
-        }
-
+    const fn norm(
+        &self,
+        mut value: Int62L<UNSAT_LIMBS>,
+        negate: ConstChoice,
+    ) -> Int62L<UNSAT_LIMBS> {
+        value = Int62L::select(&value, &value.add(&self.modulus), value.is_negative());
+        value = Int62L::select(&value, &value.neg(), negate);
+        value = Int62L::select(&value, &value.add(&self.modulus), value.is_negative());
         value
     }
 }
@@ -268,8 +259,10 @@ const fn de<const LIMBS: usize>(
     e: Int62L<LIMBS>,
 ) -> (Int62L<LIMBS>, Int62L<LIMBS>) {
     let mask = Int62L::<LIMBS>::MASK as i64;
-    let mut md = t[0][0] * d.is_negative() as i64 + t[0][1] * e.is_negative() as i64;
-    let mut me = t[1][0] * d.is_negative() as i64 + t[1][1] * e.is_negative() as i64;
+    let mut md =
+        t[0][0] * d.is_negative().to_u8() as i64 + t[0][1] * e.is_negative().to_bool() as i64;
+    let mut me =
+        t[1][0] * d.is_negative().to_u8() as i64 + t[1][1] * e.is_negative().to_bool() as i64;
 
     let cd = t[0][0]
         .wrapping_mul(d.lowest() as i64)
@@ -345,7 +338,10 @@ impl<const LIMBS: usize> Int62L<LIMBS> {
     /// The ordering of the chunks in these arrays is little-endian.
     #[allow(trivial_numeric_casts, clippy::wrong_self_convention)]
     pub const fn to_uint<const SAT_LIMBS: usize>(&self) -> Uint<SAT_LIMBS> {
-        debug_assert!(!self.is_negative(), "can't convert negative number to Uint");
+        debug_assert!(
+            !self.is_negative().to_bool(),
+            "can't convert negative number to Uint"
+        );
 
         if LIMBS != bernstein_yang_nlimbs!(SAT_LIMBS * Limb::BITS as usize) {
             panic!("incorrect number of limbs");
@@ -424,9 +420,7 @@ impl<const LIMBS: usize> Int62L<LIMBS> {
     /// Returns the result of applying 62-bit right arithmetical shift to the current number.
     pub const fn shr(&self) -> Self {
         let mut ret = Self::ZERO;
-        if self.is_negative() {
-            ret.0[LIMBS - 1] = Self::MASK;
-        }
+        ret.0[LIMBS - 1] = self.is_negative().select_u64(ret.0[LIMBS - 1], Self::MASK);
 
         let mut i = 0;
         while i < LIMBS - 1 {
@@ -451,13 +445,26 @@ impl<const LIMBS: usize> Int62L<LIMBS> {
     }
 
     /// Returns "true" iff the current number is negative.
-    pub const fn is_negative(&self) -> bool {
-        self.0[LIMBS - 1] > (Self::MASK >> 1)
+    pub const fn is_negative(&self) -> ConstChoice {
+        ConstChoice::from_u64_gt(self.0[LIMBS - 1], Self::MASK >> 1)
     }
 
     /// Returns the lowest 62 bits of the current number.
     pub const fn lowest(&self) -> u64 {
         self.0[0]
+    }
+
+    /// Select between two [`Int62L`] values in constant time.
+    pub const fn select(a: &Self, b: &Self, choice: ConstChoice) -> Self {
+        let mut ret = Self::ZERO;
+        let mut i = 0;
+
+        while i < LIMBS {
+            ret.0[i] = choice.select_u64(a.0[i], b.0[i]);
+            i += 1;
+        }
+
+        ret
     }
 }
 
@@ -515,9 +522,9 @@ mod tests {
 
     #[test]
     fn int62l_is_negative() {
-        assert!(!Int62L::ZERO.is_negative());
-        assert!(!Int62L::ONE.is_negative());
-        assert!(Int62L::MINUS_ONE.is_negative());
+        assert!(!Int62L::ZERO.is_negative().to_bool());
+        assert!(!Int62L::ONE.is_negative().to_bool());
+        assert!(Int62L::MINUS_ONE.is_negative().to_bool());
     }
 
     #[test]

--- a/src/modular/bernstein_yang/boxed.rs
+++ b/src/modular/bernstein_yang/boxed.rs
@@ -601,7 +601,7 @@ mod tests {
         fn boxed_int62l_is_negative(x in u256()) {
             let x_ref = Int62L::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
             let x_boxed = BoxedInt62L::from(&x.into());
-            assert_eq!(x_ref.is_negative(), x_boxed.is_negative());
+            assert_eq!(x_ref.is_negative().to_bool(), x_boxed.is_negative());
         }
 
         #[test]

--- a/src/modular/bernstein_yang/boxed.rs
+++ b/src/modular/bernstein_yang/boxed.rs
@@ -601,7 +601,7 @@ mod tests {
         fn boxed_int62l_is_negative(x in u256()) {
             let x_ref = Int62L::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
             let x_boxed = BoxedInt62L::from(&x.into());
-            assert_eq!(x_ref.is_negative().to_bool(), x_boxed.is_negative());
+            assert_eq!(x_ref.is_negative().to_bool_vartime(), x_boxed.is_negative());
         }
 
         #[test]


### PR DESCRIPTION
Changes `Int64L::is_negative` to return `ConstChoice` rather than `bool`, also adding a `Int64L::select` method for selecting between two values predicated on a `ConstChoice`.

This eliminates some of the branching in the implementation (#627).

cc @erik-3milabs