### PR TITLE
Make Bernstein-Yang `Int62L::eq` return `ConstChoice`

### DIFF
--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -71,6 +71,12 @@ impl ConstChoice {
 
     /// Returns the truthy value if `value != 0`, and the falsy value otherwise.
     #[inline]
+    pub(crate) const fn from_u64_nonzero(value: u64) -> Self {
+        Self::from_u64_lsb((value | value.wrapping_neg()) >> (u64::BITS - 1))
+    }
+
+    /// Returns the truthy value if `value != 0`, and the falsy value otherwise.
+    #[inline]
     pub(crate) const fn from_word_nonzero(value: Word) -> Self {
         Self::from_word_lsb((value | value.wrapping_neg()) >> (Word::BITS - 1))
     }
@@ -79,6 +85,12 @@ impl ConstChoice {
     #[inline]
     pub(crate) const fn from_u32_eq(x: u32, y: u32) -> Self {
         Self::from_u32_nonzero(x ^ y).not()
+    }
+
+    /// Returns the truthy value if `x == y`, and the falsy value otherwise.
+    #[inline]
+    pub(crate) const fn from_u64_eq(x: u64, y: u64) -> Self {
+        Self::from_u64_nonzero(x ^ y).not()
     }
 
     /// Returns the truthy value if `x == y`, and the falsy value otherwise.

--- a/src/modular/bernstein_yang/boxed.rs
+++ b/src/modular/bernstein_yang/boxed.rs
@@ -425,6 +425,7 @@ mod tests {
     use super::BoxedInt62L;
     use crate::{BoxedUint, Inverter, PrecomputeInverter, U256};
     use proptest::prelude::*;
+    use subtle::ConstantTimeEq;
 
     #[cfg(not(miri))]
     use crate::modular::bernstein_yang::Int62L;
@@ -626,7 +627,7 @@ mod tests {
         fn boxed_int62l_is_minus_one(x in u256()) {
             let x_ref = Int62L::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
             let x_boxed = BoxedInt62L::from(&x.into());
-            assert_eq!(x_ref.eq(&Int62L::MINUS_ONE), bool::from(x_boxed.is_minus_one()));
+            assert!(bool::from(x_boxed.is_minus_one().ct_eq(&x_ref.eq(&Int62L::MINUS_ONE).into())));
         }
     }
 }


### PR DESCRIPTION
Addresses some data-dependent branching and use of `bool` noted in #627