### PR TITLE
Bernstein-Yang: have `BoxedInt62L::{is_zero, is_one}` return `Choice`

### DIFF
--- a/src/modular/bernstein_yang.rs
+++ b/src/modular/bernstein_yang.rs
@@ -178,6 +178,7 @@ const fn divsteps<const LIMBS: usize>(
     let mut delta = 1;
     let mut matrix;
 
+    // TODO(tarcieri): run in a fixed number of iterations
     while !g.eq(&Int62L::ZERO).to_bool_vartime() {
         (delta, matrix) = jump(&f.0, &g.0, delta);
         (f, g) = fg(f, g, matrix);


### PR DESCRIPTION
Similar change to #630, which was for `Int62L`.

Addresses some data-dependent branching and use of `bool` noted in #627