### PR TITLE
Add `Gcd::gcd_vartime`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-subtle = { version = "2.5", default-features = false }
+subtle = { version = "2.6", default-features = false }
 
 # optional dependencies
 der = { version = "0.7", optional = true, default-features = false }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -200,9 +200,10 @@ pub trait Gcd<Rhs = Self>: Sized {
     type Output;
 
     /// Compute the greatest common divisor of `self` and `rhs`.
-    ///
-    /// Returns none unless `self` is odd (`rhs` may be even or odd)`.
     fn gcd(&self, rhs: &Rhs) -> Self::Output;
+
+    /// Compute the greatest common divisor of `self` and `rhs` in variable time.
+    fn gcd_vartime(&self, rhs: &Rhs) -> Self::Output;
 }
 
 /// Trait impl'd by precomputed modular inverters obtained via the [`PrecomputeInverter`] trait.

--- a/src/uint/boxed/gcd.rs
+++ b/src/uint/boxed/gcd.rs
@@ -23,14 +23,12 @@ impl Gcd for BoxedUint {
         let g = Self::ct_select(&s1, &s2, s2.is_odd());
         bernstein_yang::boxed::gcd(&f, &g).overflowing_shl(k).0
     }
-}
 
-impl Odd<BoxedUint> {
-    /// Compute the greatest common divisor (GCD) of this number and another.
-    ///
-    /// Runs in variable time with respect to `rhs`.
-    pub fn gcd_vartime(&self, rhs: &BoxedUint) -> BoxedUint {
-        bernstein_yang::boxed::gcd_vartime(self, rhs)
+    fn gcd_vartime(&self, rhs: &Self) -> Self::Output {
+        match Odd::<Self>::new(self.clone()).into_option() {
+            Some(odd) => odd.gcd_vartime(rhs),
+            None => self.gcd(rhs), // TODO(tarcieri): vartime support for even `self`?
+        }
     }
 }
 
@@ -39,6 +37,10 @@ impl Gcd<BoxedUint> for Odd<BoxedUint> {
 
     fn gcd(&self, rhs: &BoxedUint) -> BoxedUint {
         bernstein_yang::boxed::gcd(self, rhs)
+    }
+
+    fn gcd_vartime(&self, rhs: &BoxedUint) -> Self::Output {
+        bernstein_yang::boxed::gcd_vartime(self, rhs)
     }
 }
 

--- a/src/uint/gcd.rs
+++ b/src/uint/gcd.rs
@@ -51,6 +51,13 @@ where
     fn gcd(&self, rhs: &Self) -> Self {
         self.gcd(rhs)
     }
+
+    fn gcd_vartime(&self, rhs: &Self) -> Self::Output {
+        match Odd::<Self>::new(self.clone()).into_option() {
+            Some(odd) => odd.gcd_vartime(rhs),
+            None => self.gcd(rhs), // TODO(tarcieri): vartime support for even `self`?
+        }
+    }
 }
 
 impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize> Gcd<Uint<SAT_LIMBS>> for Odd<Uint<SAT_LIMBS>>
@@ -61,6 +68,10 @@ where
 
     fn gcd(&self, rhs: &Uint<SAT_LIMBS>) -> Uint<SAT_LIMBS> {
         <Odd<Self> as PrecomputeInverter>::Inverter::gcd(self, rhs)
+    }
+
+    fn gcd_vartime(&self, rhs: &Uint<SAT_LIMBS>) -> Self::Output {
+        <Odd<Self> as PrecomputeInverter>::Inverter::gcd_vartime(self, rhs)
     }
 }
 

--- a/src/uint/gcd.rs
+++ b/src/uint/gcd.rs
@@ -53,7 +53,7 @@ where
     }
 
     fn gcd_vartime(&self, rhs: &Self) -> Self::Output {
-        match Odd::<Self>::new(self.clone()).into_option() {
+        match Odd::<Self>::new(*self).into_option() {
             Some(odd) => odd.gcd_vartime(rhs),
             None => self.gcd(rhs), // TODO(tarcieri): vartime support for even `self`?
         }


### PR DESCRIPTION
Adds a method to the `Gcd` trait for computing greatest common divisor in variable time, permitting a faster implementation.