### PR TITLE
Rename `*Int62L` => `*UnsatInt`

### DIFF
--- a/src/modular/bernstein_yang/boxed.rs
+++ b/src/modular/bernstein_yang/boxed.rs
@@ -15,10 +15,10 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreate
 #[derive(Clone, Debug)]
 pub struct BoxedBernsteinYangInverter {
     /// Modulus
-    pub(crate) modulus: BoxedInt62L,
+    pub(crate) modulus: BoxedUnsatInt,
 
     /// Adjusting parameter (see toplevel documentation).
-    adjuster: BoxedInt62L,
+    adjuster: BoxedUnsatInt,
 
     /// Multiplicative inverse of the modulus modulo 2^62
     inverse: i64,
@@ -30,8 +30,8 @@ impl BoxedBernsteinYangInverter {
     /// Modulus must be odd. Returns `None` if it is not.
     pub fn new(modulus: &Odd<BoxedUint>, adjuster: &BoxedUint) -> Self {
         Self {
-            modulus: BoxedInt62L::from(&modulus.0),
-            adjuster: BoxedInt62L::from(&adjuster.widen(modulus.bits_precision())),
+            modulus: BoxedUnsatInt::from(&modulus.0),
+            adjuster: BoxedUnsatInt::from(&adjuster.widen(modulus.bits_precision())),
             inverse: inv_mod2_62(modulus.0.as_words()),
         }
     }
@@ -39,7 +39,7 @@ impl BoxedBernsteinYangInverter {
     /// Returns either "value (mod M)" or "-value (mod M)", where M is the modulus the inverter
     /// was created for, depending on "negate", which determines the presence of "-" in the used
     /// formula. The input integer lies in the interval (-2 * M, M).
-    fn norm(&self, mut value: BoxedInt62L, negate: Choice) -> BoxedInt62L {
+    fn norm(&self, mut value: BoxedUnsatInt, negate: Choice) -> BoxedUnsatInt {
         value.conditional_add(&self.modulus, value.is_negative());
         value.conditional_assign(&value.neg(), negate);
         value.conditional_add(&self.modulus, value.is_negative());
@@ -51,8 +51,8 @@ impl Inverter for BoxedBernsteinYangInverter {
     type Output = BoxedUint;
 
     fn invert(&self, value: &BoxedUint) -> CtOption<Self::Output> {
-        let mut d = BoxedInt62L::zero(self.modulus.nlimbs());
-        let mut g = BoxedInt62L::from(value).widen(d.nlimbs());
+        let mut d = BoxedUnsatInt::zero(self.modulus.nlimbs());
+        let mut g = BoxedUnsatInt::from(value).widen(d.nlimbs());
         let f = divsteps(&mut d, &self.adjuster, &self.modulus, &mut g, self.inverse);
 
         // At this point the absolute value of "f" equals the greatest common divisor of the
@@ -70,10 +70,10 @@ impl Inverter for BoxedBernsteinYangInverter {
 pub(crate) fn gcd(f: &BoxedUint, g: &BoxedUint) -> BoxedUint {
     let bits_precision = f.bits_precision();
     let inverse = inv_mod2_62(f.as_words());
-    let f = BoxedInt62L::from(f);
-    let mut g = BoxedInt62L::from(g);
-    let mut d = BoxedInt62L::zero(f.nlimbs());
-    let e = BoxedInt62L::one(f.nlimbs());
+    let f = BoxedUnsatInt::from(f);
+    let mut g = BoxedUnsatInt::from(g);
+    let mut d = BoxedUnsatInt::zero(f.nlimbs());
+    let e = BoxedUnsatInt::one(f.nlimbs());
 
     let mut f = divsteps(&mut d, &e, &f, &mut g, inverse);
     f.conditional_negate(f.is_negative());
@@ -86,10 +86,10 @@ pub(crate) fn gcd(f: &BoxedUint, g: &BoxedUint) -> BoxedUint {
 pub(crate) fn gcd_vartime(f: &BoxedUint, g: &BoxedUint) -> BoxedUint {
     let bits_precision = f.bits_precision();
     let inverse = inv_mod2_62(f.as_words());
-    let f = BoxedInt62L::from(f);
-    let mut g = BoxedInt62L::from(g);
-    let mut d = BoxedInt62L::zero(f.nlimbs());
-    let e = BoxedInt62L::one(f.nlimbs());
+    let f = BoxedUnsatInt::from(f);
+    let mut g = BoxedUnsatInt::from(g);
+    let mut d = BoxedUnsatInt::zero(f.nlimbs());
+    let e = BoxedUnsatInt::one(f.nlimbs());
 
     let mut f = divsteps_vartime(&mut d, &e, &f, &mut g, inverse);
     f.conditional_negate(f.is_negative());
@@ -101,12 +101,12 @@ pub(crate) fn gcd_vartime(f: &BoxedUint, g: &BoxedUint) -> BoxedUint {
 ///
 /// This version is variable-time with respect to `g`.
 fn divsteps(
-    d: &mut BoxedInt62L,
-    e: &BoxedInt62L,
-    f_0: &BoxedInt62L,
-    g: &mut BoxedInt62L,
+    d: &mut BoxedUnsatInt,
+    e: &BoxedUnsatInt,
+    f_0: &BoxedUnsatInt,
+    g: &mut BoxedUnsatInt,
     inverse: i64,
-) -> BoxedInt62L {
+) -> BoxedUnsatInt {
     debug_assert_eq!(f_0.nlimbs(), g.nlimbs());
 
     let mut e = e.clone();
@@ -129,12 +129,12 @@ fn divsteps(
 /// This version runs in a fixed number of iterations relative to the highest bit of `f` or `g`
 /// as described in Figure 11.1.
 fn divsteps_vartime(
-    d: &mut BoxedInt62L,
-    e: &BoxedInt62L,
-    f_0: &BoxedInt62L,
-    g: &mut BoxedInt62L,
+    d: &mut BoxedUnsatInt,
+    e: &BoxedUnsatInt,
+    f_0: &BoxedUnsatInt,
+    g: &mut BoxedUnsatInt,
     inverse: i64,
-) -> BoxedInt62L {
+) -> BoxedUnsatInt {
     debug_assert_eq!(f_0.nlimbs(), g.nlimbs());
 
     let mut e = e.clone();
@@ -155,7 +155,7 @@ fn divsteps_vartime(
 /// Bernstein-Yang transition matrix multiplied by 2^62.
 ///
 /// The returned vector is "matrix * (f, g)' / 2^62", where "'" is the transpose operator.
-fn fg(f: &mut BoxedInt62L, g: &mut BoxedInt62L, t: Matrix) {
+fn fg(f: &mut BoxedUnsatInt, g: &mut BoxedUnsatInt, t: Matrix) {
     // TODO(tarcieri): reduce allocations
     let mut f2 = &*f * t[0][0];
     f2 += &*g * t[0][1];
@@ -176,8 +176,14 @@ fn fg(f: &mut BoxedInt62L, g: &mut BoxedInt62L, t: Matrix) {
 /// modulus the inverter was created for and "'" stands for the transpose operator.
 ///
 /// Both the input and output values lie in the interval (-2 * M, M).
-fn de(modulus: &BoxedInt62L, inverse: i64, t: Matrix, d: &mut BoxedInt62L, e: &mut BoxedInt62L) {
-    let mask = BoxedInt62L::MASK as i64;
+fn de(
+    modulus: &BoxedUnsatInt,
+    inverse: i64,
+    t: Matrix,
+    d: &mut BoxedUnsatInt,
+    e: &mut BoxedUnsatInt,
+) {
+    let mask = BoxedUnsatInt::MASK as i64;
     let mut md =
         t[0][0] * d.is_negative().unwrap_u8() as i64 + t[0][1] * e.is_negative().unwrap_u8() as i64;
     let mut me =
@@ -215,18 +221,18 @@ fn de(modulus: &BoxedInt62L, inverse: i64, t: Matrix, d: &mut BoxedInt62L, e: &m
 ///
 /// The arithmetic operations for this type are wrapping ones.
 #[derive(Clone, Debug)]
-pub(crate) struct BoxedInt62L(Box<[u64]>);
+pub(crate) struct BoxedUnsatInt(Box<[u64]>);
 
 /// Convert from 32/64-bit saturated representation used by `Uint` to the 62-bit unsaturated
-/// representation used by `BoxedInt62L`.
+/// representation used by `BoxedUnsatInt`.
 ///
 /// Returns a big unsigned integer as an array of 62-bit chunks, which is equal modulo
 /// 2 ^ (62 * S) to the input big unsigned integer stored as an array of 64-bit chunks.
 ///
 /// The ordering of the chunks in these arrays is little-endian.
-impl From<&BoxedUint> for BoxedInt62L {
+impl From<&BoxedUint> for BoxedUnsatInt {
     #[allow(trivial_numeric_casts)]
-    fn from(input: &BoxedUint) -> BoxedInt62L {
+    fn from(input: &BoxedUint) -> BoxedUnsatInt {
         let saturated_nlimbs = if Word::BITS == 32 && input.nlimbs() == 1 {
             2
         } else {
@@ -252,7 +258,7 @@ impl From<&BoxedUint> for BoxedInt62L {
     }
 }
 
-impl BoxedInt62L {
+impl BoxedUnsatInt {
     /// Number of bits in each limb.
     pub const LIMB_BITS: usize = 62;
 
@@ -426,14 +432,14 @@ impl BoxedInt62L {
     }
 }
 
-impl AddAssign<BoxedInt62L> for BoxedInt62L {
-    fn add_assign(&mut self, rhs: BoxedInt62L) {
+impl AddAssign<BoxedUnsatInt> for BoxedUnsatInt {
+    fn add_assign(&mut self, rhs: BoxedUnsatInt) {
         self.add_assign(&rhs);
     }
 }
 
-impl AddAssign<&BoxedInt62L> for BoxedInt62L {
-    fn add_assign(&mut self, rhs: &BoxedInt62L) {
+impl AddAssign<&BoxedUnsatInt> for BoxedUnsatInt {
+    fn add_assign(&mut self, rhs: &BoxedUnsatInt) {
         debug_assert_eq!(self.nlimbs(), rhs.nlimbs());
         let mut carry = 0;
 
@@ -445,12 +451,12 @@ impl AddAssign<&BoxedInt62L> for BoxedInt62L {
     }
 }
 
-impl Mul<i64> for &BoxedInt62L {
-    type Output = BoxedInt62L;
+impl Mul<i64> for &BoxedUnsatInt {
+    type Output = BoxedUnsatInt;
 
-    fn mul(self, other: i64) -> BoxedInt62L {
+    fn mul(self, other: i64) -> BoxedUnsatInt {
         let nlimbs = self.nlimbs();
-        let mut ret = BoxedInt62L::zero(nlimbs);
+        let mut ret = BoxedUnsatInt::zero(nlimbs);
 
         // If the short multiplicand is non-negative, the standard multiplication algorithm is
         // performed. Otherwise, the product of the additively negated multiplicands is found as
@@ -466,15 +472,15 @@ impl Mul<i64> for &BoxedInt62L {
         // multiplication algorithm, where the carry flag is initialized with the additively
         // negated short multiplicand and the chunks of the long multiplicand are bitwise inverted.
         let (other, mut carry, mask) = if other < 0 {
-            (-other, -other as u64, BoxedInt62L::MASK)
+            (-other, -other as u64, BoxedUnsatInt::MASK)
         } else {
             (other, 0, 0)
         };
 
         for i in 0..nlimbs {
             let sum = (carry as u128) + ((self.0[i] ^ mask) as u128) * (other as u128);
-            ret.0[i] = sum as u64 & BoxedInt62L::MASK;
-            carry = (sum >> BoxedInt62L::LIMB_BITS) as u64;
+            ret.0[i] = sum as u64 & BoxedUnsatInt::MASK;
+            carry = (sum >> BoxedUnsatInt::LIMB_BITS) as u64;
         }
 
         ret
@@ -483,15 +489,15 @@ impl Mul<i64> for &BoxedInt62L {
 
 #[cfg(test)]
 mod tests {
-    use super::BoxedInt62L;
+    use super::BoxedUnsatInt;
     use crate::{BoxedUint, Inverter, PrecomputeInverter, U256};
     use proptest::prelude::*;
     use subtle::ConstantTimeEq;
 
     #[cfg(not(miri))]
-    use crate::modular::bernstein_yang::Int62L;
+    use crate::modular::bernstein_yang::UnsatInt;
 
-    impl PartialEq for BoxedInt62L {
+    impl PartialEq for BoxedUnsatInt {
         fn eq(&self, other: &Self) -> bool {
             self.0.ct_eq(&other.0).into()
         }
@@ -525,7 +531,7 @@ mod tests {
 
     #[test]
     fn de() {
-        let modulus = BoxedInt62L(
+        let modulus = BoxedUnsatInt(
             vec![
                 3727233105432618321,
                 3718823987352861203,
@@ -537,7 +543,7 @@ mod tests {
             .into(),
         );
         let inverse = 3687945983376704433;
-        let mut d = BoxedInt62L(
+        let mut d = BoxedUnsatInt(
             vec![
                 3490544662636853909,
                 2211268325417683828,
@@ -548,7 +554,7 @@ mod tests {
             ]
             .into(),
         );
-        let mut e = BoxedInt62L(
+        let mut e = BoxedUnsatInt(
             vec![
                 4004071259428196451,
                 1262234674432503659,
@@ -564,7 +570,7 @@ mod tests {
         super::de(&modulus, inverse, t, &mut d, &mut e);
         assert_eq!(
             d,
-            BoxedInt62L(
+            BoxedUnsatInt(
                 vec![
                     1211048314408256470,
                     1344008336933394898,
@@ -577,30 +583,30 @@ mod tests {
             )
         );
 
-        assert_eq!(e, BoxedInt62L(vec![0, 0, 0, 0, 0, 0].into()));
+        assert_eq!(e, BoxedUnsatInt(vec![0, 0, 0, 0, 0, 0].into()));
     }
 
     #[test]
     fn boxed_int62l_is_zero() {
-        let zero = BoxedInt62L::from(&U256::ZERO.into());
+        let zero = BoxedUnsatInt::from(&U256::ZERO.into());
         assert!(bool::from(zero.is_zero()));
 
-        let one = BoxedInt62L::from(&U256::ONE.into());
+        let one = BoxedUnsatInt::from(&U256::ONE.into());
         assert!(!bool::from(one.is_zero()));
     }
 
     #[test]
     fn boxed_int62l_is_one() {
-        let zero = BoxedInt62L::from(&U256::ZERO.into());
+        let zero = BoxedUnsatInt::from(&U256::ZERO.into());
         assert!(!bool::from(zero.is_one()));
 
-        let one = BoxedInt62L::from(&U256::ONE.into());
+        let one = BoxedUnsatInt::from(&U256::ONE.into());
         assert!(bool::from(one.is_one()));
     }
 
     #[test]
     fn int62l_shr_assign() {
-        let mut n = BoxedInt62L(
+        let mut n = BoxedUnsatInt(
             vec![
                 0,
                 1211048314408256470,
@@ -636,10 +642,10 @@ mod tests {
         #[test]
         #[cfg(not(miri))]
         fn boxed_int62l_add(x in u256(), y in u256()) {
-            let x_ref = Int62L::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
-            let y_ref = Int62L::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&y);
-            let mut x_boxed = BoxedInt62L::from(&x.into());
-            let y_boxed = BoxedInt62L::from(&y.into());
+            let x_ref = UnsatInt::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
+            let y_ref = UnsatInt::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&y);
+            let mut x_boxed = BoxedUnsatInt::from(&x.into());
+            let y_boxed = BoxedUnsatInt::from(&y.into());
 
             let expected = x_ref.add(&y_ref);
             x_boxed += &y_boxed;
@@ -649,8 +655,8 @@ mod tests {
         #[test]
         #[cfg(not(miri))]
         fn boxed_int62l_mul(x in u256(), y in any::<i64>()) {
-            let x_ref = Int62L::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
-            let x_boxed = BoxedInt62L::from(&x.into());
+            let x_ref = UnsatInt::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
+            let x_boxed = BoxedUnsatInt::from(&x.into());
 
             let expected = x_ref.mul(y);
             let actual = &x_boxed * y;
@@ -660,8 +666,8 @@ mod tests {
         #[test]
         #[cfg(not(miri))]
         fn boxed_int62l_neg(x in u256()) {
-            let x_ref = Int62L::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
-            let x_boxed = BoxedInt62L::from(&x.into());
+            let x_ref = UnsatInt::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
+            let x_boxed = BoxedUnsatInt::from(&x.into());
 
             let expected = x_ref.neg();
             let actual = x_boxed.neg();
@@ -671,8 +677,8 @@ mod tests {
         #[test]
         #[cfg(not(miri))]
         fn boxed_int62l_shr(x in u256()) {
-            let x_ref = Int62L::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
-            let mut x_boxed = BoxedInt62L::from(&x.into());
+            let x_ref = UnsatInt::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
+            let mut x_boxed = BoxedUnsatInt::from(&x.into());
             x_boxed.shr_assign();
 
             let expected = x_ref.shr();
@@ -683,8 +689,8 @@ mod tests {
                 #[cfg(not(miri))]
 
         fn boxed_int62l_is_negative(x in u256()) {
-            let x_ref = Int62L::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
-            let x_boxed = BoxedInt62L::from(&x.into());
+            let x_ref = UnsatInt::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
+            let x_boxed = BoxedUnsatInt::from(&x.into());
             assert_eq!(x_ref.is_negative().to_bool_vartime(), bool::from(x_boxed.is_negative()));
         }
 
@@ -692,9 +698,9 @@ mod tests {
                 #[cfg(not(miri))]
 
         fn boxed_int62l_is_minus_one(x in u256()) {
-            let x_ref = Int62L::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
-            let x_boxed = BoxedInt62L::from(&x.into());
-            assert!(bool::from(x_boxed.is_minus_one().ct_eq(&x_ref.eq(&Int62L::MINUS_ONE).into())));
+            let x_ref = UnsatInt::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
+            let x_boxed = BoxedUnsatInt::from(&x.into());
+            assert!(bool::from(x_boxed.is_minus_one().ct_eq(&x_ref.eq(&UnsatInt::MINUS_ONE).into())));
         }
     }
 }


### PR DESCRIPTION
These types are used within the Bernstein-Yang implementation(s) and implements a 62-bit unsaturated form used by the algorithm.