### PR TITLE
Fix remaining `int62l` references

### DIFF
--- a/src/modular/bernstein_yang.rs
+++ b/src/modular/bernstein_yang.rs
@@ -587,14 +587,14 @@ mod tests {
     }
 
     #[test]
-    fn int62l_add() {
+    fn unsatint_add() {
         assert_eq!(UnsatInt::ZERO, UnsatInt::ZERO.add(&UnsatInt::ZERO));
         assert_eq!(UnsatInt::ONE, UnsatInt::ONE.add(&UnsatInt::ZERO));
         assert_eq!(UnsatInt::ZERO, UnsatInt::MINUS_ONE.add(&UnsatInt::ONE));
     }
 
     #[test]
-    fn int62l_mul() {
+    fn unsatint_mul() {
         assert_eq!(UnsatInt::ZERO, UnsatInt::ZERO.mul(0));
         assert_eq!(UnsatInt::ZERO, UnsatInt::ZERO.mul(1));
         assert_eq!(UnsatInt::ZERO, UnsatInt::ONE.mul(0));
@@ -604,21 +604,21 @@ mod tests {
     }
 
     #[test]
-    fn int62l_neg() {
+    fn unsatint_neg() {
         assert_eq!(UnsatInt::ZERO, UnsatInt::ZERO.neg());
         assert_eq!(UnsatInt::MINUS_ONE, UnsatInt::ONE.neg());
         assert_eq!(UnsatInt::ONE, UnsatInt::MINUS_ONE.neg());
     }
 
     #[test]
-    fn int62l_is_negative() {
+    fn unsatint_is_negative() {
         assert!(!UnsatInt::ZERO.is_negative().to_bool_vartime());
         assert!(!UnsatInt::ONE.is_negative().to_bool_vartime());
         assert!(UnsatInt::MINUS_ONE.is_negative().to_bool_vartime());
     }
 
     #[test]
-    fn int62l_shr() {
+    fn unsatint_shr() {
         let n = super::UnsatInt([
             0,
             1211048314408256470,

--- a/src/modular/bernstein_yang/boxed.rs
+++ b/src/modular/bernstein_yang/boxed.rs
@@ -587,7 +587,7 @@ mod tests {
     }
 
     #[test]
-    fn boxed_int62l_is_zero() {
+    fn boxed_unsatint_is_zero() {
         let zero = BoxedUnsatInt::from(&U256::ZERO.into());
         assert!(bool::from(zero.is_zero()));
 
@@ -596,7 +596,7 @@ mod tests {
     }
 
     #[test]
-    fn boxed_int62l_is_one() {
+    fn boxed_unsatint_is_one() {
         let zero = BoxedUnsatInt::from(&U256::ZERO.into());
         assert!(!bool::from(zero.is_one()));
 
@@ -605,7 +605,7 @@ mod tests {
     }
 
     #[test]
-    fn int62l_shr_assign() {
+    fn unsatint_shr_assign() {
         let mut n = BoxedUnsatInt(
             vec![
                 0,
@@ -641,7 +641,7 @@ mod tests {
     proptest! {
         #[test]
         #[cfg(not(miri))]
-        fn boxed_int62l_add(x in u256(), y in u256()) {
+        fn boxed_unsatint_add(x in u256(), y in u256()) {
             let x_ref = UnsatInt::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
             let y_ref = UnsatInt::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&y);
             let mut x_boxed = BoxedUnsatInt::from(&x.into());
@@ -654,7 +654,7 @@ mod tests {
 
         #[test]
         #[cfg(not(miri))]
-        fn boxed_int62l_mul(x in u256(), y in any::<i64>()) {
+        fn boxed_unsatint_mul(x in u256(), y in any::<i64>()) {
             let x_ref = UnsatInt::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
             let x_boxed = BoxedUnsatInt::from(&x.into());
 
@@ -665,7 +665,7 @@ mod tests {
 
         #[test]
         #[cfg(not(miri))]
-        fn boxed_int62l_neg(x in u256()) {
+        fn boxed_unsatint_neg(x in u256()) {
             let x_ref = UnsatInt::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
             let x_boxed = BoxedUnsatInt::from(&x.into());
 
@@ -676,7 +676,7 @@ mod tests {
 
         #[test]
         #[cfg(not(miri))]
-        fn boxed_int62l_shr(x in u256()) {
+        fn boxed_unsatint_shr(x in u256()) {
             let x_ref = UnsatInt::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
             let mut x_boxed = BoxedUnsatInt::from(&x.into());
             x_boxed.shr_assign();
@@ -688,7 +688,7 @@ mod tests {
         #[test]
                 #[cfg(not(miri))]
 
-        fn boxed_int62l_is_negative(x in u256()) {
+        fn boxed_unsatint_is_negative(x in u256()) {
             let x_ref = UnsatInt::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
             let x_boxed = BoxedUnsatInt::from(&x.into());
             assert_eq!(x_ref.is_negative().to_bool_vartime(), bool::from(x_boxed.is_negative()));
@@ -697,7 +697,7 @@ mod tests {
         #[test]
                 #[cfg(not(miri))]
 
-        fn boxed_int62l_is_minus_one(x in u256()) {
+        fn boxed_unsatint_is_minus_one(x in u256()) {
             let x_ref = UnsatInt::<{ bernstein_yang_nlimbs!(256usize) }>::from_uint(&x);
             let x_boxed = BoxedUnsatInt::from(&x.into());
             assert!(bool::from(x_boxed.is_minus_one().ct_eq(&x_ref.eq(&UnsatInt::MINUS_ONE).into())));


### PR DESCRIPTION
The type has been renamed to `UnsatInt`, and the functions to `unsatint`