### PR TITLE
Fix vartime division edge case

### DIFF
--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -834,7 +834,7 @@ impl<const LIMBS: usize> RemLimb for Uint<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Limb, NonZero, Uint, Word, U256};
+    use crate::{Limb, NonZero, Uint, Word, U128, U256, U64};
 
     #[cfg(feature = "rand")]
     use {
@@ -912,15 +912,14 @@ mod tests {
 
     #[test]
     fn div_edge() {
-        use crate::U128;
         let lo = U128::from_be_hex("00000000000000000000000000000001");
         let hi = U128::from_be_hex("00000000000000000000000000000001");
         let y = U128::from_be_hex("00000000000000010000000000000001");
         let x = U256::from((lo, hi));
-        let expect = (U256::from(Limb::MAX), U256::from(2u64));
+        let expect = (U64::MAX.resize::<{ U256::LIMBS }>(), U256::from(2u64));
 
-        let q_r = Uint::div_rem(&x, &NonZero::new(y.resize()).unwrap());
-        assert_eq!(q_r, expect);
+        let (q1, r1) = Uint::div_rem(&x, &NonZero::new(y.resize()).unwrap());
+        assert_eq!((q1, r1), expect);
         let (q2, r2) = Uint::div_rem_vartime(&x, &NonZero::new(y).unwrap());
         assert_eq!((q2, r2.resize()), expect);
         let r3 = Uint::rem(&x, &NonZero::new(y.resize()).unwrap());

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -327,6 +327,12 @@ impl<const LIMBS: usize> Uint<LIMBS> {
                 (x[i], carry) = (Limb((x[i].0 >> lshift) | carry.0), Limb(x[i].0 << rshift));
             }
         }
+        // Clear upper limbs
+        i = LIMBS - 1;
+        while i >= yc {
+            x[i] = Limb::ZERO;
+            i -= 1;
+        }
 
         Uint::new(x)
     }

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -5,7 +5,7 @@ mod common;
 use common::to_biguint;
 use crypto_bigint::{
     modular::{MontyForm, MontyParams},
-    Encoding, Integer, Limb, NonZero, Odd, Word, U256,
+    Encoding, Integer, Limb, NonZero, Odd, Uint, Word, U256,
 };
 use num_bigint::BigUint;
 use num_integer::Integer as _;
@@ -263,6 +263,21 @@ proptest! {
             assert_eq!(expected, actual);
             let actual_vartime = a.div_rem_vartime(&b_nz);
             assert_eq!(expected, actual_vartime);
+        }
+    }
+
+
+    #[test]
+    fn rem_wide(a in uint(), b in uint(), c in uint()) {
+        let ab_bi = to_biguint(&a) * to_biguint(&b);
+        let c_bi = to_biguint(&c);
+
+        if !c_bi.is_zero() {
+            let expected = to_uint(ab_bi.div_rem(&c_bi).1);
+            let (lo, hi) = a.split_mul(&b);
+            let c_nz = NonZero::new(c).unwrap();
+            let actual = Uint::rem_wide_vartime((lo, hi), &c_nz);
+            assert_eq!(expected, actual);
         }
     }
 

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -251,6 +251,22 @@ proptest! {
     }
 
     #[test]
+    fn div_rem(a in uint(), b in uint()) {
+        let a_bi = to_biguint(&a);
+        let b_bi = to_biguint(&b);
+
+        if !b_bi.is_zero() {
+            let (q, r) = a_bi.div_rem(&b_bi);
+            let expected = (to_uint(q), to_uint(r));
+            let b_nz = NonZero::new(b).unwrap();
+            let actual = a.div_rem(&b_nz);
+            assert_eq!(expected, actual);
+            let actual_vartime = a.div_rem_vartime(&b_nz);
+            assert_eq!(expected, actual_vartime);
+        }
+    }
+
+    #[test]
     fn div_rem_limb(a in uint(), b in nonzero_limb()) {
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&U256::from(b));


### PR DESCRIPTION
Fixes #638 

A special case when the leading dividend word equalled the leading dividend word was not being handled.