### PR TITLE
Support `BoxedUint::gcd(_vartime)` where `self` and `rhs` have a different number of limbs

### DIFF
--- a/src/modular/bernstein_yang/boxed.rs
+++ b/src/modular/bernstein_yang/boxed.rs
@@ -68,6 +68,11 @@ impl Inverter for BoxedBernsteinYangInverter {
 
 /// Returns the greatest common divisor (GCD) of the two given numbers.
 pub(crate) fn gcd(f: &BoxedUint, g: &BoxedUint) -> BoxedUint {
+    // TODO (#312): depending on the decision there, this may be relaxed.
+    if f.nlimbs() != g.nlimbs() {
+        panic!("Both arguments to `gcd()` must have the same number of limbs");
+    }
+
     let bits_precision = f.bits_precision();
     let inverse = inv_mod2_62(f.as_words());
     let f = BoxedUnsatInt::from(f);
@@ -84,6 +89,11 @@ pub(crate) fn gcd(f: &BoxedUint, g: &BoxedUint) -> BoxedUint {
 ///
 /// Variable time with respect to `g`.
 pub(crate) fn gcd_vartime(f: &BoxedUint, g: &BoxedUint) -> BoxedUint {
+    // TODO (#312): depending on the decision there, this may be relaxed.
+    if f.nlimbs() != g.nlimbs() {
+        panic!("Both arguments to `gcd()` must have the same number of limbs");
+    }
+
     let bits_precision = f.bits_precision();
     let inverse = inv_mod2_62(f.as_words());
     let f = BoxedUnsatInt::from(f);

--- a/src/uint/boxed/gcd.rs
+++ b/src/uint/boxed/gcd.rs
@@ -91,4 +91,22 @@ mod tests {
         assert_eq!(f, f.gcd(&g));
         assert_eq!(f, g.gcd(&f));
     }
+
+    #[test]
+    #[should_panic(expected = "Both arguments to `gcd()` must have the same number of limbs")]
+    fn gcd_different_sizes() {
+        // Test that gcd works for boxed Uints with different numbers of limbs
+        let f = BoxedUint::from(4391633u32).widen(128).to_odd().unwrap();
+        let g = BoxedUint::from(2022161u32);
+        let _gcd = f.gcd(&g);
+    }
+
+    #[test]
+    #[should_panic(expected = "Both arguments to `gcd()` must have the same number of limbs")]
+    fn gcd_vartime_different_sizes() {
+        // Test that gcd works for boxed Uints with different numbers of limbs
+        let f = BoxedUint::from(4391633u32).widen(128).to_odd().unwrap();
+        let g = BoxedUint::from(2022161u32);
+        let _gcd = f.gcd_vartime(&g);
+    }
 }


### PR DESCRIPTION
The PR currently has just a testcase illustrating the problem. 

So the question is, what should the behavior be? We can equalize the sizes of the arguments at the top level, but that would make `gcd()` not constant time wrt numbers of limbs. Then again, would users assume that it is? 