### PR TITLE
BoxedMontyForm: always use `Arc` for `params`

### DIFF
--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -13,9 +13,7 @@ use super::{
     Retrieve,
 };
 use crate::{BoxedUint, Limb, Monty, Odd, Word};
-
-#[cfg(feature = "std")]
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -123,12 +121,6 @@ pub struct BoxedMontyForm {
     montgomery_form: BoxedUint,
 
     /// Montgomery form parameters.
-    #[cfg(not(feature = "std"))]
-    params: BoxedMontyParams,
-
-    /// Montgomery form parameters.
-    // Uses `Arc` when `std` is available.
-    #[cfg(feature = "std")]
     params: Arc<BoxedMontyParams>,
 }
 

--- a/src/modular/boxed_monty_form/inv.rs
+++ b/src/modular/boxed_monty_form/inv.rs
@@ -5,11 +5,9 @@ use crate::{
     modular::BoxedBernsteinYangInverter, Invert, Inverter, PrecomputeInverter,
     PrecomputeInverterWithAdjuster,
 };
+use alloc::sync::Arc;
 use core::fmt;
 use subtle::CtOption;
-
-#[cfg(feature = "std")]
-use std::sync::Arc;
 
 impl BoxedMontyForm {
     /// Computes `self^-1` representing the multiplicative inverse of `self`.
@@ -45,12 +43,6 @@ pub struct BoxedMontyFormInverter {
     inverter: BoxedBernsteinYangInverter,
 
     /// Residue parameters.
-    #[cfg(not(feature = "std"))]
-    params: BoxedMontyParams,
-
-    /// Residue parameters.
-    // Uses `Arc` when `std` is available.
-    #[cfg(feature = "std")]
     params: Arc<BoxedMontyParams>,
 }
 


### PR DESCRIPTION
`Arc` was previously gated on `std` but is available as `alloc::sync::Arc`.

Since `BoxedMontyForm` depends on `alloc` anyway, we can unconditionally use `Arc` for the params.

Using `Arc` avoids having to clone/duplicate the params every time a new `BoxedMontyForm` value is made with the same params.