### PR TITLE
Move schoolbook squaring implementation into a macro

### DIFF
--- a/benches/boxed_uint.rs
+++ b/benches/boxed_uint.rs
@@ -43,6 +43,31 @@ fn bench_shifts(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_mul(c: &mut Criterion) {
+    let mut group = c.benchmark_group("wrapping ops");
+
+    group.bench_function("boxed_mul", |b| {
+        b.iter_batched(
+            || {
+                (
+                    BoxedUint::random_bits(&mut OsRng, UINT_BITS),
+                    BoxedUint::random_bits(&mut OsRng, UINT_BITS),
+                )
+            },
+            |(x, y)| black_box(x.mul(&y)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("boxed_square", |b| {
+        b.iter_batched(
+            || BoxedUint::random_bits(&mut OsRng, UINT_BITS),
+            |x| black_box(x.square()),
+            BatchSize::SmallInput,
+        )
+    });
+}
+
 fn bench_division(c: &mut Criterion) {
     let mut group = c.benchmark_group("wrapping ops");
 
@@ -156,6 +181,12 @@ fn bench_boxed_sqrt(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_division, bench_shifts, bench_boxed_sqrt);
+criterion_group!(
+    benches,
+    bench_mul,
+    bench_division,
+    bench_shifts,
+    bench_boxed_sqrt
+);
 
 criterion_main!(benches);

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -1,6 +1,42 @@
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
-use crypto_bigint::{Limb, NonZero, Odd, Random, Reciprocal, Uint, U128, U2048, U256};
+use crypto_bigint::{Limb, NonZero, Odd, Random, Reciprocal, Uint, U128, U2048, U256, U4096};
 use rand_core::OsRng;
+
+fn bench_mul(c: &mut Criterion) {
+    let mut group = c.benchmark_group("wrapping ops");
+
+    group.bench_function("split_mul, U256xU256", |b| {
+        b.iter_batched(
+            || (U256::random(&mut OsRng), U256::random(&mut OsRng)),
+            |(x, y)| black_box(x.split_mul(&y)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("split_mul, U4096xU4096", |b| {
+        b.iter_batched(
+            || (U4096::random(&mut OsRng), U4096::random(&mut OsRng)),
+            |(x, y)| black_box(x.split_mul(&y)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("square_wide, U256", |b| {
+        b.iter_batched(
+            || U256::random(&mut OsRng),
+            |x| black_box(x.square_wide()),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("square_wide, U4096", |b| {
+        b.iter_batched(
+            || U4096::random(&mut OsRng),
+            |x| black_box(x.square_wide()),
+            BatchSize::SmallInput,
+        )
+    });
+}
 
 fn bench_division(c: &mut Criterion) {
     let mut group = c.benchmark_group("wrapping ops");
@@ -288,6 +324,7 @@ fn bench_sqrt(c: &mut Criterion) {
 
 criterion_group!(
     benches,
+    bench_mul,
     bench_division,
     bench_gcd,
     bench_shl,

--- a/src/uint/boxed/mul.rs
+++ b/src/uint/boxed/mul.rs
@@ -1,7 +1,8 @@
 //! [`BoxedUint`] multiplication operations.
 
 use crate::{
-    uint::mul::mul_limbs, BoxedUint, CheckedMul, Limb, WideningMul, Wrapping, WrappingMul, Zero,
+    uint::mul::{mul_limbs, square_limbs},
+    BoxedUint, CheckedMul, Limb, WideningMul, Wrapping, WrappingMul, Zero,
 };
 use core::ops::{Mul, MulAssign};
 use subtle::{Choice, CtOption};
@@ -23,8 +24,9 @@ impl BoxedUint {
 
     /// Multiply `self` by itself.
     pub fn square(&self) -> Self {
-        // TODO(tarcieri): more optimized implementation (shared with `Uint`?)
-        self.mul(self)
+        let mut limbs = vec![Limb::ZERO; self.nlimbs() * 2];
+        square_limbs(&self.limbs, &mut limbs);
+        limbs.into()
     }
 }
 


### PR DESCRIPTION
Applying this to BoxedUint results in an almost 50% speedup at 4096 bits.

Also adding benchmarks for multiplication.