### PR TITLE
Bernstein-Yang: boxing optimizations

### DIFF
--- a/src/modular/bernstein_yang/macros.rs
+++ b/src/modular/bernstein_yang/macros.rs
@@ -2,7 +2,8 @@
 
 /// Write an impl of a limb conversion function.
 ///
-/// Workaround for making this function generic around limb types while still allowing it to be `const fn`.
+/// Workaround for making this function generic around limb types while still allowing it to be
+/// `const fn`.
 macro_rules! impl_limb_convert {
     ($input_type:ty, $input_bits:expr, $input:expr, $output_type:ty, $output_bits:expr, $output:expr) => {{
         // This function is defined because the method "min" of the usize type is not constant


### PR DESCRIPTION
Adds a `BoxedUnsatInt::from_uint_widened` constructor which can be used to pad all `BoxedUnsatInt`s used as parameters to Bernstein-Yang to the same size at allocation time, rather than retroactively widening them to be the same size which may incur an additional allocation.