### PR TITLE
Derive Hash for a bunch of types

### DIFF
--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -20,7 +20,7 @@ use zeroize::Zeroize;
 
 /// Parameters to efficiently go to/from the Montgomery form for an odd modulus whose size and value
 /// are both chosen at runtime.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct BoxedMontyParams {
     /// The constant modulus
     modulus: Odd<BoxedUint>,
@@ -115,7 +115,7 @@ impl BoxedMontyParams {
 }
 
 /// An integer in Montgomery form represented using heap-allocated limbs.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct BoxedMontyForm {
     /// Value in the Montgomery form.
     montgomery_form: BoxedUint,

--- a/src/modular/boxed_monty_form/inv.rs
+++ b/src/modular/boxed_monty_form/inv.rs
@@ -37,7 +37,7 @@ impl PrecomputeInverter for BoxedMontyParams {
     }
 }
 
-/// Bernstein-Yang inverter which inverts [`DynResidue`] types.
+/// Bernstein-Yang inverter which inverts [`MontyForm`] types.
 pub struct BoxedMontyFormInverter {
     /// Precomputed Bernstein-Yang inverter.
     inverter: BoxedSafeGcdInverter,

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -68,7 +68,7 @@ pub trait ConstMontyParams<const LIMBS: usize>:
 /// The modulus is constant, so it cannot be set at runtime.
 ///
 /// Internally, the value is stored in Montgomery form (multiplied by MOD::ONE) until it is retrieved.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ConstMontyForm<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> {
     montgomery_form: Uint<LIMBS>,
     phantom: PhantomData<MOD>,

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -17,7 +17,7 @@ use crate::{Concat, Limb, Monty, NonZero, Odd, Split, Uint, Word};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 /// Parameters to efficiently go to/from the Montgomery form for an odd modulus provided at runtime.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct MontyParams<const LIMBS: usize> {
     /// The constant modulus
     modulus: Odd<Uint<LIMBS>>,
@@ -145,7 +145,7 @@ impl<const LIMBS: usize> ConstantTimeEq for MontyParams<LIMBS> {
 
 /// An integer in Montgomery form represented using `LIMBS` limbs.
 /// The odd modulus is set at runtime.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MontyForm<const LIMBS: usize> {
     montgomery_form: Uint<LIMBS>,
     params: MontyParams<LIMBS>,

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -187,7 +187,7 @@ pub(crate) const fn div3by2(
 }
 
 /// A pre-calculated reciprocal for division by a single limb.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Reciprocal {
     divisor_normalized: Word,
     shift: u32,

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -17,7 +17,7 @@ use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};
 ///
 /// This is analogous to [`core::num::Wrapping`] but allows this crate to
 /// define trait impls for this type.
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct Wrapping<T>(pub T);
 
 impl<T: WrappingAdd> Add<Self> for Wrapping<T> {


### PR DESCRIPTION
Some of the types in the crate do not derive `Hash` which make them difficult to use in hashmaps or sets.

It would be nice to make `Checked` also be `Hash`, but that requires https://github.com/dalek-cryptography/subtle/pull/138 so perhaps that can be a separate PR.