### PR TITLE
Montgomery form arithmetic improvements

### DIFF
--- a/benches/boxed_monty.rs
+++ b/benches/boxed_monty.rs
@@ -19,7 +19,69 @@ fn to_biguint(uint: &BoxedUint) -> BigUint {
 fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let params = BoxedMontyParams::new(Odd::<BoxedUint>::random(&mut OsRng, UINT_BITS));
 
-    group.bench_function("invert, 4096-bit", |b| {
+    group.bench_function(format!("add, {UINT_BITS}-bit"), |b| {
+        b.iter_batched(
+            || {
+                let a = BoxedMontyForm::new(
+                    BoxedUint::random_mod(&mut OsRng, params.modulus().as_nz_ref()),
+                    params.clone(),
+                );
+                let b = BoxedMontyForm::new(
+                    BoxedUint::random_mod(&mut OsRng, params.modulus().as_nz_ref()),
+                    params.clone(),
+                );
+                (a, b)
+            },
+            |(a, b)| black_box(a).add(&black_box(b)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function(format!("double, {UINT_BITS}-bit"), |b| {
+        b.iter_batched(
+            || {
+                BoxedMontyForm::new(
+                    BoxedUint::random_mod(&mut OsRng, params.modulus().as_nz_ref()),
+                    params.clone(),
+                )
+            },
+            |a| black_box(a).double(),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function(format!("sub, {UINT_BITS}-bit"), |b| {
+        b.iter_batched(
+            || {
+                let a = BoxedMontyForm::new(
+                    BoxedUint::random_mod(&mut OsRng, params.modulus().as_nz_ref()),
+                    params.clone(),
+                );
+                let b = BoxedMontyForm::new(
+                    BoxedUint::random_mod(&mut OsRng, params.modulus().as_nz_ref()),
+                    params.clone(),
+                );
+                (a, b)
+            },
+            |(a, b)| black_box(a).sub(&black_box(b)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function(format!("neg, {UINT_BITS}-bit"), |b| {
+        b.iter_batched(
+            || {
+                BoxedMontyForm::new(
+                    BoxedUint::random_mod(&mut OsRng, params.modulus().as_nz_ref()),
+                    params.clone(),
+                )
+            },
+            |a| black_box(a).neg(),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function(format!("invert, {UINT_BITS}-bit"), |b| {
         b.iter_batched(
             || {
                 BoxedMontyForm::new(
@@ -36,11 +98,11 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 let x = BoxedMontyForm::new(
-                    BoxedUint::random_bits(&mut OsRng, UINT_BITS),
+                    BoxedUint::random_mod(&mut OsRng, params.modulus().as_nz_ref()),
                     params.clone(),
                 );
                 let y = BoxedMontyForm::new(
-                    BoxedUint::random_bits(&mut OsRng, UINT_BITS),
+                    BoxedUint::random_mod(&mut OsRng, params.modulus().as_nz_ref()),
                     params.clone(),
                 );
                 (x, y)

--- a/benches/const_monty.rs
+++ b/benches/const_monty.rs
@@ -2,7 +2,9 @@ use criterion::{
     black_box, criterion_group, criterion_main, measurement::Measurement, BatchSize,
     BenchmarkGroup, Criterion,
 };
-use crypto_bigint::{impl_modulus, modular::ConstMontyParams, Invert, Inverter, Random, U256};
+use crypto_bigint::{
+    impl_modulus, modular::ConstMontyParams, Invert, Inverter, Random, RandomMod, U256,
+};
 use rand_core::OsRng;
 
 #[cfg(feature = "alloc")]
@@ -14,12 +16,19 @@ impl_modulus!(
     "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"
 );
 
+impl_modulus!(
+    UnsatModulus,
+    U256,
+    "4fffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"
+);
+
 type ConstMontyForm = crypto_bigint::modular::ConstMontyForm<Modulus, { U256::LIMBS }>;
+type UnsatConstMontyForm = crypto_bigint::modular::ConstMontyForm<UnsatModulus, { U256::LIMBS }>;
 
 fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("ConstMontyForm creation", |b| {
         b.iter_batched(
-            || U256::random(&mut OsRng),
+            || U256::random_mod(&mut OsRng, Modulus::MODULUS.as_nz_ref()),
             |x| black_box(ConstMontyForm::new(&x)),
             BatchSize::SmallInput,
         )
@@ -27,7 +36,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
 
     group.bench_function("ConstMontyForm retrieve", |b| {
         b.iter_batched(
-            || ConstMontyForm::new(&U256::random(&mut OsRng)),
+            || ConstMontyForm::random(&mut OsRng),
             |x| black_box(x.retrieve()),
             BatchSize::SmallInput,
         )
@@ -35,9 +44,69 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
 }
 
 fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
+    group.bench_function("add, U256", |b| {
+        b.iter_batched(
+            || {
+                let a = ConstMontyForm::random(&mut OsRng);
+                let b = ConstMontyForm::random(&mut OsRng);
+                (a, b)
+            },
+            |(a, b)| black_box(a).add(&black_box(b)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("add, U256, unsaturated", |b| {
+        b.iter_batched(
+            || {
+                let a = UnsatConstMontyForm::random(&mut OsRng);
+                let b = UnsatConstMontyForm::random(&mut OsRng);
+                (a, b)
+            },
+            |(a, b)| black_box(&a).add(&black_box(b)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    // group.bench_function("double, U256", |b| {
+    //     b.iter_batched(
+    //         || ConstMontyForm::random(&mut OsRng),
+    //         |a| black_box(a).double(),
+    //         BatchSize::SmallInput,
+    //     )
+    // });
+
+    // group.bench_function("double, U256, unsaturated", |b| {
+    //     b.iter_batched(
+    //         || UnsatConstMontyForm::random(&mut OsRng),
+    //         |a| black_box(a).double(),
+    //         BatchSize::SmallInput,
+    //     )
+    // });
+
+    group.bench_function("sub, U256", |b| {
+        b.iter_batched(
+            || {
+                let a = ConstMontyForm::random(&mut OsRng);
+                let b = ConstMontyForm::random(&mut OsRng);
+                (a, b)
+            },
+            |(a, b)| black_box(a).sub(&black_box(b)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("neg, U256", |b| {
+        b.iter_batched(
+            || ConstMontyForm::random(&mut OsRng),
+            |a| black_box(a).neg(),
+            BatchSize::SmallInput,
+        )
+    });
+
     group.bench_function("invert, U256", |b| {
         b.iter_batched(
-            || ConstMontyForm::new(&U256::random(&mut OsRng)),
+            || ConstMontyForm::random(&mut OsRng),
             |x| black_box(x).invert(),
             BatchSize::SmallInput,
         )
@@ -46,7 +115,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("Bernstein-Yang invert, U256", |b| {
         b.iter_batched(
             || {
-                let x = ConstMontyForm::new(&U256::random(&mut OsRng));
+                let x = ConstMontyForm::random(&mut OsRng);
                 let inverter = Modulus::precompute_inverter();
                 (x, inverter)
             },
@@ -58,11 +127,19 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("multiplication, U256*U256", |b| {
         b.iter_batched(
             || {
-                let x = ConstMontyForm::new(&U256::random(&mut OsRng));
-                let y = ConstMontyForm::new(&U256::random(&mut OsRng));
+                let x = ConstMontyForm::random(&mut OsRng);
+                let y = ConstMontyForm::random(&mut OsRng);
                 (x, y)
             },
-            |(x, y)| black_box(x * y),
+            |(x, y)| black_box(x).mul(&black_box(y)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("squaring, U256*U256", |b| {
+        b.iter_batched(
+            || ConstMontyForm::random(&mut OsRng),
+            |x| black_box(x).square(),
             BatchSize::SmallInput,
         )
     });
@@ -70,8 +147,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("modpow, U256^U256", |b| {
         b.iter_batched(
             || {
-                let x = U256::random(&mut OsRng);
-                let x_m = ConstMontyForm::new(&x);
+                let x_m = ConstMontyForm::random(&mut OsRng);
                 let p = U256::random(&mut OsRng) | (U256::ONE << (U256::BITS - 1));
                 (x_m, p)
             },
@@ -89,8 +165,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                     || {
                         let bases_and_exponents: Vec<(ConstMontyForm, U256)> = (1..=i)
                             .map(|_| {
-                                let x = U256::random(&mut OsRng);
-                                let x_m = ConstMontyForm::new(&x);
+                                let x_m = ConstMontyForm::random(&mut OsRng);
                                 let p = U256::random(&mut OsRng) | (U256::ONE << (U256::BITS - 1));
                                 (x_m, p)
                             })

--- a/benches/const_monty.rs
+++ b/benches/const_monty.rs
@@ -16,14 +16,7 @@ impl_modulus!(
     "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"
 );
 
-impl_modulus!(
-    UnsatModulus,
-    U256,
-    "4fffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"
-);
-
 type ConstMontyForm = crypto_bigint::modular::ConstMontyForm<Modulus, { U256::LIMBS }>;
-type UnsatConstMontyForm = crypto_bigint::modular::ConstMontyForm<UnsatModulus, { U256::LIMBS }>;
 
 fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("ConstMontyForm creation", |b| {
@@ -56,33 +49,13 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         )
     });
 
-    group.bench_function("add, U256, unsaturated", |b| {
+    group.bench_function("double, U256", |b| {
         b.iter_batched(
-            || {
-                let a = UnsatConstMontyForm::random(&mut OsRng);
-                let b = UnsatConstMontyForm::random(&mut OsRng);
-                (a, b)
-            },
-            |(a, b)| black_box(&a).add(&black_box(b)),
+            || ConstMontyForm::random(&mut OsRng),
+            |a| black_box(a).double(),
             BatchSize::SmallInput,
         )
     });
-
-    // group.bench_function("double, U256", |b| {
-    //     b.iter_batched(
-    //         || ConstMontyForm::random(&mut OsRng),
-    //         |a| black_box(a).double(),
-    //         BatchSize::SmallInput,
-    //     )
-    // });
-
-    // group.bench_function("double, U256, unsaturated", |b| {
-    //     b.iter_batched(
-    //         || UnsatConstMontyForm::random(&mut OsRng),
-    //         |a| black_box(a).double(),
-    //         BatchSize::SmallInput,
-    //     )
-    // });
 
     group.bench_function("sub, U256", |b| {
         b.iter_batched(

--- a/src/limb/shl.rs
+++ b/src/limb/shl.rs
@@ -11,6 +11,12 @@ impl Limb {
     pub const fn shl(self, shift: u32) -> Self {
         Limb(self.0 << shift)
     }
+
+    /// Computes `self << 1` and return the result and the carry (0 or 1).
+    #[inline(always)]
+    pub(crate) const fn shl1(self) -> (Self, Self) {
+        (Self(self.0 << 1), Self(self.0 >> Self::HI_BIT))
+    }
 }
 
 macro_rules! impl_shl {

--- a/src/modular/add.rs
+++ b/src/modular/add.rs
@@ -7,3 +7,10 @@ pub(crate) const fn add_montgomery_form<const LIMBS: usize>(
 ) -> Uint<LIMBS> {
     a.add_mod(b, &modulus.0)
 }
+
+pub(crate) const fn double_montgomery_form<const LIMBS: usize>(
+    a: &Uint<LIMBS>,
+    modulus: &Odd<Uint<LIMBS>>,
+) -> Uint<LIMBS> {
+    a.double_mod(&modulus.0)
+}

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -14,6 +14,7 @@ use super::{
 };
 use crate::{BoxedUint, Limb, Monty, Odd, Word};
 use alloc::sync::Arc;
+use subtle::Choice;
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -184,6 +185,25 @@ impl BoxedMontyForm {
             montgomery_form: params.one.clone(),
             params: params.into(),
         }
+    }
+
+    /// Determine if this value is equal to zero.
+    ///
+    /// # Returns
+    ///
+    /// If zero, returns `Choice(1)`. Otherwise, returns `Choice(0)`.
+    pub fn is_zero(&self) -> Choice {
+        self.montgomery_form.is_zero()
+    }
+
+    /// Determine if this value is not equal to zero.
+    ///
+    /// # Returns
+    ///
+    /// If zero, returns `Choice(0)`. Otherwise, returns `Choice(1)`.
+    #[inline]
+    pub fn is_nonzero(&self) -> Choice {
+        !self.is_zero()
     }
 
     /// Returns the parameter struct used to initialize this object.

--- a/src/modular/boxed_monty_form/add.rs
+++ b/src/modular/boxed_monty_form/add.rs
@@ -15,6 +15,14 @@ impl BoxedMontyForm {
             params: self.params.clone(),
         }
     }
+
+    /// Double `self`.
+    pub fn double(&self) -> Self {
+        Self {
+            montgomery_form: self.montgomery_form.double_mod(&self.params.modulus),
+            params: self.params.clone(),
+        }
+    }
 }
 
 impl Add<&BoxedMontyForm> for &BoxedMontyForm {

--- a/src/modular/boxed_monty_form/neg.rs
+++ b/src/modular/boxed_monty_form/neg.rs
@@ -1,18 +1,15 @@
 //! Negations of boxed integers in Montgomery form.
 
 use super::BoxedMontyForm;
-use crate::BoxedUint;
 use core::ops::Neg;
 
 impl BoxedMontyForm {
     /// Negates the number.
     pub fn neg(&self) -> Self {
-        let zero = Self {
-            montgomery_form: BoxedUint::zero_with_precision(self.params.bits_precision()),
+        Self {
+            montgomery_form: self.montgomery_form.neg_mod(&self.params.modulus),
             params: self.params.clone(),
-        };
-
-        zero.sub(self)
+        }
     }
 }
 

--- a/src/modular/boxed_monty_form/neg.rs
+++ b/src/modular/boxed_monty_form/neg.rs
@@ -26,3 +26,31 @@ impl Neg for &BoxedMontyForm {
         BoxedMontyForm::neg(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        modular::{BoxedMontyForm, BoxedMontyParams},
+        BoxedUint,
+    };
+    use hex_literal::hex;
+
+    #[test]
+    fn neg_expected() {
+        let modulus = BoxedUint::from_be_slice(
+            &hex!("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"),
+            256,
+        )
+        .expect("error creating modulus");
+        let params = BoxedMontyParams::new(modulus.to_odd().unwrap());
+
+        let x = BoxedUint::from_be_slice(
+            &hex!("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56"),
+            256,
+        )
+        .expect("error creating boxeduint");
+        let x_mod = BoxedMontyForm::new(x, params.clone());
+
+        assert!(bool::from((x_mod.neg() + x_mod).is_zero()));
+    }
+}

--- a/src/modular/const_monty_form/add.rs
+++ b/src/modular/const_monty_form/add.rs
@@ -1,7 +1,7 @@
 //! Additions between integers in Montgomery form with a constant modulus.
 
 use super::{ConstMontyForm, ConstMontyParams};
-use crate::modular::add::add_montgomery_form;
+use crate::modular::add::{add_montgomery_form, double_montgomery_form};
 use core::ops::{Add, AddAssign};
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
@@ -13,6 +13,14 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
                 &rhs.montgomery_form,
                 &MOD::MODULUS,
             ),
+            phantom: core::marker::PhantomData,
+        }
+    }
+
+    /// Double `self`.
+    pub const fn double(&self) -> Self {
+        Self {
+            montgomery_form: double_montgomery_form(&self.montgomery_form, &MOD::MODULUS),
             phantom: core::marker::PhantomData,
         }
     }

--- a/src/modular/const_monty_form/neg.rs
+++ b/src/modular/const_monty_form/neg.rs
@@ -6,7 +6,10 @@ use core::ops::Neg;
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Negates the number.
     pub const fn neg(&self) -> Self {
-        Self::ZERO.sub(self)
+        Self {
+            montgomery_form: self.montgomery_form.neg_mod(MOD::MODULUS.as_ref()),
+            phantom: self.phantom,
+        }
     }
 }
 

--- a/src/modular/monty_form/add.rs
+++ b/src/modular/monty_form/add.rs
@@ -1,7 +1,7 @@
 //! Additions between integers in Montgomery form with a modulus set at runtime.
 
 use super::MontyForm;
-use crate::modular::add::add_montgomery_form;
+use crate::modular::add::{add_montgomery_form, double_montgomery_form};
 use core::ops::{Add, AddAssign};
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
@@ -13,6 +13,14 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
                 &rhs.montgomery_form,
                 &self.params.modulus,
             ),
+            params: self.params,
+        }
+    }
+
+    /// Double `self`.
+    pub const fn double(&self) -> Self {
+        Self {
+            montgomery_form: double_montgomery_form(&self.montgomery_form, &self.params.modulus),
             params: self.params,
         }
     }

--- a/src/modular/monty_form/neg.rs
+++ b/src/modular/monty_form/neg.rs
@@ -6,7 +6,10 @@ use core::ops::Neg;
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Negates the number.
     pub const fn neg(&self) -> Self {
-        Self::zero(self.params).sub(self)
+        Self {
+            montgomery_form: self.montgomery_form.neg_mod(self.params.modulus.as_ref()),
+            params: self.params,
+        }
     }
 }
 

--- a/src/uint/boxed/add_mod.rs
+++ b/src/uint/boxed/add_mod.rs
@@ -29,7 +29,17 @@ impl BoxedUint {
     ///
     /// Assumes `self` as unbounded integer is `< p`.
     pub fn double_mod(&self, p: &Self) -> Self {
-        self.add_mod(self, p)
+        let (mut w, carry) = self.overflowing_shl1();
+
+        // Attempt to subtract the modulus, to ensure the result is in the field.
+        let borrow = w.sbb_assign(p, Limb::ZERO);
+        let (_, borrow) = carry.sbb(Limb::ZERO, borrow);
+
+        // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
+        // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
+        // modulus.
+        w.conditional_adc_assign(p, !borrow.is_zero());
+        w
     }
 }
 
@@ -74,5 +84,21 @@ mod tests {
         .unwrap();
 
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn double_mod_expected() {
+        let a = BoxedUint::from_be_hex(
+            "44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56",
+            256,
+        )
+        .unwrap();
+        let n = BoxedUint::from_be_hex(
+            "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+            256,
+        )
+        .unwrap();
+
+        assert_eq!(a.add_mod(&a, &n), a.double_mod(&n));
     }
 }

--- a/src/uint/boxed/add_mod.rs
+++ b/src/uint/boxed/add_mod.rs
@@ -23,6 +23,13 @@ impl BoxedUint {
         // modulus.
         w.wrapping_add(&p.bitand_limb(mask))
     }
+
+    /// Computes `self + self mod p`.
+    ///
+    /// Assumes `self` as unbounded integer is `< p`.
+    pub fn double_mod(&self, p: &Self) -> Self {
+        self.add_mod(self, p)
+    }
 }
 
 impl AddMod for BoxedUint {

--- a/src/uint/boxed/sub_mod.rs
+++ b/src/uint/boxed/sub_mod.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] modular subtraction operations.
 
-use crate::{BoxedUint, Limb, SubMod};
+use crate::{BoxedUint, Limb, SubMod, Zero};
 
 impl BoxedUint {
     /// Computes `self - rhs mod p`.
@@ -12,11 +12,12 @@ impl BoxedUint {
         debug_assert!(self < p);
         debug_assert!(rhs < p);
 
-        let (out, mask) = self.sbb(rhs, Limb::ZERO);
+        let (mut out, borrow) = self.sbb(rhs, Limb::ZERO);
 
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the modulus.
-        out.wrapping_add(&p.bitand_limb(mask))
+        out.conditional_adc_assign(p, !borrow.is_zero());
+        out
     }
 
     /// Computes `self - rhs mod p` for the special modulus

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -160,6 +160,23 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         (Uint::<LIMBS>::new(limbs), Limb(carry))
     }
+
+    /// Computes `self << 1` in constant-time, returning [`ConstChoice::TRUE`]
+    /// if the most significant bit was set, and [`ConstChoice::FALSE`] otherwise.
+    #[inline(always)]
+    pub(crate) const fn overflowing_shl1(&self) -> (Self, Limb) {
+        let mut ret = Self::ZERO;
+        let mut i = 0;
+        let mut carry = Limb::ZERO;
+        while i < LIMBS {
+            let (shifted, new_carry) = self.limbs[i].shl1();
+            ret.limbs[i] = shifted.bitor(carry);
+            carry = new_carry;
+            i += 1;
+        }
+
+        (ret, carry)
+    }
 }
 
 macro_rules! impl_shl {
@@ -242,6 +259,7 @@ mod tests {
     #[test]
     fn shl1() {
         assert_eq!(N << 1, TWO_N);
+        assert_eq!(N.overflowing_shl1(), (TWO_N, Limb::ONE));
     }
 
     #[test]


### PR DESCRIPTION
- Adds benchmarks for Montgomery arithmetic methods
- Adds a `double` method for Montgomery forms and `double_mod` method for Uint/BoxedUint, using a left shift instead of adding `self`
- Uses the existing (faster) `neg_mod` methods in Montgomery form `neg` methods
- Optimizes `add_mod` and `sub_mod` for `BoxedMontyForm` to remove allocations