### PR TITLE
Fix `clippy::too_long_first_doc_paragraph` violations

### DIFF
--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -27,8 +27,9 @@ use {
 #[macro_use]
 mod macros;
 
-/// The parameters to efficiently go to and from the Montgomery form for a given odd modulus. An
-/// easy way to generate these parameters is using the [`impl_modulus!`][`crate::impl_modulus`]
+/// The parameters to efficiently go to and from the Montgomery form for a given odd modulus.
+///
+/// An easy way to generate these parameters is using the [`impl_modulus!`][`crate::impl_modulus`]
 /// macro. These parameters are constant, so they cannot be set at runtime.
 ///
 /// Unfortunately, `LIMBS` must be generic for now until const generics are stabilized.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -31,9 +31,10 @@ pub trait Bounded {
     const BYTES: usize;
 }
 
-/// Trait for types which are conditionally selectable in constant time, similar to (and blanket impl'd for) `subtle`'s
-/// [`ConditionallySelectable`] trait, but without the `Copy` bound which allows it to be impl'd for heap allocated
-/// types such as `BoxedUint`.
+/// Trait for types which are conditionally selectable in constant time.
+///
+/// Similar to (and blanket impl'd for) `subtle`'s [`ConditionallySelectable`] trait, but without
+/// the `Copy` bound which allows it to be impl'd for heap allocated types such as `BoxedUint`.
 ///
 /// It also provides generic implementations of conditional assignment and conditional swaps.
 pub trait ConstantTimeSelect: Clone {


### PR DESCRIPTION
This is a `nightly`-only lint but it caught some rustdoc comments which are too long and needed to be broken up with more newlines.