### PR TITLE
Bump `hybrid-array` to v0.2.0-rc.10; MSRV 1.81

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.73.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -48,7 +48,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.73.0 # MSRV
+            rust: 1.81.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -56,7 +56,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.73.0 # MSRV
+            rust: 1.81.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.80.0
+          toolchain: 1.81.0
           components: clippy
       - run: cargo clippy --all --all-features -- -D warnings
 
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.73.0
+          toolchain: 1.81.0
       - run: cargo build --benches
       - run: cargo build --all-features --benches
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,9 +299,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.9"
+version = "0.2.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d306b679262030ad8813a82d4915fc04efff97776e4db7f8eb5137039d56400"
+checksum = "bae36f8710514b3e7aab028021733330de6e455e0352e19c6dd4513eecb7aa9a"
 dependencies = [
  "typenum",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,14 @@ keywords = ["arbitrary", "crypto", "bignum", "integer", "precision"]
 readme = "README.md"
 resolver = "2"
 edition = "2021"
-rust-version = "1.73"
+rust-version = "1.81"
 
 [dependencies]
 subtle = { version = "2.6", default-features = false }
 
 # optional dependencies
 der = { version = "0.8.0-rc.1", optional = true, default-features = false }
-hybrid-array = { version = "0.2.0-rc.8", optional = true }
+hybrid-array = { version = "0.2.0-rc.10", optional = true }
 num-traits = { version = "0.2.19", default-features = false }
 rand_core = { version = "0.6.4", optional = true }
 rlp = { version = "0.6", optional = true, default-features = false }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ microcontrollers).
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.73** at a minimum.
+This crate requires **Rust 1.81** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -68,7 +68,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/crypto-bigint/actions/workflows/crypto-bigint.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/crypto-bigint/actions/workflows/crypto-bigint.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.73+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.81+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300602-crypto-bigint
 


### PR DESCRIPTION
This version leverages the new `core::error::Error` stabilization.

We plan on bumping MSRV to 1.83 before a final release to get the `const_mut_refs` stabilization (#667), so this is something of an interim bump.