### PR TITLE
Remove `std` feature; leverage `core::error::Error`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ rand_chacha = "0.3"
 [features]
 default = ["rand"]
 alloc = ["serdect?/alloc"]
-std = ["alloc"]
 
 extra-sizes = []
 rand = ["rand_core/std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,9 +155,6 @@
 #[macro_use]
 extern crate alloc;
 
-#[cfg(feature = "std")]
-extern crate std;
-
 #[macro_use]
 mod macros;
 

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -158,7 +158,6 @@ impl BoxedMontyForm {
     }
 
     /// Instantiates a new [`BoxedMontyForm`] that represents an integer modulo the provided params.
-    #[cfg(feature = "std")]
     pub fn new_with_arc(mut integer: BoxedUint, params: Arc<BoxedMontyParams>) -> Self {
         debug_assert_eq!(integer.bits_precision(), params.bits_precision());
         convert_to_montgomery(&mut integer, &params);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -337,8 +337,8 @@ impl fmt::Display for RandomBitsError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for RandomBitsError {}
+#[cfg(feature = "rand_core")]
+impl core::error::Error for RandomBitsError {}
 
 /// Random bits generation support.
 #[cfg(feature = "rand_core")]
@@ -572,8 +572,7 @@ impl fmt::Display for DecodeError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DecodeError {}
+impl core::error::Error for DecodeError {}
 
 /// Support for optimized squaring
 pub trait Square {


### PR DESCRIPTION
Now that the MSRV is 1.81, use `core::error::Error` instead of `std::error::Error`.

Since this was our only dependency on `std`, we can also remove the entire `std` feature.