### PR TITLE
docs: fix comparison documentation

### DIFF
--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -54,7 +54,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         Limb(acc).is_nonzero().not()
     }
 
-    /// Returns the truthy value if `self <= rhs` and the falsy value otherwise.
+    /// Returns the truthy value if `self < rhs` and the falsy value otherwise.
     #[inline]
     pub(crate) const fn lt(lhs: &Self, rhs: &Self) -> ConstChoice {
         // We could use the same approach as in Limb::ct_lt(),
@@ -64,7 +64,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         ConstChoice::from_word_mask(borrow.0)
     }
 
-    /// Returns the truthy value if `self >= rhs` and the falsy value otherwise.
+    /// Returns the truthy value if `self > rhs` and the falsy value otherwise.
     #[inline]
     pub(crate) const fn gt(lhs: &Self, rhs: &Self) -> ConstChoice {
         let (_res, borrow) = rhs.sbb(lhs, Limb::ZERO);


### PR DESCRIPTION
This PR fixes the documentation for `Uint` comparison. This documentation currently indicates that both [`Uint::lt`](https://github.com/RustCrypto/crypto-bigint/blob/1c946074e6a7f589cf89e3c91448d0068d730a88/src/uint/cmp.rs#L57) and [`Uint::gt`](https://github.com/RustCrypto/crypto-bigint/blob/1c946074e6a7f589cf89e3c91448d0068d730a88/src/uint/cmp.rs#L67) return truthy if the operands are equal. However, included tests for both [`Uint::lt`](https://github.com/RustCrypto/crypto-bigint/blob/1c946074e6a7f589cf89e3c91448d0068d730a88/src/uint/cmp.rs#L227-L229) and [`Uint::gt`](https://github.com/RustCrypto/crypto-bigint/blob/1c946074e6a7f589cf89e3c91448d0068d730a88/src/uint/cmp.rs#L208-L210) show that this is not the case.

Closes #682.