### PR TITLE
rem_wide_vartime broke in rc.3

### DIFF
--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -1053,6 +1053,25 @@ mod tests {
     }
 
     #[test]
+    fn rem_wide_vartime_corner_case() {
+        // Moduli with the 33rd byte higher than 8 triggers the bug (e.g. "…81…1" below)
+        let modulus = "0000000000000000000000000000000081000000000000000000000000000001";
+        let modulus = NonZero::new(U256::from_be_hex(modulus)).expect("it's odd and not zero");
+        let one_squared_wide = (
+            // Result of `square_wide()` applied to the `one` variable from `MontyParams::new_vartime`
+            U256::from_be_hex("40F9003F02F813D06F023B0AE83390F2FDE8ADA6AEAA9AE9ECA5B68EEA1BE809"),
+            U256::ZERO,
+        );
+        // The problem is somewhere in here
+        let r2 = U256::rem_wide_vartime(one_squared_wide, &modulus);
+
+        // This is the output of v0.6.0-rc.2
+        let expected_r2 =
+            U256::from_be_hex("0000000000000000000000000000000025F88D6923D0282E856FAC8D1D4E6132");
+        assert_eq!(r2, expected_r2);
+    }
+
+    #[test]
     fn reduce_max() {
         let mut a = U256::ZERO;
         let mut b = U256::ZERO;


### PR DESCRIPTION
While working in `crypto-primes` I noticed that one of the benchmarks was hanging. The benchmark in question is finding 128 bit primes but returns them in a 256 bit wide uint.
I have reduced the problem somewhat to commit e948539b in `crypto-bigint` and the operations required for [`MontyParams::new_vartime`](https://github.com/RustCrypto/crypto-bigint/blob/master/src/modular/monty_form.rs#L81). 
In particular the problem is somewhere in [`rem_wide_vartime`](https://github.com/RustCrypto/crypto-bigint/blob/master/src/uint/div.rs#L320) which doesn’t treat the lower operand correctly for some rhs values. 

This PR contains a failing test that illustrates the problem. 
