### PR TITLE
Add `double` and `lincomb_vartime` methods to `Monty` trait

### DIFF
--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -294,8 +294,16 @@ impl Monty for BoxedMontyForm {
         &self.montgomery_form
     }
 
+    fn double(&self) -> Self {
+        BoxedMontyForm::double(self)
+    }
+
     fn div_by_2(&self) -> Self {
         BoxedMontyForm::div_by_2(self)
+    }
+
+    fn lincomb_vartime(products: &[(&Self, &Self)]) -> Self {
+        BoxedMontyForm::lincomb_vartime(products)
     }
 }
 

--- a/src/modular/lincomb.rs
+++ b/src/modular/lincomb.rs
@@ -103,7 +103,7 @@ pub const fn lincomb_const_monty_form<MOD: ConstMontyParams<LIMBS>, const LIMBS:
 }
 
 pub const fn lincomb_monty_form<const LIMBS: usize>(
-    mut products: &[(MontyForm<LIMBS>, MontyForm<LIMBS>)],
+    mut products: &[(&MontyForm<LIMBS>, &MontyForm<LIMBS>)],
     modulus: &Odd<Uint<LIMBS>>,
     mod_neg_inv: Limb,
     mod_leading_zeros: u32,

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -275,8 +275,16 @@ impl<const LIMBS: usize> Monty for MontyForm<LIMBS> {
         &self.montgomery_form
     }
 
+    fn double(&self) -> Self {
+        MontyForm::double(self)
+    }
+
     fn div_by_2(&self) -> Self {
         MontyForm::div_by_2(self)
+    }
+
+    fn lincomb_vartime(products: &[(&Self, &Self)]) -> Self {
+        MontyForm::lincomb_vartime(products)
     }
 }
 

--- a/src/modular/monty_form/lincomb.rs
+++ b/src/modular/monty_form/lincomb.rs
@@ -11,7 +11,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     ///
     /// This method will panic if `products` is empty. All terms must be associated
     /// with equivalent `MontyParams`.
-    pub const fn lincomb_vartime(products: &[(Self, Self)]) -> Self {
+    pub const fn lincomb_vartime(products: &[(&Self, &Self)]) -> Self {
         assert!(!products.is_empty(), "empty products");
         let params = &products[0].0.params;
         Self {
@@ -51,8 +51,8 @@ mod tests {
             assert_eq!(
                 a.mul_mod(&b, m).add_mod(&c.mul_mod(&d, m), m),
                 MontyForm::lincomb_vartime(&[
-                    (MontyForm::new(&a, params), MontyForm::new(&b, params)),
-                    (MontyForm::new(&c, params), MontyForm::new(&d, params)),
+                    (&MontyForm::new(&a, params), &MontyForm::new(&b, params)),
+                    (&MontyForm::new(&c, params), &MontyForm::new(&d, params)),
                 ])
                 .retrieve(),
                 "n={n}, a={a}, b={b}, c={c}, d={d}"

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -836,6 +836,18 @@ pub trait Monty:
     /// Access the value in Montgomery form.
     fn as_montgomery(&self) -> &Self::Integer;
 
+    /// Performs doubling, returning `self + self`.
+    fn double(&self) -> Self;
+
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
     fn div_by_2(&self) -> Self;
+
+    /// Calculate the sum of products of pairs `(a, b)` in `products`.
+    ///
+    /// This method is variable time only with the value of the modulus.
+    /// For a modulus with leading zeros, this method is more efficient than a naive sum of products.
+    ///
+    /// This method will panic if `products` is empty. All terms must be associated with equivalent
+    /// Montgomery parameters.
+    fn lincomb_vartime(products: &[(&Self, &Self)]) -> Self;
 }


### PR DESCRIPTION
This changes the signature of `MontyForm::lincomb_vartime` to take references, for consistency with `BoxedMontyForm` and the trait method. `ConstMontyForm` I've left with owned values, as changing to references seems to have a 15% performance penalty on the benchmark.