### PR TITLE
Leverage `div_ceil`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,7 +5,7 @@
 #[macro_export]
 macro_rules! nlimbs {
     ($bits:expr) => {
-        (($bits + $crate::Limb::BITS - 1) / $crate::Limb::BITS) as usize
+        u32::div_ceil($bits, $crate::Limb::BITS) as usize
     };
 }
 

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -52,7 +52,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         let dbits = rhs.0.bits();
         assert!(dbits > 0, "zero divisor");
-        let dwords = (dbits + Limb::BITS - 1) / Limb::BITS;
+        let dwords = dbits.div_ceil(Limb::BITS);
         let lshift = (Limb::BITS - (dbits % Limb::BITS)) % Limb::BITS;
 
         // Shift entire divisor such that the high bit is set
@@ -198,7 +198,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // Further explanation at https://janmr.com/blog/2014/04/basic-multiple-precision-long-division/
 
         let dbits = rhs.0.bits_vartime();
-        let yc = ((dbits + Limb::BITS - 1) / Limb::BITS) as usize;
+        let yc = dbits.div_ceil(Limb::BITS) as usize;
 
         // Short circuit for small or extra large divisors
         if yc == 1 {
@@ -319,7 +319,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// to `self`.
     pub const fn rem_wide_vartime(lower_upper: (Self, Self), rhs: &NonZero<Self>) -> Self {
         let dbits = rhs.0.bits_vartime();
-        let yc = ((dbits + Limb::BITS - 1) / Limb::BITS) as usize;
+        let yc = dbits.div_ceil(Limb::BITS) as usize;
 
         // If the divisor is a single limb, use limb division
         if yc == 1 {

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -33,7 +33,7 @@ pub(crate) fn random_bits_core(
     let buffer: Word = 0;
     let mut buffer = buffer.to_be_bytes();
 
-    let nonzero_limbs = ((bit_length + Limb::BITS - 1) / Limb::BITS) as usize;
+    let nonzero_limbs = bit_length.div_ceil(Limb::BITS) as usize;
     let partial_limb = bit_length % Limb::BITS;
     let mask = Word::MAX >> ((Word::BITS - partial_limb) % Word::BITS);
 
@@ -111,7 +111,7 @@ pub(super) fn random_mod_core<T>(
     T: AsMut<[Limb]> + ConstantTimeLess + Zero,
 {
     let n_bytes = ((n_bits + 7) / 8) as usize;
-    let n_limbs = ((n_bits + Limb::BITS - 1) / Limb::BITS) as usize;
+    let n_limbs = n_bits.div_ceil(Limb::BITS) as usize;
     let hi_bytes = n_bytes - (n_limbs - 1) * Limb::BYTES;
 
     let mut bytes = Limb::ZERO.to_le_bytes();


### PR DESCRIPTION
Fixes clippy warnings about `div_ceil` which are appearing on recent nightlies