### PR TITLE
Remove `const_assert_*`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -24,59 +24,6 @@ macro_rules! safegcd_nlimbs {
     };
 }
 
-/// Internal implementation detail of [`const_assert_eq`] and [`const_assert_ne`].
-#[doc(hidden)]
-#[macro_export]
-macro_rules! const_assert_n {
-    ($n:ident, $($arg:tt)*) => {{
-        // TODO(tarcieri): gensym a name so it's unique per invocation of the macro?
-        mod __const_assert {
-            pub(super) struct Assert<const $n: usize>;
-
-            impl<const $n: usize> Assert<$n> {
-                pub(super) const ASSERT: () = assert!($($arg)*);
-            }
-        }
-
-        __const_assert::Assert::<$n>::ASSERT
-    }};
-}
-
-/// Const-friendly assertion that two values are equal.
-///
-/// The first/leftmost operand MUST be a `usize` constant.
-///
-/// ```ignore
-/// const N: usize = 0;
-/// const _: () = crypto_bigint::const_assert_eq!(N, 0, "zero equals zero");
-/// ```
-#[allow(unused_macros)] // TODO(tarcieri): not ready for external use
-macro_rules! const_assert_eq {
-    ($left:ident, $right:expr $(,)?) => (
-        $crate::const_assert_n!($left, $left == $right)
-    );
-    ($left:ident, $right:expr, $($arg:tt)+) => (
-        $crate::const_assert_n!($left, $left == $right, $($arg)+)
-    );
-}
-
-/// Const-friendly assertion that two values are NOT equal.
-///
-/// The first/leftmost operand MUST be a `usize` constant.
-///
-/// ```ignore
-/// const N: usize = 0;
-/// const _: () = crypto_bigint::const_assert_ne!(N, 1, "zero is NOT equal to one");
-/// ```
-macro_rules! const_assert_ne {
-    ($left:ident, $right:expr $(,)?) => (
-        $crate::const_assert_n!($left, $left != $right)
-    );
-    ($left:ident, $right:expr, $($arg:tt)+) => (
-        $crate::const_assert_n!($left, $left != $right, $($arg)+)
-    );
-}
-
 #[cfg(test)]
 mod tests {
     #[cfg(target_pointer_width = "32")]

--- a/src/modular/monty_form/pow.rs
+++ b/src/modular/monty_form/pow.rs
@@ -58,7 +58,7 @@ impl<const N: usize, const LIMBS: usize, const RHS_LIMBS: usize>
         bases_and_exponents: &[(Self, Uint<RHS_LIMBS>); N],
         exponent_bits: u32,
     ) -> Self {
-        const_assert_ne!(N, 0, "bases_and_exponents must not be empty");
+        assert!(N != 0, "bases_and_exponents must not be empty");
         let params = bases_and_exponents[0].0.params;
 
         let mut bases_and_exponents_montgomery_form =


### PR DESCRIPTION
These were half-baked and cause weird compile errors in several situations.

We'll be better off with const support for `assert_eq`/`assert_ne` whenever that lands.