### PR TITLE
Update documentation for random functionality

### DIFF
--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -232,10 +232,12 @@ impl<T> Random for NonZero<T>
 where
     T: Random + Zero,
 {
+    /// This uses rejection sampling to avoid zero.
+    ///
+    /// As a result, it runs in variable time. If the generator `rng` is
+    /// cryptographically secure (for example, it implements `CryptoRng`),
+    /// then this is guaranteed not to leak anything about the output value.
     fn random(mut rng: &mut impl RngCore) -> Self {
-        // Use rejection sampling to eliminate zero values.
-        // While this method isn't constant-time, the attacker shouldn't learn
-        // anything about unrelated outputs so long as `rng` is a CSRNG.
         loop {
             if let Some(result) = Self::new(T::random(&mut rng)).into() {
                 break result;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -392,14 +392,13 @@ pub trait RandomBits: Sized {
 pub trait RandomMod: Sized + Zero {
     /// Generate a random number which is less than a given `modulus`.
     ///
-    /// This function uses rejection sampling, a method which produces an
-    /// unbiased distribution of in-range values provided the underlying
-    /// RNG is unbiased, but runs in variable-time.
+    /// This uses rejection sampling.
     ///
-    /// The variable-time nature of the algorithm should not pose a security
-    /// issue so long as the underlying random number generator is a
-    /// CSRNG, where previous outputs are unrelated to subsequent
-    /// outputs and do not reveal information about the RNG's internal state.
+    /// As a result, it runs in variable time that depends in part on
+    /// `modulus`. If the generator `rng` is cryptographically secure (for
+    /// example, it implements `CryptoRng`), then this is guaranteed not to
+    /// leak anything about the output value aside from it being less than
+    /// `modulus`.
     fn random_mod(rng: &mut impl RngCore, modulus: &NonZero<Self>) -> Self;
 }
 

--- a/src/uint/boxed/rand.rs
+++ b/src/uint/boxed/rand.rs
@@ -31,16 +31,6 @@ impl RandomBits for BoxedUint {
 }
 
 impl RandomMod for BoxedUint {
-    /// Generate a random [`BoxedUint`] which is less than a given `modulus`.
-    ///
-    /// This function uses rejection sampling, a method which produces an
-    /// unbiased distribution of in-range values provided the underlying
-    /// RNG is unbiased, but runs in variable-time.
-    ///
-    /// The variable-time nature of the algorithm should not pose a security
-    /// issue so long as the underlying random number generator is a
-    /// CSRNG, where previous outputs are unrelated to subsequent
-    /// outputs and do not reveal information about the RNG's internal state.
     fn random_mod(rng: &mut impl RngCore, modulus: &NonZero<Self>) -> Self {
         let mut n = BoxedUint::zero_with_precision(modulus.bits_precision());
         random_mod_core(rng, &mut n, modulus, modulus.bits());

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -78,16 +78,6 @@ impl<const LIMBS: usize> RandomBits for Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize> RandomMod for Uint<LIMBS> {
-    /// Generate a random number which is less than a given `modulus`.
-    ///
-    /// This function uses rejection sampling, a method which produces an
-    /// unbiased distribution of in-range values provided the underlying
-    /// RNG is unbiased, but runs in variable-time.
-    ///
-    /// The variable-time nature of the algorithm should not pose a security
-    /// issue so long as the underlying random number generator is a
-    /// CSRNG, where previous outputs are unrelated to subsequent
-    /// outputs and do not reveal information about the RNG's internal state.
     fn random_mod(rng: &mut impl RngCore, modulus: &NonZero<Self>) -> Self {
         let mut n = Self::ZERO;
         random_mod_core(rng, &mut n, modulus, modulus.bits_vartime());


### PR DESCRIPTION
Recent work in #710 relaxes the trait bound for random number generators. This means that functions generating random values using rejection sampling are no longer guaranteed not to leak anything about output values. This PR updates the documentation to make this clear.