### PR TITLE
Add `Add`/`Mul`/`SubAssign` bounds for `Integer`

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -82,6 +82,8 @@ pub trait Integer:
     'static
     + Add<Output = Self>
     + for<'a> Add<&'a Self, Output = Self>
+    + AddAssign<Self>
+    + for<'a> AddAssign<&'a Self>
     + AddMod<Output = Self>
     + AsRef<[Limb]>
     + BitAnd<Output = Self>
@@ -121,6 +123,8 @@ pub trait Integer:
     + From<Limb>
     + Mul<Output = Self>
     + for<'a> Mul<&'a Self, Output = Self>
+    + MulAssign<Self>
+    + for<'a> MulAssign<&'a Self>
     + MulMod<Output = Self>
     + NegMod<Output = Self>
     + Not<Output = Self>
@@ -140,6 +144,8 @@ pub trait Integer:
     + ShrVartime
     + Sub<Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
+    + SubAssign<Self>
+    + for<'a> SubAssign<&'a Self>
     + SubMod<Output = Self>
     + Sync
     + SquareRoot

--- a/src/uint/boxed/add.rs
+++ b/src/uint/boxed/add.rs
@@ -66,12 +66,37 @@ impl Add<&BoxedUint> for BoxedUint {
     }
 }
 
+impl Add<BoxedUint> for &BoxedUint {
+    type Output = BoxedUint;
+
+    fn add(self, rhs: BoxedUint) -> BoxedUint {
+        Add::add(self, &rhs)
+    }
+}
+
 impl Add<&BoxedUint> for &BoxedUint {
     type Output = BoxedUint;
 
     fn add(self, rhs: &BoxedUint) -> BoxedUint {
         self.checked_add(rhs)
             .expect("attempted to add with overflow")
+    }
+}
+
+impl AddAssign<BoxedUint> for BoxedUint {
+    fn add_assign(&mut self, rhs: BoxedUint) {
+        self.add_assign(&rhs)
+    }
+}
+
+impl AddAssign<&BoxedUint> for BoxedUint {
+    fn add_assign(&mut self, rhs: &BoxedUint) {
+        let carry = self.adc_assign(rhs, Limb::ZERO);
+        assert_eq!(
+            carry.is_zero().unwrap_u8(),
+            1,
+            "attempted to add with overflow"
+        );
     }
 }
 

--- a/src/uint/boxed/mul.rs
+++ b/src/uint/boxed/mul.rs
@@ -102,6 +102,18 @@ impl Mul<&BoxedUint> for &BoxedUint {
     }
 }
 
+impl MulAssign<BoxedUint> for BoxedUint {
+    fn mul_assign(&mut self, rhs: BoxedUint) {
+        self.mul_assign(&rhs)
+    }
+}
+
+impl MulAssign<&BoxedUint> for BoxedUint {
+    fn mul_assign(&mut self, rhs: &BoxedUint) {
+        *self = self.clone().mul(rhs)
+    }
+}
+
 impl MulAssign<Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
     fn mul_assign(&mut self, other: Wrapping<BoxedUint>) {
         *self = Wrapping(self.0.wrapping_mul(&other.0));

--- a/src/uint/boxed/sub.rs
+++ b/src/uint/boxed/sub.rs
@@ -73,12 +73,37 @@ impl Sub<&BoxedUint> for BoxedUint {
     }
 }
 
+impl Sub<BoxedUint> for &BoxedUint {
+    type Output = BoxedUint;
+
+    fn sub(self, rhs: BoxedUint) -> BoxedUint {
+        Sub::sub(self, &rhs)
+    }
+}
+
 impl Sub<&BoxedUint> for &BoxedUint {
     type Output = BoxedUint;
 
     fn sub(self, rhs: &BoxedUint) -> BoxedUint {
         self.checked_sub(rhs)
             .expect("attempted to subtract with underflow")
+    }
+}
+
+impl SubAssign<BoxedUint> for BoxedUint {
+    fn sub_assign(&mut self, rhs: BoxedUint) {
+        self.sub_assign(&rhs)
+    }
+}
+
+impl SubAssign<&BoxedUint> for BoxedUint {
+    fn sub_assign(&mut self, rhs: &BoxedUint) {
+        let carry = self.sbb_assign(rhs, Limb::ZERO);
+        assert_eq!(
+            carry.is_zero().unwrap_u8(),
+            1,
+            "attempted to subtract with underflow"
+        );
     }
 }
 

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -244,6 +244,18 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Mul<&Uint<RHS_LIMBS>> for &Uint
     }
 }
 
+impl<const LIMBS: usize, const RHS_LIMBS: usize> MulAssign<Uint<RHS_LIMBS>> for Uint<LIMBS> {
+    fn mul_assign(&mut self, rhs: Uint<RHS_LIMBS>) {
+        *self = self.mul(&rhs)
+    }
+}
+
+impl<const LIMBS: usize, const RHS_LIMBS: usize> MulAssign<&Uint<RHS_LIMBS>> for Uint<LIMBS> {
+    fn mul_assign(&mut self, rhs: &Uint<RHS_LIMBS>) {
+        *self = self.mul(rhs)
+    }
+}
+
 impl<const LIMBS: usize> MulAssign<Wrapping<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
     fn mul_assign(&mut self, other: Wrapping<Uint<LIMBS>>) {
         *self = *self * other;

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -59,6 +59,18 @@ impl<const LIMBS: usize> Sub<&Uint<LIMBS>> for Uint<LIMBS> {
     }
 }
 
+impl<const LIMBS: usize> SubAssign<Uint<LIMBS>> for Uint<LIMBS> {
+    fn sub_assign(&mut self, rhs: Uint<LIMBS>) {
+        *self = self.sub(&rhs)
+    }
+}
+
+impl<const LIMBS: usize> SubAssign<&Uint<LIMBS>> for Uint<LIMBS> {
+    fn sub_assign(&mut self, rhs: &Uint<LIMBS>) {
+        *self = self.sub(rhs)
+    }
+}
+
 impl<const LIMBS: usize> SubAssign for Wrapping<Uint<LIMBS>> {
     fn sub_assign(&mut self, other: Self) {
         *self = *self - other;


### PR DESCRIPTION
Adds `Add`/`Mul`/`SubAssign` bounds for `Integer`; also adds:
- `impl Add<BoxedUint> for &BoxedUint`
- `impl AddAssign<BoxedUint> for BoxedUint`
- `impl AddAssign<&BoxedUint> for BoxedUint`
- `impl MulAssign<BoxedUint> for BoxedUint`
- `impl MulAssign<&BoxedUint> for BoxedUint`
- `impl Sub<BoxedUint> for &BoxedUint`
- `impl SubAssign<BoxedUint> for BoxedUint`
- `impl SubAssign<&BoxedUint> for BoxedUint`
- `impl<const LIMBS: usize, const RHS_LIMBS: usize> MulAssign<Uint<RHS_LIMBS>> for Uint<LIMBS>`
- `impl<const LIMBS: usize, const RHS_LIMBS: usize> MulAssign<&Uint<RHS_LIMBS>> for Uint<LIMBS>`
- `impl<const LIMBS: usize> SubAssign<Uint<LIMBS>> for Uint<LIMBS>`
- `impl<const LIMBS: usize> SubAssign<&Uint<LIMBS>> for Uint<LIMBS>`