### PR TITLE
Bump `serdect` dependency to v0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.3.0-rc.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a504c8ee181e3e594d84052f983d60afe023f4d94d050900be18062bbbf7b58"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
 dependencies = [
  "base16ct",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ hybrid-array = { version = "0.2", optional = true }
 num-traits = { version = "0.2.19", default-features = false }
 rand_core = { version = "0.6.4", optional = true }
 rlp = { version = "0.6", optional = true, default-features = false }
-serdect = { version = "0.3.0-rc.0", optional = true, default-features = false }
+serdect = { version = "0.3", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
NOTE: this release includes breaking changes to the wire format. See RustCrypto/formats#1631