### PR TITLE
Variable-time modular inversion support

### DIFF
--- a/src/modular/boxed_monty_form/inv.rs
+++ b/src/modular/boxed_monty_form/inv.rs
@@ -10,18 +10,33 @@ use core::fmt;
 use subtle::CtOption;
 
 impl BoxedMontyForm {
-    /// Computes `self^-1` representing the multiplicative inverse of `self`.
-    /// I.e. `self * self^-1 = 1`.
+    /// Computes `self^-1` representing the multiplicative inverse of `self`,
+    /// i.e. `self * self^-1 = 1`.
     pub fn invert(&self) -> CtOption<Self> {
         let inverter = self.params.precompute_inverter();
         inverter.invert(self)
+    }
+
+    /// Computes `self^-1` representing the multiplicative inverse of `self`,
+    /// i.e. `self * self^-1 = 1`.
+    ///
+    /// This version is variable-time with respect to the value of `self`, but constant-time with
+    /// respect to `self`'s `params`.
+    pub fn invert_vartime(&self) -> CtOption<Self> {
+        let inverter = self.params.precompute_inverter();
+        inverter.invert_vartime(self)
     }
 }
 
 impl Invert for BoxedMontyForm {
     type Output = CtOption<Self>;
+
     fn invert(&self) -> Self::Output {
         self.invert()
+    }
+
+    fn invert_vartime(&self) -> Self::Output {
+        self.invert_vartime()
     }
 }
 
@@ -53,6 +68,20 @@ impl Inverter for BoxedMontyFormInverter {
         debug_assert_eq!(self.params, value.params);
 
         let montgomery_form = self.inverter.invert(&value.montgomery_form);
+        let is_some = montgomery_form.is_some();
+        let montgomery_form2 = value.montgomery_form.clone();
+        let ret = BoxedMontyForm {
+            montgomery_form: Option::from(montgomery_form).unwrap_or(montgomery_form2),
+            params: value.params.clone(),
+        };
+
+        CtOption::new(ret, is_some)
+    }
+
+    fn invert_vartime(&self, value: &BoxedMontyForm) -> CtOption<Self::Output> {
+        debug_assert_eq!(self.params, value.params);
+
+        let montgomery_form = self.inverter.invert_vartime(&value.montgomery_form);
         let is_some = montgomery_form.is_some();
         let montgomery_form2 = value.montgomery_form.clone();
         let ret = BoxedMontyForm {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -220,9 +220,15 @@ pub trait Inverter {
     /// Output of an inversion.
     type Output;
 
-    /// Compute a modular inversion, returning `None` if the result is undefined (i.e. if `value` is zero or isn't
-    /// prime relative to the modulus).
+    /// Compute a modular inversion, returning `None` if the result is undefined (i.e. if `value` is
+    /// zero or isn't prime relative to the modulus).
     fn invert(&self, value: &Self::Output) -> CtOption<Self::Output>;
+
+    /// Compute a modular inversion, returning `None` if the result is undefined (i.e. if `value` is
+    /// zero or isn't prime relative to the modulus).
+    ///
+    /// This version is variable-time with respect to `value`.
+    fn invert_vartime(&self, value: &Self::Output) -> CtOption<Self::Output>;
 }
 
 /// Obtain a precomputed inverter for efficiently computing modular inversions for a given modulus.
@@ -759,6 +765,9 @@ pub trait Invert: Sized {
 
     /// Computes the inverse.
     fn invert(&self) -> Self::Output;
+
+    /// Computes the inverse in variable-time.
+    fn invert_vartime(&self) -> Self::Output;
 }
 
 /// Widening multiply: returns a value with a number of limbs equal to the sum of the inputs.

--- a/tests/safegcd.rs
+++ b/tests/safegcd.rs
@@ -51,6 +51,10 @@ proptest! {
             let inv_bi = to_biguint(&actual);
             let res = (inv_bi * x_bi) % p_bi;
             prop_assert_eq!(res, BigUint::one());
+
+            // check vartime implementation equivalence
+            let actual_vartime = inverter.invert_vartime(&x).unwrap();
+            prop_assert_eq!(actual, actual_vartime);
         }
     }
 
@@ -73,6 +77,10 @@ proptest! {
             let inv_bi = to_biguint(&actual);
             let res = (inv_bi * x_bi) % p_bi;
             prop_assert_eq!(res, BigUint::one());
+
+            // check vartime implementation equivalence
+            let actual_vartime = inverter.invert_vartime(&x).unwrap();
+            prop_assert_eq!(actual, actual_vartime);
         }
     }
 }


### PR DESCRIPTION
Adds (back) support for computing modular inversions in variable-time with respect to the value being inverted, which computes the specific number of safegcd divsteps to perform based on the input, as opposed to using a worst case number based on the bit length.

Closes #728