### PR TITLE
`Int` - square operations

### DIFF
--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -1,6 +1,6 @@
 use subtle::{Choice, CtOption};
 
-use crate::{Int, Limb, modular::SafeGcdInverter, NonZero, Odd, Uint, WideWord, Word};
+use crate::{modular::SafeGcdInverter, Int, Limb, NonZero, Odd, Uint, WideWord, Word};
 
 /// A boolean value returned by constant-time `const fn`s.
 // TODO: should be replaced by `subtle::Choice` or `CtOption`

--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -1,6 +1,6 @@
 use subtle::{Choice, CtOption};
 
-use crate::{modular::SafeGcdInverter, Int, Limb, NonZero, Odd, Uint, WideWord, Word};
+use crate::{Int, Limb, modular::SafeGcdInverter, NonZero, Odd, Uint, WideWord, Word};
 
 /// A boolean value returned by constant-time `const fn`s.
 // TODO: should be replaced by `subtle::Choice` or `CtOption`
@@ -395,7 +395,7 @@ impl<const LIMBS: usize> ConstCtOption<Uint<LIMBS>> {
     /// Returns the contained value, interpreting the underlying [`Uint`] value as an [`Int`].
     #[inline]
     pub const fn as_int(&self) -> ConstCtOption<Int<LIMBS>> {
-        ConstCtOption::new(Int::from_bits(self.value), self.is_some)
+        ConstCtOption::new(self.value.as_int(), self.is_some)
     }
 }
 

--- a/src/int/add.rs
+++ b/src/int/add.rs
@@ -14,8 +14,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
         ConstCtOption::new(value, overflow.not())
     }
 
-    /// Perform `self + rhs`, returns the result, as well as a flag indicating whether the
-    /// addition overflowed.
+    /// Perform addition, raising the `overflow` flag on overflow.
     pub const fn overflowing_add(&self, rhs: &Self) -> (Self, ConstChoice) {
         // Step 1. add operands
         let res = Self(self.0.wrapping_add(&rhs.0));
@@ -31,6 +30,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
             .eq(rhs.is_negative())
             .and(self_msb.ne(res.is_negative()));
 
+        // Step 3. Construct result
         (res, overflow)
     }
 
@@ -106,107 +106,220 @@ impl<const LIMBS: usize> WrappingAdd for Int<LIMBS> {
 
 #[cfg(test)]
 mod tests {
+    use crate::{ConstChoice, I128, U128};
 
-    #[cfg(test)]
-    mod tests {
-        use crate::{I128, U128};
+    #[test]
+    fn checked_add() {
+        let min_plus_one = I128 {
+            0: I128::MIN.0.wrapping_add(&I128::ONE.0),
+        };
+        let max_minus_one = I128 {
+            0: I128::MAX.0.wrapping_sub(&I128::ONE.0),
+        };
+        let two = I128 {
+            0: U128::from(2u32),
+        };
 
-        #[test]
-        fn checked_add() {
-            let min_plus_one = I128 {
-                0: I128::MIN.0.wrapping_add(&I128::ONE.0),
-            };
-            let max_minus_one = I128 {
-                0: I128::MAX.0.wrapping_sub(&I128::ONE.0),
-            };
-            let two = I128 {
-                0: U128::from(2u32),
-            };
+        // lhs = MIN
 
-            // lhs = MIN
+        let result = I128::MIN.checked_add(&I128::MIN);
+        assert!(bool::from(result.is_none()));
 
-            let result = I128::MIN.checked_add(&I128::MIN);
-            assert!(bool::from(result.is_none()));
+        let result = I128::MIN.checked_add(&I128::MINUS_ONE);
+        assert!(bool::from(result.is_none()));
 
-            let result = I128::MIN.checked_add(&I128::MINUS_ONE);
-            assert!(bool::from(result.is_none()));
+        let result = I128::MIN.checked_add(&I128::ZERO);
+        assert_eq!(result.unwrap(), I128::MIN);
 
-            let result = I128::MIN.checked_add(&I128::ZERO);
-            assert_eq!(result.unwrap(), I128::MIN);
+        let result = I128::MIN.checked_add(&I128::ONE);
+        assert_eq!(result.unwrap(), min_plus_one);
 
-            let result = I128::MIN.checked_add(&I128::ONE);
-            assert_eq!(result.unwrap(), min_plus_one);
+        let result = I128::MIN.checked_add(&I128::MAX);
+        assert_eq!(result.unwrap(), I128::MINUS_ONE);
 
-            let result = I128::MIN.checked_add(&I128::MAX);
-            assert_eq!(result.unwrap(), I128::MINUS_ONE);
+        // lhs = -1
 
-            // lhs = -1
+        let result = I128::MINUS_ONE.checked_add(&I128::MIN);
+        assert!(bool::from(result.is_none()));
 
-            let result = I128::MINUS_ONE.checked_add(&I128::MIN);
-            assert!(bool::from(result.is_none()));
+        let result = I128::MINUS_ONE.checked_add(&I128::MINUS_ONE);
+        assert_eq!(result.unwrap(), two.checked_neg().unwrap());
 
-            let result = I128::MINUS_ONE.checked_add(&I128::MINUS_ONE);
-            assert_eq!(result.unwrap(), two.checked_neg().unwrap());
+        let result = I128::MINUS_ONE.checked_add(&I128::ZERO);
+        assert_eq!(result.unwrap(), I128::MINUS_ONE);
 
-            let result = I128::MINUS_ONE.checked_add(&I128::ZERO);
-            assert_eq!(result.unwrap(), I128::MINUS_ONE);
+        let result = I128::MINUS_ONE.checked_add(&I128::ONE);
+        assert_eq!(result.unwrap(), I128::ZERO);
 
-            let result = I128::MINUS_ONE.checked_add(&I128::ONE);
-            assert_eq!(result.unwrap(), I128::ZERO);
+        let result = I128::MINUS_ONE.checked_add(&I128::MAX);
+        assert_eq!(result.unwrap(), max_minus_one);
 
-            let result = I128::MINUS_ONE.checked_add(&I128::MAX);
-            assert_eq!(result.unwrap(), max_minus_one);
+        // lhs = 0
 
-            // lhs = 0
+        let result = I128::ZERO.checked_add(&I128::MIN);
+        assert_eq!(result.unwrap(), I128::MIN);
 
-            let result = I128::ZERO.checked_add(&I128::MIN);
-            assert_eq!(result.unwrap(), I128::MIN);
+        let result = I128::ZERO.checked_add(&I128::MINUS_ONE);
+        assert_eq!(result.unwrap(), I128::MINUS_ONE);
 
-            let result = I128::ZERO.checked_add(&I128::MINUS_ONE);
-            assert_eq!(result.unwrap(), I128::MINUS_ONE);
+        let result = I128::ZERO.checked_add(&I128::ZERO);
+        assert_eq!(result.unwrap(), I128::ZERO);
 
-            let result = I128::ZERO.checked_add(&I128::ZERO);
-            assert_eq!(result.unwrap(), I128::ZERO);
+        let result = I128::ZERO.checked_add(&I128::ONE);
+        assert_eq!(result.unwrap(), I128::ONE);
 
-            let result = I128::ZERO.checked_add(&I128::ONE);
-            assert_eq!(result.unwrap(), I128::ONE);
+        let result = I128::ZERO.checked_add(&I128::MAX);
+        assert_eq!(result.unwrap(), I128::MAX);
 
-            let result = I128::ZERO.checked_add(&I128::MAX);
-            assert_eq!(result.unwrap(), I128::MAX);
+        // lhs = 1
 
-            // lhs = 1
+        let result = I128::ONE.checked_add(&I128::MIN);
+        assert_eq!(result.unwrap(), min_plus_one);
 
-            let result = I128::ONE.checked_add(&I128::MIN);
-            assert_eq!(result.unwrap(), min_plus_one);
+        let result = I128::ONE.checked_add(&I128::MINUS_ONE);
+        assert_eq!(result.unwrap(), I128::ZERO);
 
-            let result = I128::ONE.checked_add(&I128::MINUS_ONE);
-            assert_eq!(result.unwrap(), I128::ZERO);
+        let result = I128::ONE.checked_add(&I128::ZERO);
+        assert_eq!(result.unwrap(), I128::ONE);
 
-            let result = I128::ONE.checked_add(&I128::ZERO);
-            assert_eq!(result.unwrap(), I128::ONE);
+        let result = I128::ONE.checked_add(&I128::ONE);
+        assert_eq!(result.unwrap(), two);
 
-            let result = I128::ONE.checked_add(&I128::ONE);
-            assert_eq!(result.unwrap(), two);
+        let result = I128::ONE.checked_add(&I128::MAX);
+        assert!(bool::from(result.is_none()));
 
-            let result = I128::ONE.checked_add(&I128::MAX);
-            assert!(bool::from(result.is_none()));
+        // lhs = MAX
 
-            // lhs = MAX
+        let result = I128::MAX.checked_add(&I128::MIN);
+        assert_eq!(result.unwrap(), I128::MINUS_ONE);
 
-            let result = I128::MAX.checked_add(&I128::MIN);
-            assert_eq!(result.unwrap(), I128::MINUS_ONE);
+        let result = I128::MAX.checked_add(&I128::MINUS_ONE);
+        assert_eq!(result.unwrap(), max_minus_one);
 
-            let result = I128::MAX.checked_add(&I128::MINUS_ONE);
-            assert_eq!(result.unwrap(), max_minus_one);
+        let result = I128::MAX.checked_add(&I128::ZERO);
+        assert_eq!(result.unwrap(), I128::MAX);
 
-            let result = I128::MAX.checked_add(&I128::ZERO);
-            assert_eq!(result.unwrap(), I128::MAX);
+        let result = I128::MAX.checked_add(&I128::ONE);
+        assert!(bool::from(result.is_none()));
 
-            let result = I128::MAX.checked_add(&I128::ONE);
-            assert!(bool::from(result.is_none()));
+        let result = I128::MAX.checked_add(&I128::MAX);
+        assert!(bool::from(result.is_none()));
+    }
 
-            let result = I128::MAX.checked_add(&I128::MAX);
-            assert!(bool::from(result.is_none()));
-        }
+    #[test]
+    fn overflowing_add() {
+        let min_plus_one = I128 {
+            0: I128::MIN.0.wrapping_add(&I128::ONE.0),
+        };
+        let max_minus_one = I128 {
+            0: I128::MAX.0.wrapping_sub(&I128::ONE.0),
+        };
+        let two = I128 {
+            0: U128::from(2u32),
+        };
+
+        // lhs = MIN
+
+        let (_val, overflow) = I128::MIN.overflowing_add(&I128::MIN);
+        assert_eq!(overflow, ConstChoice::TRUE);
+
+        let (_val, overflow) = I128::MIN.overflowing_add(&I128::MINUS_ONE);
+        assert_eq!(overflow, ConstChoice::TRUE);
+
+        let (val, overflow) = I128::MIN.overflowing_add(&I128::ZERO);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, I128::MIN);
+
+        let (val, overflow) = I128::MIN.overflowing_add(&I128::ONE);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, min_plus_one);
+
+        let (val, overflow) = I128::MIN.overflowing_add(&I128::MAX);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, I128::MINUS_ONE);
+
+        // lhs = -1
+
+        let (_val, overflow) = I128::MINUS_ONE.overflowing_add(&I128::MIN);
+        assert_eq!(overflow, ConstChoice::TRUE);
+
+        let (val, overflow) = I128::MINUS_ONE.overflowing_add(&I128::MINUS_ONE);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, two.wrapping_neg());
+
+        let (val, overflow) = I128::MINUS_ONE.overflowing_add(&I128::ZERO);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, I128::MINUS_ONE);
+
+        let (val, overflow) = I128::MINUS_ONE.overflowing_add(&I128::ONE);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, I128::ZERO);
+
+        let (val, overflow) = I128::MINUS_ONE.overflowing_add(&I128::MAX);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, max_minus_one);
+
+        // lhs = 0
+
+        let (val, overflow) = I128::ZERO.overflowing_add(&I128::MIN);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, I128::MIN);
+
+        let (val, overflow) = I128::ZERO.overflowing_add(&I128::MINUS_ONE);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, I128::MINUS_ONE);
+
+        let (val, overflow) = I128::ZERO.overflowing_add(&I128::ZERO);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, I128::ZERO);
+
+        let (val, overflow) = I128::ZERO.overflowing_add(&I128::ONE);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, I128::ONE);
+
+        let (val, overflow) = I128::ZERO.overflowing_add(&I128::MAX);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, I128::MAX);
+
+        // lhs = 1
+
+        let (val, overflow) = I128::ONE.overflowing_add(&I128::MIN);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, min_plus_one);
+
+        let (val, overflow) = I128::ONE.overflowing_add(&I128::MINUS_ONE);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, I128::ZERO);
+
+        let (val, overflow) = I128::ONE.overflowing_add(&I128::ZERO);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, I128::ONE);
+
+        let (val, overflow) = I128::ONE.overflowing_add(&I128::ONE);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, two);
+
+        let (_val, overflow) = I128::ONE.overflowing_add(&I128::MAX);
+        assert_eq!(overflow, ConstChoice::TRUE);
+
+        // lhs = MAX
+
+        let (val, overflow) = I128::MAX.overflowing_add(&I128::MIN);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, I128::MINUS_ONE);
+
+        let (val, overflow) = I128::MAX.overflowing_add(&I128::MINUS_ONE);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, max_minus_one);
+
+        let (val, overflow) = I128::MAX.overflowing_add(&I128::ZERO);
+        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(val, I128::MAX);
+
+        let (_val, overflow) = I128::MAX.overflowing_add(&I128::ONE);
+        assert_eq!(overflow, ConstChoice::TRUE);
+
+        let (_val, overflow) = I128::MAX.overflowing_add(&I128::MAX);
+        assert_eq!(overflow, ConstChoice::TRUE);
     }
 }

--- a/src/int/bit_and.rs
+++ b/src/int/bit_and.rs
@@ -131,10 +131,14 @@ mod tests {
     #[test]
     fn checked_and_ok() {
         assert_eq!(I128::ZERO.checked_and(&I128::ONE).unwrap(), I128::ZERO);
+        assert_eq!(I128::ONE.checked_and(&I128::ONE).unwrap(), I128::ONE);
+        assert_eq!(I128::MAX.checked_and(&I128::ONE).unwrap(), I128::ONE);
     }
 
     #[test]
-    fn overlapping_and_ok() {
+    fn wrapping_and_ok() {
+        assert_eq!(I128::ZERO.wrapping_and(&I128::ONE), I128::ZERO);
+        assert_eq!(I128::ONE.wrapping_and(&I128::ONE), I128::ONE);
         assert_eq!(I128::MAX.wrapping_and(&I128::ONE), I128::ONE);
     }
 }

--- a/src/int/bit_or.rs
+++ b/src/int/bit_or.rs
@@ -123,10 +123,14 @@ mod tests {
     #[test]
     fn checked_or_ok() {
         assert_eq!(I128::ZERO.checked_or(&I128::ONE).unwrap(), I128::ONE);
+        assert_eq!(I128::ONE.checked_or(&I128::ONE).unwrap(), I128::ONE);
+        assert_eq!(I128::MAX.checked_or(&I128::ONE).unwrap(), I128::MAX);
     }
 
     #[test]
-    fn overlapping_or_ok() {
+    fn wrapping_or_ok() {
+        assert_eq!(I128::ZERO.wrapping_or(&I128::ONE), I128::ONE);
+        assert_eq!(I128::ONE.wrapping_or(&I128::ONE), I128::ONE);
         assert_eq!(I128::MAX.wrapping_or(&I128::ONE), I128::MAX);
     }
 }

--- a/src/int/bit_xor.rs
+++ b/src/int/bit_xor.rs
@@ -123,10 +123,17 @@ mod tests {
     #[test]
     fn checked_xor_ok() {
         assert_eq!(I128::ZERO.checked_xor(&I128::ONE).unwrap(), I128::ONE);
+        assert_eq!(I128::ONE.checked_xor(&I128::ONE).unwrap(), I128::ZERO);
+        assert_eq!(
+            I128::MAX.checked_xor(&I128::ONE).unwrap(),
+            I128::MAX - I128::ONE
+        );
     }
 
     #[test]
-    fn overlapping_xor_ok() {
+    fn wrapping_xor_ok() {
         assert_eq!(I128::ZERO.wrapping_xor(&I128::ONE), I128::ONE);
+        assert_eq!(I128::ONE.wrapping_xor(&I128::ONE), I128::ZERO);
+        assert_eq!(I128::MAX.wrapping_xor(&I128::ONE), I128::MAX - I128::ONE);
     }
 }

--- a/src/int/mul.rs
+++ b/src/int/mul.rs
@@ -10,8 +10,9 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Compute "wide" multiplication as a 3-tuple `(lo, hi, negate)`.
     /// The `(lo, hi)` components contain the _magnitude of the product_, with sizes
     /// corresponding to the sizes of the operands; `negate` indicates whether the result should be
-    /// negated when converted from `Uint` to `Int`. Note: even if `negate` is truthy, the magnitude
-    /// might be zero!
+    /// negated when converted from [`Uint`] to [`Int`].
+    ///
+    /// Note: even if `negate` is truthy, the magnitude might be zero!
     pub const fn split_mul<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,

--- a/src/int/neg.rs
+++ b/src/int/neg.rs
@@ -95,7 +95,7 @@ mod tests {
     }
 
     #[test]
-    fn neg() {
+    fn checked_neg() {
         assert_eq!(I128::MIN.checked_neg().is_none(), ConstChoice::TRUE);
         assert_eq!(I128::MINUS_ONE.checked_neg().unwrap(), I128::ONE);
         assert_eq!(I128::ZERO.checked_neg().unwrap(), I128::ZERO);

--- a/src/int/shr.rs
+++ b/src/int/shr.rs
@@ -180,6 +180,8 @@ impl<const LIMBS: usize> ShrVartime for Int<LIMBS> {
 
 #[cfg(test)]
 mod tests {
+    use core::ops::Div;
+
     use crate::I256;
 
     const N: I256 =
@@ -203,11 +205,11 @@ mod tests {
     fn shr5() {
         assert_eq!(
             I256::MAX >> 5,
-            I256::from_be_hex("03FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+            I256::MAX.div(I256::from(32).to_nz().unwrap()).unwrap()
         );
         assert_eq!(
             I256::MIN >> 5,
-            I256::from_be_hex("FC00000000000000000000000000000000000000000000000000000000000000")
+            I256::MIN.div(I256::from(32).to_nz().unwrap()).unwrap()
         );
     }
 
@@ -215,11 +217,11 @@ mod tests {
     fn shr7_vartime() {
         assert_eq!(
             I256::MAX.shr_vartime(7),
-            I256::from_be_hex("00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+            I256::MAX.div(I256::from(128).to_nz().unwrap()).unwrap()
         );
         assert_eq!(
             I256::MIN.shr_vartime(7),
-            I256::from_be_hex("FF00000000000000000000000000000000000000000000000000000000000000")
+            I256::MIN.div(I256::from(128).to_nz().unwrap()).unwrap()
         );
     }
 

--- a/src/int/sub.rs
+++ b/src/int/sub.rs
@@ -81,7 +81,7 @@ mod tests {
     mod tests {
         use num_traits::WrappingSub;
 
-        use crate::{CheckedSub, I128, Int, U128};
+        use crate::{CheckedSub, Int, I128, U128};
 
         #[test]
         fn checked_sub() {

--- a/src/int/sub.rs
+++ b/src/int/sub.rs
@@ -81,7 +81,7 @@ mod tests {
     mod tests {
         use num_traits::WrappingSub;
 
-        use crate::{CheckedSub, Int, I128, U128};
+        use crate::{CheckedSub, I128, Int, U128};
 
         #[test]
         fn checked_sub() {
@@ -127,7 +127,7 @@ mod tests {
             assert_eq!(result.unwrap(), I128::MINUS_ONE);
 
             let result = I128::MINUS_ONE.checked_sub(&I128::ONE);
-            assert_eq!(result.unwrap(), two.checked_neg().unwrap());
+            assert_eq!(result.unwrap(), two.wrapping_neg());
 
             let result = I128::MINUS_ONE.checked_sub(&I128::MAX);
             assert_eq!(result.unwrap(), I128::MIN);

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -1,11 +1,15 @@
 //! [`Uint`] multiplication operations.
 
-use self::karatsuba::UintKaratsubaMul;
-use crate::{
-    Checked, CheckedMul, Concat, ConcatMixed, Limb, Uint, WideningMul, Wrapping, WrappingMul, Zero,
-};
 use core::ops::{Mul, MulAssign};
+
 use subtle::CtOption;
+
+use crate::{
+    Checked, CheckedMul, Concat, ConcatMixed, ConstCtOption, Limb, Uint, WideningMul, Wrapping,
+    WrappingMul, Zero,
+};
+
+use self::karatsuba::UintKaratsubaMul;
 
 pub(crate) mod karatsuba;
 
@@ -182,7 +186,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let (res, overflow) = self.split_mul(rhs);
         Self::select(&res, &Self::MAX, overflow.is_nonzero())
     }
+}
 
+/// Squaring operations
+impl<const LIMBS: usize> Uint<LIMBS> {
     /// Square self, returning a "wide" result in two parts as (lo, hi).
     pub const fn square_wide(&self) -> (Self, Self) {
         if LIMBS == 128 {
@@ -196,6 +203,32 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
 
         uint_square_limbs(&self.limbs)
+    }
+
+    /// Square self, returning a concatenated "wide" result.
+    pub const fn widening_square<const WIDE_LIMBS: usize>(&self) -> Uint<WIDE_LIMBS>
+    where
+        Self: ConcatMixed<Uint<LIMBS>, MixedOutput = Uint<WIDE_LIMBS>>,
+    {
+        let (lo, hi) = self.square_wide();
+        Uint::concat_mixed(&lo, &hi)
+    }
+
+    /// Square self, checking that the result fits in the original [`Uint`] size.
+    pub const fn checked_square(&self) -> ConstCtOption<Uint<LIMBS>> {
+        let (lo, hi) = self.square_wide();
+        ConstCtOption::new(lo, Self::eq(&hi, &Self::ZERO))
+    }
+
+    /// Perform wrapping square, discarding overflow.
+    pub const fn wrapping_square(&self) -> Uint<LIMBS> {
+        self.square_wide().0
+    }
+
+    /// Perform saturating squaring, returning `MAX` on overflow.
+    pub const fn saturating_square(&self) -> Self {
+        let (res, overflow) = self.square_wide();
+        Self::select(&res, &Self::MAX, overflow.is_nonzero())
     }
 }
 
@@ -349,7 +382,7 @@ pub(crate) fn square_limbs(limbs: &[Limb], out: &mut [Limb]) {
 
 #[cfg(test)]
 mod tests {
-    use crate::{CheckedMul, Zero, U128, U192, U256, U64};
+    use crate::{CheckedMul, ConstChoice, Zero, U128, U192, U256, U64};
 
     #[test]
     fn mul_wide_zero_and_one() {
@@ -437,6 +470,33 @@ mod tests {
         let (lo, hi) = n.square().split();
         assert_eq!(lo, U256::ONE);
         assert_eq!(hi, U256::MAX.wrapping_sub(&U256::ONE));
+    }
+
+    #[test]
+    fn checked_square() {
+        let n = U256::from_u64(u64::MAX).wrapping_add(&U256::ONE);
+        let n2 = n.checked_square();
+        assert_eq!(n2.is_some(), ConstChoice::TRUE);
+        let n4 = n2.unwrap().checked_square();
+        assert_eq!(n4.is_none(), ConstChoice::TRUE);
+    }
+
+    #[test]
+    fn wrapping_square() {
+        let n = U256::from_u64(u64::MAX).wrapping_add(&U256::ONE);
+        let n2 = n.wrapping_square();
+        assert_eq!(n2, U256::from_u128(u128::MAX).wrapping_add(&U256::ONE));
+        let n4 = n2.wrapping_square();
+        assert_eq!(n4, U256::ZERO);
+    }
+
+    #[test]
+    fn saturating_square() {
+        let n = U256::from_u64(u64::MAX).wrapping_add(&U256::ONE);
+        let n2 = n.saturating_square();
+        assert_eq!(n2, U256::from_u128(u128::MAX).wrapping_add(&U256::ONE));
+        let n4 = n2.saturating_square();
+        assert_eq!(n4, U256::MAX);
     }
 
     #[cfg(feature = "rand_core")]


### PR DESCRIPTION
- Expand the `Uint::square` operation set 
- Implement `Int::square` operations. 

Replaces #724.