### PR TITLE
Generic `InvMod`: add `Rhs` param and associated `Output`

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -458,9 +458,12 @@ pub trait MulMod<Rhs = Self> {
 }
 
 /// Compute `1 / self mod p`.
-pub trait InvMod: Sized {
+pub trait InvMod<Rhs = Self>: Sized {
+    /// Output type.
+    type Output;
+
     /// Compute `1 / self mod p`.
-    fn inv_mod(&self, p: &Self) -> CtOption<Self>;
+    fn inv_mod(&self, p: &Rhs) -> CtOption<Self::Output>;
 }
 
 /// Checked addition.

--- a/src/uint/boxed/inv_mod.rs
+++ b/src/uint/boxed/inv_mod.rs
@@ -80,6 +80,8 @@ impl BoxedUint {
 }
 
 impl InvMod for BoxedUint {
+    type Output = Self;
+
     fn inv_mod(&self, modulus: &Self) -> CtOption<Self> {
         self.inv_mod(modulus)
     }

--- a/src/uint/inv_mod.rs
+++ b/src/uint/inv_mod.rs
@@ -137,6 +137,8 @@ impl<const LIMBS: usize, const UNSAT_LIMBS: usize> InvMod for Uint<LIMBS>
 where
     Odd<Self>: PrecomputeInverter<Inverter = SafeGcdInverter<LIMBS, UNSAT_LIMBS>>,
 {
+    type Output = Self;
+
     fn inv_mod(&self, modulus: &Self) -> CtOption<Self> {
         self.inv_mod(modulus).into()
     }


### PR DESCRIPTION
As needed for #737.

This uses a shape similar to the `MulMod` trait.