### PR TITLE
Make `Rem` impl on `Uint` constant-time

### DIFF
--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -861,7 +861,7 @@ impl<const LIMBS: usize> Rem<NonZero<Uint<LIMBS>>> for Uint<LIMBS> {
     type Output = Uint<LIMBS>;
 
     fn rem(self, rhs: NonZero<Uint<LIMBS>>) -> Self::Output {
-        Self::rem_vartime(&self, &rhs)
+        Self::rem(&self, &rhs)
     }
 }
 


### PR DESCRIPTION
It was previously using `rem_vartime` as introduced in #466. This goes against the "constant time by default" guarantees of this library.