### PR TITLE
Downgrade `der` to v0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.1"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82db698b33305f0134faf590b9d1259dc171b5481ac41d5c8146c3b3ee7d4319"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.83"
 subtle = { version = "2.6", default-features = false }
 
 # optional dependencies
-der = { version = "0.8.0-rc.1", optional = true, default-features = false }
+der = { version = "0.7", optional = true, default-features = false }
 hybrid-array = { version = "0.2", optional = true }
 num-traits = { version = "0.2.19", default-features = false }
 rand_core = { version = "0.6.4", optional = true }

--- a/src/uint/encoding/der.rs
+++ b/src/uint/encoding/der.rs
@@ -35,8 +35,6 @@ impl<'a, const LIMBS: usize> DecodeValue<'a> for Uint<LIMBS>
 where
     Uint<LIMBS>: ArrayEncoding,
 {
-    type Error = der::Error;
-
     fn decode_value<R: der::Reader<'a>>(reader: &mut R, header: der::Header) -> der::Result<Self> {
         UintRef::decode_value(reader, header)?.try_into()
     }


### PR DESCRIPTION
This unblocks a release by downgrading to the latest stable version so we don't need to wait on a final release of v0.8.