### PR TITLE
Have `rand` feature enable `rand_core/getrandom`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ default = ["rand"]
 alloc = ["serdect?/alloc"]
 
 extra-sizes = []
-rand = ["rand_core/std"]
+rand = ["rand_core/getrandom"]
 serde = ["dep:serdect"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
...as opposed to `rand_core/std`, which links the `std` crate