### PR TITLE
Add a RemMixed trait and impl for Uints

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -627,7 +627,7 @@ pub trait DivRemLimb: Sized {
 }
 
 /// Support for calculating the remainder of two differently sized integers.
-pub trait RemMixed<Reductor, Tail>: Sized {
+pub trait RemMixed<Reductor>: Sized {
     /// Calculate the remainder of `self` by the `reductor`.
     fn rem_mixed(&self, reductor: &NonZero<Reductor>) -> Reductor;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -626,6 +626,12 @@ pub trait DivRemLimb: Sized {
     fn div_rem_limb_with_reciprocal(&self, reciprocal: &Reciprocal) -> (Self, Limb);
 }
 
+/// Support for calculating the remainder of two differently sized integers.
+pub trait RemMixed<Reductor, Tail>: Sized {
+    /// Calculate the remainder of `self` by the `reductor`.
+    fn rem_mixed(&self, reductor: &NonZero<Reductor>) -> Reductor;
+}
+
 /// Support for optimized division by a single limb.
 pub trait RemLimb: Sized {
     /// Computes `self % rhs` using a pre-made reciprocal.

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -439,7 +439,7 @@ impl_uint_concat_split_even! {
     U16384,
 }
 
-// Implement mixed concat and split for combinations not implemented by
+// Implement mixed concat, split and reduce for combinations not implemented by
 // impl_uint_concat_split_even. The numbers represent the size of each
 // component Uint in multiple of 64 bits. For example,
 // (U256, [1, 3]) will allow splitting U256 into (U64, U192) as well as

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -6,7 +6,7 @@ use crate::{
         div_limb::{div2by1, div3by2},
     },
     BoxedUint, CheckedDiv, ConstChoice, ConstantTimeSelect, DivRemLimb, Limb, NonZero, Reciprocal,
-    RemLimb, Wrapping,
+    RemLimb, RemMixed, Wrapping,
 };
 use core::ops::{Div, DivAssign, Rem, RemAssign};
 use subtle::CtOption;
@@ -388,6 +388,12 @@ impl DivRemLimb for BoxedUint {
 impl RemLimb for BoxedUint {
     fn rem_limb_with_reciprocal(&self, reciprocal: &Reciprocal) -> Limb {
         Self::rem_limb_with_reciprocal(self, reciprocal)
+    }
+}
+
+impl RemMixed<BoxedUint> for BoxedUint {
+    fn rem_mixed(&self, reductor: &NonZero<BoxedUint>) -> BoxedUint {
+        Self::div_rem_vartime(&self, reductor).1
     }
 }
 

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -393,7 +393,7 @@ impl RemLimb for BoxedUint {
 
 impl RemMixed<BoxedUint> for BoxedUint {
     fn rem_mixed(&self, reductor: &NonZero<BoxedUint>) -> BoxedUint {
-        Self::div_rem_vartime(&self, reductor).1
+        Self::div_rem_vartime(self, reductor).1
     }
 }
 

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -1160,8 +1160,10 @@ mod tests {
         let rem_control = x.rem(&NonZero::new(y2).unwrap());
 
         assert_eq!(rem.bits(), rem_control.bits());
-        assert_eq!(rem.as_words(), &rem_control.as_words()[0..2]);
-        assert!(rem_control.as_words()[2..].iter().all(|w| *w == 0));
+        assert_eq!(rem.as_words(), &rem_control.as_words()[0..U128::LIMBS]);
+        assert!(rem_control.as_words()[U128::LIMBS..]
+            .iter()
+            .all(|w| *w == 0));
     }
 
     #[test]

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -953,11 +953,7 @@ impl<const LIMBS: usize> RemLimb for Uint<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use core::marker::PhantomData;
-
-    use crate::{
-        ConcatMixed, Limb, NonZero, RemMixed, Uint, Word, Zero, U1024, U128, U256, U64, U896,
-    };
+    use crate::{Limb, NonZero, RemMixed, Uint, Word, Zero, U1024, U128, U256, U64, U896};
 
     #[cfg(feature = "rand")]
     use {
@@ -1152,7 +1148,7 @@ mod tests {
 
     #[test]
     fn rem_mixed() {
-        let x= U1024::from_be_hex("3740C11DB8F260753BC6B97DD2B8746D3E2694412772AC6ABD975119EE0A6190F27F6F0969BCA069D8D151031AF83EE2283CC2E3E4FADBBDB9EEDBF0B8F4C1FD51912C0D329FDC37D49176DB0A1A2D17E5E6D4F9F6B217FE9412EAA2F881F7027A831C1B06D31D3618D218D6E667DBD85BFC7B6B6B93422D52516989376AA29A");
+        let x = U1024::from_be_hex("3740C11DB8F260753BC6B97DD2B8746D3E2694412772AC6ABD975119EE0A6190F27F6F0969BCA069D8D151031AF83EE2283CC2E3E4FADBBDB9EEDBF0B8F4C1FD51912C0D329FDC37D49176DB0A1A2D17E5E6D4F9F6B217FE9412EAA2F881F7027A831C1B06D31D3618D218D6E667DBD85BFC7B6B6B93422D52516989376AA29A");
         let y = U128::from_u64(1234567890987654321);
         let rem = x.rem_mixed(&y.to_nz().unwrap());
 
@@ -1168,16 +1164,14 @@ mod tests {
 
     #[test]
     fn rem_mixed_through_traits() {
-        struct A<T, U, V> {
+        struct A<T, U> {
             t: T,
             u: U,
-            _phantom: PhantomData<V>,
         }
-        impl<T, U, V> A<T, U, V>
+        impl<T, U> A<T, U>
         where
-            T: RemMixed<U, V>,
+            T: RemMixed<U>,
             U: Clone + Zero,
-            U: ConcatMixed<V>,
         {
             fn reduce_t_by_u(&self) -> U {
                 let rhs = &NonZero::new(self.u.clone()).unwrap();
@@ -1188,7 +1182,6 @@ mod tests {
         let a = A {
             t: U1024::from(1234567890u64),
             u: U128::from(456u64),
-            _phantom: PhantomData,
         };
         assert_eq!(a.reduce_t_by_u(), U128::from(330u64));
     }

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -953,7 +953,11 @@ impl<const LIMBS: usize> RemLimb for Uint<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Limb, NonZero, Uint, Word, U128, U256, U64};
+    use core::marker::PhantomData;
+
+    use crate::{
+        ConcatMixed, Limb, NonZero, RemMixed, Uint, Word, Zero, U1024, U128, U256, U64, U896,
+    };
 
     #[cfg(feature = "rand")]
     use {
@@ -1144,5 +1148,46 @@ mod tests {
         assert_eq!(a % &b, c);
         assert_eq!(&a % b, c);
         assert_eq!(&a % &b, c);
+    }
+
+    #[test]
+    fn rem_mixed() {
+        let x= U1024::from_be_hex("3740C11DB8F260753BC6B97DD2B8746D3E2694412772AC6ABD975119EE0A6190F27F6F0969BCA069D8D151031AF83EE2283CC2E3E4FADBBDB9EEDBF0B8F4C1FD51912C0D329FDC37D49176DB0A1A2D17E5E6D4F9F6B217FE9412EAA2F881F7027A831C1B06D31D3618D218D6E667DBD85BFC7B6B6B93422D52516989376AA29A");
+        let y = U128::from_u64(1234567890987654321);
+        let rem = x.rem_mixed(&y.to_nz().unwrap());
+
+        let y2: U1024 = U128::concat_mixed(&y, &U896::ZERO);
+        let rem_control = x.rem(&NonZero::new(y2).unwrap());
+
+        assert_eq!(rem.bits(), rem_control.bits());
+        assert_eq!(rem.as_words(), &rem_control.as_words()[0..2]);
+        assert!(rem_control.as_words()[2..].iter().all(|w| *w == 0u64));
+    }
+
+    #[test]
+    fn rem_mixed_through_traits() {
+        struct A<T, U, V> {
+            t: T,
+            u: U,
+            _phantom: PhantomData<V>,
+        }
+        impl<T, U, V> A<T, U, V>
+        where
+            T: RemMixed<U, V>,
+            U: Clone + Zero,
+            U: ConcatMixed<V>,
+        {
+            fn reduce_t_by_u(&self) -> U {
+                let rhs = &NonZero::new(self.u.clone()).unwrap();
+                self.t.rem_mixed(rhs)
+            }
+        }
+
+        let a = A {
+            t: U1024::from(1234567890u64),
+            u: U128::from(456u64),
+            _phantom: PhantomData,
+        };
+        assert_eq!(a.reduce_t_by_u(), U128::from(330u64));
     }
 }

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -1161,7 +1161,7 @@ mod tests {
 
         assert_eq!(rem.bits(), rem_control.bits());
         assert_eq!(rem.as_words(), &rem_control.as_words()[0..2]);
-        assert!(rem_control.as_words()[2..].iter().all(|w| *w == 0u64));
+        assert!(rem_control.as_words()[2..].iter().all(|w| *w == 0));
     }
 
     #[test]

--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -98,7 +98,7 @@ macro_rules! impl_uint_concat_split_mixed {
             }
         }
 
-        impl $crate::traits::RemMixed<Uint<{ U64::LIMBS * $size }>, Uint<{ <$name>::LIMBS - U64::LIMBS * $size }>> for $name
+        impl $crate::traits::RemMixed<Uint<{ U64::LIMBS * $size }>> for $name
         {
             fn rem_mixed(&self, reductor: &NonZero<Uint<{ U64::LIMBS * $size }>>) -> Uint<{ U64::LIMBS * $size }> {
                 self.div_rem_vartime(reductor).1

--- a/src/uint/macros.rs
+++ b/src/uint/macros.rs
@@ -97,6 +97,13 @@ macro_rules! impl_uint_concat_split_mixed {
                 self.split_mixed()
             }
         }
+
+        impl $crate::traits::RemMixed<Uint<{ U64::LIMBS * $size }>, Uint<{ <$name>::LIMBS - U64::LIMBS * $size }>> for $name
+        {
+            fn rem_mixed(&self, reductor: &NonZero<Uint<{ U64::LIMBS * $size }>>) -> Uint<{ U64::LIMBS * $size }> {
+                self.div_rem_vartime(reductor).1
+            }
+        }
     };
     ($name:ident, [ $($size:literal),+ ]) => {
         $(

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -94,13 +94,13 @@ pub(crate) const fn schoolbook_squaring(limbs: &[Limb], lo: &mut [Limb], hi: &mu
     let mut carry = Limb::ZERO;
     let mut i = 0;
     while i < limbs.len() {
-        (lo[i].0, carry) = (lo[i].0 << 1 | carry.0, lo[i].shr(Limb::BITS - 1));
+        (lo[i].0, carry) = ((lo[i].0 << 1) | carry.0, lo[i].shr(Limb::BITS - 1));
         i += 1;
     }
 
     let mut i = 0;
     while i < limbs.len() - 1 {
-        (hi[i].0, carry) = (hi[i].0 << 1 | carry.0, hi[i].shr(Limb::BITS - 1));
+        (hi[i].0, carry) = ((hi[i].0 << 1) | carry.0, hi[i].shr(Limb::BITS - 1));
         i += 1;
     }
     hi[limbs.len() - 1] = carry;


### PR DESCRIPTION
Add a `RemMixed` trait in the same vein as `SplitMixed` and `ConcatMixed`, to calculate the remainder of differently sized integers.

Fixes #739. 
