### PR TITLE
Speedup `Uint::shr`

### DIFF
--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -390,7 +390,7 @@ fn shr_benchmark<const LIMBS: usize>(group: &mut BenchmarkGroup<WallTime>) {
     });
     group.bench_function(BenchmarkId::new("shr_vartime_wide, large", LIMBS), |b| {
         b.iter_batched(
-            || ( Uint::<LIMBS>::ONE,  Uint::<LIMBS>::ONE),
+            || (Uint::<LIMBS>::ONE, Uint::<LIMBS>::ONE),
             |x| Uint::overflowing_shr_vartime_wide(x, Uint::<LIMBS>::BITS / 2 + 10),
             BatchSize::SmallInput,
         )

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -529,14 +529,14 @@ fn bench_sqrt(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    // bench_random,
-    // bench_mul,
-    // bench_division,
-    // bench_gcd,
-    // bench_shl,
+    bench_random,
+    bench_mul,
+    bench_division,
+    bench_gcd,
+    bench_shl,
     bench_shr,
-    // bench_inv_mod,
-    // bench_sqrt
+    bench_inv_mod,
+    bench_sqrt
 );
 
 criterion_main!(benches);

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -388,20 +388,6 @@ fn shr_benchmark<const LIMBS: usize>(group: &mut BenchmarkGroup<WallTime>) {
             BatchSize::SmallInput,
         )
     });
-    group.bench_function(BenchmarkId::new("split_overflowing_shr", LIMBS), |b| {
-        b.iter_batched(
-            || Uint::<LIMBS>::ONE,
-            |x| x.split_overflowing_shr(Uint::<LIMBS>::BITS / 2 + 10),
-            BatchSize::SmallInput,
-        )
-    });
-    group.bench_function(BenchmarkId::new("fast_split_overflowing_shr", LIMBS), |b| {
-        b.iter_batched(
-            || Uint::<LIMBS>::ONE,
-            |x| x.fast_split_overflowing_shr(Uint::<LIMBS>::BITS / 2 + 10),
-            BatchSize::SmallInput,
-        )
-    });
 }
 
 fn bench_shr(c: &mut Criterion) {

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -374,14 +374,35 @@ fn bench_shl(c: &mut Criterion) {
 }
 
 fn shr_benchmark<const LIMBS: usize>(group: &mut BenchmarkGroup<WallTime>) {
-    group.bench_function(BenchmarkId::new("overflowing_shr_vartime", LIMBS), |b| {
+    group.bench_function(BenchmarkId::new("shr_vartime, small", LIMBS), |b| {
+        b.iter_batched(
+            || Uint::<LIMBS>::ONE,
+            |x| x.overflowing_shr_vartime(10),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function(BenchmarkId::new("shr_vartime, large", LIMBS), |b| {
         b.iter_batched(
             || Uint::<LIMBS>::ONE,
             |x| x.overflowing_shr_vartime(Uint::<LIMBS>::BITS / 2 + 10),
             BatchSize::SmallInput,
         )
     });
-    group.bench_function(BenchmarkId::new("overflowing_shr", LIMBS), |b| {
+    group.bench_function(BenchmarkId::new("shr_vartime_wide, large", LIMBS), |b| {
+        b.iter_batched(
+            || ( Uint::<LIMBS>::ONE,  Uint::<LIMBS>::ONE),
+            |x| Uint::overflowing_shr_vartime_wide(x, Uint::<LIMBS>::BITS / 2 + 10),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function(BenchmarkId::new("shr, small", LIMBS), |b| {
+        b.iter_batched(
+            || Uint::<LIMBS>::ONE,
+            |x| x.overflowing_shr(10),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function(BenchmarkId::new("shr, large", LIMBS), |b| {
         b.iter_batched(
             || Uint::<LIMBS>::ONE,
             |x| x.overflowing_shr(Uint::<LIMBS>::BITS / 2 + 10),
@@ -392,38 +413,6 @@ fn shr_benchmark<const LIMBS: usize>(group: &mut BenchmarkGroup<WallTime>) {
 
 fn bench_shr(c: &mut Criterion) {
     let mut group = c.benchmark_group("right shift");
-
-    group.bench_function("shr_vartime, small, U2048", |b| {
-        b.iter_batched(
-            || U2048::ONE,
-            |x| x.overflowing_shr_vartime(10),
-            BatchSize::SmallInput,
-        )
-    });
-
-    group.bench_function("shr_vartime, large, U2048", |b| {
-        b.iter_batched(
-            || U2048::ONE,
-            |x| x.overflowing_shr_vartime(1024 + 10),
-            BatchSize::SmallInput,
-        )
-    });
-
-    group.bench_function("shr_vartime_wide, large, U2048", |b| {
-        b.iter_batched(
-            || (U2048::ONE, U2048::ONE),
-            |x| Uint::overflowing_shr_vartime_wide(x, 1024 + 10),
-            BatchSize::SmallInput,
-        )
-    });
-
-    group.bench_function("shr, U2048", |b| {
-        b.iter_batched(
-            || U2048::ONE,
-            |x| x.overflowing_shr(1024 + 10),
-            BatchSize::SmallInput,
-        )
-    });
 
     shr_benchmark::<{ U256::LIMBS }>(&mut group);
     shr_benchmark::<{ U512::LIMBS }>(&mut group);

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -395,6 +395,13 @@ fn shr_benchmark<const LIMBS: usize>(group: &mut BenchmarkGroup<WallTime>) {
             BatchSize::SmallInput,
         )
     });
+    group.bench_function(BenchmarkId::new("fast_split_overflowing_shr", LIMBS), |b| {
+        b.iter_batched(
+            || Uint::<LIMBS>::ONE,
+            |x| x.fast_split_overflowing_shr(Uint::<LIMBS>::BITS / 2 + 10),
+            BatchSize::SmallInput,
+        )
+    });
 }
 
 fn bench_shr(c: &mut Criterion) {
@@ -522,14 +529,14 @@ fn bench_sqrt(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    bench_random,
-    bench_mul,
-    bench_division,
-    bench_gcd,
-    bench_shl,
+    // bench_random,
+    // bench_mul,
+    // bench_division,
+    // bench_gcd,
+    // bench_shl,
     bench_shr,
-    bench_inv_mod,
-    bench_sqrt
+    // bench_inv_mod,
+    // bench_sqrt
 );
 
 criterion_main!(benches);

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -335,45 +335,59 @@ fn bench_gcd(c: &mut Criterion) {
     group.finish();
 }
 
-fn bench_shl(c: &mut Criterion) {
-    let mut group = c.benchmark_group("left shift");
-
-    group.bench_function("shl_vartime, small, U2048", |b| {
+fn shl_benchmarks<const LIMBS: usize>(group: &mut BenchmarkGroup<WallTime>) {
+    group.bench_function(BenchmarkId::new("shl_vartime, small", LIMBS), |b| {
         b.iter_batched(
-            || U2048::ONE,
+            || Uint::<LIMBS>::ONE,
             |x| x.overflowing_shl_vartime(10),
             BatchSize::SmallInput,
         )
     });
-
-    group.bench_function("shl_vartime, large, U2048", |b| {
+    group.bench_function(BenchmarkId::new("shl_vartime, large", LIMBS), |b| {
         b.iter_batched(
-            || U2048::ONE,
-            |x| black_box(x.overflowing_shl_vartime(1024 + 10)),
+            || Uint::<LIMBS>::ONE,
+            |x| black_box(x.overflowing_shl_vartime(Uint::<LIMBS>::BITS/2 + 10)),
             BatchSize::SmallInput,
         )
     });
-
-    group.bench_function("shl_vartime_wide, large, U2048", |b| {
+    group.bench_function(BenchmarkId::new("shl_vartime_wide, large", LIMBS), |b| {
         b.iter_batched(
-            || (U2048::ONE, U2048::ONE),
-            |x| Uint::overflowing_shl_vartime_wide(x, 1024 + 10),
+            || (Uint::<LIMBS>::ONE, Uint::<LIMBS>::ONE),
+            |x| Uint::overflowing_shl_vartime_wide(x, Uint::<LIMBS>::BITS/2 + 10),
             BatchSize::SmallInput,
         )
     });
-
-    group.bench_function("shl, U2048", |b| {
+    group.bench_function(BenchmarkId::new("shl, small", LIMBS), |b| {
         b.iter_batched(
-            || U2048::ONE,
-            |x| x.overflowing_shl(1024 + 10),
+            || Uint::<LIMBS>::ONE,
+            |x| x.overflowing_shl( 10),
             BatchSize::SmallInput,
         )
     });
+    group.bench_function(BenchmarkId::new("shl, large", LIMBS), |b| {
+        b.iter_batched(
+            || Uint::<LIMBS>::ONE,
+            |x| x.overflowing_shl( Uint::<LIMBS>::BITS/2 + 10),
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+fn bench_shl(c: &mut Criterion) {
+    let mut group = c.benchmark_group("left shift");
+
+    shl_benchmarks::<{ U256::LIMBS }>(&mut group);
+    shl_benchmarks::<{ U512::LIMBS }>(&mut group);
+    shl_benchmarks::<{ U1024::LIMBS }>(&mut group);
+    shl_benchmarks::<{ U2048::LIMBS }>(&mut group);
+    shl_benchmarks::<{ U4096::LIMBS }>(&mut group);
+    shl_benchmarks::<{ U8192::LIMBS }>(&mut group);
+    shl_benchmarks::<{ U16384::LIMBS }>(&mut group);
 
     group.finish();
 }
 
-fn shr_benchmark<const LIMBS: usize>(group: &mut BenchmarkGroup<WallTime>) {
+fn shr_benchmarks<const LIMBS: usize>(group: &mut BenchmarkGroup<WallTime>) {
     group.bench_function(BenchmarkId::new("shr_vartime, small", LIMBS), |b| {
         b.iter_batched(
             || Uint::<LIMBS>::ONE,
@@ -414,13 +428,13 @@ fn shr_benchmark<const LIMBS: usize>(group: &mut BenchmarkGroup<WallTime>) {
 fn bench_shr(c: &mut Criterion) {
     let mut group = c.benchmark_group("right shift");
 
-    shr_benchmark::<{ U256::LIMBS }>(&mut group);
-    shr_benchmark::<{ U512::LIMBS }>(&mut group);
-    shr_benchmark::<{ U1024::LIMBS }>(&mut group);
-    shr_benchmark::<{ U2048::LIMBS }>(&mut group);
-    shr_benchmark::<{ U4096::LIMBS }>(&mut group);
-    shr_benchmark::<{ U8192::LIMBS }>(&mut group);
-    shr_benchmark::<{ U16384::LIMBS }>(&mut group);
+    shr_benchmarks::<{ U256::LIMBS }>(&mut group);
+    shr_benchmarks::<{ U512::LIMBS }>(&mut group);
+    shr_benchmarks::<{ U1024::LIMBS }>(&mut group);
+    shr_benchmarks::<{ U2048::LIMBS }>(&mut group);
+    shr_benchmarks::<{ U4096::LIMBS }>(&mut group);
+    shr_benchmarks::<{ U8192::LIMBS }>(&mut group);
+    shr_benchmarks::<{ U16384::LIMBS }>(&mut group);
 
     group.finish();
 }

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -346,28 +346,28 @@ fn shl_benchmarks<const LIMBS: usize>(group: &mut BenchmarkGroup<WallTime>) {
     group.bench_function(BenchmarkId::new("shl_vartime, large", LIMBS), |b| {
         b.iter_batched(
             || Uint::<LIMBS>::ONE,
-            |x| black_box(x.overflowing_shl_vartime(Uint::<LIMBS>::BITS/2 + 10)),
+            |x| black_box(x.overflowing_shl_vartime(Uint::<LIMBS>::BITS / 2 + 10)),
             BatchSize::SmallInput,
         )
     });
     group.bench_function(BenchmarkId::new("shl_vartime_wide, large", LIMBS), |b| {
         b.iter_batched(
             || (Uint::<LIMBS>::ONE, Uint::<LIMBS>::ONE),
-            |x| Uint::overflowing_shl_vartime_wide(x, Uint::<LIMBS>::BITS/2 + 10),
+            |x| Uint::overflowing_shl_vartime_wide(x, Uint::<LIMBS>::BITS / 2 + 10),
             BatchSize::SmallInput,
         )
     });
     group.bench_function(BenchmarkId::new("shl, small", LIMBS), |b| {
         b.iter_batched(
             || Uint::<LIMBS>::ONE,
-            |x| x.overflowing_shl( 10),
+            |x| x.overflowing_shl(10),
             BatchSize::SmallInput,
         )
     });
     group.bench_function(BenchmarkId::new("shl, large", LIMBS), |b| {
         b.iter_batched(
             || Uint::<LIMBS>::ONE,
-            |x| x.overflowing_shl( Uint::<LIMBS>::BITS/2 + 10),
+            |x| x.overflowing_shl(Uint::<LIMBS>::BITS / 2 + 10),
             BatchSize::SmallInput,
         )
     });

--- a/src/limb/shl.rs
+++ b/src/limb/shl.rs
@@ -12,12 +12,6 @@ impl Limb {
         Limb(self.0 << shift)
     }
 
-    /// Computes `self << 1` and return the result and the carry (0 or 1).
-    #[inline(always)]
-    pub(crate) const fn shl1(self) -> (Self, Self) {
-        (Self(self.0 << 1), Self(self.0 >> Self::HI_BIT))
-    }
-
     /// Computes `self << shift` and returns the result as well as the carry: the `shift` _least_
     /// significant bits of the `carry` are equal to the `shift` _most_ significant bits of `self`.
     ///

--- a/src/limb/shr.rs
+++ b/src/limb/shr.rs
@@ -1,6 +1,6 @@
 //! Limb right bitshift
 
-use crate::{Limb, WrappingShr};
+use crate::{ConstChoice, Limb, WrappingShr};
 use core::ops::{Shr, ShrAssign};
 
 impl Limb {
@@ -15,6 +15,23 @@ impl Limb {
     #[inline(always)]
     pub(crate) const fn shr1(self) -> (Self, Self) {
         (Self(self.0 >> 1), Self(self.0 << Self::HI_BIT))
+    }
+
+    /// Computes `self >> shift` and returns the result as well as the carry: the `shift` _most_
+    /// significant bits of the `carry` are equal to the `shift` _least_ significant bits of `self`.
+    ///
+    /// Panics if `shift` overflows `Limb::BITS`.
+    #[inline(always)]
+    pub const fn carrying_shr(self, shift: u32) -> (Self, Self) {
+        // Note that we can compute carry = self << (Self::BITS - shift) whenever shift > 0.
+        // However, we need to account for the case that shift = 0:
+        // - the carry should be 0, and
+        // - the value by which carry is left shifted should be made to be < Self::BITS.
+        let shift_is_zero = ConstChoice::from_u32_eq(shift, 0);
+        let carry = Self::select(self, Self::ZERO, shift_is_zero);
+        let left_shift = shift_is_zero.select_u32(Self::BITS - shift, 0);
+
+        (self.shr(shift), carry.shl(left_shift))
     }
 }
 

--- a/src/limb/shr.rs
+++ b/src/limb/shr.rs
@@ -11,12 +11,6 @@ impl Limb {
         Limb(self.0 >> shift)
     }
 
-    /// Computes `self >> 1` and return the result and the carry (0 or `1 << HI_BIT`).
-    #[inline(always)]
-    pub(crate) const fn shr1(self) -> (Self, Self) {
-        (Self(self.0 >> 1), Self(self.0 << Self::HI_BIT))
-    }
-
     /// Computes `self >> shift` and returns the result as well as the carry: the `shift` _most_
     /// significant bits of the `carry` are equal to the `shift` _least_ significant bits of `self`.
     ///

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -165,7 +165,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Borrow the limbs of this [`Uint`] mutably.
-    pub fn as_limbs_mut(&mut self) -> &mut [Limb; LIMBS] {
+    pub const fn as_limbs_mut(&mut self) -> &mut [Limb; LIMBS] {
         &mut self.limbs
     }
 

--- a/src/uint/add_mod.rs
+++ b/src/uint/add_mod.rs
@@ -38,7 +38,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Assumes `self` as unbounded integer is `< p`.
     pub const fn double_mod(&self, p: &Self) -> Self {
-        let (w, carry) = self.overflowing_shl1();
+        let (w, carry) = self.carrying_shl1();
 
         // Attempt to subtract the modulus, to ensure the result is in the field.
         let (w, borrow) = w.sbb(p, Limb::ZERO);

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -51,6 +51,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Returns `None` if `shift >= Self::BITS`.
     pub const fn split_overflowing_shr(&self, shift: u32) -> ConstCtOption<Self> {
+        // Split shift into (shift % Limb::BITS, shift / Limb::BITS)
+        // Since Limb::BITS is known to be a power of two, this can also be computed as follows:
         let limb_bits_bits = u32::BITS - (Limb::BITS - 1).leading_zeros();
         let intra_limb_shift = shift & (Limb::BITS - 1);
         let limb_shift = shift >> limb_bits_bits;
@@ -118,6 +120,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Returns `None` if `shift >= Self::BITS`.
     pub const fn fast_split_overflowing_shr(&self, shift: u32) -> ConstCtOption<Self> {
+        // Split shift into (shift % Limb::BITS, shift / Limb::BITS)
+        // Since Limb::BITS is known to be a power of two, this can also be computed as follows:
         let limb_bits_bits = u32::BITS - (Limb::BITS - 1).leading_zeros();
         let intra_limb_shift = shift & (Limb::BITS - 1);
         let limb_shift = shift >> limb_bits_bits;

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -25,14 +25,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Returns `None` if `shift >= Self::BITS`.
     pub const fn overflowing_shr(&self, shift: u32) -> ConstCtOption<Self> {
-        // `floor(log2(BITS - 1))` is the number of bits in the representation of `shift`
-        // (which lies in range `0 <= shift < BITS`).
-        //
-        // Split shift into (shift % Limb::BITS, shift / Limb::BITS)
-        // Since Limb::BITS is known to be a power of two, this can also be computed as follows:
-        let limb_bits_bits = u32::BITS - (Limb::BITS - 1).leading_zeros();
-        let intra_limb_shift = shift & (Limb::BITS - 1);
-        let limb_shift = shift >> limb_bits_bits;
+        let (intra_limb_shift, limb_shift) = Self::decompose_shift(shift);
         self.intra_limb_shr(intra_limb_shift)
             .full_limb_overflowing_shr(limb_shift)
     }
@@ -107,30 +100,19 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             return ConstCtOption::none(Self::ZERO);
         }
 
-        let shift_num = (shift / Limb::BITS) as usize;
-        let rem = shift % Limb::BITS;
-
+        let (rem, shift_num) = Self::decompose_shift(shift);
+        let shift_num = shift_num as usize;
         let mut i = 0;
         while i < LIMBS - shift_num {
             limbs[i] = self.limbs[i + shift_num];
             i += 1;
         }
 
-        if rem == 0 {
-            return ConstCtOption::some(Self { limbs });
+        let mut shifted = Self { limbs };
+        if rem != 0 {
+            shifted = shifted.intra_limb_shr(rem);
         }
-
-        let mut carry = Limb::ZERO;
-
-        while i > 0 {
-            i -= 1;
-            let shifted = limbs[i].shr(rem);
-            let new_carry = limbs[i].shl(Limb::BITS - rem);
-            limbs[i] = shifted.bitor(carry);
-            carry = new_carry;
-        }
-
-        ConstCtOption::some(Self { limbs })
+        ConstCtOption::some(shifted)
     }
 
     /// Computes a right shift on a wide input as `(lo, hi)`.

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -51,7 +51,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Returns `None` if `shift >= Self::BITS`.
     pub const fn split_overflowing_shr(&self, shift: u32) -> ConstCtOption<Self> {
-        let (intra_limb_shift, limb_shift) = (shift % Limb::BITS, shift / Limb::BITS);
+        let limb_bits_bits = u32::BITS - (Limb::BITS - 1).leading_zeros();
+        let intra_limb_shift = shift & (Limb::BITS - 1);
+        let limb_shift = shift >> limb_bits_bits;
         self.intra_limb_carrying_shr_internal(intra_limb_shift)
             .full_limb_shr(limb_shift)
     }
@@ -116,7 +118,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Returns `None` if `shift >= Self::BITS`.
     pub const fn fast_split_overflowing_shr(&self, shift: u32) -> ConstCtOption<Self> {
-        let (intra_limb_shift, limb_shift) = (shift % Limb::BITS, shift / Limb::BITS);
+        let limb_bits_bits = u32::BITS - (Limb::BITS - 1).leading_zeros();
+        let intra_limb_shift = shift & (Limb::BITS - 1);
+        let limb_shift = shift >> limb_bits_bits;
         self.intra_limb_carrying_shr_internal(intra_limb_shift)
             .fast_full_limb_shr(limb_shift)
     }

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -34,7 +34,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let intra_limb_shift = shift & (Limb::BITS - 1);
         let limb_shift = shift >> limb_bits_bits;
         self.intra_limb_shr(intra_limb_shift)
-            .full_limb_shr(limb_shift)
+            .full_limb_overflowing_shr(limb_shift)
     }
 
     /// Computes `self >> shift`, for `shift < Limb::BITS`.
@@ -63,7 +63,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Returns `None` if `limb_shift >= Self::LIMBS`.
     #[inline]
-    pub const fn full_limb_shr(&self, limb_shift: u32) -> ConstCtOption<Self> {
+    pub const fn full_limb_overflowing_shr(&self, limb_shift: u32) -> ConstCtOption<Self> {
         let shift_bits = u32::BITS - (LIMBS as u32 - 1).leading_zeros();
         let overflow = ConstChoice::from_u32_lt(limb_shift, LIMBS as u32).not();
         let limb_shift = limb_shift % LIMBS as u32;

--- a/tests/limb.rs
+++ b/tests/limb.rs
@@ -20,4 +20,18 @@ proptest! {
             assert_eq!(limb.carrying_shr(shift), (limb.shr(shift), limb.shl(Limb::BITS - shift)));
         }
     }
+
+    #[test]
+    fn carrying_shl_doesnt_panic(limb in limb(), shift in 0..32u32) {
+        limb.carrying_shl(shift);
+    }
+
+    #[test]
+    fn carrying_shl(limb in limb(), shift in 0..32u32) {
+        if shift == 0 {
+            assert_eq!(limb.carrying_shl(shift), (limb, Limb::ZERO));
+        } else {
+            assert_eq!(limb.carrying_shl(shift), (limb.shl(shift), limb.shr(Limb::BITS - shift)));
+        }
+    }
 }

--- a/tests/limb.rs
+++ b/tests/limb.rs
@@ -1,0 +1,23 @@
+use crypto_bigint::{Limb, Word};
+use proptest::prelude::*;
+
+prop_compose! {
+    fn limb()(x in any::<Word>()) -> Limb {
+        Limb::from(x)
+    }
+}
+proptest! {
+    #[test]
+    fn carrying_shr_doesnt_panic(limb in limb(), shift in 0..32u32) {
+        limb.carrying_shr(shift);
+    }
+
+    #[test]
+    fn carrying_shr(limb in limb(), shift in 0..32u32) {
+        if shift == 0 {
+            assert_eq!(limb.carrying_shr(shift), (limb, Limb::ZERO));
+        } else {
+            assert_eq!(limb.carrying_shr(shift), (limb.shr(shift), limb.shl(Limb::BITS - shift)));
+        }
+    }
+}


### PR DESCRIPTION
Refactor `Uint::shr`, achieving a >60% speed up for `U2048`.

## Benchmarks (run on commit b2dcb20)

```
right shift/shr, U2048  time:   [292.04 ns 292.16 ns 292.30 ns]
                        change: [-0.2073% -0.0666% +0.0669%] (p = 0.34 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe
right shift/new shr, U2048
                        time:   [114.34 ns 114.48 ns 114.62 ns]
                        change: [+0.8375% +1.0410% +1.2401%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
```
