### PR TITLE
Make `Uint::as_limbs_mut` const

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -119,7 +119,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 
     /// Borrow the limbs of this [`Int`] mutably.
-    pub fn as_limbs_mut(&mut self) -> &mut [Limb; LIMBS] {
+    pub const fn as_limbs_mut(&mut self) -> &mut [Limb; LIMBS] {
         self.0.as_limbs_mut()
     }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -165,7 +165,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Borrow the limbs of this [`Uint`] mutably.
-    pub fn as_limbs_mut(&mut self) -> &mut [Limb; LIMBS] {
+    pub const fn as_limbs_mut(&mut self) -> &mut [Limb; LIMBS] {
         &mut self.limbs
     }
 


### PR DESCRIPTION
While developing #753, we found that `Uint::as_limbs_mut` can be made `const`. This PR introduces this very minor improvement.