### PR TITLE
Add `?Sized` to all `RngCore` bounds

### DIFF
--- a/src/int/rand.rs
+++ b/src/int/rand.rs
@@ -8,18 +8,21 @@ use super::Uint;
 
 impl<const LIMBS: usize> Random for Int<LIMBS> {
     /// Generate a cryptographically secure random [`Int`].
-    fn random(rng: &mut impl RngCore) -> Self {
+    fn random(rng: &mut (impl RngCore + ?Sized)) -> Self {
         Self(Uint::random(rng))
     }
 }
 
 impl<const LIMBS: usize> RandomBits for Int<LIMBS> {
-    fn try_random_bits(rng: &mut impl RngCore, bit_length: u32) -> Result<Self, RandomBitsError> {
+    fn try_random_bits(
+        rng: &mut (impl RngCore + ?Sized),
+        bit_length: u32,
+    ) -> Result<Self, RandomBitsError> {
         Self::try_random_bits_with_precision(rng, bit_length, Self::BITS)
     }
 
     fn try_random_bits_with_precision(
-        rng: &mut impl RngCore,
+        rng: &mut (impl RngCore + ?Sized),
         bit_length: u32,
         bits_precision: u32,
     ) -> Result<Self, RandomBitsError> {

--- a/src/limb/rand.rs
+++ b/src/limb/rand.rs
@@ -7,18 +7,18 @@ use subtle::ConstantTimeLess;
 
 impl Random for Limb {
     #[cfg(target_pointer_width = "32")]
-    fn random(rng: &mut impl RngCore) -> Self {
+    fn random(rng: &mut (impl RngCore + ?Sized)) -> Self {
         Self(rng.next_u32())
     }
 
     #[cfg(target_pointer_width = "64")]
-    fn random(rng: &mut impl RngCore) -> Self {
+    fn random(rng: &mut (impl RngCore + ?Sized)) -> Self {
         Self(rng.next_u64())
     }
 }
 
 impl RandomMod for Limb {
-    fn random_mod(rng: &mut impl RngCore, modulus: &NonZero<Self>) -> Self {
+    fn random_mod(rng: &mut (impl RngCore + ?Sized), modulus: &NonZero<Self>) -> Self {
         let mut bytes = <Self as Encoding>::Repr::default();
 
         let n_bits = modulus.bits() as usize;

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -207,7 +207,7 @@ where
     MOD: ConstMontyParams<LIMBS>,
 {
     #[inline]
-    fn random(rng: &mut impl RngCore) -> Self {
+    fn random(rng: &mut (impl RngCore + ?Sized)) -> Self {
         Self::new(&Uint::random_mod(rng, MOD::MODULUS.as_nz_ref()))
     }
 }

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -246,7 +246,7 @@ where
     /// As a result, it runs in variable time. If the generator `rng` is
     /// cryptographically secure (for example, it implements `CryptoRng`),
     /// then this is guaranteed not to leak anything about the output value.
-    fn random(mut rng: &mut impl RngCore) -> Self {
+    fn random(mut rng: &mut (impl RngCore + ?Sized)) -> Self {
         loop {
             if let Some(result) = Self::new(T::random(&mut rng)).into() {
                 break result;

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -153,7 +153,7 @@ impl PartialOrd<Odd<BoxedUint>> for BoxedUint {
 #[cfg(feature = "rand_core")]
 impl<const LIMBS: usize> Random for Odd<Uint<LIMBS>> {
     /// Generate a random `Odd<Uint<T>>`.
-    fn random(rng: &mut impl RngCore) -> Self {
+    fn random(rng: &mut (impl RngCore + ?Sized)) -> Self {
         let mut ret = Uint::random(rng);
         ret.limbs[0] |= Limb::ONE;
         Odd(ret)
@@ -163,7 +163,7 @@ impl<const LIMBS: usize> Random for Odd<Uint<LIMBS>> {
 #[cfg(all(feature = "alloc", feature = "rand_core"))]
 impl Odd<BoxedUint> {
     /// Generate a random `Odd<Uint<T>>`.
-    pub fn random(rng: &mut impl RngCore, bit_length: u32) -> Self {
+    pub fn random(rng: &mut (impl RngCore + ?Sized), bit_length: u32) -> Self {
         let mut ret = BoxedUint::random_bits(rng, bit_length);
         ret.limbs[0] |= Limb::ONE;
         Odd(ret)

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -299,7 +299,7 @@ pub trait Random: Sized {
     /// Generate a random value.
     ///
     /// If `rng` is a CSRNG, the generation is cryptographically secure as well.
-    fn random(rng: &mut impl RngCore) -> Self;
+    fn random(rng: &mut (impl RngCore + ?Sized)) -> Self;
 }
 
 /// Possible errors of the methods in [`RandomBits`] trait.
@@ -362,7 +362,7 @@ pub trait RandomBits: Sized {
     /// Generate a random value in range `[0, 2^bit_length)`.
     ///
     /// A wrapper for [`RandomBits::try_random_bits`] that panics on error.
-    fn random_bits(rng: &mut impl RngCore, bit_length: u32) -> Self {
+    fn random_bits(rng: &mut (impl RngCore + ?Sized), bit_length: u32) -> Self {
         Self::try_random_bits(rng, bit_length).expect("try_random_bits() failed")
     }
 
@@ -371,7 +371,10 @@ pub trait RandomBits: Sized {
     /// This method is variable time wrt `bit_length`.
     ///
     /// If `rng` is a CSRNG, the generation is cryptographically secure as well.
-    fn try_random_bits(rng: &mut impl RngCore, bit_length: u32) -> Result<Self, RandomBitsError>;
+    fn try_random_bits(
+        rng: &mut (impl RngCore + ?Sized),
+        bit_length: u32,
+    ) -> Result<Self, RandomBitsError>;
 
     /// Generate a random value in range `[0, 2^bit_length)`,
     /// returning an integer with the closest available size to `bits_precision`
@@ -379,7 +382,7 @@ pub trait RandomBits: Sized {
     ///
     /// A wrapper for [`RandomBits::try_random_bits_with_precision`] that panics on error.
     fn random_bits_with_precision(
-        rng: &mut impl RngCore,
+        rng: &mut (impl RngCore + ?Sized),
         bit_length: u32,
         bits_precision: u32,
     ) -> Self {
@@ -395,7 +398,7 @@ pub trait RandomBits: Sized {
     ///
     /// If `rng` is a CSRNG, the generation is cryptographically secure as well.
     fn try_random_bits_with_precision(
-        rng: &mut impl RngCore,
+        rng: &mut (impl RngCore + ?Sized),
         bit_length: u32,
         bits_precision: u32,
     ) -> Result<Self, RandomBitsError>;
@@ -413,7 +416,7 @@ pub trait RandomMod: Sized + Zero {
     /// example, it implements `CryptoRng`), then this is guaranteed not to
     /// leak anything about the output value aside from it being less than
     /// `modulus`.
-    fn random_mod(rng: &mut impl RngCore, modulus: &NonZero<Self>) -> Self;
+    fn random_mod(rng: &mut (impl RngCore + ?Sized), modulus: &NonZero<Self>) -> Self;
 }
 
 /// Compute `self + rhs mod p`.

--- a/src/uint/boxed/rand.rs
+++ b/src/uint/boxed/rand.rs
@@ -8,12 +8,15 @@ use crate::{
 use rand_core::RngCore;
 
 impl RandomBits for BoxedUint {
-    fn try_random_bits(rng: &mut impl RngCore, bit_length: u32) -> Result<Self, RandomBitsError> {
+    fn try_random_bits(
+        rng: &mut (impl RngCore + ?Sized),
+        bit_length: u32,
+    ) -> Result<Self, RandomBitsError> {
         Self::try_random_bits_with_precision(rng, bit_length, bit_length)
     }
 
     fn try_random_bits_with_precision(
-        rng: &mut impl RngCore,
+        rng: &mut (impl RngCore + ?Sized),
         bit_length: u32,
         bits_precision: u32,
     ) -> Result<Self, RandomBitsError> {
@@ -31,7 +34,7 @@ impl RandomBits for BoxedUint {
 }
 
 impl RandomMod for BoxedUint {
-    fn random_mod(rng: &mut impl RngCore, modulus: &NonZero<Self>) -> Self {
+    fn random_mod(rng: &mut (impl RngCore + ?Sized), modulus: &NonZero<Self>) -> Self {
         let mut n = BoxedUint::zero_with_precision(modulus.bits_precision());
         random_mod_core(rng, &mut n, modulus, modulus.bits());
         n

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -6,7 +6,7 @@ use rand_core::RngCore;
 use subtle::ConstantTimeLess;
 
 impl<const LIMBS: usize> Random for Uint<LIMBS> {
-    fn random(mut rng: &mut impl RngCore) -> Self {
+    fn random(mut rng: &mut (impl RngCore + ?Sized)) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
 
         for limb in &mut limbs {
@@ -21,7 +21,7 @@ impl<const LIMBS: usize> Random for Uint<LIMBS> {
 ///
 /// NOTE: Assumes that the limbs in the given slice are zeroed!
 pub(crate) fn random_bits_core(
-    rng: &mut impl RngCore,
+    rng: &mut (impl RngCore + ?Sized),
     zeroed_limbs: &mut [Limb],
     bit_length: u32,
 ) -> Result<(), RandomBitsError> {
@@ -50,12 +50,15 @@ pub(crate) fn random_bits_core(
 }
 
 impl<const LIMBS: usize> RandomBits for Uint<LIMBS> {
-    fn try_random_bits(rng: &mut impl RngCore, bit_length: u32) -> Result<Self, RandomBitsError> {
+    fn try_random_bits(
+        rng: &mut (impl RngCore + ?Sized),
+        bit_length: u32,
+    ) -> Result<Self, RandomBitsError> {
         Self::try_random_bits_with_precision(rng, bit_length, Self::BITS)
     }
 
     fn try_random_bits_with_precision(
-        rng: &mut impl RngCore,
+        rng: &mut (impl RngCore + ?Sized),
         bit_length: u32,
         bits_precision: u32,
     ) -> Result<Self, RandomBitsError> {
@@ -78,7 +81,7 @@ impl<const LIMBS: usize> RandomBits for Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize> RandomMod for Uint<LIMBS> {
-    fn random_mod(rng: &mut impl RngCore, modulus: &NonZero<Self>) -> Self {
+    fn random_mod(rng: &mut (impl RngCore + ?Sized), modulus: &NonZero<Self>) -> Self {
         let mut n = Self::ZERO;
         random_mod_core(rng, &mut n, modulus, modulus.bits_vartime());
         n
@@ -88,7 +91,7 @@ impl<const LIMBS: usize> RandomMod for Uint<LIMBS> {
 /// Generic implementation of `random_mod` which can be shared with `BoxedUint`.
 // TODO(tarcieri): obtain `n_bits` via a trait like `Integer`
 pub(super) fn random_mod_core<T>(
-    rng: &mut impl RngCore,
+    rng: &mut (impl RngCore + ?Sized),
     n: &mut T,
     modulus: &NonZero<T>,
     n_bits: u32,

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -259,7 +259,7 @@ impl<T: fmt::UpperHex> fmt::UpperHex for Wrapping<T> {
 
 #[cfg(feature = "rand_core")]
 impl<T: Random> Random for Wrapping<T> {
-    fn random(rng: &mut impl RngCore) -> Self {
+    fn random(rng: &mut (impl RngCore + ?Sized)) -> Self {
         Wrapping(Random::random(rng))
     }
 }


### PR DESCRIPTION
Doesn't matter to us, but allows users to pass `dyn RngCore` args. 