### PR TITLE
v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2025-02-14)
+### Added
+- `?Sized` to all RngCore bounds ([#760])
+
+### Changed
+-  Make `as_limbs_mut` const ([#757])
+
+[#757]: https://github.com/RustCrypto/crypto-bigint/pull/757
+[#760]: https://github.com/RustCrypto/crypto-bigint/pull/760
+
 ## 0.6.0 (2025-01-22)
 ### Added
 - `TryFrom<&[u8]>` bound on `Encoding::Repr` ([#261])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.6.0"
+version = "0.6.1"
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,


### PR DESCRIPTION
### Added
- `?Sized` to all RngCore bounds ([#760])

### Changed
-  Make `as_limbs_mut` const ([#757])

[#757]: https://github.com/RustCrypto/crypto-bigint/pull/757
[#760]: https://github.com/RustCrypto/crypto-bigint/pull/760