### PR TITLE
Bump version to v0.7.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.6.1"
+version = "0.7.0-pre"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.6.1"
+version = "0.7.0-pre"
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,


### PR DESCRIPTION
Note: not for release, that will be `v0.7.0-pre.0`

This sets `master` back to a development branch.

v0.6 development now has its own branch: https://github.com/RustCrypto/crypto-bigint/tree/v0.6