### PR TITLE
provide `RandomMod::try_random_mod` and `Random::try_random` methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,8 +565,7 @@ dependencies = [
 [[package]]
 name = "rand_core"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88e0da7a2c97baa202165137c158d0a2e824ac465d13d81046727b34cb247d3"
+source = "git+https://github.com/rust-random/rand.git#775b05be1b8a4fdef17c6601cd223551fbf67edc"
 dependencies = [
  "getrandom 0.3.1",
  "zerocopy 0.8.14",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ subtle = { version = "2.6", default-features = false }
 der = { version = "0.8.0-rc.1", optional = true, default-features = false }
 hybrid-array = { version = "0.2", optional = true }
 num-traits = { version = "0.2.19", default-features = false }
-rand_core = { version = "0.9", optional = true, default-features = false }
+rand_core = { version = "0.9.2", optional = true, default-features = false }
 rlp = { version = "0.6", optional = true, default-features = false }
 serdect = { version = "0.3", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
@@ -81,7 +81,3 @@ harness = false
 [[bench]]
 name = "int"
 harness = false
-
-[patch.crates-io]
-# https://github.com/rust-random/rand/pull/1593
-rand_core = { git = "https://github.com/rust-random/rand.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,7 @@ harness = false
 [[bench]]
 name = "int"
 harness = false
+
+[patch.crates-io]
+# https://github.com/rust-random/rand/pull/1593
+rand_core = { git = "https://github.com/rust-random/rand.git" }

--- a/src/int/rand.rs
+++ b/src/int/rand.rs
@@ -1,6 +1,6 @@
 //! Random number generator support
 
-use rand_core::{RngCore, TryRngCore};
+use rand_core::TryRngCore;
 
 use crate::{Int, Random, RandomBits, RandomBitsError};
 
@@ -8,8 +8,8 @@ use super::Uint;
 
 impl<const LIMBS: usize> Random for Int<LIMBS> {
     /// Generate a cryptographically secure random [`Int`].
-    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
-        Self(Uint::random(rng))
+    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        Ok(Self(Uint::try_random(rng)?))
     }
 }
 

--- a/src/limb/rand.rs
+++ b/src/limb/rand.rs
@@ -2,18 +2,17 @@
 
 use super::Limb;
 use crate::{Encoding, NonZero, Random, RandomMod};
-use rand_core::{RngCore, TryRngCore};
+use rand_core::TryRngCore;
 use subtle::ConstantTimeLess;
 
 impl Random for Limb {
-    #[cfg(target_pointer_width = "32")]
-    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
-        Self(rng.next_u32())
-    }
+    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        #[cfg(target_pointer_width = "32")]
+        let val = rng.try_next_u32()?;
+        #[cfg(target_pointer_width = "64")]
+        let val = rng.try_next_u64()?;
 
-    #[cfg(target_pointer_width = "64")]
-    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
-        Self(rng.next_u64())
+        Ok(Self(val))
     }
 }
 

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -15,7 +15,7 @@ use core::{fmt::Debug, marker::PhantomData};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 #[cfg(feature = "rand_core")]
-use crate::{Random, RandomMod, rand_core::RngCore};
+use crate::{Random, RandomMod, rand_core::TryRngCore};
 
 #[cfg(feature = "serde")]
 use {
@@ -204,8 +204,11 @@ where
     MOD: ConstMontyParams<LIMBS>,
 {
     #[inline]
-    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
-        Self::new(&Uint::random_mod(rng, MOD::MODULUS.as_nz_ref()))
+    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        Ok(Self::new(&Uint::try_random_mod(
+            rng,
+            MOD::MODULUS.as_nz_ref(),
+        )?))
     }
 }
 

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -12,7 +12,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use crate::{ArrayEncoding, ByteArray};
 
 #[cfg(feature = "rand_core")]
-use {crate::Random, rand_core::RngCore};
+use {crate::Random, rand_core::TryRngCore};
 
 #[cfg(feature = "serde")]
 use serdect::serde::{
@@ -246,10 +246,10 @@ where
     /// As a result, it runs in variable time. If the generator `rng` is
     /// cryptographically secure (for example, it implements `CryptoRng`),
     /// then this is guaranteed not to leak anything about the output value.
-    fn random<R: RngCore + ?Sized>(mut rng: &mut R) -> Self {
+    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         loop {
-            if let Some(result) = Self::new(T::random(&mut rng)).into() {
-                break result;
+            if let Some(result) = Self::new(T::try_random(rng)?).into() {
+                break Ok(result);
             }
         }
     }

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -8,10 +8,10 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use crate::BoxedUint;
 
 #[cfg(feature = "rand_core")]
-use {crate::Random, rand_core::RngCore};
+use crate::{Random, rand_core::TryRngCore};
 
 #[cfg(all(feature = "alloc", feature = "rand_core"))]
-use {crate::RandomBits, rand_core::TryRngCore};
+use crate::RandomBits;
 
 #[cfg(feature = "serde")]
 use crate::Zero;
@@ -153,10 +153,10 @@ impl PartialOrd<Odd<BoxedUint>> for BoxedUint {
 #[cfg(feature = "rand_core")]
 impl<const LIMBS: usize> Random for Odd<Uint<LIMBS>> {
     /// Generate a random `Odd<Uint<T>>`.
-    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
-        let mut ret = Uint::random(rng);
+    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        let mut ret = Uint::try_random(rng)?;
         ret.limbs[0] |= Limb::ONE;
-        Odd(ret)
+        Ok(Odd(ret))
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -419,7 +419,24 @@ pub trait RandomMod: Sized + Zero {
     /// example, it implements `CryptoRng`), then this is guaranteed not to
     /// leak anything about the output value aside from it being less than
     /// `modulus`.
-    fn random_mod<R: RngCore + ?Sized>(rng: &mut R, modulus: &NonZero<Self>) -> Self;
+    fn random_mod<R: RngCore + ?Sized>(rng: &mut R, modulus: &NonZero<Self>) -> Self {
+        let Ok(out) = Self::try_random_mod(rng, modulus);
+        out
+    }
+
+    /// Generate a random number which is less than a given `modulus`.
+    ///
+    /// This uses rejection sampling.
+    ///
+    /// As a result, it runs in variable time that depends in part on
+    /// `modulus`. If the generator `rng` is cryptographically secure (for
+    /// example, it implements `CryptoRng`), then this is guaranteed not to
+    /// leak anything about the output value aside from it being less than
+    /// `modulus`.
+    fn try_random_mod<R: TryRngCore + ?Sized>(
+        rng: &mut R,
+        modulus: &NonZero<Self>,
+    ) -> Result<Self, R::Error>;
 }
 
 /// Compute `self + rhs mod p`.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -299,7 +299,15 @@ pub trait Random: Sized {
     /// Generate a random value.
     ///
     /// If `rng` is a CSRNG, the generation is cryptographically secure as well.
-    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self;
+    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
+        let Ok(out) = Self::try_random(rng);
+        out
+    }
+
+    /// Generate a random value.
+    ///
+    /// If `rng` is a CSRNG, the generation is cryptographically secure as well.
+    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error>;
 }
 
 /// Possible errors of the methods in [`RandomBits`] trait.

--- a/src/uint/boxed/rand.rs
+++ b/src/uint/boxed/rand.rs
@@ -36,8 +36,17 @@ impl RandomBits for BoxedUint {
 impl RandomMod for BoxedUint {
     fn random_mod<R: RngCore + ?Sized>(rng: &mut R, modulus: &NonZero<Self>) -> Self {
         let mut n = BoxedUint::zero_with_precision(modulus.bits_precision());
-        random_mod_core(rng, &mut n, modulus, modulus.bits());
+        let Ok(()) = random_mod_core(rng, &mut n, modulus, modulus.bits());
         n
+    }
+
+    fn try_random_mod<R: TryRngCore + ?Sized>(
+        rng: &mut R,
+        modulus: &NonZero<Self>,
+    ) -> Result<Self, R::Error> {
+        let mut n = BoxedUint::zero_with_precision(modulus.bits_precision());
+        random_mod_core(rng, &mut n, modulus, modulus.bits())?;
+        Ok(n)
     }
 }
 

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -83,35 +83,45 @@ impl<const LIMBS: usize> RandomBits for Uint<LIMBS> {
 impl<const LIMBS: usize> RandomMod for Uint<LIMBS> {
     fn random_mod<R: RngCore + ?Sized>(rng: &mut R, modulus: &NonZero<Self>) -> Self {
         let mut n = Self::ZERO;
-        random_mod_core(rng, &mut n, modulus, modulus.bits_vartime());
+        let Ok(()) = random_mod_core(rng, &mut n, modulus, modulus.bits_vartime());
         n
+    }
+
+    fn try_random_mod<R: TryRngCore + ?Sized>(
+        rng: &mut R,
+        modulus: &NonZero<Self>,
+    ) -> Result<Self, R::Error> {
+        let mut n = Self::ZERO;
+        random_mod_core(rng, &mut n, modulus, modulus.bits_vartime())?;
+        Ok(n)
     }
 }
 
 /// Generic implementation of `random_mod` which can be shared with `BoxedUint`.
 // TODO(tarcieri): obtain `n_bits` via a trait like `Integer`
-pub(super) fn random_mod_core<T, R: RngCore + ?Sized>(
+pub(super) fn random_mod_core<T, R: TryRngCore + ?Sized>(
     rng: &mut R,
     n: &mut T,
     modulus: &NonZero<T>,
     n_bits: u32,
-) where
+) -> Result<(), R::Error>
+where
     T: AsMut<[Limb]> + AsRef<[Limb]> + ConstantTimeLess + Zero,
 {
     #[cfg(target_pointer_width = "64")]
-    let mut next_word = || rng.next_u64();
+    let mut next_word = || rng.try_next_u64();
     #[cfg(target_pointer_width = "32")]
-    let mut next_word = || rng.next_u32();
+    let mut next_word = || rng.try_next_u32();
 
     let n_limbs = n_bits.div_ceil(Limb::BITS) as usize;
 
     let hi_word_modulus = modulus.as_ref().as_ref()[n_limbs - 1].0;
     let mask = !0 >> hi_word_modulus.leading_zeros();
-    let mut hi_word = next_word() & mask;
+    let mut hi_word = next_word()? & mask;
 
     loop {
         while hi_word > hi_word_modulus {
-            hi_word = next_word() & mask;
+            hi_word = next_word()? & mask;
         }
         // Set high limb
         n.as_mut()[n_limbs - 1] = Limb::from_le_bytes(hi_word.to_le_bytes());
@@ -120,15 +130,16 @@ pub(super) fn random_mod_core<T, R: RngCore + ?Sized>(
             // Need to deserialize from little-endian to make sure that two 32-bit limbs
             // deserialized sequentially are equal to one 64-bit limb produced from the same
             // byte stream.
-            n.as_mut()[i] = Limb::from_le_bytes(next_word().to_le_bytes());
+            n.as_mut()[i] = Limb::from_le_bytes(next_word()?.to_le_bytes());
         }
         // If the high limb is equal to the modulus' high limb, it's still possible
         // that the full uint is too big so we check and repeat if it is.
         if n.ct_lt(modulus).into() {
             break;
         }
-        hi_word = next_word() & mask;
+        hi_word = next_word()? & mask;
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -6,14 +6,14 @@ use rand_core::{RngCore, TryRngCore};
 use subtle::ConstantTimeLess;
 
 impl<const LIMBS: usize> Random for Uint<LIMBS> {
-    fn random<R: RngCore + ?Sized>(mut rng: &mut R) -> Self {
+    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut limbs = [Limb::ZERO; LIMBS];
 
         for limb in &mut limbs {
-            *limb = Limb::random(&mut rng)
+            *limb = Limb::try_random(rng)?
         }
 
-        limbs.into()
+        Ok(limbs.into())
     }
 }
 

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -8,7 +8,7 @@ use core::{
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 #[cfg(feature = "rand_core")]
-use {crate::Random, rand_core::RngCore};
+use {crate::Random, rand_core::TryRngCore};
 
 #[cfg(feature = "serde")]
 use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -259,8 +259,8 @@ impl<T: fmt::UpperHex> fmt::UpperHex for Wrapping<T> {
 
 #[cfg(feature = "rand_core")]
 impl<T: Random> Random for Wrapping<T> {
-    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
-        Wrapping(Random::random(rng))
+    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        Ok(Wrapping(Random::try_random(rng)?))
     }
 }
 


### PR DESCRIPTION
This method is to be used by downstream crates:
  - https://github.com/RustCrypto/RSA/pull/478
  
Depends on:
 - https://github.com/rust-random/rand/pull/1593