### PR TITLE
Monty-related performance improvements

### DIFF
--- a/benches/monty.rs
+++ b/benches/monty.rs
@@ -180,6 +180,17 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         )
     });
 
+    group.bench_function("div_by_2, U256", |b| {
+        b.iter_batched(
+            || {
+                let x = U256::random_mod(&mut rng, params.modulus().as_nz_ref());
+                MontyForm::new(&x, params)
+            },
+            |x| black_box(x.div_by_2()),
+            BatchSize::SmallInput,
+        )
+    });
+
     #[cfg(feature = "alloc")]
     for i in [1, 2, 3, 4, 10, 100] {
         group.bench_function(

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -256,6 +256,12 @@ impl BoxedMontyForm {
             params: self.params.clone(),
         }
     }
+
+    /// Performs division by 2 inplace, that is finds `x` such that `x + x = self`
+    /// and writes it into `self`.
+    pub fn div_by_2_assign(&mut self) {
+        div_by_2::div_by_2_boxed_assign(&mut self.montgomery_form, &self.params.modulus)
+    }
 }
 
 impl Retrieve for BoxedMontyForm {
@@ -299,6 +305,10 @@ impl Monty for BoxedMontyForm {
 
     fn div_by_2(&self) -> Self {
         BoxedMontyForm::div_by_2(self)
+    }
+
+    fn div_by_2_assign(&mut self) {
+        BoxedMontyForm::div_by_2_assign(self)
     }
 
     fn lincomb_vartime(products: &[(&Self, &Self)]) -> Self {

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -8,7 +8,7 @@ mod neg;
 mod pow;
 mod sub;
 
-use super::{ConstMontyParams, Retrieve, div_by_2, reduction::montgomery_reduction_boxed};
+use super::{ConstMontyParams, Retrieve, div_by_2};
 use mul::MontyMultiplier;
 
 use crate::{BoxedUint, Limb, Monty, Odd, Word};
@@ -187,19 +187,8 @@ impl BoxedMontyForm {
 
     /// Retrieves the integer currently encoded in this [`BoxedMontyForm`], guaranteed to be reduced.
     pub fn retrieve(&self) -> BoxedUint {
-        let mut montgomery_form = self.montgomery_form.widen(self.bits_precision() * 2);
-
-        let ret = montgomery_reduction_boxed(
-            &mut montgomery_form,
-            &self.params.modulus,
-            self.params.mod_neg_inv,
-        );
-
-        #[cfg(feature = "zeroize")]
-        montgomery_form.zeroize();
-
-        debug_assert!(ret < self.params.modulus);
-        ret
+        let mut mm = MontyMultiplier::from(self.params.as_ref());
+        mm.mul_by_one(&self.montgomery_form)
     }
 
     /// Instantiates a new `ConstMontyForm` that represents zero.

--- a/src/modular/boxed_monty_form/add.rs
+++ b/src/modular/boxed_monty_form/add.rs
@@ -58,9 +58,8 @@ impl Add<BoxedMontyForm> for BoxedMontyForm {
 impl AddAssign<&BoxedMontyForm> for BoxedMontyForm {
     fn add_assign(&mut self, rhs: &BoxedMontyForm) {
         debug_assert_eq!(self.params, rhs.params);
-        self.montgomery_form = self
-            .montgomery_form
-            .add_mod(&rhs.montgomery_form, &self.params.modulus)
+        self.montgomery_form
+            .add_mod_assign(&rhs.montgomery_form, &self.params.modulus);
     }
 }
 

--- a/src/modular/boxed_monty_form/mul.rs
+++ b/src/modular/boxed_monty_form/mul.rs
@@ -6,12 +6,11 @@
 //! Originally (c) 2014 The Rust Project Developers, dual licensed Apache 2.0+MIT.
 
 use super::{BoxedMontyForm, BoxedMontyParams};
-use crate::{BoxedUint, ConstChoice, Limb, Square, SquareAssign, Word, Zero};
+use crate::{BoxedUint, ConstChoice, Limb, Square, SquareAssign, Word};
 use core::{
     borrow::Borrow,
     ops::{Mul, MulAssign},
 };
-use subtle::{ConditionallySelectable, ConstantTimeLess};
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -264,54 +263,55 @@ impl Drop for MontyMultiplier<'_> {
 ///
 /// Note: this was adapted from an implementation in `num-bigint`'s `monty.rs`.
 // TODO(tarcieri): refactor into `reduction.rs`, share impl with `MontyForm`?
-fn almost_montgomery_mul(z: &mut [Limb], x: &[Limb], y: &[Limb], m: &[Limb], k: Limb) {
+const fn almost_montgomery_mul(z: &mut [Limb], x: &[Limb], y: &[Limb], m: &[Limb], k: Limb) {
     // This code assumes x, y, m are all the same length (required by addMulVVW and the for loop).
     // It also assumes that x, y are already reduced mod m, or else the result will not be properly
     // reduced.
     let n = m.len();
 
     // This preconditions check allows compiler to remove bound checks later in the code.
-    // `z.len() > n && z[n..].len() == n` is used intentionally instead of `z.len() == 2* n`
-    // since the latter prevents compiler from removing some bound checks.
-    let pre_cond = z.len() > n && z[n..].len() == n && x.len() == n && y.len() == n && m.len() == n;
+    let pre_cond = z.len() > n && x.len() == n && y.len() == n && m.len() == n;
     if !pre_cond {
         panic!("Failed preconditions in montgomery_mul");
     }
 
-    let mut c = Limb::ZERO;
+    let mut c = ConstChoice::FALSE;
 
-    for i in 0..n {
-        let c2 = add_mul_vvw(&mut z[i..n + i], x, y[i]);
-        let t = z[i].wrapping_mul(k);
-        let c3 = add_mul_vvw(&mut z[i..n + i], m, t);
-        let cx = c.wrapping_add(c2);
+    let mut i = 0;
+    while i < n {
+        let (_, z_slice) = z.split_at_mut(i);
+        let c2 = add_mul_vvw(z_slice, x, y[i]);
+        let t = z_slice[0].wrapping_mul(k);
+        let c3 = add_mul_vvw(z_slice, m, t);
+        let cx = c2.wrapping_add(Limb(c.to_u8() as Word));
         let cy = cx.wrapping_add(c3);
         z[n + i] = cy;
-        c = Limb((cx.ct_lt(&c2) | cy.ct_lt(&c3)).unwrap_u8() as Word);
+        c = ConstChoice::from_word_lt(cx.0, c2.0).or(ConstChoice::from_word_lt(cy.0, c3.0));
+        i += 1;
     }
 
     let (lower, upper) = z.split_at_mut(n);
     sub_vv(lower, upper, m);
 
-    let is_zero = c.is_zero();
-    for (a, b) in lower.iter_mut().zip(upper.iter()) {
-        a.conditional_assign(b, is_zero);
+    let is_zero = c.not();
+    let mut i = 0;
+    while i < n {
+        lower[i] = Limb::select(lower[i], upper[i], is_zero);
+        i += 1;
     }
 }
 
 /// Same as `almost_montgomery_mul` with `y == 1`.
 ///
 /// Used for retrieving from Montgomery form.
-fn almost_montgomery_mul_by_one(z: &mut [Limb], x: &[Limb], m: &[Limb], k: Limb) {
+const fn almost_montgomery_mul_by_one(z: &mut [Limb], x: &[Limb], m: &[Limb], k: Limb) {
     // This code assumes x, m are all the same length (required by addMulVVW and the for loop).
     // It also assumes that x is already reduced mod m, or else the result will not be properly
     // reduced.
     let n = m.len();
 
     // This preconditions check allows compiler to remove bound checks later in the code.
-    // `z.len() > n && z[n..].len() == n` is used intentionally instead of `z.len() == 2* n`
-    // since the latter prevents compiler from removing some bound checks.
-    let pre_cond = z.len() > n && z[n..].len() == n && x.len() == n && m.len() == n;
+    let pre_cond = z.len() > n && x.len() == n && m.len() == n;
     if !pre_cond {
         panic!("Failed preconditions in montgomery_mul");
     }
@@ -319,53 +319,74 @@ fn almost_montgomery_mul_by_one(z: &mut [Limb], x: &[Limb], m: &[Limb], k: Limb)
     let mut c = ConstChoice::FALSE;
 
     // The unrolled first iteration.
-    let c2 = add_mul_vvw(&mut z[0..n], x, Limb::ONE);
+    let c2 = add_mul_vvw(z, x, Limb::ONE);
     let t = z[0].wrapping_mul(k);
-    let c3 = add_mul_vvw(&mut z[0..n], m, t);
+    let c3 = add_mul_vvw(z, m, t);
     let cx = c2.wrapping_add(Limb(c.to_u8() as Word));
     let cy = cx.wrapping_add(c3);
     z[n] = cy;
     c = ConstChoice::from_word_lt(cx.0, c2.0).or(ConstChoice::from_word_lt(cy.0, c3.0));
 
-    for i in 1..n {
-        let c2 = add_mul_vvw(&mut z[i..n + i], x, Limb::ZERO);
-        let t = z[i].wrapping_mul(k);
-        let c3 = add_mul_vvw(&mut z[i..n + i], m, t);
+    let mut i = 1;
+    while i < n {
+        let (_, z_slice) = z.split_at_mut(i);
+        let c2 = add_mul_vvw(z_slice, x, Limb::ZERO);
+        let t = z_slice[0].wrapping_mul(k);
+        let c3 = add_mul_vvw(z_slice, m, t);
         let cx = c2.wrapping_add(Limb(c.to_u8() as Word));
         let cy = cx.wrapping_add(c3);
         z[n + i] = cy;
         c = ConstChoice::from_word_lt(cx.0, c2.0).or(ConstChoice::from_word_lt(cy.0, c3.0));
+        i += 1;
     }
 
     let (lower, upper) = z.split_at_mut(n);
     sub_vv(lower, upper, m);
 
     let is_zero = c.not();
-    for (a, b) in lower.iter_mut().zip(upper.iter()) {
-        *a = Limb::select(*a, *b, is_zero);
+    let mut i = 0;
+    while i < n {
+        lower[i] = Limb::select(lower[i], upper[i], is_zero);
+        i += 1;
     }
 }
 
 #[inline]
-fn add_mul_vvw(z: &mut [Limb], x: &[Limb], y: Limb) -> Limb {
+const fn add_mul_vvw(z: &mut [Limb], x: &[Limb], y: Limb) -> Limb {
+    let n = x.len();
+    if n > z.len() {
+        panic!("Failed preconditions in montgomery_mul");
+    }
+
     let mut c = Limb::ZERO;
-    for (zi, xi) in z.iter_mut().zip(x.iter()) {
-        let (z0, z1) = zi.mac(*xi, y, Limb::ZERO);
+
+    let mut i = 0;
+    while i < n {
+        let (z0, z1) = z[i].mac(x[i], y, Limb::ZERO);
         let (zi_, c_) = z0.overflowing_add(c);
-        *zi = zi_;
+        z[i] = zi_;
         c = c_.wrapping_add(z1);
+        i += 1;
     }
 
     c
 }
 
 #[inline(always)]
-fn sub_vv(z: &mut [Limb], x: &[Limb], y: &[Limb]) {
+const fn sub_vv(z: &mut [Limb], x: &[Limb], y: &[Limb]) {
+    let n = z.len();
+    if !(n == x.len() && n == y.len()) {
+        panic!("Failed preconditions in montgomery_mul");
+    }
+
     let mut borrow = Limb::ZERO;
-    for (i, (&xi, &yi)) in x.iter().zip(y.iter()).enumerate().take(z.len()) {
-        let (zi, new_borrow) = xi.sbb(yi, borrow);
+
+    let mut i = 0;
+    while i < n {
+        let (zi, new_borrow) = x[i].sbb(y[i], borrow);
         z[i] = zi;
         borrow = new_borrow;
+        i += 1;
     }
 }
 

--- a/src/modular/boxed_monty_form/mul.rs
+++ b/src/modular/boxed_monty_form/mul.rs
@@ -6,7 +6,7 @@
 //! Originally (c) 2014 The Rust Project Developers, dual licensed Apache 2.0+MIT.
 
 use super::{BoxedMontyForm, BoxedMontyParams};
-use crate::{BoxedUint, Limb, Square, SquareAssign, Word, Zero};
+use crate::{BoxedUint, ConstChoice, Limb, Square, SquareAssign, Word, Zero};
 use core::{
     borrow::Borrow,
     ops::{Mul, MulAssign},
@@ -133,6 +133,26 @@ impl<'a> MontyMultiplier<'a> {
         a.sub_assign_mod_with_carry(Limb::ZERO, self.modulus, self.modulus);
 
         debug_assert!(&*a < self.modulus);
+    }
+
+    /// Perform a Montgomery multiplication, assigning a fully reduced result to `a`.
+    pub(super) fn mul_by_one(&mut self, a: &BoxedUint) -> BoxedUint {
+        debug_assert_eq!(a.bits_precision(), self.modulus.bits_precision());
+
+        let mut ret = a.clone();
+
+        self.clear_product();
+        almost_montgomery_mul_by_one(
+            self.product.as_limbs_mut(),
+            a.as_limbs(),
+            self.modulus.as_limbs(),
+            self.mod_neg_inv,
+        );
+        ret.limbs
+            .copy_from_slice(&self.product.limbs[..a.limbs.len()]);
+        ret.sub_assign_mod_with_carry(Limb::ZERO, self.modulus, self.modulus);
+
+        ret
     }
 
     /// Perform a squaring using Montgomery multiplication, returning a fully reduced result.
@@ -276,6 +296,53 @@ fn almost_montgomery_mul(z: &mut [Limb], x: &[Limb], y: &[Limb], m: &[Limb], k: 
     let is_zero = c.is_zero();
     for (a, b) in lower.iter_mut().zip(upper.iter()) {
         a.conditional_assign(b, is_zero);
+    }
+}
+
+/// Same as `almost_montgomery_mul` with `y == 1`.
+///
+/// Used for retrieving from Montgomery form.
+fn almost_montgomery_mul_by_one(z: &mut [Limb], x: &[Limb], m: &[Limb], k: Limb) {
+    // This code assumes x, m are all the same length (required by addMulVVW and the for loop).
+    // It also assumes that x is already reduced mod m, or else the result will not be properly
+    // reduced.
+    let n = m.len();
+
+    // This preconditions check allows compiler to remove bound checks later in the code.
+    // `z.len() > n && z[n..].len() == n` is used intentionally instead of `z.len() == 2* n`
+    // since the latter prevents compiler from removing some bound checks.
+    let pre_cond = z.len() > n && z[n..].len() == n && x.len() == n && m.len() == n;
+    if !pre_cond {
+        panic!("Failed preconditions in montgomery_mul");
+    }
+
+    let mut c = ConstChoice::FALSE;
+
+    // The unrolled first iteration.
+    let c2 = add_mul_vvw(&mut z[0..n], x, Limb::ONE);
+    let t = z[0].wrapping_mul(k);
+    let c3 = add_mul_vvw(&mut z[0..n], m, t);
+    let cx = c2.wrapping_add(Limb(c.to_u8() as Word));
+    let cy = cx.wrapping_add(c3);
+    z[n] = cy;
+    c = ConstChoice::from_word_lt(cx.0, c2.0).or(ConstChoice::from_word_lt(cy.0, c3.0));
+
+    for i in 1..n {
+        let c2 = add_mul_vvw(&mut z[i..n + i], x, Limb::ZERO);
+        let t = z[i].wrapping_mul(k);
+        let c3 = add_mul_vvw(&mut z[i..n + i], m, t);
+        let cx = c2.wrapping_add(Limb(c.to_u8() as Word));
+        let cy = cx.wrapping_add(c3);
+        z[n + i] = cy;
+        c = ConstChoice::from_word_lt(cx.0, c2.0).or(ConstChoice::from_word_lt(cy.0, c3.0));
+    }
+
+    let (lower, upper) = z.split_at_mut(n);
+    sub_vv(lower, upper, m);
+
+    let is_zero = c.not();
+    for (a, b) in lower.iter_mut().zip(upper.iter()) {
+        *a = Limb::select(*a, *b, is_zero);
     }
 }
 

--- a/src/modular/boxed_monty_form/pow.rs
+++ b/src/modular/boxed_monty_form/pow.rs
@@ -1,6 +1,6 @@
 //! Modular exponentiation support for [`BoxedMontyForm`].
 
-use super::{BoxedMontyForm, mul::MontyMultiplier};
+use super::{BoxedMontyForm, mul::BoxedMontyMultiplier};
 use crate::{BoxedUint, ConstantTimeSelect, Limb, PowBoundedExp, Word};
 use alloc::vec::Vec;
 use subtle::{ConstantTimeEq, ConstantTimeLess};
@@ -60,7 +60,7 @@ fn pow_montgomery_form(
     const WINDOW: u32 = 4;
     const WINDOW_MASK: Word = (1 << WINDOW) - 1;
 
-    let mut multiplier = MontyMultiplier::new(modulus, mod_neg_inv);
+    let mut multiplier = BoxedMontyMultiplier::new(modulus, mod_neg_inv);
 
     // powers[i] contains x^i
     let mut powers = Vec::with_capacity(1 << WINDOW);

--- a/src/modular/boxed_monty_form/pow.rs
+++ b/src/modular/boxed_monty_form/pow.rs
@@ -111,12 +111,21 @@ fn pow_montgomery_form(
         }
     }
 
-    // Ensure output is properly reduced: AMM only reduces to the bit length of `modulus`
-    // See RustCrypto/crypto-bigint#441
-    z.conditional_sbb_assign(modulus, !z.ct_lt(modulus));
+    // Ensure the output is properly reduced.
+    //
+    // Using the properties of `almost_mongtomery_mul()` (see its documentation):
+    // - We have an incoming `x` which is fully reduced (`floor(x / modulus) = 0`).
+    // - We build an array of `powers` which are produced by multiplying the previous power by `x`,
+    //   so for each power `floor(power / modulus) <= 1`.
+    // - Then we take turns squaring the accumulator `z` (bringing `floor(z / modulus)` to 1
+    //   regardless of the previous reduction level) and multiplying by a power of `x`
+    //   (bringing `floor(z / modulus)` to at most 2).
+    // - Then we either exit the loop, or square again, which brings `floor(z / modulus)` back to 1.
+    //
+    // Now that we exited the loop, we need to reduce `z` at most twice
+    // to bring it within `[0, modulus)`.
 
-    // Subtract again to ensure output is fully reduced
-    // See RustCrypto/crypto-bigint#455 and golang.org/issue/13907
+    z.conditional_sbb_assign(modulus, !z.ct_lt(modulus));
     z.conditional_sbb_assign(modulus, !z.ct_lt(modulus));
     debug_assert!(&z < modulus);
 

--- a/src/modular/boxed_monty_form/sub.rs
+++ b/src/modular/boxed_monty_form/sub.rs
@@ -1,6 +1,7 @@
 //! Subtractions between boxed integers in Montgomery form.
 
 use super::BoxedMontyForm;
+use crate::Limb;
 use core::ops::{Sub, SubAssign};
 
 impl BoxedMontyForm {
@@ -51,9 +52,11 @@ impl Sub<BoxedMontyForm> for BoxedMontyForm {
 impl SubAssign<&BoxedMontyForm> for BoxedMontyForm {
     fn sub_assign(&mut self, rhs: &BoxedMontyForm) {
         debug_assert_eq!(self.params, rhs.params);
-        self.montgomery_form = self
-            .montgomery_form
-            .sub_mod(&rhs.montgomery_form, &self.params.modulus)
+        self.montgomery_form.sub_assign_mod_with_carry(
+            Limb::ZERO,
+            &rhs.montgomery_form,
+            &self.params.modulus,
+        );
     }
 }
 

--- a/src/modular/div_by_2.rs
+++ b/src/modular/div_by_2.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "alloc")]
-use crate::{BoxedUint, ConstantTimeSelect};
-use crate::{Odd, Uint};
+use crate::{BoxedUint, Integer};
+use crate::{Limb, Odd, Uint};
 
 pub(crate) const fn div_by_2<const LIMBS: usize>(
     a: &Uint<LIMBS>,
@@ -10,38 +10,33 @@ pub(crate) const fn div_by_2<const LIMBS: usize>(
     // Two possibilities:
     // - if `a` is even, we can just divide by 2;
     // - if `a` is odd, we divide `(a + modulus)` by 2.
-    // To stay within the modulus we open the parentheses turning it into `a / 2 + modulus / 2 + 1`
-    // ("+1" because both `a` and `modulus` are odd, we lose 0.5 in each integer division).
-    // This will not overflow, so we can just use wrapping operations.
 
     // Note that this also works if `a` is a Montgomery representation modulo `modulus`
     // of some integer `x`.
     // If `b + b = a mod modulus` it means that `y + y = x mod modulus` where `y` is the integer
     // whose Montgomery representation is `b`.
 
-    let (half, is_odd) = a.shr1_with_carry();
-    let half_modulus = modulus.0.shr1();
-
-    let if_even = half;
-    let if_odd = half
-        .wrapping_add(&half_modulus)
-        .wrapping_add(&Uint::<LIMBS>::ONE);
-
-    Uint::<LIMBS>::select(&if_even, &if_odd, is_odd)
+    let is_odd = a.is_odd();
+    let (if_odd, carry) = a.adc(&modulus.0, Limb::ZERO);
+    let carry = Limb::select(Limb::ZERO, carry, is_odd);
+    Uint::<LIMBS>::select(a, &if_odd, is_odd)
+        .shr1()
+        .set_bit(Uint::<LIMBS>::BITS - 1, carry.is_nonzero())
 }
 
 #[cfg(feature = "alloc")]
 pub(crate) fn div_by_2_boxed(a: &BoxedUint, modulus: &Odd<BoxedUint>) -> BoxedUint {
+    let mut result = a.clone();
+    div_by_2_boxed_assign(&mut result, modulus);
+    result
+}
+
+#[cfg(feature = "alloc")]
+pub(crate) fn div_by_2_boxed_assign(a: &mut BoxedUint, modulus: &Odd<BoxedUint>) {
     debug_assert_eq!(a.bits_precision(), modulus.bits_precision());
 
-    let (mut half, is_odd) = a.shr1_with_carry();
-    let half_modulus = modulus.shr1();
-
-    let if_odd = half
-        .wrapping_add(&half_modulus)
-        .wrapping_add(&BoxedUint::one_with_precision(a.bits_precision()));
-
-    half.ct_assign(&if_odd, is_odd);
-
-    half
+    let is_odd = a.is_odd();
+    let carry = a.conditional_adc_assign(modulus, is_odd);
+    a.shr1_assign();
+    a.set_bit(a.bits_precision() - 1, carry);
 }

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -15,6 +15,7 @@ use super::{
     reduction::montgomery_reduction,
 };
 use crate::{Concat, ConstChoice, Limb, Monty, NonZero, Odd, Split, Uint, Word};
+use mul::DynMontyMultiplier;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 /// Parameters to efficiently go to/from the Montgomery form for an odd modulus provided at runtime.
@@ -271,6 +272,7 @@ impl<const LIMBS: usize> Retrieve for MontyForm<LIMBS> {
 impl<const LIMBS: usize> Monty for MontyForm<LIMBS> {
     type Integer = Uint<LIMBS>;
     type Params = MontyParams<LIMBS>;
+    type Multiplier<'a> = DynMontyMultiplier<'a, LIMBS>;
 
     fn new_params_vartime(modulus: Odd<Self::Integer>) -> Self::Params {
         MontyParams::new_vartime(modulus)
@@ -294,6 +296,11 @@ impl<const LIMBS: usize> Monty for MontyForm<LIMBS> {
 
     fn as_montgomery(&self) -> &Self::Integer {
         &self.montgomery_form
+    }
+
+    fn copy_montgomery_from(&mut self, other: &Self) {
+        debug_assert_eq!(self.params, other.params);
+        self.montgomery_form = other.montgomery_form;
     }
 
     fn double(&self) -> Self {

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -55,7 +55,7 @@ where
 
         // The modular inverse should always exist, because it was ensured odd above, which also ensures it's non-zero
         let inv_mod = modulus
-            .inv_mod2k(Word::BITS)
+            .inv_mod2k_vartime(Word::BITS)
             .expect("modular inverse should exist");
 
         let mod_neg_inv = Limb(Word::MIN.wrapping_sub(inv_mod.limbs[0].0));
@@ -90,7 +90,7 @@ impl<const LIMBS: usize> MontyParams<LIMBS> {
 
         // The modular inverse should always exist, because it was ensured odd above, which also ensures it's non-zero
         let inv_mod = modulus
-            .inv_mod2k_vartime(Word::BITS)
+            .inv_mod2k_full_vartime(Word::BITS)
             .expect("modular inverse should exist");
 
         let mod_neg_inv = Limb(Word::MIN.wrapping_sub(inv_mod.limbs[0].0));

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -14,7 +14,7 @@ use super::{
     div_by_2::div_by_2,
     reduction::montgomery_reduction,
 };
-use crate::{Concat, Limb, Monty, NonZero, Odd, Split, Uint, Word};
+use crate::{Concat, ConstChoice, Limb, Monty, NonZero, Odd, Split, Uint, Word};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 /// Parameters to efficiently go to/from the Montgomery form for an odd modulus provided at runtime.
@@ -41,7 +41,7 @@ where
     Uint<WIDE_LIMBS>: Split<Output = Uint<LIMBS>>,
 {
     /// Instantiates a new set of `MontyParams` representing the given odd `modulus`.
-    pub fn new(modulus: Odd<Uint<LIMBS>>) -> Self {
+    pub const fn new(modulus: Odd<Uint<LIMBS>>) -> Self {
         // `R mod modulus` where `R = 2^BITS`.
         // Represents 1 in Montgomery form.
         let one = Uint::MAX.rem(modulus.as_nz_ref()).wrapping_add(&Uint::ONE);
@@ -55,12 +55,15 @@ where
 
         // The modular inverse should always exist, because it was ensured odd above, which also ensures it's non-zero
         let inv_mod = modulus
+            .as_ref()
             .inv_mod2k_vartime(Word::BITS)
             .expect("modular inverse should exist");
 
         let mod_neg_inv = Limb(Word::MIN.wrapping_sub(inv_mod.limbs[0].0));
 
-        let mod_leading_zeros = modulus.as_ref().leading_zeros().min(Word::BITS - 1);
+        let mod_leading_zeros = modulus.as_ref().leading_zeros();
+        let mod_leading_zeros = ConstChoice::from_u32_lt(mod_leading_zeros, Word::BITS - 1)
+            .select_u32(Word::BITS - 1, mod_leading_zeros);
 
         // `R^3 mod modulus`, used for inversion in Montgomery form.
         let r3 = montgomery_reduction(&r2.square_wide(), &modulus, mod_neg_inv);
@@ -78,7 +81,7 @@ where
 
 impl<const LIMBS: usize> MontyParams<LIMBS> {
     /// Instantiates a new set of `MontyParams` representing the given odd `modulus`.
-    pub fn new_vartime(modulus: Odd<Uint<LIMBS>>) -> Self {
+    pub const fn new_vartime(modulus: Odd<Uint<LIMBS>>) -> Self {
         // `R mod modulus` where `R = 2^BITS`.
         // Represents 1 in Montgomery form.
         let one = Uint::MAX
@@ -90,12 +93,18 @@ impl<const LIMBS: usize> MontyParams<LIMBS> {
 
         // The modular inverse should always exist, because it was ensured odd above, which also ensures it's non-zero
         let inv_mod = modulus
+            .as_ref()
             .inv_mod2k_full_vartime(Word::BITS)
             .expect("modular inverse should exist");
 
         let mod_neg_inv = Limb(Word::MIN.wrapping_sub(inv_mod.limbs[0].0));
 
-        let mod_leading_zeros = modulus.as_ref().leading_zeros_vartime().min(Word::BITS - 1);
+        let mod_leading_zeros = modulus.as_ref().leading_zeros_vartime();
+        let mod_leading_zeros = if mod_leading_zeros < Word::BITS - 1 {
+            mod_leading_zeros
+        } else {
+            Word::BITS - 1
+        };
 
         // `R^3 mod modulus`, used for inversion in Montgomery form.
         let r3 = montgomery_reduction(&r2.square_wide(), &modulus, mod_neg_inv);

--- a/src/modular/monty_form/mul.rs
+++ b/src/modular/monty_form/mul.rs
@@ -2,8 +2,11 @@
 
 use super::MontyForm;
 use crate::{
-    Square, SquareAssign,
-    modular::mul::{mul_montgomery_form, square_montgomery_form},
+    MontyMultiplier, Square, SquareAssign,
+    modular::{
+        MontyParams,
+        mul::{mul_montgomery_form, square_montgomery_form},
+    },
 };
 use core::ops::{Mul, MulAssign};
 
@@ -86,5 +89,36 @@ impl<const LIMBS: usize> Square for MontyForm<LIMBS> {
 impl<const LIMBS: usize> SquareAssign for MontyForm<LIMBS> {
     fn square_assign(&mut self) {
         *self = self.square()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DynMontyMultiplier<'a, const LIMBS: usize>(&'a MontyParams<LIMBS>);
+
+impl<'a, const LIMBS: usize> From<&'a MontyParams<LIMBS>> for DynMontyMultiplier<'a, LIMBS> {
+    fn from(source: &'a MontyParams<LIMBS>) -> Self {
+        Self(source)
+    }
+}
+
+impl<'a, const LIMBS: usize> MontyMultiplier<'a> for DynMontyMultiplier<'a, LIMBS> {
+    type Monty = MontyForm<LIMBS>;
+
+    /// Performs a Montgomery multiplication, assigning a fully reduced result to `lhs`.
+    fn mul_assign(&mut self, lhs: &mut Self::Monty, rhs: &Self::Monty) {
+        let product = mul_montgomery_form(
+            &lhs.montgomery_form,
+            &rhs.montgomery_form,
+            &self.0.modulus,
+            self.0.mod_neg_inv,
+        );
+        lhs.montgomery_form = product;
+    }
+
+    /// Performs a Montgomery squaring, assigning a fully reduced result to `lhs`.
+    fn square_assign(&mut self, lhs: &mut Self::Monty) {
+        let product =
+            square_montgomery_form(&lhs.montgomery_form, &self.0.modulus, self.0.mod_neg_inv);
+        lhs.montgomery_form = product;
     }
 }

--- a/src/modular/reduction.rs
+++ b/src/modular/reduction.rs
@@ -3,7 +3,7 @@
 use crate::{Limb, Odd, Uint};
 
 #[cfg(feature = "alloc")]
-use {crate::BoxedUint, subtle::Choice};
+use crate::BoxedUint;
 
 /// Algorithm 14.32 in Handbook of Applied Cryptography <https://cacr.uwaterloo.ca/hac/about/chap14.pdf>
 #[inline(always)]
@@ -84,15 +84,11 @@ pub(crate) fn montgomery_reduction_boxed_mut(
     let (lower, upper) = x.limbs.split_at_mut(modulus.nlimbs());
     let meta_carry = montgomery_reduction_inner(upper, lower, &modulus.limbs, mod_neg_inv);
 
+    // Division is simply taking the upper half of the limbs
+    // Final reduction (at this point, the value is at most 2 * modulus,
+    // so `meta_carry` is either 0 or 1)
     out.limbs.copy_from_slice(upper);
-    let borrow = out.sbb_assign(modulus, Limb::ZERO);
-
-    // The new `borrow = Word::MAX` iff `carry == 0` and `borrow == Word::MAX`.
-    let borrow = Limb((!meta_carry.0.wrapping_neg()) & borrow.0);
-
-    // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
-    // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the modulus.
-    out.conditional_adc_assign(modulus, Choice::from((borrow.0 & 1) as u8));
+    out.sub_assign_mod_with_carry(meta_carry, modulus, modulus);
 }
 
 /// Algorithm 14.32 in Handbook of Applied Cryptography <https://cacr.uwaterloo.ca/hac/about/chap14.pdf>

--- a/src/modular/safegcd/boxed.rs
+++ b/src/modular/safegcd/boxed.rs
@@ -310,6 +310,9 @@ impl BoxedUnsatInt {
     /// Convert to a `BoxedUint` of the given precision.
     #[allow(trivial_numeric_casts)]
     fn to_uint(&self, mut bits_precision: u32) -> BoxedUint {
+        // Shorten to the required value after conversion.
+        let shorten = bits_precision == 32;
+
         // The current Bernstein-Yang implementation is natively 64-bit on all targets
         if bits_precision == 32 {
             bits_precision = 64;
@@ -334,7 +337,12 @@ impl BoxedUnsatInt {
             ret.as_words_mut()
         );
 
-        ret
+        if shorten {
+            debug_assert!(ret.bits_vartime() <= 32);
+            ret.shorten(32)
+        } else {
+            ret
+        }
     }
 
     /// Conditionally add the given value to this one depending on the given [`Choice`].

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -61,7 +61,13 @@ pub(crate) const fn mac(a: Word, b: Word, c: Word, carry: Word) -> (Word, Word) 
     let a = a as WideWord;
     let b = b as WideWord;
     let c = c as WideWord;
-    let carry = carry as WideWord;
-    let ret = a + (b * c) + carry;
-    (ret as Word, (ret >> Word::BITS) as Word)
+    let ret = a + (b * c);
+    let (lo, hi) = (ret as Word, (ret >> Word::BITS) as Word);
+
+    let (lo, c) = lo.overflowing_add(carry);
+
+    // Even if all the arguments are `Word::MAX` we can't overflow `hi`.
+    let hi = hi.wrapping_add(c as Word);
+
+    (lo, hi)
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -898,6 +898,12 @@ pub trait Monty:
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
     fn div_by_2(&self) -> Self;
 
+    /// Performs division by 2 inplace, that is finds `x` such that `x + x = self`
+    /// and writes it into `self`.
+    fn div_by_2_assign(&mut self) {
+        *self = self.div_by_2()
+    }
+
     /// Calculate the sum of products of pairs `(a, b)` in `products`.
     ///
     /// This method is variable time only with the value of the modulus.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -870,6 +870,9 @@ pub trait Monty:
     /// The original integer type.
     type Integer: Integer<Monty = Self>;
 
+    /// Prepared Montgomery multiplier for tight loops.
+    type Multiplier<'a>: Debug + Clone + MontyMultiplier<'a, Monty = Self>;
+
     /// The precomputed data needed for this representation.
     type Params: 'static + Clone + Debug + Eq + Sized + Send + Sync;
 
@@ -892,6 +895,10 @@ pub trait Monty:
     /// Access the value in Montgomery form.
     fn as_montgomery(&self) -> &Self::Integer;
 
+    /// Copy the Montgomery representation from `other` into `self`.
+    /// NOTE: the parameters remain unchanged.
+    fn copy_montgomery_from(&mut self, other: &Self);
+
     /// Performs doubling, returning `self + self`.
     fn double(&self) -> Self;
 
@@ -912,4 +919,22 @@ pub trait Monty:
     /// This method will panic if `products` is empty. All terms must be associated with equivalent
     /// Montgomery parameters.
     fn lincomb_vartime(products: &[(&Self, &Self)]) -> Self;
+}
+
+/// Prepared Montgomery multiplier for tight loops.
+///
+/// Allows one to perform inplace multiplication without allocations
+/// (important for the `BoxedUint` case).
+///
+/// NOTE: You will be operating with Montgomery represntations directly,
+/// make sure they all correspond to the same set of parameters.
+pub trait MontyMultiplier<'a>: From<&'a <Self::Monty as Monty>::Params> {
+    /// The associated Montgomery-representation integer.
+    type Monty: Monty;
+
+    /// Performs a Montgomery multiplication, assigning a fully reduced result to `lhs`.
+    fn mul_assign(&mut self, lhs: &mut Self::Monty, rhs: &Self::Monty);
+
+    /// Performs a Montgomery squaring, assigning a fully reduced result to `lhs`.
+    fn square_assign(&mut self, lhs: &mut Self::Monty);
 }

--- a/src/uint/boxed/inv_mod.rs
+++ b/src/uint/boxed/inv_mod.rs
@@ -13,13 +13,77 @@ impl BoxedUint {
     }
 
     /// Computes 1/`self` mod `2^k`.
+    /// This method is variable w.r.t. `self` and `k`.
     ///
     /// If the inverse does not exist (`k > 0` and `self` is even),
     /// returns `Choice::FALSE` as the second element of the tuple,
     /// otherwise returns `Choice::TRUE`.
-    pub(crate) fn inv_mod2k(&self, k: u32) -> (Self, Choice) {
+    pub(crate) fn inv_mod2k_full_vartime(&self, k: u32) -> (Self, Choice) {
         let mut x = Self::zero_with_precision(self.bits_precision()); // keeps `x` during iterations
         let mut b = Self::one_with_precision(self.bits_precision()); // keeps `b_i` during iterations
+
+        // The inverse exists either if `k` is 0 or if `self` is odd.
+        if k != 0 && !bool::from(self.is_odd()) {
+            return (x, Choice::from(0));
+        }
+
+        for i in 0..k {
+            // X_i = b_i mod 2
+            let x_i = b.limbs[0].0 & 1;
+            // b_{i+1} = (b_i - a * X_i) / 2
+            if x_i != 0 {
+                b.wrapping_sub_assign(self);
+            }
+            b.shr1_assign();
+            // Store the X_i bit in the result (x = x | (1 << X_i))
+            x.set_bit_vartime(i, x_i != 0);
+        }
+
+        (x, Choice::from(1))
+    }
+
+    /// Computes 1/`self` mod `2^k`.
+    /// This method is constant-time w.r.t. `self` but not `k`.
+    ///
+    /// If the inverse does not exist (`k > 0` and `self` is even),
+    /// returns `Choice::FALSE` as the second element of the tuple,
+    /// otherwise returns `Choice::TRUE`.
+    pub fn inv_mod2k_vartime(&self, k: u32) -> (Self, Choice) {
+        let mut x = Self::zero_with_precision(self.bits_precision()); // keeps `x` during iterations
+        let mut b = Self::one_with_precision(self.bits_precision()); // keeps `b_i` during iterations
+        // Additional temporary storage we will need.
+        let mut b_opt = Self::zero_with_precision(self.bits_precision());
+
+        // The inverse exists either if `k` is 0 or if `self` is odd.
+        let is_some = k.ct_eq(&0) | self.is_odd();
+
+        for i in 0..k {
+            // X_i = b_i mod 2
+            let x_i = b.limbs[0].0 & 1;
+            let x_i_choice = Choice::from(x_i as u8);
+            // b_{i+1} = (b_i - a * X_i) / 2
+            b_opt.as_words_mut().copy_from_slice(b.as_words());
+            b_opt.wrapping_sub_assign(self);
+            b.ct_assign(&b_opt, x_i_choice);
+            b.shr1_assign();
+
+            // Store the X_i bit in the result (x = x | (1 << X_i))
+            x.set_bit(i, x_i_choice);
+        }
+
+        (x, is_some)
+    }
+
+    /// Computes 1/`self` mod `2^k`.
+    ///
+    /// If the inverse does not exist (`k > 0` and `self` is even),
+    /// returns `Choice::FALSE` as the second element of the tuple,
+    /// otherwise returns `Choice::TRUE`.
+    pub fn inv_mod2k(&self, k: u32) -> (Self, Choice) {
+        let mut x = Self::zero_with_precision(self.bits_precision()); // keeps `x` during iterations
+        let mut b = Self::one_with_precision(self.bits_precision()); // keeps `b_i` during iterations
+        // Additional temporary storage we will need.
+        let mut b_opt = Self::zero_with_precision(self.bits_precision());
 
         // The inverse exists either if `k` is 0 or if `self` is odd.
         let is_some = k.ct_eq(&0) | self.is_odd();
@@ -33,7 +97,10 @@ impl BoxedUint {
             let x_i = b.limbs[0].0 & 1;
             let x_i_choice = Choice::from(x_i as u8);
             // b_{i+1} = (b_i - a * X_i) / 2
-            b = Self::ct_select(&b, &b.wrapping_sub(self), x_i_choice).shr1();
+            b_opt.as_words_mut().copy_from_slice(b.as_words());
+            b_opt.wrapping_sub_assign(self);
+            b.ct_assign(&b_opt, x_i_choice);
+            b.shr1_assign();
 
             // Store the X_i bit in the result (x = x | (1 << X_i))
             // Don't change the result in dummy iterations.

--- a/src/uint/boxed/shr.rs
+++ b/src/uint/boxed/shr.rs
@@ -128,13 +128,6 @@ impl BoxedUint {
         success.map(|_| result)
     }
 
-    /// Computes `self >> 1` in constant-time, returning a true [`Choice`]
-    /// if the least significant bit was set, and a false [`Choice::FALSE`] otherwise.
-    pub(crate) fn shr1_with_carry(&self) -> (Self, Choice) {
-        let carry = self.limbs[0].0 & 1;
-        (self.shr1(), Choice::from(carry as u8))
-    }
-
     /// Computes `self >> 1` in constant-time.
     pub(crate) fn shr1(&self) -> Self {
         let mut ret = self.clone();

--- a/src/uint/boxed/sub.rs
+++ b/src/uint/boxed/sub.rs
@@ -27,6 +27,11 @@ impl BoxedUint {
         borrow
     }
 
+    /// Perform wrapping subtraction inplace, discarding overflow.
+    pub(crate) fn wrapping_sub_assign(&mut self, rhs: &Self) {
+        self.sbb_assign(rhs, Limb::ZERO);
+    }
+
     /// Perform wrapping subtraction, discarding overflow.
     pub fn wrapping_sub(&self, rhs: &Self) -> Self {
         self.sbb(rhs, Limb::ZERO).0

--- a/tests/boxed_monty_form.rs
+++ b/tests/boxed_monty_form.rs
@@ -10,6 +10,7 @@ use crypto_bigint::{
     modular::{BoxedMontyForm, BoxedMontyParams},
 };
 use num_bigint::BigUint;
+use num_integer::Integer as _;
 use num_modular::ModularUnaryOps;
 use proptest::prelude::*;
 use std::cmp::Ordering;
@@ -152,5 +153,26 @@ proptest! {
         let expected = a_bi.modpow(&b_bi, &n_bi);
 
         prop_assert_eq!(retrieve_biguint(&actual), expected);
+    }
+
+    #[test]
+    fn div_by_2(a in monty_form()) {
+        let actual = a.div_by_2();
+        let mut actual_inplace = a.clone();
+        actual_inplace.div_by_2_assign();
+
+        let p = a.params().modulus();
+        let a_bi = retrieve_biguint(&a);
+        let p_bi = to_biguint(&p);
+
+        let expected = if a_bi.is_odd() {
+            (a_bi + p_bi) >> 1
+        }
+        else {
+            a_bi >> 1
+        };
+
+        prop_assert_eq!(&retrieve_biguint(&actual), &expected);
+        prop_assert_eq!(&retrieve_biguint(&actual_inplace), &expected);
     }
 }


### PR DESCRIPTION
Trying to figure out massive slowdowns `crypto-primes` experiences for boxed uints (up to 4x). Could be the reason of the slowdowns in `RSA` as well. 

Public changes:
- Added `Monty::div_by_2_assign()` (with a blanket impl).
- Added `BoxedUint::inv_mod2k_vartime()`. 
- Made `BoxedUint::inv_mod2k()` public. 
- Added `Monty::Multiplier` associated type and `Monty::copy_montgomery_from()` to assist with tight loops (specifically, Lucas test in `crypto-primes`). 
- Cleaned up AMM, added comments and references, and reduced the size of the internal buffer to N from 2N. Also made it `const fn`. Closes #782

**Note:** the multiplier for `Uint` is called `DynMontyMultiplier`. Not happy with the name, but we already have `MontyMultiplier` as a trait, and it clashes.

**Note:** the exact way MontyMultiplier is exposed and the naming I'm not sure about, also not sure how hazmat do we want to make them. Potentially AMM can be exposed too, but it would be good to wrap the results in some struct that will propagate the "reduction level". Not for this PR, I need to finalize the minimum viable solution.

Fixes:
- Fixed a bug in `BoxedUnsatInt::to_uint()` which created a 64-bit number instead of a 32-bit one on 32-bit targets

Internal:
- Added tests for `BoxedUint::inv_mod2k()` and `inv_mod2k_vartime()`. 
- Removed allocations inside the loop in `BoxedUint::inv_mod2k()`.
- Used  and `inv_mod2k_vartime()` in `BoxedMontyParams::new_vartime()` and `new()` - since it's only vartime in the `k`, which is fixed.
- `new_vartime()` can be made even faster (~15% for Uint, 25% for Boxed) if we make a variant of `inv_mod2k` that is vartime in both arguments. Currently added in the commit as `inv_mod2k_full_vartime()` (crate-private). **Can be removed if that's too much detail.**
- Removed an unnecessary allocation in Add/SubAssign of `BoxedMontgomeryForm`.

Performance notes:
- `BoxedUint::div_by_2()` uses `div_by_2_assign()` because it is faster and does not allocate. 
- `Uint::div_by_2()` uses the same approach, gets rid of one addition and one `shr1()`, so it is marginally faster (~10%).  
- As expected, because of `inv_mod2k_vartime()` usage `MontyParams::new/_vartime()` became massively faster (~10x for Uint, ~15x for Boxed, 4096 bits). 
- I tried using AMM in `Uint`, but it leads to performance degradation for smaller uints (U256). So for now we'll keep the status quo with `Uint` using multiply + reduce. Worth investigating later.
