### PR TITLE
Make `random_bits_core` platform independent

### DIFF
--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -121,6 +121,27 @@ fn bench_random(c: &mut Criterion) {
     });
 }
 
+fn bench_random_bits(c: &mut Criterion) {
+    let mut group = c.benchmark_group("random_bits");
+
+    let mut rng = make_rng();
+    group.bench_function("random_bits, U256, full", |b| {
+        b.iter(|| black_box(U256::random_bits(&mut rng, U256::BITS)));
+    });
+
+    group.bench_function("random_bits, U256, bounded", |b| {
+        b.iter(|| black_box(U256::random_bits(&mut rng, 219)));
+    });
+
+    group.bench_function("random_bits, U2048, full", |b| {
+        b.iter(|| black_box(U2048::random_bits(&mut rng, U2048::BITS)));
+    });
+
+    group.bench_function("random_bits, U2048, bounded", |b| {
+        b.iter(|| black_box(U2048::random_bits(&mut rng, 1947)));
+    });
+}
+
 fn bench_mul(c: &mut Criterion) {
     let mut group = c.benchmark_group("wrapping ops");
 
@@ -493,6 +514,7 @@ fn bench_sqrt(c: &mut Criterion) {
 criterion_group!(
     benches,
     bench_random,
+    bench_random_bits,
     bench_mul,
     bench_division,
     bench_gcd,

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -176,9 +176,9 @@ mod tests {
         "0F6760A48F9B887CB2FB0D3281E2A6E67746A55FBAD8C037B585F767A79A3B6C"
     ]);
 
-    /// Construct 4-sequential `rng`, i.e.,
+    /// Construct a 4-sequential `rng`, i.e., an `rng` such that
     /// `rng.fill_bytes(&mut buffer[..x]); rng.fill_bytes(&mut buffer[x..])` will construct the
-    /// same `buffer`, regardless the choice of `x` in `0..buffer.len()`.
+    /// same `buffer`, for `x` any in `0..buffer.len()` that is `0 mod 4`.
     fn get_four_sequential_rng() -> ChaCha8Rng {
         ChaCha8Rng::seed_from_u64(0)
     }

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -20,6 +20,12 @@ impl<const LIMBS: usize> Random for Uint<LIMBS> {
 /// Fill the given limbs slice with random bits.
 ///
 /// NOTE: Assumes that the limbs in the given slice are zeroed!
+///
+/// When combined with a platform-independent "sequential" `rng`, this function acts
+/// platform-independent and deterministic. We consider an RNG "sequential" when
+/// `rng.fill_bytes(&mut buffer[..x]); rng.fill_bytes(&mut buffer[x..])` will construct the same
+/// `buffer`, regardless the choice of `x` in `0..buffer.len()`.
+/// Note that the `TryRngCore` trait does _not_ require this behaviour from `rng`.
 pub(crate) fn random_bits_core<R: TryRngCore + ?Sized>(
     rng: &mut R,
     zeroed_limbs: &mut [Limb],

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -160,8 +160,8 @@ where
 mod tests {
     use crate::uint::rand::random_bits_core;
     use crate::{Limb, NonZero, RandomBits, RandomMod, Uint, U1024, U256};
-    use rand_chacha::{ChaCha20Core, ChaCha20Rng};
     use rand_chacha::ChaCha8Rng;
+    use rand_chacha::{ChaCha20Core, ChaCha20Rng};
     use rand_core::{RngCore, SeedableRng};
 
     #[test]

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -159,7 +159,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::uint::rand::random_bits_core;
-    use crate::{Limb, NonZero, RandomBits, RandomMod, Uint, U1024, U256};
+    use crate::{Limb, NonZero, RandomBits, RandomMod, U1024, U256, Uint};
     use rand_chacha::ChaCha8Rng;
     use rand_chacha::{ChaCha20Core, ChaCha20Rng};
     use rand_core::{RngCore, SeedableRng};
@@ -262,7 +262,9 @@ mod tests {
 
         assert_eq!(
             state,
-            [75, 121, 77, 111, 45, 9, 160, 230, 99, 38, 108, 225, 174, 126, 209, 8]
+            [
+                75, 121, 77, 111, 45, 9, 160, 230, 99, 38, 108, 225, 174, 126, 209, 8
+            ]
         );
     }
 }

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -39,12 +39,26 @@ pub(crate) fn random_bits_core<R: TryRngCore + ?Sized>(
     for i in 0..nonzero_limbs - 1 {
         rng.try_fill_bytes(&mut buffer)
             .map_err(RandomBitsError::RandCore)?;
-        zeroed_limbs[i] = Limb(Word::from_be_bytes(buffer));
+        zeroed_limbs[i] = Limb(Word::from_le_bytes(buffer));
     }
 
-    rng.try_fill_bytes(&mut buffer)
+    // This algorithm should sample the same number of random bytes, regardless of the pointer width
+    // of the target platform. To this end, special attention has to be paid to the case where
+    // bit_length - 1 < 32 mod 64. Bit strings of that size can be represented using `2X+1` 32-bit
+    // words or `X+1` 64-bit words. Note that 64*(X+1) - 32*(2X+1) = 32. Hence, if we sample full
+    // words only, a 64-bit platform will sample 32 bits more than a 32-bit platform. We prevent
+    // this by forcing both platforms to only sample 4 bytes for the last word in this case.
+    let slice = if partial_limb > 0 && partial_limb <= 32 {
+        // Note: we do not have to zeroize the second half of the buffer, as the mask will take
+        // care of this in the end.
+        &mut buffer[0..4]
+    } else {
+        buffer.as_mut_slice()
+    };
+
+    rng.try_fill_bytes(slice)
         .map_err(RandomBitsError::RandCore)?;
-    zeroed_limbs[nonzero_limbs - 1] = Limb(Word::from_be_bytes(buffer) & mask);
+    zeroed_limbs[nonzero_limbs - 1] = Limb(Word::from_le_bytes(buffer) & mask);
 
     Ok(())
 }
@@ -144,9 +158,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{Limb, NonZero, RandomBits, RandomMod, U256};
+    use crate::uint::rand::random_bits_core;
+    use crate::{Limb, NonZero, RandomBits, RandomMod, Uint, U1024, U256};
+    use rand_chacha::{ChaCha20Core, ChaCha20Rng};
     use rand_chacha::ChaCha8Rng;
-    use rand_core::SeedableRng;
+    use rand_core::{RngCore, SeedableRng};
 
     #[test]
     fn random_mod() {
@@ -218,5 +234,35 @@ mod tests {
             let res = U256::random_bits(&mut rng, bit_length);
             assert_eq!(res, U256::ZERO);
         }
+    }
+
+    /// Make sure the random_bits output is consistent across platforms
+    #[test]
+    fn random_bits_platform_independence() {
+        let zero_seed = [0u8; 32];
+        let mut rng = ChaCha20Rng::from(ChaCha20Core::from_seed(zero_seed));
+
+        let mut val = U1024::ZERO;
+        let bytes = val.as_limbs_mut().as_mut_slice();
+        random_bits_core(&mut rng, bytes, 989).expect("safe");
+
+        assert_eq!(
+            val,
+            Uint::from_be_hex(concat![
+                "000000001F0AE1AC45FB0A51281FED31D539D874B03371D5434EE69C7621B729",
+                "ED7AEE323E53C6126965E348A0290FCB0D082D737C97BA987A385155BEE7079F",
+                "8665EEB269B687C31CA11815F4B8436A374AD8B83FE024778D4857517C5941DA",
+                "C70D778BCCEF36A81AED8DA0B819D2BD28BD8653E56A5D40903DF1A0ADE0B876"
+            ])
+        );
+
+        // Test that the RNG is in the same state
+        let mut state = [0u8; 16];
+        rng.fill_bytes(&mut state);
+
+        assert_eq!(
+            state,
+            [75, 121, 77, 111, 45, 9, 160, 230, 99, 38, 108, 225, 174, 126, 209, 8]
+        );
     }
 }

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -167,22 +167,20 @@ mod tests {
     use crate::uint::rand::random_bits_core;
     use crate::{Limb, NonZero, Random, RandomBits, RandomMod, U256, U1024, Uint};
     use rand_chacha::ChaCha8Rng;
-    use rand_chacha::{ChaCha20Core, ChaCha20Rng};
     use rand_core::{RngCore, SeedableRng};
 
     const RANDOM_OUTPUT: U1024 = Uint::from_be_hex(concat![
-        "6F4D794B1F0AE1AC45FB0A51281FED31D539D874B03371D5434EE69C7621B729",
-        "ED7AEE323E53C6126965E348A0290FCB0D082D737C97BA987A385155BEE7079F",
-        "8665EEB269B687C31CA11815F4B8436A374AD8B83FE024778D4857517C5941DA",
-        "C70D778BCCEF36A81AED8DA0B819D2BD28BD8653E56A5D40903DF1A0ADE0B876"
+        "A484C4C693EECC47C3B919AE0D16DF2259CD1A8A9B8EA8E0862878227D4B40A3",
+        "C54302F2EB1E2F69E17653A37F1BCC44277FA208E6B31E08CDC4A23A7E88E660",
+        "EF781C7DD2D368BAD438539D6A2E923C8CAE14CB947EB0BDE10D666732024679",
+        "0F6760A48F9B887CB2FB0D3281E2A6E67746A55FBAD8C037B585F767A79A3B6C"
     ]);
 
     /// Construct 4-sequential `rng`, i.e.,
     /// `rng.fill_bytes(&mut buffer[..x]); rng.fill_bytes(&mut buffer[x..])` will construct the
     /// same `buffer`, regardless the choice of `x` in `0..buffer.len()`.
-    fn get_four_sequential_rng() -> ChaCha20Rng {
-        let zero_seed = [0u8; 32];
-        ChaCha20Rng::from(ChaCha20Core::from_seed(zero_seed))
+    fn get_four_sequential_rng() -> ChaCha8Rng {
+        ChaCha8Rng::seed_from_u64(0)
     }
 
     /// Make sure the random value constructed is consistent across platforms
@@ -285,7 +283,7 @@ mod tests {
         assert_eq!(
             state,
             [
-                75, 121, 77, 111, 45, 9, 160, 230, 99, 38, 108, 225, 174, 126, 209, 8
+                198, 196, 132, 164, 240, 211, 223, 12, 36, 189, 139, 48, 94, 1, 123, 253
             ]
         );
     }


### PR DESCRIPTION
In its current state, `random_bits_core` behaves differently on 32-bit and 64-bit targets in two ways:
1. The platforms order the randomly sampled bytes in a different order, generating different outputs.
2. For bit_length $\mod 64 \in [1, 32]$, the 64-bit platform samples four random bytes more than the 32-bit platform.
    a.  this means the state of the RNG after calling this function is platform-dependent. This makes it impossible to use this function as an rng-seed-to-integer map.

This patch introduces:
- benchmarks to gauge the performance of the `random_bits_core` function,
- a patch to the `random_bits_core` function, and
- a test ensuring the `random_bits_core` output and rng state after calling it are platform-independent.

On my local machine, the function's performance remains constant with this patch applied.