### PR TITLE
[0.6] Fixup assertion in `AddAssign` and `SubAssign` of `BoxedUint`

### DIFF
--- a/src/uint/boxed/add.rs
+++ b/src/uint/boxed/add.rs
@@ -16,7 +16,7 @@ impl BoxedUint {
     /// Panics if `rhs` has a larger precision than `self`.
     #[inline]
     pub fn adc_assign(&mut self, rhs: impl AsRef<[Limb]>, mut carry: Limb) -> Limb {
-        debug_assert!(self.bits_precision() <= (rhs.as_ref().len() as u32 * Limb::BITS));
+        debug_assert!(self.bits_precision() >= (rhs.as_ref().len() as u32 * Limb::BITS));
 
         for i in 0..self.nlimbs() {
             let (limb, b) = self.limbs[i].adc(*rhs.as_ref().get(i).unwrap_or(&Limb::ZERO), carry);
@@ -263,5 +263,12 @@ mod tests {
     fn checked_add_overflow() {
         let result = BoxedUint::max(Limb::BITS).checked_add(&BoxedUint::one());
         assert!(!bool::from(result.is_some()));
+    }
+
+    #[test]
+    fn add_assign() {
+        let mut h = BoxedUint::one().widen(1024);
+
+        h += BoxedUint::one();
     }
 }

--- a/src/uint/boxed/sub.rs
+++ b/src/uint/boxed/sub.rs
@@ -16,7 +16,7 @@ impl BoxedUint {
     /// Panics if `rhs` has a larger precision than `self`.
     #[inline(always)]
     pub fn sbb_assign(&mut self, rhs: impl AsRef<[Limb]>, mut borrow: Limb) -> Limb {
-        debug_assert!(self.bits_precision() <= (rhs.as_ref().len() as u32 * Limb::BITS));
+        debug_assert!(self.bits_precision() >= (rhs.as_ref().len() as u32 * Limb::BITS));
 
         for i in 0..self.nlimbs() {
             let (limb, b) = self.limbs[i].sbb(*rhs.as_ref().get(i).unwrap_or(&Limb::ZERO), borrow);
@@ -267,5 +267,11 @@ mod tests {
     fn checked_sub_overflow() {
         let result = BoxedUint::zero().checked_sub(&BoxedUint::one());
         assert!(!bool::from(result.is_some()));
+    }
+
+    #[test]
+    fn sub_assign() {
+        let mut h = BoxedUint::one().widen(1024);
+        h -= BoxedUint::one();
     }
 }


### PR DESCRIPTION
Backport of #785