### PR TITLE
Make Integer be Binary, LowerHex and UpperHex

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -349,6 +349,36 @@ mod tests {
         assert_eq!(hex, n.to_string());
     }
 
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn fmt_lower_hex() {
+        let n = I128::from_be_hex("AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
+        assert_eq!(format!("{n:x}"), "aaaaaaaabbbbbbbbccccccccdddddddd");
+        assert_eq!(format!("{n:#x}"), "0xaaaaaaaabbbbbbbbccccccccdddddddd");
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn fmt_upper_hex() {
+        let n = I128::from_be_hex("aaaaaaaabbbbbbbbccccccccdddddddd");
+        assert_eq!(format!("{n:X}"), "AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
+        assert_eq!(format!("{n:#X}"), "0xAAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn fmt_binary() {
+        let n = I128::from_be_hex("AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
+        assert_eq!(
+            format!("{n:b}"),
+            "10101010101010101010101010101010101110111011101110111011101110111100110011001100110011001100110011011101110111011101110111011101"
+        );
+        assert_eq!(
+            format!("{n:#b}"),
+            "0b10101010101010101010101010101010101110111011101110111011101110111100110011001100110011001100110011011101110111011101110111011101"
+        );
+    }
+
     #[test]
     fn conditional_select() {
         let a = I128::from_be_hex("00002222444466668888AAAACCCCEEEE");

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -160,6 +160,10 @@ impl fmt::Display for Limb {
 impl fmt::Binary for Limb {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "0b")?;
+        }
+
         write!(f, "{:0width$b}", &self.0, width = Self::BITS as usize)
     }
 }
@@ -167,6 +171,9 @@ impl fmt::Binary for Limb {
 impl fmt::LowerHex for Limb {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
         write!(f, "{:0width$x}", &self.0, width = Self::BYTES * 2)
     }
 }
@@ -174,6 +181,9 @@ impl fmt::LowerHex for Limb {
 impl fmt::UpperHex for Limb {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
         write!(f, "{:0width$X}", &self.0, width = Self::BYTES * 2)
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -116,6 +116,9 @@ pub trait Integer:
     + for<'a> DivAssign<&'a NonZero<Self>>
     + DivRemLimb
     + Eq
+    + fmt::LowerHex
+    + fmt::UpperHex
+    + fmt::Binary
     + From<u8>
     + From<u16>
     + From<u32>

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -307,8 +307,12 @@ impl<const LIMBS: usize> fmt::Debug for Uint<LIMBS> {
 
 impl<const LIMBS: usize> fmt::Binary for Uint<LIMBS> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "0b")?;
+        }
+
         for limb in self.limbs.iter().rev() {
-            fmt::Binary::fmt(limb, f)?;
+            write!(f, "{:0width$b}", &limb.0, width = Limb::BITS as usize)?;
         }
         Ok(())
     }
@@ -322,8 +326,11 @@ impl<const LIMBS: usize> fmt::Display for Uint<LIMBS> {
 
 impl<const LIMBS: usize> fmt::LowerHex for Uint<LIMBS> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
         for limb in self.limbs.iter().rev() {
-            fmt::LowerHex::fmt(limb, f)?;
+            write!(f, "{:0width$x}", &limb.0, width = Limb::BYTES * 2)?;
         }
         Ok(())
     }
@@ -331,8 +338,11 @@ impl<const LIMBS: usize> fmt::LowerHex for Uint<LIMBS> {
 
 impl<const LIMBS: usize> fmt::UpperHex for Uint<LIMBS> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
         for limb in self.limbs.iter().rev() {
-            fmt::UpperHex::fmt(limb, f)?;
+            write!(f, "{:0width$X}", &limb.0, width = Limb::BYTES * 2)?;
         }
         Ok(())
     }
@@ -521,6 +531,69 @@ mod tests {
         let hex = "AAAAAAAABBBBBBBB0CCCCCCCDDDDDDDD";
         let n = U128::from_be_hex(hex);
         assert_eq!(hex, n.to_string());
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn fmt_lower_hex() {
+        let n = U128::from_be_hex("AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
+        assert_eq!(format!("{n:x}"), "aaaaaaaabbbbbbbbccccccccdddddddd");
+        assert_eq!(format!("{n:#x}"), "0xaaaaaaaabbbbbbbbccccccccdddddddd");
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn fmt_lower_hex_from_trait() {
+        fn format_int<T: crate::Integer>(n: T) -> alloc::string::String {
+            format!("{n:x}")
+        }
+        let n = U128::from_be_hex("AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
+        assert_eq!(format_int(n), "aaaaaaaabbbbbbbbccccccccdddddddd");
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn fmt_upper_hex() {
+        let n = U128::from_be_hex("aaaaaaaabbbbbbbbccccccccdddddddd");
+        assert_eq!(format!("{n:X}"), "AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
+        assert_eq!(format!("{n:#X}"), "0xAAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn fmt_upper_hex_from_trait() {
+        fn format_int<T: crate::Integer>(n: T) -> alloc::string::String {
+            format!("{n:X}")
+        }
+        let n = U128::from_be_hex("aaaaaaaabbbbbbbbccccccccdddddddd");
+        assert_eq!(format_int(n), "AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn fmt_binary() {
+        let n = U128::from_be_hex("AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
+        assert_eq!(
+            format!("{n:b}"),
+            "10101010101010101010101010101010101110111011101110111011101110111100110011001100110011001100110011011101110111011101110111011101"
+        );
+        assert_eq!(
+            format!("{n:#b}"),
+            "0b10101010101010101010101010101010101110111011101110111011101110111100110011001100110011001100110011011101110111011101110111011101"
+        );
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn fmt_binary_from_trait() {
+        fn format_int<T: crate::Integer>(n: T) -> alloc::string::String {
+            format!("{n:b}")
+        }
+        let n = U128::from_be_hex("aaaaaaaabbbbbbbbccccccccdddddddd");
+        assert_eq!(
+            format_int(n),
+            "10101010101010101010101010101010101110111011101110111011101110111100110011001100110011001100110011011101110111011101110111011101"
+        );
     }
 
     #[test]

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -375,8 +375,12 @@ impl fmt::Binary for BoxedUint {
             return fmt::Binary::fmt(&Limb::ZERO, f);
         }
 
+        if f.alternate() {
+            write!(f, "0b")?;
+        }
+
         for limb in self.limbs.iter().rev() {
-            fmt::Binary::fmt(limb, f)?;
+            write!(f, "{:0width$b}", &limb.0, width = Limb::BITS as usize)?;
         }
         Ok(())
     }
@@ -388,8 +392,11 @@ impl fmt::LowerHex for BoxedUint {
             return fmt::LowerHex::fmt(&Limb::ZERO, f);
         }
 
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
         for limb in self.limbs.iter().rev() {
-            fmt::LowerHex::fmt(limb, f)?;
+            write!(f, "{:0width$x}", &limb.0, width = Limb::BYTES * 2)?;
         }
         Ok(())
     }
@@ -401,8 +408,11 @@ impl fmt::UpperHex for BoxedUint {
             return fmt::LowerHex::fmt(&Limb::ZERO, f);
         }
 
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
         for limb in self.limbs.iter().rev() {
-            fmt::UpperHex::fmt(limb, f)?;
+            write!(f, "{:0width$X}", &limb.0, width = Limb::BYTES * 2)?;
         }
         Ok(())
     }
@@ -420,5 +430,32 @@ mod tests {
         let uint = BoxedUint::from(Vec::from(words));
         assert_eq!(uint.nlimbs(), 4);
         assert_eq!(uint.as_words(), words);
+    }
+
+    #[test]
+    fn fmt_lower_hex() {
+        let n = BoxedUint::from_be_hex("AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD", 128).unwrap();
+        assert_eq!(format!("{n:x}"), "aaaaaaaabbbbbbbbccccccccdddddddd");
+        assert_eq!(format!("{n:#x}"), "0xaaaaaaaabbbbbbbbccccccccdddddddd");
+    }
+
+    #[test]
+    fn fmt_upper_hex() {
+        let n = BoxedUint::from_be_hex("aaaaaaaabbbbbbbbccccccccdddddddd", 128).unwrap();
+        assert_eq!(format!("{n:X}"), "AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
+        assert_eq!(format!("{n:#X}"), "0xAAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
+    }
+
+    #[test]
+    fn fmt_binary() {
+        let n = BoxedUint::from_be_hex("aaaaaaaabbbbbbbbccccccccdddddddd", 128).unwrap();
+        assert_eq!(
+            format!("{n:b}"),
+            "10101010101010101010101010101010101110111011101110111011101110111100110011001100110011001100110011011101110111011101110111011101"
+        );
+        assert_eq!(
+            format!("{n:#b}"),
+            "0b10101010101010101010101010101010101110111011101110111011101110111100110011001100110011001100110011011101110111011101110111011101"
+        );
     }
 }


### PR DESCRIPTION
As per the title, but also add support for the "alternate" formatting flag for Binary, LowerHex and UpperHex. And tests.

Question: is it at all useful to test that `Integer` has the bounds? Probably not eh?
