### PR TITLE
Rename `as_(limbs|words)_mut` => `as_mut_(limbs|words)`

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -109,8 +109,14 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 
     /// Borrow the inner limbs as a mutable array of [`Word`]s.
-    pub fn as_words_mut(&mut self) -> &mut [Word; LIMBS] {
-        self.0.as_words_mut()
+    pub fn as_mut_words(&mut self) -> &mut [Word; LIMBS] {
+        self.0.as_mut_words()
+    }
+
+    /// Borrow the inner limbs as a mutable slice of [`Word`]s.
+    #[deprecated(since = "0.7.0", note = "please use `as_mut_words` instead")]
+    pub fn as_words_mut(&mut self) -> &mut [Word] {
+        self.as_mut_words()
     }
 
     /// Borrow the limbs of this [`Int`].
@@ -119,8 +125,14 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 
     /// Borrow the limbs of this [`Int`] mutably.
-    pub const fn as_limbs_mut(&mut self) -> &mut [Limb; LIMBS] {
-        self.0.as_limbs_mut()
+    pub const fn as_mut_limbs(&mut self) -> &mut [Limb; LIMBS] {
+        self.0.as_mut_limbs()
+    }
+
+    /// Borrow the limbs of this [`Int`] mutably.
+    #[deprecated(since = "0.7.0", note = "please use `as_mut_limbs` instead")]
+    pub const fn as_limbs_mut(&mut self) -> &mut [Limb] {
+        self.as_mut_limbs()
     }
 
     /// Convert this [`Int`] into its inner limbs.
@@ -171,7 +183,7 @@ impl<const LIMBS: usize> AsRef<[Word; LIMBS]> for Int<LIMBS> {
 
 impl<const LIMBS: usize> AsMut<[Word; LIMBS]> for Int<LIMBS> {
     fn as_mut(&mut self) -> &mut [Word; LIMBS] {
-        self.as_words_mut()
+        self.as_mut_words()
     }
 }
 
@@ -183,7 +195,7 @@ impl<const LIMBS: usize> AsRef<[Limb]> for Int<LIMBS> {
 
 impl<const LIMBS: usize> AsMut<[Limb]> for Int<LIMBS> {
     fn as_mut(&mut self) -> &mut [Limb] {
-        self.as_limbs_mut()
+        self.as_mut_limbs()
     }
 }
 
@@ -313,7 +325,7 @@ mod tests {
     #[test]
     fn as_words_mut() {
         let mut n = I128::from_be_hex("AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
-        assert_eq!(n.as_words_mut(), &[0xCCCCCCCCDDDDDDDD, 0xAAAAAAAABBBBBBBB]);
+        assert_eq!(n.as_mut_words(), &[0xCCCCCCCCDDDDDDDD, 0xAAAAAAAABBBBBBBB]);
     }
 
     #[cfg(feature = "alloc")]

--- a/src/modular/boxed_monty_form/mul.rs
+++ b/src/modular/boxed_monty_form/mul.rs
@@ -156,7 +156,7 @@ impl<'a> BoxedMontyMultiplier<'a> {
 
         self.clear_product();
         almost_montgomery_mul_by_one(
-            self.product.as_limbs_mut(),
+            self.product.as_mut_limbs(),
             a.as_limbs(),
             self.modulus.as_limbs(),
             self.mod_neg_inv,
@@ -204,7 +204,7 @@ impl<'a> BoxedMontyMultiplier<'a> {
 
         self.clear_product();
         almost_montgomery_mul(
-            self.product.as_limbs_mut(),
+            self.product.as_mut_limbs(),
             a.as_limbs(),
             b.as_limbs(),
             self.modulus.as_limbs(),
@@ -236,7 +236,7 @@ impl<'a> BoxedMontyMultiplier<'a> {
         // TODO(tarcieri): optimized implementation
         self.clear_product();
         almost_montgomery_mul(
-            self.product.as_limbs_mut(),
+            self.product.as_mut_limbs(),
             a.as_limbs(),
             a.as_limbs(),
             self.modulus.as_limbs(),

--- a/src/modular/safegcd/boxed.rs
+++ b/src/modular/safegcd/boxed.rs
@@ -334,7 +334,7 @@ impl BoxedUnsatInt {
             &self.0,
             Word,
             Word::BITS as usize,
-            ret.as_words_mut()
+            ret.as_mut_words()
         );
 
         if shorten {

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -151,12 +151,18 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Borrow the inner limbs as a mutable array of [`Word`]s.
-    pub fn as_words_mut(&mut self) -> &mut [Word; LIMBS] {
+    pub const fn as_mut_words(&mut self) -> &mut [Word; LIMBS] {
         // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
         #[allow(unsafe_code)]
         unsafe {
             &mut *self.limbs.as_mut_ptr().cast()
         }
+    }
+
+    /// Borrow the inner limbs as a mutable slice of [`Word`]s.
+    #[deprecated(since = "0.7.0", note = "please use `as_mut_words` instead")]
+    pub const fn as_words_mut(&mut self) -> &mut [Word] {
+        self.as_mut_words()
     }
 
     /// Borrow the limbs of this [`Uint`].
@@ -165,8 +171,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Borrow the limbs of this [`Uint`] mutably.
-    pub const fn as_limbs_mut(&mut self) -> &mut [Limb; LIMBS] {
+    pub const fn as_mut_limbs(&mut self) -> &mut [Limb; LIMBS] {
         &mut self.limbs
+    }
+
+    /// Borrow the limbs of this [`Uint`] mutably.
+    #[deprecated(since = "0.7.0", note = "please use `as_mut_limbs` instead")]
+    pub const fn as_limbs_mut(&mut self) -> &mut [Limb] {
+        self.as_mut_limbs()
     }
 
     /// Convert this [`Uint`] into its inner limbs.
@@ -202,7 +214,7 @@ impl<const LIMBS: usize> AsRef<[Word; LIMBS]> for Uint<LIMBS> {
 
 impl<const LIMBS: usize> AsMut<[Word; LIMBS]> for Uint<LIMBS> {
     fn as_mut(&mut self) -> &mut [Word; LIMBS] {
-        self.as_words_mut()
+        self.as_mut_words()
     }
 }
 
@@ -214,7 +226,7 @@ impl<const LIMBS: usize> AsRef<[Limb]> for Uint<LIMBS> {
 
 impl<const LIMBS: usize> AsMut<[Limb]> for Uint<LIMBS> {
     fn as_mut(&mut self) -> &mut [Limb] {
-        self.as_limbs_mut()
+        self.as_mut_limbs()
     }
 }
 
@@ -497,7 +509,7 @@ mod tests {
     #[test]
     fn as_words_mut() {
         let mut n = U128::from_be_hex("AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
-        assert_eq!(n.as_words_mut(), &[0xCCCCCCCCDDDDDDDD, 0xAAAAAAAABBBBBBBB]);
+        assert_eq!(n.as_mut_words(), &[0xCCCCCCCCDDDDDDDD, 0xAAAAAAAABBBBBBBB]);
     }
 
     #[cfg(feature = "alloc")]

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -142,12 +142,18 @@ impl BoxedUint {
     }
 
     /// Borrow the inner limbs as a mutable slice of [`Word`]s.
-    pub fn as_words_mut(&mut self) -> &mut [Word] {
+    pub fn as_mut_words(&mut self) -> &mut [Word] {
         // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
         #[allow(trivial_casts, unsafe_code)]
         unsafe {
             &mut *((&mut *self.limbs as *mut [Limb]) as *mut [Word])
         }
+    }
+
+    /// Borrow the inner limbs as a mutable slice of [`Word`]s.
+    #[deprecated(since = "0.7.0", note = "please use `as_mut_words` instead")]
+    pub fn as_words_mut(&mut self) -> &mut [Word] {
+        self.as_mut_words()
     }
 
     /// Borrow the limbs of this [`BoxedUint`].
@@ -156,8 +162,14 @@ impl BoxedUint {
     }
 
     /// Borrow the limbs of this [`BoxedUint`] mutably.
-    pub fn as_limbs_mut(&mut self) -> &mut [Limb] {
+    pub fn as_mut_limbs(&mut self) -> &mut [Limb] {
         self.limbs.as_mut()
+    }
+
+    /// Borrow the limbs of this [`BoxedUint`] mutably.
+    #[deprecated(since = "0.7.0", note = "please use `as_mut_limbs` instead")]
+    pub fn as_limbs_mut(&mut self) -> &mut [Limb] {
+        self.as_mut_limbs()
     }
 
     /// Convert this [`BoxedUint`] into its inner limbs.
@@ -276,7 +288,7 @@ impl AsRef<[Word]> for BoxedUint {
 
 impl AsMut<[Word]> for BoxedUint {
     fn as_mut(&mut self) -> &mut [Word] {
-        self.as_words_mut()
+        self.as_mut_words()
     }
 }
 
@@ -288,7 +300,7 @@ impl AsRef<[Limb]> for BoxedUint {
 
 impl AsMut<[Limb]> for BoxedUint {
     fn as_mut(&mut self) -> &mut [Limb] {
-        self.as_limbs_mut()
+        self.as_mut_limbs()
     }
 }
 

--- a/src/uint/boxed/inv_mod.rs
+++ b/src/uint/boxed/inv_mod.rs
@@ -62,7 +62,7 @@ impl BoxedUint {
             let x_i = b.limbs[0].0 & 1;
             let x_i_choice = Choice::from(x_i as u8);
             // b_{i+1} = (b_i - a * X_i) / 2
-            b_opt.as_words_mut().copy_from_slice(b.as_words());
+            b_opt.as_mut_words().copy_from_slice(b.as_words());
             b_opt.wrapping_sub_assign(self);
             b.ct_assign(&b_opt, x_i_choice);
             b.shr1_assign();
@@ -97,7 +97,7 @@ impl BoxedUint {
             let x_i = b.limbs[0].0 & 1;
             let x_i_choice = Choice::from(x_i as u8);
             // b_{i+1} = (b_i - a * X_i) / 2
-            b_opt.as_words_mut().copy_from_slice(b.as_words());
+            b_opt.as_mut_words().copy_from_slice(b.as_words());
             b_opt.wrapping_sub_assign(self);
             b.ct_assign(&b_opt, x_i_choice);
             b.shr1_assign();

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -202,7 +202,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     #[cfg(feature = "alloc")]
     pub fn to_string_radix_vartime(&self, radix: u32) -> String {
         let mut buf = *self;
-        radix_encode_limbs_mut_to_string(radix, buf.as_limbs_mut())
+        radix_encode_limbs_mut_to_string(radix, buf.as_mut_limbs())
     }
 }
 

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -269,7 +269,7 @@ mod tests {
 
         let bit_length = 989;
         let mut val = U1024::ZERO;
-        random_bits_core(&mut rng, val.as_limbs_mut(), bit_length).expect("safe");
+        random_bits_core(&mut rng, val.as_mut_limbs(), bit_length).expect("safe");
 
         assert_eq!(
             val,
@@ -298,8 +298,8 @@ mod tests {
             let mut rng = get_four_sequential_rng();
             let mut first = U1024::ZERO;
             let mut second = U1024::ZERO;
-            random_bits_core(&mut rng, first.as_limbs_mut(), bit_length).expect("safe");
-            random_bits_core(&mut rng, second.as_limbs_mut(), U1024::BITS - bit_length)
+            random_bits_core(&mut rng, first.as_mut_limbs(), bit_length).expect("safe");
+            random_bits_core(&mut rng, second.as_mut_limbs(), U1024::BITS - bit_length)
                 .expect("safe");
             assert_eq!(second.shl(bit_length).bitor(&first), RANDOM_OUTPUT);
         }


### PR DESCRIPTION
This better follows Rust conventions like `as_mut_slice`, where the ordering is like Rust's `mut T`.

The old names are retained, but deprecated.