### PR TITLE
Keep `BoxedMontyParams` in an `Arc`

### DIFF
--- a/src/modular/boxed_monty_form/add.rs
+++ b/src/modular/boxed_monty_form/add.rs
@@ -11,7 +11,7 @@ impl BoxedMontyForm {
         Self {
             montgomery_form: self
                 .montgomery_form
-                .add_mod(&rhs.montgomery_form, &self.params.modulus),
+                .add_mod(&rhs.montgomery_form, self.params.modulus()),
             params: self.params.clone(),
         }
     }
@@ -19,7 +19,7 @@ impl BoxedMontyForm {
     /// Double `self`.
     pub fn double(&self) -> Self {
         Self {
-            montgomery_form: self.montgomery_form.double_mod(&self.params.modulus),
+            montgomery_form: self.montgomery_form.double_mod(self.params.modulus()),
             params: self.params.clone(),
         }
     }
@@ -59,7 +59,7 @@ impl AddAssign<&BoxedMontyForm> for BoxedMontyForm {
     fn add_assign(&mut self, rhs: &BoxedMontyForm) {
         debug_assert_eq!(self.params, rhs.params);
         self.montgomery_form
-            .add_mod_assign(&rhs.montgomery_form, &self.params.modulus);
+            .add_mod_assign(&rhs.montgomery_form, self.params.modulus());
     }
 }
 

--- a/src/modular/boxed_monty_form/inv.rs
+++ b/src/modular/boxed_monty_form/inv.rs
@@ -5,7 +5,6 @@ use crate::{
     Invert, Inverter, PrecomputeInverter, PrecomputeInverterWithAdjuster,
     modular::BoxedSafeGcdInverter,
 };
-use alloc::sync::Arc;
 use core::fmt;
 use subtle::CtOption;
 
@@ -45,7 +44,7 @@ impl PrecomputeInverter for BoxedMontyParams {
     fn precompute_inverter(&self) -> BoxedMontyFormInverter {
         BoxedMontyFormInverter {
             inverter: self.modulus.precompute_inverter_with_adjuster(&self.r2),
-            params: self.clone().into(),
+            params: self.clone(),
         }
     }
 }
@@ -56,7 +55,7 @@ pub struct BoxedMontyFormInverter {
     inverter: BoxedSafeGcdInverter,
 
     /// Residue parameters.
-    params: Arc<BoxedMontyParams>,
+    params: BoxedMontyParams,
 }
 
 impl Inverter for BoxedMontyFormInverter {

--- a/src/modular/boxed_monty_form/inv.rs
+++ b/src/modular/boxed_monty_form/inv.rs
@@ -43,7 +43,7 @@ impl PrecomputeInverter for BoxedMontyParams {
 
     fn precompute_inverter(&self) -> BoxedMontyFormInverter {
         BoxedMontyFormInverter {
-            inverter: self.modulus.precompute_inverter_with_adjuster(&self.r2),
+            inverter: self.modulus().precompute_inverter_with_adjuster(self.r2()),
             params: self.clone(),
         }
     }

--- a/src/modular/boxed_monty_form/lincomb.rs
+++ b/src/modular/boxed_monty_form/lincomb.rs
@@ -17,9 +17,9 @@ impl BoxedMontyForm {
         Self {
             montgomery_form: lincomb_boxed_monty_form(
                 products,
-                &params.modulus,
-                params.mod_neg_inv,
-                params.mod_leading_zeros,
+                params.modulus(),
+                params.mod_neg_inv(),
+                params.mod_leading_zeros(),
             ),
             params: products[0].0.params.clone(),
         }

--- a/src/modular/boxed_monty_form/mul.rs
+++ b/src/modular/boxed_monty_form/mul.rs
@@ -106,7 +106,7 @@ pub struct BoxedMontyMultiplier<'a> {
 
 impl<'a> From<&'a BoxedMontyParams> for BoxedMontyMultiplier<'a> {
     fn from(params: &'a BoxedMontyParams) -> BoxedMontyMultiplier<'a> {
-        BoxedMontyMultiplier::new(&params.modulus, params.mod_neg_inv)
+        BoxedMontyMultiplier::new(params.modulus(), params.mod_neg_inv())
     }
 }
 

--- a/src/modular/boxed_monty_form/neg.rs
+++ b/src/modular/boxed_monty_form/neg.rs
@@ -7,7 +7,7 @@ impl BoxedMontyForm {
     /// Negates the number.
     pub fn neg(&self) -> Self {
         Self {
-            montgomery_form: self.montgomery_form.neg_mod(&self.params.modulus),
+            montgomery_form: self.montgomery_form.neg_mod(self.params.modulus()),
             params: self.params.clone(),
         }
     }

--- a/src/modular/boxed_monty_form/pow.rs
+++ b/src/modular/boxed_monty_form/pow.rs
@@ -22,14 +22,14 @@ impl BoxedMontyForm {
                 &self.montgomery_form,
                 exponent,
                 exponent_bits,
-                &self.params.modulus,
-                &self.params.one,
-                self.params.mod_neg_inv,
+                self.params.modulus(),
+                self.params.one(),
+                self.params.mod_neg_inv(),
             ),
             params: self.params.clone(),
         };
 
-        debug_assert!(ret.retrieve() < self.params.modulus);
+        debug_assert!(&ret.retrieve() < self.params.modulus());
         ret
     }
 }

--- a/src/modular/boxed_monty_form/sub.rs
+++ b/src/modular/boxed_monty_form/sub.rs
@@ -12,7 +12,7 @@ impl BoxedMontyForm {
         Self {
             montgomery_form: self
                 .montgomery_form
-                .sub_mod(&rhs.montgomery_form, &self.params.modulus),
+                .sub_mod(&rhs.montgomery_form, self.params.modulus()),
             params: self.params.clone(),
         }
     }
@@ -55,7 +55,7 @@ impl SubAssign<&BoxedMontyForm> for BoxedMontyForm {
         self.montgomery_form.sub_assign_mod_with_carry(
             Limb::ZERO,
             &rhs.montgomery_form,
-            &self.params.modulus,
+            self.params.modulus(),
         );
     }
 }


### PR DESCRIPTION
Fixes #804

Deref impl leaks the inner type. Should I make the conversion explicit instead?