### PR TITLE
Remove `Invert` trait bounds and add default `invert_vartime`

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -807,7 +807,7 @@ where
 }
 
 /// Constant-time inversion.
-pub trait Invert: Sized {
+pub trait Invert {
     /// Output of the inversion.
     type Output;
 
@@ -815,7 +815,9 @@ pub trait Invert: Sized {
     fn invert(&self) -> Self::Output;
 
     /// Computes the inverse in variable-time.
-    fn invert_vartime(&self) -> Self::Output;
+    fn invert_vartime(&self) -> Self::Output {
+        self.invert()
+    }
 }
 
 /// Widening multiply: returns a value with a number of limbs equal to the sum of the inputs.


### PR DESCRIPTION
These changes will allow the trait to act as a drop-in replacement for the `Invert` trait in the `elliptic-curve` crate.