### PR TITLE
Adopt `core` naming conventions for bigint methods

### DIFF
--- a/benches/int.rs
+++ b/benches/int.rs
@@ -60,54 +60,54 @@ fn bench_mul(c: &mut Criterion) {
     });
 }
 
-fn bench_widening_mul(c: &mut Criterion) {
+fn bench_concatenating_mul(c: &mut Criterion) {
     let mut rng = ChaChaRng::from_os_rng();
     let mut group = c.benchmark_group("widening ops");
 
-    group.bench_function("widening_mul, I128xI128", |b| {
+    group.bench_function("concatenating_mul, I128xI128", |b| {
         b.iter_batched(
             || (I128::random(&mut rng), I128::random(&mut rng)),
-            |(x, y)| black_box(x.widening_mul(&y)),
+            |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
         )
     });
 
-    group.bench_function("widening_mul, I256xI256", |b| {
+    group.bench_function("concatenating_mul, I256xI256", |b| {
         b.iter_batched(
             || (I256::random(&mut rng), I256::random(&mut rng)),
-            |(x, y)| black_box(x.widening_mul(&y)),
+            |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
         )
     });
 
-    group.bench_function("widening_mul, I512xI512", |b| {
+    group.bench_function("concatenating_mul, I512xI512", |b| {
         b.iter_batched(
             || (I512::random(&mut rng), I512::random(&mut rng)),
-            |(x, y)| black_box(x.widening_mul(&y)),
+            |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
         )
     });
 
-    group.bench_function("widening_mul, I1024xI1024", |b| {
+    group.bench_function("concatenating_mul, I1024xI1024", |b| {
         b.iter_batched(
             || (I1024::random(&mut rng), I1024::random(&mut rng)),
-            |(x, y)| black_box(x.widening_mul(&y)),
+            |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
         )
     });
 
-    group.bench_function("widening_mul, I2048xI2048", |b| {
+    group.bench_function("concatenating_mul, I2048xI2048", |b| {
         b.iter_batched(
             || (I2048::random(&mut rng), I2048::random(&mut rng)),
-            |(x, y)| black_box(x.widening_mul(&y)),
+            |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
         )
     });
 
-    group.bench_function("widening_mul, I4096xI4096", |b| {
+    group.bench_function("concatenating_mul, I4096xI4096", |b| {
         b.iter_batched(
             || (I4096::random(&mut rng), I4096::random(&mut rng)),
-            |(x, y)| black_box(x.widening_mul(&y)),
+            |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
         )
     });
@@ -341,7 +341,7 @@ fn bench_sub(c: &mut Criterion) {
 criterion_group!(
     benches,
     bench_mul,
-    bench_widening_mul,
+    bench_concatenating_mul,
     bench_div,
     bench_add,
     bench_sub,

--- a/benches/int.rs
+++ b/benches/int.rs
@@ -11,50 +11,50 @@ fn bench_mul(c: &mut Criterion) {
     let mut rng = ChaChaRng::from_os_rng();
     let mut group = c.benchmark_group("wrapping ops");
 
-    group.bench_function("split_mul, I128xI128", |b| {
+    group.bench_function("widening_mul, I128xI128", |b| {
         b.iter_batched(
             || (I256::random(&mut rng), I256::random(&mut rng)),
-            |(x, y)| black_box(x.split_mul(&y)),
+            |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
     });
 
-    group.bench_function("split_mul, I256xI256", |b| {
+    group.bench_function("widening_mul, I256xI256", |b| {
         b.iter_batched(
             || (I256::random(&mut rng), I256::random(&mut rng)),
-            |(x, y)| black_box(x.split_mul(&y)),
+            |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
     });
 
-    group.bench_function("split_mul, I512xI512", |b| {
+    group.bench_function("widening_mul, I512xI512", |b| {
         b.iter_batched(
             || (I512::random(&mut rng), I512::random(&mut rng)),
-            |(x, y)| black_box(x.split_mul(&y)),
+            |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
     });
 
-    group.bench_function("split_mul, I1024xI1024", |b| {
+    group.bench_function("widening_mul, I1024xI1024", |b| {
         b.iter_batched(
             || (I1024::random(&mut rng), I1024::random(&mut rng)),
-            |(x, y)| black_box(x.split_mul(&y)),
+            |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
     });
 
-    group.bench_function("split_mul, I2048xI2048", |b| {
+    group.bench_function("widening_mul, I2048xI2048", |b| {
         b.iter_batched(
             || (I2048::random(&mut rng), I2048::random(&mut rng)),
-            |(x, y)| black_box(x.split_mul(&y)),
+            |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
     });
 
-    group.bench_function("split_mul, I4096xI4096", |b| {
+    group.bench_function("widening_mul, I4096xI4096", |b| {
         b.iter_batched(
             || (I4096::random(&mut rng), I4096::random(&mut rng)),
-            |(x, y)| black_box(x.split_mul(&y)),
+            |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
     });

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -146,18 +146,18 @@ fn bench_mul(c: &mut Criterion) {
     let mut group = c.benchmark_group("wrapping ops");
 
     let mut rng = make_rng();
-    group.bench_function("split_mul, U256xU256", |b| {
+    group.bench_function("widening_mul, U256xU256", |b| {
         b.iter_batched(
             || (U256::random(&mut rng), U256::random(&mut rng)),
-            |(x, y)| black_box(x.split_mul(&y)),
+            |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
     });
 
-    group.bench_function("split_mul, U4096xU4096", |b| {
+    group.bench_function("widening_mul, U4096xU4096", |b| {
         b.iter_batched(
             || (U4096::random(&mut rng), U4096::random(&mut rng)),
-            |(x, y)| black_box(x.split_mul(&y)),
+            |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
     });

--- a/src/int/mul.rs
+++ b/src/int/mul.rs
@@ -34,7 +34,19 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 
     /// Multiply `self` by `rhs`, returning a concatenated "wide" result.
+    #[deprecated(since = "0.7.0", note = "please use `concatenating_mul` instead")]
     pub const fn widening_mul<const RHS_LIMBS: usize, const WIDE_LIMBS: usize>(
+        &self,
+        rhs: &Int<RHS_LIMBS>,
+    ) -> Int<WIDE_LIMBS>
+    where
+        Uint<LIMBS>: ConcatMixed<Uint<RHS_LIMBS>, MixedOutput = Uint<WIDE_LIMBS>>,
+    {
+        self.concatenating_mul(rhs)
+    }
+
+    /// Multiply `self` by `rhs`, returning a concatenated "wide" result.
+    pub const fn concatenating_mul<const RHS_LIMBS: usize, const WIDE_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
     ) -> Int<WIDE_LIMBS>
@@ -43,7 +55,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     {
         let (lhs_abs, lhs_sign) = self.abs_sign();
         let (rhs_abs, rhs_sign) = rhs.abs_sign();
-        let product_abs = lhs_abs.widening_mul(&rhs_abs);
+        let product_abs = lhs_abs.concatenating_mul(&rhs_abs);
         let product_sign = lhs_sign.xor(rhs_sign);
 
         // always fits
@@ -133,15 +145,15 @@ impl<const LIMBS: usize> MulAssign<&Checked<Int<LIMBS>>> for Checked<Int<LIMBS>>
 
 // TODO(lleoha): unfortunately we cannot satisfy this (yet!).
 // impl<const LIMBS: usize, const RHS_LIMBS: usize, const WIDE_LIMBS: usize>
-// WideningMul<Int<RHS_LIMBS>> for Int<LIMBS>
+// ConcatenatingMul<Int<RHS_LIMBS>> for Int<LIMBS>
 // where
 //     Uint<LIMBS>: ConcatMixed<Uint<RHS_LIMBS>, MixedOutput = Uint<WIDE_LIMBS>>,
 // {
 //     type Output = Int<WIDE_LIMBS>;
 //
 //     #[inline]
-//     fn widening_mul(&self, rhs: Int<RHS_LIMBS>) -> Self::Output {
-//         self.widening_mul(&rhs)
+//     fn concatenating_mul(&self, rhs: Int<RHS_LIMBS>) -> Self::Output {
+//         self.concatenating_mul(&rhs)
 //     }
 // }
 
@@ -243,70 +255,79 @@ mod tests {
     }
 
     #[test]
-    fn test_widening_mul() {
+    fn test_concatenating_mul() {
         assert_eq!(
-            I128::MIN.widening_mul(&I128::MIN),
+            I128::MIN.concatenating_mul(&I128::MIN),
             I256::from_be_hex("4000000000000000000000000000000000000000000000000000000000000000")
         );
         assert_eq!(
-            I128::MIN.widening_mul(&I128::MINUS_ONE),
+            I128::MIN.concatenating_mul(&I128::MINUS_ONE),
             I256::from_be_hex("0000000000000000000000000000000080000000000000000000000000000000")
         );
-        assert_eq!(I128::MIN.widening_mul(&I128::ZERO), I256::ZERO);
+        assert_eq!(I128::MIN.concatenating_mul(&I128::ZERO), I256::ZERO);
         assert_eq!(
-            I128::MIN.widening_mul(&I128::ONE),
+            I128::MIN.concatenating_mul(&I128::ONE),
             I256::from_be_hex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF80000000000000000000000000000000")
         );
         assert_eq!(
-            I128::MIN.widening_mul(&I128::MAX),
+            I128::MIN.concatenating_mul(&I128::MAX),
             I256::from_be_hex("C000000000000000000000000000000080000000000000000000000000000000")
         );
 
         assert_eq!(
-            I128::MINUS_ONE.widening_mul(&I128::MIN),
+            I128::MINUS_ONE.concatenating_mul(&I128::MIN),
             I256::from_be_hex("0000000000000000000000000000000080000000000000000000000000000000")
         );
-        assert_eq!(I128::MINUS_ONE.widening_mul(&I128::MINUS_ONE), I256::ONE);
-        assert_eq!(I128::MINUS_ONE.widening_mul(&I128::ZERO), I256::ZERO);
-        assert_eq!(I128::MINUS_ONE.widening_mul(&I128::ONE), I256::MINUS_ONE);
         assert_eq!(
-            I128::MINUS_ONE.widening_mul(&I128::MAX),
+            I128::MINUS_ONE.concatenating_mul(&I128::MINUS_ONE),
+            I256::ONE
+        );
+        assert_eq!(I128::MINUS_ONE.concatenating_mul(&I128::ZERO), I256::ZERO);
+        assert_eq!(
+            I128::MINUS_ONE.concatenating_mul(&I128::ONE),
+            I256::MINUS_ONE
+        );
+        assert_eq!(
+            I128::MINUS_ONE.concatenating_mul(&I128::MAX),
             I256::from_be_hex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF80000000000000000000000000000001")
         );
 
-        assert_eq!(I128::ZERO.widening_mul(&I128::MIN), I256::ZERO);
-        assert_eq!(I128::ZERO.widening_mul(&I128::MINUS_ONE), I256::ZERO);
-        assert_eq!(I128::ZERO.widening_mul(&I128::ZERO), I256::ZERO);
-        assert_eq!(I128::ZERO.widening_mul(&I128::ONE), I256::ZERO);
-        assert_eq!(I128::ZERO.widening_mul(&I128::MAX), I256::ZERO);
+        assert_eq!(I128::ZERO.concatenating_mul(&I128::MIN), I256::ZERO);
+        assert_eq!(I128::ZERO.concatenating_mul(&I128::MINUS_ONE), I256::ZERO);
+        assert_eq!(I128::ZERO.concatenating_mul(&I128::ZERO), I256::ZERO);
+        assert_eq!(I128::ZERO.concatenating_mul(&I128::ONE), I256::ZERO);
+        assert_eq!(I128::ZERO.concatenating_mul(&I128::MAX), I256::ZERO);
 
         assert_eq!(
-            I128::ONE.widening_mul(&I128::MIN),
+            I128::ONE.concatenating_mul(&I128::MIN),
             I256::from_be_hex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF80000000000000000000000000000000")
         );
-        assert_eq!(I128::ONE.widening_mul(&I128::MINUS_ONE), I256::MINUS_ONE);
-        assert_eq!(I128::ONE.widening_mul(&I128::ZERO), I256::ZERO);
-        assert_eq!(I128::ONE.widening_mul(&I128::ONE), I256::ONE);
         assert_eq!(
-            I128::ONE.widening_mul(&I128::MAX),
+            I128::ONE.concatenating_mul(&I128::MINUS_ONE),
+            I256::MINUS_ONE
+        );
+        assert_eq!(I128::ONE.concatenating_mul(&I128::ZERO), I256::ZERO);
+        assert_eq!(I128::ONE.concatenating_mul(&I128::ONE), I256::ONE);
+        assert_eq!(
+            I128::ONE.concatenating_mul(&I128::MAX),
             I256::from_be_hex("000000000000000000000000000000007FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
         );
 
         assert_eq!(
-            I128::MAX.widening_mul(&I128::MIN),
+            I128::MAX.concatenating_mul(&I128::MIN),
             I256::from_be_hex("C000000000000000000000000000000080000000000000000000000000000000")
         );
         assert_eq!(
-            I128::MAX.widening_mul(&I128::MINUS_ONE),
+            I128::MAX.concatenating_mul(&I128::MINUS_ONE),
             I256::from_be_hex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF80000000000000000000000000000001")
         );
-        assert_eq!(I128::MAX.widening_mul(&I128::ZERO), I256::ZERO);
+        assert_eq!(I128::MAX.concatenating_mul(&I128::ZERO), I256::ZERO);
         assert_eq!(
-            I128::MAX.widening_mul(&I128::ONE),
+            I128::MAX.concatenating_mul(&I128::ONE),
             I256::from_be_hex("000000000000000000000000000000007FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
         );
         assert_eq!(
-            I128::MAX.widening_mul(&I128::MAX),
+            I128::MAX.concatenating_mul(&I128::MAX),
             I256::from_be_hex("3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000001")
         );
     }

--- a/src/limb/add.rs
+++ b/src/limb/add.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Checked, CheckedAdd, Limb, Wrapping, WrappingAdd, Zero,
-    primitives::{adc, overflowing_add},
+    primitives::{carrying_add, overflowing_add},
 };
 use core::ops::{Add, AddAssign};
 use subtle::CtOption;
@@ -16,9 +16,15 @@ impl Limb {
     }
 
     /// Computes `self + rhs + carry`, returning the result along with the new carry.
-    #[inline(always)]
+    #[deprecated(since = "0.7.0", note = "please use `carrying_add` instead")]
     pub const fn adc(self, rhs: Limb, carry: Limb) -> (Limb, Limb) {
-        let (res, carry) = adc(self.0, rhs.0, carry.0);
+        self.carrying_add(rhs, carry)
+    }
+
+    /// Computes `self + rhs + carry`, returning the result along with the new carry.
+    #[inline(always)]
+    pub const fn carrying_add(self, rhs: Limb, carry: Limb) -> (Limb, Limb) {
+        let (res, carry) = carrying_add(self.0, rhs.0, carry.0);
         (Limb(res), Limb(carry))
     }
 
@@ -93,14 +99,14 @@ mod tests {
     use crate::{CheckedAdd, Limb};
 
     #[test]
-    fn adc_no_carry() {
+    fn carrying_add_no_carry() {
         let (res, carry) = Limb::ZERO.overflowing_add(Limb::ONE);
         assert_eq!(res, Limb::ONE);
         assert_eq!(carry, Limb::ZERO);
     }
 
     #[test]
-    fn adc_with_carry() {
+    fn carrying_add_with_carry() {
         let (res, carry) = Limb::MAX.overflowing_add(Limb::ONE);
         assert_eq!(res, Limb::ZERO);
         assert_eq!(carry, Limb::ONE);

--- a/src/limb/mul.rs
+++ b/src/limb/mul.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Checked, CheckedMul, Limb, Wrapping, Zero,
-    primitives::{mac, widening_mul},
+    primitives::{carrying_mul_add, widening_mul},
 };
 use core::ops::{Mul, MulAssign};
 use num_traits::WrappingMul;
@@ -10,9 +10,15 @@ use subtle::CtOption;
 
 impl Limb {
     /// Computes `self + (b * c) + carry`, returning the result along with the new carry.
-    #[inline(always)]
+    #[deprecated(since = "0.7.0", note = "please use `carrying_mul_add` instead")]
     pub const fn mac(self, b: Limb, c: Limb, carry: Limb) -> (Limb, Limb) {
-        let (res, carry) = mac(self.0, b.0, c.0, carry.0);
+        self.carrying_mul_add(b, c, carry)
+    }
+
+    /// Computes `self + (b * c) + carry`, returning the result along with the new carry.
+    #[inline(always)]
+    pub const fn carrying_mul_add(self, b: Limb, c: Limb, carry: Limb) -> (Limb, Limb) {
+        let (res, carry) = carrying_mul_add(self.0, b.0, c.0, carry.0);
         (Limb(res), Limb(carry))
     }
 

--- a/src/limb/mul.rs
+++ b/src/limb/mul.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Checked, CheckedMul, Limb, Wrapping, Zero,
-    primitives::{mac, mul_wide},
+    primitives::{mac, widening_mul},
 };
 use core::ops::{Mul, MulAssign};
 use num_traits::WrappingMul;
@@ -29,8 +29,8 @@ impl Limb {
     }
 
     /// Compute "wide" multiplication, with a product twice the size of the input.
-    pub(crate) const fn mul_wide(&self, rhs: Self) -> (Self, Self) {
-        let (lo, hi) = mul_wide(self.0, rhs.0);
+    pub(crate) const fn widening_mul(&self, rhs: Self) -> (Self, Self) {
+        let (lo, hi) = widening_mul(self.0, rhs.0);
         (Limb(lo), Limb(hi))
     }
 }
@@ -38,7 +38,7 @@ impl Limb {
 impl CheckedMul for Limb {
     #[inline]
     fn checked_mul(&self, rhs: &Self) -> CtOption<Self> {
-        let (lo, hi) = self.mul_wide(*rhs);
+        let (lo, hi) = self.widening_mul(*rhs);
         CtOption::new(lo, hi.is_zero())
     }
 }

--- a/src/limb/mul.rs
+++ b/src/limb/mul.rs
@@ -12,13 +12,13 @@ impl Limb {
     /// Computes `self + (b * c) + carry`, returning the result along with the new carry.
     #[deprecated(since = "0.7.0", note = "please use `carrying_mul_add` instead")]
     pub const fn mac(self, b: Limb, c: Limb, carry: Limb) -> (Limb, Limb) {
-        self.carrying_mul_add(b, c, carry)
+        b.carrying_mul_add(c, self, carry)
     }
 
-    /// Computes `self + (b * c) + carry`, returning the result along with the new carry.
+    /// Computes `(self * rhs) + addend + carry`, returning the result along with the new carry.
     #[inline(always)]
-    pub const fn carrying_mul_add(self, b: Limb, c: Limb, carry: Limb) -> (Limb, Limb) {
-        let (res, carry) = carrying_mul_add(self.0, b.0, c.0, carry.0);
+    pub const fn carrying_mul_add(self, rhs: Limb, addend: Limb, carry: Limb) -> (Limb, Limb) {
+        let (res, carry) = carrying_mul_add(self.0, rhs.0, addend.0, carry.0);
         (Limb(res), Limb(carry))
     }
 

--- a/src/modular.rs
+++ b/src/modular.rs
@@ -137,7 +137,7 @@ mod tests {
         // Reducing xR should return x
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
-        let product = x.split_mul(&Modulus2::ONE);
+        let product = x.widening_mul(&Modulus2::ONE);
         assert_eq!(
             montgomery_reduction::<{ Modulus2::LIMBS }>(
                 &product,
@@ -153,10 +153,10 @@ mod tests {
         // Reducing xR^2 should return xR
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
-        let product = x.split_mul(&Modulus2::R2);
+        let product = x.widening_mul(&Modulus2::R2);
 
         // Computing xR mod modulus without Montgomery reduction
-        let (lo, hi) = x.split_mul(&Modulus2::ONE);
+        let (lo, hi) = x.widening_mul(&Modulus2::ONE);
         let c = lo.concat(&hi);
         let red = c.rem_vartime(&NonZero::new(Modulus2::MODULUS.0.concat(&U256::ZERO)).unwrap());
         let (lo, hi) = red.split();

--- a/src/modular/boxed_monty_form/mul.rs
+++ b/src/modular/boxed_monty_form/mul.rs
@@ -378,7 +378,7 @@ const fn add_mul_carry(z: &mut [Limb], x: &[Limb], y: Limb) -> Limb {
     let mut c = Limb::ZERO;
     let mut i = 0;
     while i < n {
-        (z[i], c) = z[i].mac(x[i], y, c);
+        (z[i], c) = z[i].carrying_mul_add(x[i], y, c);
         i += 1;
     }
     c
@@ -392,13 +392,13 @@ const fn add_mul_carry_and_shift(z: &mut [Limb], x: &[Limb], y: Limb) -> Limb {
         panic!("Failed preconditions in `add_mul_carry_and_shift`");
     }
 
-    let (_, mut c) = z[0].mac(x[0], y, Limb::ZERO);
+    let (_, mut c) = z[0].carrying_mul_add(x[0], y, Limb::ZERO);
 
     let mut i = 1;
     let mut i1 = 0;
     // Help the compiler elide bound checking
     while i < n && i1 < n {
-        (z[i1], c) = z[i].mac(x[i], y, c);
+        (z[i1], c) = z[i].carrying_mul_add(x[i], y, c);
         i += 1;
         i1 += 1;
     }

--- a/src/modular/boxed_monty_form/mul.rs
+++ b/src/modular/boxed_monty_form/mul.rs
@@ -417,7 +417,7 @@ const fn conditional_sub(z: &mut [Limb], x: &[Limb], c: ConstChoice) {
     let mut borrow = Limb::ZERO;
     let mut i = 0;
     while i < n {
-        let (zi, new_borrow) = z[i].sbb(Limb(c.if_true_word(x[i].0)), borrow);
+        let (zi, new_borrow) = z[i].borrowing_sub(Limb(c.if_true_word(x[i].0)), borrow);
         z[i] = zi;
         borrow = new_borrow;
         i += 1;

--- a/src/modular/boxed_monty_form/mul.rs
+++ b/src/modular/boxed_monty_form/mul.rs
@@ -378,7 +378,7 @@ const fn add_mul_carry(z: &mut [Limb], x: &[Limb], y: Limb) -> Limb {
     let mut c = Limb::ZERO;
     let mut i = 0;
     while i < n {
-        (z[i], c) = z[i].carrying_mul_add(x[i], y, c);
+        (z[i], c) = x[i].carrying_mul_add(y, z[i], c);
         i += 1;
     }
     c
@@ -392,13 +392,13 @@ const fn add_mul_carry_and_shift(z: &mut [Limb], x: &[Limb], y: Limb) -> Limb {
         panic!("Failed preconditions in `add_mul_carry_and_shift`");
     }
 
-    let (_, mut c) = z[0].carrying_mul_add(x[0], y, Limb::ZERO);
+    let (_, mut c) = x[0].carrying_mul_add(y, z[0], Limb::ZERO);
 
     let mut i = 1;
     let mut i1 = 0;
     // Help the compiler elide bound checking
     while i < n && i1 < n {
-        (z[i1], c) = z[i].carrying_mul_add(x[i], y, c);
+        (z[i1], c) = x[i].carrying_mul_add(y, z[i], c);
         i += 1;
         i1 += 1;
     }

--- a/src/modular/boxed_monty_form/pow.rs
+++ b/src/modular/boxed_monty_form/pow.rs
@@ -125,8 +125,8 @@ fn pow_montgomery_form(
     // Now that we exited the loop, we need to reduce `z` at most twice
     // to bring it within `[0, modulus)`.
 
-    z.conditional_sbb_assign(modulus, !z.ct_lt(modulus));
-    z.conditional_sbb_assign(modulus, !z.ct_lt(modulus));
+    z.conditional_borrowing_sub_assign(modulus, !z.ct_lt(modulus));
+    z.conditional_borrowing_sub_assign(modulus, !z.ct_lt(modulus));
     debug_assert!(&z < modulus);
 
     z

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -97,7 +97,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     /// Internal helper function to convert to Montgomery form;
     /// this lets us cleanly wrap the constructors.
     const fn from_integer(integer: &Uint<LIMBS>) -> Self {
-        let product = integer.split_mul(&MOD::R2);
+        let product = integer.widening_mul(&MOD::R2);
         let montgomery_form =
             montgomery_reduction::<LIMBS>(&product, &MOD::MODULUS, MOD::MOD_NEG_INV);
 

--- a/src/modular/div_by_2.rs
+++ b/src/modular/div_by_2.rs
@@ -17,7 +17,7 @@ pub(crate) const fn div_by_2<const LIMBS: usize>(
     // whose Montgomery representation is `b`.
 
     let is_odd = a.is_odd();
-    let (if_odd, carry) = a.adc(&modulus.0, Limb::ZERO);
+    let (if_odd, carry) = a.carrying_add(&modulus.0, Limb::ZERO);
     let carry = Limb::select(Limb::ZERO, carry, is_odd);
     Uint::<LIMBS>::select(a, &if_odd, is_odd)
         .shr1()
@@ -36,7 +36,7 @@ pub(crate) fn div_by_2_boxed_assign(a: &mut BoxedUint, modulus: &Odd<BoxedUint>)
     debug_assert_eq!(a.bits_precision(), modulus.bits_precision());
 
     let is_odd = a.is_odd();
-    let carry = a.conditional_adc_assign(modulus, is_odd);
+    let carry = a.conditional_carrying_add_assign(modulus, is_odd);
     a.shr1_assign();
     a.set_bit(a.bits_precision() - 1, carry);
 }

--- a/src/modular/lincomb.rs
+++ b/src/modular/lincomb.rs
@@ -39,9 +39,9 @@ macro_rules! impl_longa_monty_lincomb {
 
                 let mut k = 0;
                 while k < $nlimbs {
-                    ($u[k], carry) = $u[k].carrying_mul_add(
-                        ai.as_montgomery().limbs[j],
+                    ($u[k], carry) = ai.as_montgomery().limbs[j].carrying_mul_add(
                         bi.as_montgomery().limbs[k],
+                        $u[k],
                         carry,
                     );
                     k += 1;
@@ -54,11 +54,11 @@ macro_rules! impl_longa_monty_lincomb {
 
             let q = $u[0].wrapping_mul($mod_neg_inv);
 
-            (_, carry) = $u[0].carrying_mul_add(q, $modulus[0], Limb::ZERO);
+            (_, carry) = q.carrying_mul_add($modulus[0], $u[0], Limb::ZERO);
 
             i = 1;
             while i < $nlimbs {
-                ($u[i - 1], carry) = $u[i].carrying_mul_add(q, $modulus[i], carry);
+                ($u[i - 1], carry) = q.carrying_mul_add($modulus[i], $u[i], carry);
                 i += 1;
             }
             ($u[$nlimbs - 1], carry) = hi.carrying_add(carry, Limb::ZERO);

--- a/src/modular/lincomb.rs
+++ b/src/modular/lincomb.rs
@@ -46,7 +46,7 @@ macro_rules! impl_longa_monty_lincomb {
                     );
                     k += 1;
                 }
-                (hi, carry) = hi.adc(carry, Limb::ZERO);
+                (hi, carry) = hi.carrying_add(carry, Limb::ZERO);
                 hi_carry = hi_carry.wrapping_add(carry);
 
                 i += 1;
@@ -61,7 +61,7 @@ macro_rules! impl_longa_monty_lincomb {
                 ($u[i - 1], carry) = $u[i].mac(q, $modulus[i], carry);
                 i += 1;
             }
-            ($u[$nlimbs - 1], carry) = hi.adc(carry, Limb::ZERO);
+            ($u[$nlimbs - 1], carry) = hi.carrying_add(carry, Limb::ZERO);
             hi_carry = hi_carry.wrapping_add(carry);
 
             j += 1;
@@ -162,7 +162,7 @@ pub fn lincomb_boxed_monty_form(
             let carry =
                 impl_longa_monty_lincomb!(window, buf.limbs, modulus.0.limbs, mod_neg_inv, nlimbs);
             buf.sub_assign_mod_with_carry(carry, &modulus.0, &modulus.0);
-            let carry = ret.adc_assign(&buf, Limb::ZERO);
+            let carry = ret.carrying_add_assign(&buf, Limb::ZERO);
             ret.sub_assign_mod_with_carry(carry, &modulus.0, &modulus.0);
             remain -= count;
         }

--- a/src/modular/lincomb.rs
+++ b/src/modular/lincomb.rs
@@ -39,7 +39,7 @@ macro_rules! impl_longa_monty_lincomb {
 
                 let mut k = 0;
                 while k < $nlimbs {
-                    ($u[k], carry) = $u[k].mac(
+                    ($u[k], carry) = $u[k].carrying_mul_add(
                         ai.as_montgomery().limbs[j],
                         bi.as_montgomery().limbs[k],
                         carry,
@@ -54,11 +54,11 @@ macro_rules! impl_longa_monty_lincomb {
 
             let q = $u[0].wrapping_mul($mod_neg_inv);
 
-            (_, carry) = $u[0].mac(q, $modulus[0], Limb::ZERO);
+            (_, carry) = $u[0].carrying_mul_add(q, $modulus[0], Limb::ZERO);
 
             i = 1;
             while i < $nlimbs {
-                ($u[i - 1], carry) = $u[i].mac(q, $modulus[i], carry);
+                ($u[i - 1], carry) = $u[i].carrying_mul_add(q, $modulus[i], carry);
                 i += 1;
             }
             ($u[$nlimbs - 1], carry) = hi.carrying_add(carry, Limb::ZERO);

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -191,7 +191,7 @@ pub struct MontyForm<const LIMBS: usize> {
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Instantiates a new `MontyForm` that represents this `integer` mod `MOD`.
     pub const fn new(integer: &Uint<LIMBS>, params: MontyParams<LIMBS>) -> Self {
-        let product = integer.split_mul(&params.r2);
+        let product = integer.widening_mul(&params.r2);
         let montgomery_form = montgomery_reduction(&product, &params.modulus, params.mod_neg_inv);
 
         Self {

--- a/src/modular/mul.rs
+++ b/src/modular/mul.rs
@@ -7,7 +7,7 @@ pub(crate) const fn mul_montgomery_form<const LIMBS: usize>(
     modulus: &Odd<Uint<LIMBS>>,
     mod_neg_inv: Limb,
 ) -> Uint<LIMBS> {
-    let product = a.split_mul(b);
+    let product = a.widening_mul(b);
     montgomery_reduction::<LIMBS>(&product, modulus, mod_neg_inv)
 }
 

--- a/src/modular/reduction.rs
+++ b/src/modular/reduction.rs
@@ -21,17 +21,17 @@ const fn montgomery_reduction_inner(
     while i < nlimbs {
         let u = lower[i].wrapping_mul(mod_neg_inv);
 
-        let (_, mut carry) = lower[i].mac(u, modulus[0], Limb::ZERO);
+        let (_, mut carry) = lower[i].carrying_mul_add(u, modulus[0], Limb::ZERO);
         let mut new_limb;
 
         let mut j = 1;
         while j < (nlimbs - i) {
-            (new_limb, carry) = lower[i + j].mac(u, modulus[j], carry);
+            (new_limb, carry) = lower[i + j].carrying_mul_add(u, modulus[j], carry);
             lower[i + j] = new_limb;
             j += 1;
         }
         while j < nlimbs {
-            (new_limb, carry) = upper[i + j - nlimbs].mac(u, modulus[j], carry);
+            (new_limb, carry) = upper[i + j - nlimbs].carrying_mul_add(u, modulus[j], carry);
             upper[i + j - nlimbs] = new_limb;
             j += 1;
         }

--- a/src/modular/reduction.rs
+++ b/src/modular/reduction.rs
@@ -21,17 +21,17 @@ const fn montgomery_reduction_inner(
     while i < nlimbs {
         let u = lower[i].wrapping_mul(mod_neg_inv);
 
-        let (_, mut carry) = lower[i].carrying_mul_add(u, modulus[0], Limb::ZERO);
+        let (_, mut carry) = u.carrying_mul_add(modulus[0], lower[i], Limb::ZERO);
         let mut new_limb;
 
         let mut j = 1;
         while j < (nlimbs - i) {
-            (new_limb, carry) = lower[i + j].carrying_mul_add(u, modulus[j], carry);
+            (new_limb, carry) = u.carrying_mul_add(modulus[j], lower[i + j], carry);
             lower[i + j] = new_limb;
             j += 1;
         }
         while j < nlimbs {
-            (new_limb, carry) = upper[i + j - nlimbs].carrying_mul_add(u, modulus[j], carry);
+            (new_limb, carry) = u.carrying_mul_add(modulus[j], upper[i + j - nlimbs], carry);
             upper[i + j - nlimbs] = new_limb;
             j += 1;
         }

--- a/src/modular/reduction.rs
+++ b/src/modular/reduction.rs
@@ -36,7 +36,7 @@ const fn montgomery_reduction_inner(
             j += 1;
         }
 
-        (new_sum, meta_carry) = upper[i].adc(carry, meta_carry);
+        (new_sum, meta_carry) = upper[i].carrying_add(carry, meta_carry);
         upper[i] = new_sum;
 
         i += 1;

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,12 +1,12 @@
 use crate::{WideWord, Word};
 
-/// Adds wide numbers represented by pairs of (most significant word, least significant word)
-/// and returns the result in the same format `(hi, lo)`.
+/// Adds wide numbers represented by pairs of (least significant word, most significant word)
+/// and returns the result in the same format `(lo, hi)`.
 #[inline(always)]
-pub(crate) const fn addhilo(x_hi: Word, x_lo: Word, y_hi: Word, y_lo: Word) -> (Word, Word) {
+pub(crate) const fn addhilo(x_lo: Word, x_hi: Word, y_lo: Word, y_hi: Word) -> (Word, Word) {
     let res = (((x_hi as WideWord) << Word::BITS) | (x_lo as WideWord))
         + (((y_hi as WideWord) << Word::BITS) | (y_lo as WideWord));
-    ((res >> Word::BITS) as Word, res as Word)
+    (res as Word, (res >> Word::BITS) as Word)
 }
 
 /// Computes `lhs + rhs + carry`, returning the result along with the new carry (0, 1, or 2).

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -19,7 +19,7 @@ pub(crate) const fn addhilo(x_hi: Word, x_lo: Word, y_hi: Word, y_lo: Word) -> (
 
 /// Computes `lhs + rhs + carry`, returning the result along with the new carry (0, 1, or 2).
 #[inline(always)]
-pub const fn adc(lhs: Word, rhs: Word, carry: Word) -> (Word, Word) {
+pub const fn carrying_add(lhs: Word, rhs: Word, carry: Word) -> (Word, Word) {
     // We could use `Word::overflowing_add()` here analogous to `overflowing_add()`,
     // but this version seems to produce a slightly better assembly.
     let a = lhs as WideWord;

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -57,7 +57,7 @@ pub const fn widening_mul(lhs: Word, rhs: Word) -> (Word, Word) {
 
 /// Computes `a + (b * c) + carry`, returning the result along with the new carry.
 #[inline(always)]
-pub(crate) const fn mac(a: Word, b: Word, c: Word, carry: Word) -> (Word, Word) {
+pub(crate) const fn carrying_mul_add(a: Word, b: Word, c: Word, carry: Word) -> (Word, Word) {
     let a = a as WideWord;
     let b = b as WideWord;
     let c = c as WideWord;

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -55,13 +55,18 @@ pub const fn widening_mul(lhs: Word, rhs: Word) -> (Word, Word) {
     (ret as Word, (ret >> Word::BITS) as Word)
 }
 
-/// Computes `a + (b * c) + carry`, returning the result along with the new carry.
+/// Computes `(lhs * rhs) + addend + carry`, returning the result along with the new carry.
 #[inline(always)]
-pub(crate) const fn carrying_mul_add(a: Word, b: Word, c: Word, carry: Word) -> (Word, Word) {
-    let a = a as WideWord;
-    let b = b as WideWord;
-    let c = c as WideWord;
-    let ret = a + (b * c);
+pub(crate) const fn carrying_mul_add(
+    lhs: Word,
+    rhs: Word,
+    addend: Word,
+    carry: Word,
+) -> (Word, Word) {
+    let lhs = lhs as WideWord;
+    let rhs = rhs as WideWord;
+    let addend = addend as WideWord;
+    let ret = (lhs * rhs) + addend;
     let (lo, hi) = (ret as Word, (ret >> Word::BITS) as Word);
 
     let (lo, c) = lo.overflowing_add(carry);

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -48,7 +48,7 @@ pub const fn borrowing_sub(lhs: Word, rhs: Word, borrow: Word) -> (Word, Word) {
 
 /// Computes `lhs * rhs`, returning the low and the high words of the result.
 #[inline(always)]
-pub const fn mul_wide(lhs: Word, rhs: Word) -> (Word, Word) {
+pub const fn widening_mul(lhs: Word, rhs: Word) -> (Word, Word) {
     let a = lhs as WideWord;
     let b = rhs as WideWord;
     let ret = a * b;

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -11,7 +11,7 @@ pub(crate) const fn addhilo(x_lo: Word, x_hi: Word, y_lo: Word, y_hi: Word) -> (
 
 /// Computes `lhs + rhs + carry`, returning the result along with the new carry (0, 1, or 2).
 #[inline(always)]
-pub const fn carrying_add(lhs: Word, rhs: Word, carry: Word) -> (Word, Word) {
+pub(crate) const fn carrying_add(lhs: Word, rhs: Word, carry: Word) -> (Word, Word) {
     // We could use `Word::overflowing_add()` here analogous to `overflowing_add()`,
     // but this version seems to produce a slightly better assembly.
     let a = lhs as WideWord;
@@ -23,14 +23,14 @@ pub const fn carrying_add(lhs: Word, rhs: Word, carry: Word) -> (Word, Word) {
 
 /// Computes `lhs + rhs`, returning the result along with the carry (0 or 1).
 #[inline(always)]
-pub const fn overflowing_add(lhs: Word, rhs: Word) -> (Word, Word) {
+pub(crate) const fn overflowing_add(lhs: Word, rhs: Word) -> (Word, Word) {
     let (res, carry) = lhs.overflowing_add(rhs);
     (res, carry as Word)
 }
 
 /// Computes `lhs - (rhs + borrow)`, returning the result along with the new borrow.
 #[inline(always)]
-pub const fn borrowing_sub(lhs: Word, rhs: Word, borrow: Word) -> (Word, Word) {
+pub(crate) const fn borrowing_sub(lhs: Word, rhs: Word, borrow: Word) -> (Word, Word) {
     let a = lhs as WideWord;
     let b = rhs as WideWord;
     let borrow = (borrow >> (Word::BITS - 1)) as WideWord;
@@ -40,7 +40,7 @@ pub const fn borrowing_sub(lhs: Word, rhs: Word, borrow: Word) -> (Word, Word) {
 
 /// Computes `lhs * rhs`, returning the low and the high words of the result.
 #[inline(always)]
-pub const fn widening_mul(lhs: Word, rhs: Word) -> (Word, Word) {
+pub(crate) const fn widening_mul(lhs: Word, rhs: Word) -> (Word, Word) {
     let a = lhs as WideWord;
     let b = rhs as WideWord;
     let ret = a * b;

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -36,9 +36,9 @@ pub const fn overflowing_add(lhs: Word, rhs: Word) -> (Word, Word) {
     (res, carry as Word)
 }
 
-/// Computes `self - (rhs + borrow)`, returning the result along with the new borrow.
+/// Computes `lhs - (rhs + borrow)`, returning the result along with the new borrow.
 #[inline(always)]
-pub const fn sbb(lhs: Word, rhs: Word, borrow: Word) -> (Word, Word) {
+pub const fn borrowing_sub(lhs: Word, rhs: Word, borrow: Word) -> (Word, Word) {
     let a = lhs as WideWord;
     let b = rhs as WideWord;
     let borrow = (borrow >> (Word::BITS - 1)) as WideWord;

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,13 +1,5 @@
 use crate::{WideWord, Word};
 
-/// Multiplies `x` and `y`, returning the most significant
-/// and the least significant words as `(hi, lo)`.
-#[inline(always)]
-pub(crate) const fn mulhilo(x: Word, y: Word) -> (Word, Word) {
-    let res = (x as WideWord) * (y as WideWord);
-    ((res >> Word::BITS) as Word, res as Word)
-}
-
 /// Adds wide numbers represented by pairs of (most significant word, least significant word)
 /// and returns the result in the same format `(hi, lo)`.
 #[inline(always)]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -843,12 +843,34 @@ pub trait Invert {
 }
 
 /// Widening multiply: returns a value with a number of limbs equal to the sum of the inputs.
+#[deprecated(since = "0.7.0", note = "please use `ConcatenatingMul` instead")]
 pub trait WideningMul<Rhs = Self>: Sized {
     /// Output of the widening multiplication.
     type Output: Integer;
 
     /// Perform widening multiplication.
     fn widening_mul(&self, rhs: Rhs) -> Self::Output;
+}
+
+#[allow(deprecated)]
+impl<T, Rhs> WideningMul<Rhs> for T
+where
+    T: ConcatenatingMul<Rhs>,
+{
+    type Output = <T as ConcatenatingMul<Rhs>>::Output;
+
+    fn widening_mul(&self, rhs: Rhs) -> Self::Output {
+        self.concatenating_mul(rhs)
+    }
+}
+
+/// Widening multiply: returns a value with a number of limbs equal to the sum of the inputs.
+pub trait ConcatenatingMul<Rhs = Self>: Sized {
+    /// Output of the widening multiplication.
+    type Output: Integer;
+
+    /// Perform widening multiplication.
+    fn concatenating_mul(&self, rhs: Rhs) -> Self::Output;
 }
 
 /// Left shifts, variable time in `shift`.

--- a/src/uint/add_mod.rs
+++ b/src/uint/add_mod.rs
@@ -7,7 +7,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Assumes `self + rhs` as unbounded integer is `< 2p`.
     pub const fn add_mod(&self, rhs: &Self, p: &Self) -> Self {
-        let (w, carry) = self.adc(rhs, Limb::ZERO);
+        let (w, carry) = self.carrying_add(rhs, Limb::ZERO);
 
         // Attempt to subtract the modulus, to ensure the result is in the field.
         let (w, borrow) = w.sbb(p, Limb::ZERO);
@@ -24,8 +24,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Assumes `self + rhs` as unbounded integer is `< 2p`.
     pub const fn add_mod_special(&self, rhs: &Self, c: Limb) -> Self {
-        // `Uint::adc` also works with a carry greater than 1.
-        let (out, carry) = self.adc(rhs, c);
+        // `Uint::carrying_add` also works with a carry greater than 1.
+        let (out, carry) = self.carrying_add(rhs, c);
 
         // If overflow occurred, then above addition of `c` already accounts
         // for the overflow. Otherwise, we need to subtract `c` again, which

--- a/src/uint/add_mod.rs
+++ b/src/uint/add_mod.rs
@@ -10,8 +10,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let (w, carry) = self.carrying_add(rhs, Limb::ZERO);
 
         // Attempt to subtract the modulus, to ensure the result is in the field.
-        let (w, borrow) = w.sbb(p, Limb::ZERO);
-        let (_, mask) = carry.sbb(Limb::ZERO, borrow);
+        let (w, borrow) = w.borrowing_sub(p, Limb::ZERO);
+        let (_, mask) = carry.borrowing_sub(Limb::ZERO, borrow);
 
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
@@ -41,8 +41,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let (w, carry) = self.overflowing_shl1();
 
         // Attempt to subtract the modulus, to ensure the result is in the field.
-        let (w, borrow) = w.sbb(p, Limb::ZERO);
-        let (_, mask) = carry.sbb(Limb::ZERO, borrow);
+        let (w, borrow) = w.borrowing_sub(p, Limb::ZERO);
+        let (_, mask) = carry.borrowing_sub(Limb::ZERO, borrow);
 
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the

--- a/src/uint/boxed/add_mod.rs
+++ b/src/uint/boxed/add_mod.rs
@@ -21,7 +21,7 @@ impl BoxedUint {
         debug_assert!(&*self < p);
         debug_assert!(rhs < p);
 
-        let carry = self.adc_assign(rhs, Limb::ZERO);
+        let carry = self.carrying_add_assign(rhs, Limb::ZERO);
 
         // Attempt to subtract the modulus, to ensure the result is in the field.
         let borrow = self.sbb_assign(p, Limb::ZERO);
@@ -30,7 +30,7 @@ impl BoxedUint {
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
         // modulus.
-        self.conditional_adc_assign(p, !borrow.is_zero());
+        self.conditional_carrying_add_assign(p, !borrow.is_zero());
     }
 
     /// Computes `self + self mod p`.
@@ -46,7 +46,7 @@ impl BoxedUint {
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
         // modulus.
-        w.conditional_adc_assign(p, !borrow.is_zero());
+        w.conditional_carrying_add_assign(p, !borrow.is_zero());
         w
     }
 }

--- a/src/uint/boxed/add_mod.rs
+++ b/src/uint/boxed/add_mod.rs
@@ -24,8 +24,8 @@ impl BoxedUint {
         let carry = self.carrying_add_assign(rhs, Limb::ZERO);
 
         // Attempt to subtract the modulus, to ensure the result is in the field.
-        let borrow = self.sbb_assign(p, Limb::ZERO);
-        let (_, borrow) = carry.sbb(Limb::ZERO, borrow);
+        let borrow = self.borrowing_sub_assign(p, Limb::ZERO);
+        let (_, borrow) = carry.borrowing_sub(Limb::ZERO, borrow);
 
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the
@@ -40,8 +40,8 @@ impl BoxedUint {
         let (mut w, carry) = self.overflowing_shl1();
 
         // Attempt to subtract the modulus, to ensure the result is in the field.
-        let borrow = w.sbb_assign(p, Limb::ZERO);
-        let (_, borrow) = carry.sbb(Limb::ZERO, borrow);
+        let borrow = w.borrowing_sub_assign(p, Limb::ZERO);
+        let (_, borrow) = carry.borrowing_sub(Limb::ZERO, borrow);
 
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the

--- a/src/uint/boxed/cmp.rs
+++ b/src/uint/boxed/cmp.rs
@@ -18,7 +18,7 @@ impl BoxedUint {
         loop {
             // TODO: investigate if directly comparing limbs is faster than performing a
             // subtraction between limbs
-            let (val, borrow) = self.limbs[i].sbb(rhs.limbs[i], Limb::ZERO);
+            let (val, borrow) = self.limbs[i].borrowing_sub(rhs.limbs[i], Limb::ZERO);
             if val.0 != 0 {
                 return if borrow.0 != 0 {
                     Ordering::Less
@@ -53,7 +53,7 @@ impl ConstantTimeEq for BoxedUint {
 impl ConstantTimeGreater for BoxedUint {
     #[inline]
     fn ct_gt(&self, other: &Self) -> Choice {
-        let (_, borrow) = other.sbb(self, Limb::ZERO);
+        let (_, borrow) = other.borrowing_sub(self, Limb::ZERO);
         ConstChoice::from_word_mask(borrow.0).into()
     }
 }
@@ -61,7 +61,7 @@ impl ConstantTimeGreater for BoxedUint {
 impl ConstantTimeLess for BoxedUint {
     #[inline]
     fn ct_lt(&self, other: &Self) -> Choice {
-        let (_, borrow) = self.sbb(other, Limb::ZERO);
+        let (_, borrow) = self.borrowing_sub(other, Limb::ZERO);
         ConstChoice::from_word_mask(borrow.0).into()
     }
 }

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -181,7 +181,7 @@ impl BoxedUint {
             let mut tmp;
             i = 0;
             while i <= xi {
-                (tmp, carry) = Limb::ZERO.mac(y[size - xi + i - 1], Limb(quo), carry);
+                (tmp, carry) = Limb::ZERO.carrying_mul_add(y[size - xi + i - 1], Limb(quo), carry);
                 (x[i], borrow) = x[i].borrowing_sub(tmp, borrow);
                 i += 1;
             }
@@ -485,7 +485,7 @@ pub(crate) fn div_rem_vartime_in_place(x: &mut [Limb], y: &mut [Limb]) {
             let mut borrow = Limb::ZERO;
             let mut tmp;
             for i in 0..yc {
-                (tmp, carry) = Limb::ZERO.mac(y[i], Limb(quo), carry);
+                (tmp, carry) = Limb::ZERO.carrying_mul_add(y[i], Limb(quo), carry);
                 (x[xi + i + 1 - yc], borrow) = x[xi + i + 1 - yc].borrowing_sub(tmp, borrow);
             }
             (_, borrow) = x_hi.borrowing_sub(carry, borrow);

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -182,10 +182,10 @@ impl BoxedUint {
             i = 0;
             while i <= xi {
                 (tmp, carry) = Limb::ZERO.mac(y[size - xi + i - 1], Limb(quo), carry);
-                (x[i], borrow) = x[i].sbb(tmp, borrow);
+                (x[i], borrow) = x[i].borrowing_sub(tmp, borrow);
                 i += 1;
             }
-            (_, borrow) = x_hi.sbb(carry, borrow);
+            (_, borrow) = x_hi.borrowing_sub(carry, borrow);
 
             // If the subtraction borrowed, then decrement q and add back the divisor
             // The probability of this being needed is very low, about 2/(Limb::MAX+1)
@@ -486,9 +486,9 @@ pub(crate) fn div_rem_vartime_in_place(x: &mut [Limb], y: &mut [Limb]) {
             let mut tmp;
             for i in 0..yc {
                 (tmp, carry) = Limb::ZERO.mac(y[i], Limb(quo), carry);
-                (x[xi + i + 1 - yc], borrow) = x[xi + i + 1 - yc].sbb(tmp, borrow);
+                (x[xi + i + 1 - yc], borrow) = x[xi + i + 1 - yc].borrowing_sub(tmp, borrow);
             }
-            (_, borrow) = x_hi.sbb(carry, borrow);
+            (_, borrow) = x_hi.borrowing_sub(carry, borrow);
             borrow
         };
 

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -181,7 +181,7 @@ impl BoxedUint {
             let mut tmp;
             i = 0;
             while i <= xi {
-                (tmp, carry) = Limb::ZERO.carrying_mul_add(y[size - xi + i - 1], Limb(quo), carry);
+                (tmp, carry) = y[size - xi + i - 1].carrying_mul_add(Limb(quo), carry, Limb::ZERO);
                 (x[i], borrow) = x[i].borrowing_sub(tmp, borrow);
                 i += 1;
             }
@@ -485,7 +485,7 @@ pub(crate) fn div_rem_vartime_in_place(x: &mut [Limb], y: &mut [Limb]) {
             let mut borrow = Limb::ZERO;
             let mut tmp;
             for i in 0..yc {
-                (tmp, carry) = Limb::ZERO.carrying_mul_add(y[i], Limb(quo), carry);
+                (tmp, carry) = y[i].carrying_mul_add(Limb(quo), carry, Limb::ZERO);
                 (x[xi + i + 1 - yc], borrow) = x[xi + i + 1 - yc].borrowing_sub(tmp, borrow);
             }
             (_, borrow) = x_hi.borrowing_sub(carry, borrow);

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -193,7 +193,7 @@ impl BoxedUint {
             carry = Limb::ZERO;
             i = 0;
             while i <= xi {
-                (x[i], carry) = x[i].adc(
+                (x[i], carry) = x[i].carrying_add(
                     Limb::select(Limb::ZERO, y[size - xi + i - 1], ct_borrow),
                     carry,
                 );
@@ -498,8 +498,8 @@ pub(crate) fn div_rem_vartime_in_place(x: &mut [Limb], y: &mut [Limb]) {
             let ct_borrow = ConstChoice::from_word_mask(borrow.0);
             let mut carry = Limb::ZERO;
             for i in 0..yc {
-                (x[xi + i + 1 - yc], carry) =
-                    x[xi + i + 1 - yc].adc(Limb::select(Limb::ZERO, y[i], ct_borrow), carry);
+                (x[xi + i + 1 - yc], carry) = x[xi + i + 1 - yc]
+                    .carrying_add(Limb::select(Limb::ZERO, y[i], ct_borrow), carry);
             }
             ct_borrow.select_word(quo, quo.wrapping_sub(1))
         };

--- a/src/uint/boxed/mul.rs
+++ b/src/uint/boxed/mul.rs
@@ -1,7 +1,7 @@
 //! [`BoxedUint`] multiplication operations.
 
 use crate::{
-    BoxedUint, CheckedMul, Limb, Resize, WideningMul, Wrapping, WrappingMul, Zero,
+    BoxedUint, CheckedMul, ConcatenatingMul, Limb, Resize, Wrapping, WrappingMul, Zero,
     uint::mul::{
         karatsuba::{KARATSUBA_MIN_STARTING_LIMBS, karatsuba_mul_limbs, karatsuba_square_limbs},
         mul_limbs, square_limbs,
@@ -126,20 +126,20 @@ impl MulAssign<&Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
     }
 }
 
-impl WideningMul for BoxedUint {
+impl ConcatenatingMul for BoxedUint {
     type Output = Self;
 
     #[inline]
-    fn widening_mul(&self, rhs: BoxedUint) -> Self {
+    fn concatenating_mul(&self, rhs: BoxedUint) -> Self {
         self.mul(&rhs)
     }
 }
 
-impl WideningMul<&BoxedUint> for BoxedUint {
+impl ConcatenatingMul<&BoxedUint> for BoxedUint {
     type Output = Self;
 
     #[inline]
-    fn widening_mul(&self, rhs: &BoxedUint) -> Self {
+    fn concatenating_mul(&self, rhs: &BoxedUint) -> Self {
         self.mul(rhs)
     }
 }

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -65,7 +65,7 @@ impl BoxedUint {
 
         let (lo, _) = {
             let rhs = carry.0.wrapping_sub(1) & c.0;
-            lo.sbb(&Self::from(rhs), Limb::ZERO)
+            lo.borrowing_sub(&Self::from(rhs), Limb::ZERO)
         };
 
         lo

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -137,7 +137,7 @@ mod tests {
                         assert!(c < **p, "not reduced: {} >= {} ", c, p);
 
                         let expected = {
-                            let (lo, hi) = a.split_mul(&b);
+                            let (lo, hi) = a.widening_mul(&b);
                             let mut prod = Uint::<{ 2 * $size }>::ZERO;
                             prod.limbs[..$size].clone_from_slice(&lo.limbs);
                             prod.limbs[$size..].clone_from_slice(&hi.limbs);

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -86,7 +86,7 @@ fn mac_by_limb(a: &BoxedUint, b: &BoxedUint, c: Limb, carry: Limb) -> (BoxedUint
     let mut carry = carry;
 
     for i in 0..a.nlimbs() {
-        let (n, c) = a.limbs[i].carrying_mul_add(b.limbs[i], c, carry);
+        let (n, c) = b.limbs[i].carrying_mul_add(c, a.limbs[i], carry);
         a.limbs[i] = n;
         carry = c;
     }

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -86,7 +86,7 @@ fn mac_by_limb(a: &BoxedUint, b: &BoxedUint, c: Limb, carry: Limb) -> (BoxedUint
     let mut carry = carry;
 
     for i in 0..a.nlimbs() {
-        let (n, c) = a.limbs[i].mac(b.limbs[i], c, carry);
+        let (n, c) = a.limbs[i].carrying_mul_add(b.limbs[i], c, carry);
         a.limbs[i] = n;
         carry = c;
     }

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -60,7 +60,7 @@ impl BoxedUint {
 
         let (lo, carry) = {
             let rhs = (carry.0 + 1) as WideWord * c.0 as WideWord;
-            lo.adc(&Self::from(rhs), Limb::ZERO)
+            lo.carrying_add(&Self::from(rhs), Limb::ZERO)
         };
 
         let (lo, _) = {

--- a/src/uint/boxed/neg_mod.rs
+++ b/src/uint/boxed/neg_mod.rs
@@ -9,7 +9,7 @@ impl BoxedUint {
     pub fn neg_mod(&self, p: &Self) -> Self {
         debug_assert_eq!(self.bits_precision(), p.bits_precision());
         let is_zero = self.is_zero();
-        let mut ret = p.sbb(self, Limb::ZERO).0;
+        let mut ret = p.borrowing_sub(self, Limb::ZERO).0;
 
         for i in 0..self.nlimbs() {
             // Set ret to 0 if the original value was 0, in which

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -37,7 +37,7 @@ impl BoxedUint {
                 j += 1;
             }
             let (q, _) = self.div_rem(&nz_x);
-            x.conditional_adc_assign(&q, x_nonzero);
+            x.conditional_carrying_add_assign(&q, x_nonzero);
             x.shr1_assign();
             i += 1;
         }

--- a/src/uint/boxed/sub_mod.rs
+++ b/src/uint/boxed/sub_mod.rs
@@ -12,7 +12,7 @@ impl BoxedUint {
         debug_assert!(self < p);
         debug_assert!(rhs < p);
 
-        let (mut out, borrow) = self.sbb(rhs, Limb::ZERO);
+        let (mut out, borrow) = self.borrowing_sub(rhs, Limb::ZERO);
 
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the modulus.
@@ -26,7 +26,7 @@ impl BoxedUint {
     pub(crate) fn sub_assign_mod_with_carry(&mut self, carry: Limb, rhs: &Self, p: &Self) {
         debug_assert!(carry.0 <= 1);
 
-        let borrow = self.sbb_assign(rhs, Limb::ZERO);
+        let borrow = self.borrowing_sub_assign(rhs, Limb::ZERO);
 
         // The new `borrow = Word::MAX` iff `carry == 0` and `borrow == Word::MAX`.
         let mask = carry.wrapping_neg().not().bitand(borrow);
@@ -41,7 +41,7 @@ impl BoxedUint {
     ///
     /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
     pub fn sub_mod_special(&self, rhs: &Self, c: Limb) -> Self {
-        let (out, borrow) = self.sbb(rhs, Limb::ZERO);
+        let (out, borrow) = self.borrowing_sub(rhs, Limb::ZERO);
 
         // If underflow occurred, then we need to subtract `c` to account for
         // the underflow. This cannot underflow due to the assumption

--- a/src/uint/boxed/sub_mod.rs
+++ b/src/uint/boxed/sub_mod.rs
@@ -16,7 +16,7 @@ impl BoxedUint {
 
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the modulus.
-        out.conditional_adc_assign(p, !borrow.is_zero());
+        out.conditional_carrying_add_assign(p, !borrow.is_zero());
         out
     }
 
@@ -33,7 +33,7 @@ impl BoxedUint {
 
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the modulus.
-        self.conditional_adc_assign(p, !mask.is_zero());
+        self.conditional_carrying_add_assign(p, !mask.is_zero());
     }
 
     /// Computes `self - rhs mod p` for the special modulus

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -61,9 +61,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     #[inline]
     pub(crate) const fn lt(lhs: &Self, rhs: &Self) -> ConstChoice {
         // We could use the same approach as in Limb::ct_lt(),
-        // but since we have to use Uint::wrapping_sub(), which calls `sbb()`,
-        // there are no savings compared to just calling `sbb()` directly.
-        let (_res, borrow) = lhs.sbb(rhs, Limb::ZERO);
+        // but since we have to use Uint::wrapping_sub(), which calls `borrowing_sub()`,
+        // there are no savings compared to just calling `borrowing_sub()` directly.
+        let (_res, borrow) = lhs.borrowing_sub(rhs, Limb::ZERO);
         ConstChoice::from_word_mask(borrow.0)
     }
 
@@ -76,7 +76,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Returns the truthy value if `self > rhs` and the falsy value otherwise.
     #[inline]
     pub(crate) const fn gt(lhs: &Self, rhs: &Self) -> ConstChoice {
-        let (_res, borrow) = rhs.sbb(lhs, Limb::ZERO);
+        let (_res, borrow) = rhs.borrowing_sub(lhs, Limb::ZERO);
         ConstChoice::from_word_mask(borrow.0)
     }
 
@@ -92,7 +92,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mut diff = Limb::ZERO;
 
         while i < LIMBS {
-            let (w, b) = rhs.limbs[i].sbb(lhs.limbs[i], borrow);
+            let (w, b) = rhs.limbs[i].borrowing_sub(lhs.limbs[i], borrow);
             diff = diff.bitor(w);
             borrow = b;
             i += 1;
@@ -105,7 +105,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     pub const fn cmp_vartime(&self, rhs: &Self) -> Ordering {
         let mut i = LIMBS - 1;
         loop {
-            let (val, borrow) = self.limbs[i].sbb(rhs.limbs[i], Limb::ZERO);
+            let (val, borrow) = self.limbs[i].borrowing_sub(rhs.limbs[i], Limb::ZERO);
             if val.0 != 0 {
                 return if borrow.0 != 0 {
                     Ordering::Less

--- a/src/uint/concat.rs
+++ b/src/uint/concat.rs
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn convert() {
-        let res: U128 = U64::ONE.split_mul(&U64::ONE).into();
+        let res: U128 = U64::ONE.widening_mul(&U64::ONE).into();
         assert_eq!(res, U128::ONE);
 
         let res: U128 = U64::ONE.square_wide().into();

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -83,7 +83,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             let mut tmp;
             i = 0;
             while i <= xi {
-                (tmp, carry) = Limb::ZERO.mac(y[LIMBS - xi + i - 1], Limb(quo), carry);
+                (tmp, carry) = Limb::ZERO.carrying_mul_add(y[LIMBS - xi + i - 1], Limb(quo), carry);
                 (x[i], borrow) = x[i].borrowing_sub(tmp, borrow);
                 i += 1;
             }
@@ -243,7 +243,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
                 let mut tmp;
                 i = 0;
                 while i < yc {
-                    (tmp, carry) = Limb::ZERO.mac(y[i], Limb(quo), carry);
+                    (tmp, carry) = Limb::ZERO.carrying_mul_add(y[i], Limb(quo), carry);
                     (x[xi + i + 1 - yc], borrow) = x[xi + i + 1 - yc].borrowing_sub(tmp, borrow);
                     i += 1;
                 }
@@ -370,7 +370,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
                 let mut tmp;
                 i = 0;
                 while i < yc {
-                    (tmp, carry) = Limb::ZERO.mac(y[i], Limb(quo), carry);
+                    (tmp, carry) = Limb::ZERO.carrying_mul_add(y[i], Limb(quo), carry);
                     (x[xi + i + 1 - yc], borrow) = x[xi + i + 1 - yc].borrowing_sub(tmp, borrow);
                     i += 1;
                 }

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -84,10 +84,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             i = 0;
             while i <= xi {
                 (tmp, carry) = Limb::ZERO.mac(y[LIMBS - xi + i - 1], Limb(quo), carry);
-                (x[i], borrow) = x[i].sbb(tmp, borrow);
+                (x[i], borrow) = x[i].borrowing_sub(tmp, borrow);
                 i += 1;
             }
-            (_, borrow) = x_hi.sbb(carry, borrow);
+            (_, borrow) = x_hi.borrowing_sub(carry, borrow);
 
             // If the subtraction borrowed, then decrement q and add back the divisor
             // The probability of this being needed is very low, about 2/(Limb::MAX+1)
@@ -244,10 +244,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
                 i = 0;
                 while i < yc {
                     (tmp, carry) = Limb::ZERO.mac(y[i], Limb(quo), carry);
-                    (x[xi + i + 1 - yc], borrow) = x[xi + i + 1 - yc].sbb(tmp, borrow);
+                    (x[xi + i + 1 - yc], borrow) = x[xi + i + 1 - yc].borrowing_sub(tmp, borrow);
                     i += 1;
                 }
-                (_, borrow) = x_hi.sbb(carry, borrow);
+                (_, borrow) = x_hi.borrowing_sub(carry, borrow);
                 borrow
             };
 
@@ -371,10 +371,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
                 i = 0;
                 while i < yc {
                     (tmp, carry) = Limb::ZERO.mac(y[i], Limb(quo), carry);
-                    (x[xi + i + 1 - yc], borrow) = x[xi + i + 1 - yc].sbb(tmp, borrow);
+                    (x[xi + i + 1 - yc], borrow) = x[xi + i + 1 - yc].borrowing_sub(tmp, borrow);
                     i += 1;
                 }
-                (_, borrow) = x_hi.sbb(carry, borrow);
+                (_, borrow) = x_hi.borrowing_sub(carry, borrow);
                 borrow
             };
 

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -83,7 +83,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             let mut tmp;
             i = 0;
             while i <= xi {
-                (tmp, carry) = Limb::ZERO.carrying_mul_add(y[LIMBS - xi + i - 1], Limb(quo), carry);
+                (tmp, carry) = y[LIMBS - xi + i - 1].carrying_mul_add(Limb(quo), carry, Limb::ZERO);
                 (x[i], borrow) = x[i].borrowing_sub(tmp, borrow);
                 i += 1;
             }
@@ -243,7 +243,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
                 let mut tmp;
                 i = 0;
                 while i < yc {
-                    (tmp, carry) = Limb::ZERO.carrying_mul_add(y[i], Limb(quo), carry);
+                    (tmp, carry) = y[i].carrying_mul_add(Limb(quo), carry, Limb::ZERO);
                     (x[xi + i + 1 - yc], borrow) = x[xi + i + 1 - yc].borrowing_sub(tmp, borrow);
                     i += 1;
                 }
@@ -370,7 +370,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
                 let mut tmp;
                 i = 0;
                 while i < yc {
-                    (tmp, carry) = Limb::ZERO.carrying_mul_add(y[i], Limb(quo), carry);
+                    (tmp, carry) = y[i].carrying_mul_add(Limb(quo), carry, Limb::ZERO);
                     (x[xi + i + 1 - yc], borrow) = x[xi + i + 1 - yc].borrowing_sub(tmp, borrow);
                     i += 1;
                 }

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -95,7 +95,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             carry = Limb::ZERO;
             i = 0;
             while i <= xi {
-                (x[i], carry) = x[i].adc(
+                (x[i], carry) = x[i].carrying_add(
                     Limb::select(Limb::ZERO, y[LIMBS - xi + i - 1], ct_borrow),
                     carry,
                 );
@@ -258,8 +258,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
                 let mut carry = Limb::ZERO;
                 i = 0;
                 while i < yc {
-                    (x[xi + i + 1 - yc], carry) =
-                        x[xi + i + 1 - yc].adc(Limb::select(Limb::ZERO, y[i], ct_borrow), carry);
+                    (x[xi + i + 1 - yc], carry) = x[xi + i + 1 - yc]
+                        .carrying_add(Limb::select(Limb::ZERO, y[i], ct_borrow), carry);
                     i += 1;
                 }
                 ct_borrow.select_word(quo, quo.wrapping_sub(1))
@@ -385,8 +385,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
                 let mut carry = Limb::ZERO;
                 i = 0;
                 while i < yc {
-                    (x[xi + i + 1 - yc], carry) =
-                        x[xi + i + 1 - yc].adc(Limb::select(Limb::ZERO, y[i], ct_borrow), carry);
+                    (x[xi + i + 1 - yc], carry) = x[xi + i + 1 - yc]
+                        .carrying_add(Limb::select(Limb::ZERO, y[i], ct_borrow), carry);
                     i += 1;
                 }
             }

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -126,7 +126,7 @@ pub(crate) const fn div2by1(u1: Word, u0: Word, reciprocal: &Reciprocal) -> (Wor
     debug_assert!(u1 < d);
 
     let (q0, q1) = widening_mul(reciprocal.reciprocal, u1);
-    let (q1, q0) = addhilo(q1, q0, u1, u0);
+    let (q0, q1) = addhilo(q0, q1, u0, u1);
     let q1 = q1.wrapping_add(1);
     let r = u0.wrapping_sub(q1.wrapping_mul(d));
 

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -426,7 +426,7 @@ fn radix_decode_str_digits<D: DecodeByLimb>(
         // Multiply the existing limbs by `radix` ^ `limb_digits`,
         // and add the new least-significant limb
         for limb in out.limbs_mut().iter_mut() {
-            (*limb, carry) = Limb::ZERO.mac(*limb, limb_max, carry);
+            (*limb, carry) = Limb::ZERO.carrying_mul_add(*limb, limb_max, carry);
         }
         // Append the new carried limb, if any
         if carry.0 != 0 && !out.push_limb(carry) {
@@ -760,7 +760,7 @@ const fn radix_large_divisor(
         let mut carry = Limb::ZERO;
         let mut j = 0;
         while j < top {
-            (out[j], carry) = Limb::ZERO.mac(out[j], div_limb.0, carry);
+            (out[j], carry) = Limb::ZERO.carrying_mul_add(out[j], div_limb.0, carry);
             j += 1;
         }
         if carry.0 != 0 {
@@ -775,7 +775,7 @@ const fn radix_large_divisor(
         let mut carry = Limb::ZERO;
         let mut j = 0;
         while j < RADIX_ENCODING_LIMBS_LARGE {
-            (out_test[j], carry) = Limb::ZERO.mac(out[j], Limb(radix as Word), carry);
+            (out_test[j], carry) = Limb::ZERO.carrying_mul_add(out[j], Limb(radix as Word), carry);
             j += 1;
         }
         if carry.0 == 0 {

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -426,7 +426,7 @@ fn radix_decode_str_digits<D: DecodeByLimb>(
         // Multiply the existing limbs by `radix` ^ `limb_digits`,
         // and add the new least-significant limb
         for limb in out.limbs_mut().iter_mut() {
-            (*limb, carry) = Limb::ZERO.carrying_mul_add(*limb, limb_max, carry);
+            (*limb, carry) = limb.carrying_mul_add(limb_max, carry, Limb::ZERO);
         }
         // Append the new carried limb, if any
         if carry.0 != 0 && !out.push_limb(carry) {
@@ -760,7 +760,7 @@ const fn radix_large_divisor(
         let mut carry = Limb::ZERO;
         let mut j = 0;
         while j < top {
-            (out[j], carry) = Limb::ZERO.carrying_mul_add(out[j], div_limb.0, carry);
+            (out[j], carry) = out[j].carrying_mul_add(div_limb.0, carry, Limb::ZERO);
             j += 1;
         }
         if carry.0 != 0 {
@@ -775,7 +775,7 @@ const fn radix_large_divisor(
         let mut carry = Limb::ZERO;
         let mut j = 0;
         while j < RADIX_ENCODING_LIMBS_LARGE {
-            (out_test[j], carry) = Limb::ZERO.carrying_mul_add(out[j], Limb(radix as Word), carry);
+            (out_test[j], carry) = out[j].carrying_mul_add(Limb(radix as Word), carry, Limb::ZERO);
             j += 1;
         }
         if carry.0 == 0 {

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -33,9 +33,9 @@ const fn schoolbook_multiplication(lhs: &[Limb], rhs: &[Limb], lo: &mut [Limb], 
             let k = i + j;
 
             if k >= lhs.len() {
-                (hi[k - lhs.len()], carry) = hi[k - lhs.len()].carrying_mul_add(xi, rhs[j], carry);
+                (hi[k - lhs.len()], carry) = xi.carrying_mul_add(rhs[j], hi[k - lhs.len()], carry);
             } else {
-                (lo[k], carry) = lo[k].carrying_mul_add(xi, rhs[j], carry);
+                (lo[k], carry) = xi.carrying_mul_add(rhs[j], lo[k], carry);
             }
 
             j += 1;
@@ -75,9 +75,9 @@ pub(crate) const fn schoolbook_squaring(limbs: &[Limb], lo: &mut [Limb], hi: &mu
 
             if k >= limbs.len() {
                 (hi[k - limbs.len()], carry) =
-                    hi[k - limbs.len()].carrying_mul_add(xi, limbs[j], carry);
+                    xi.carrying_mul_add(limbs[j], hi[k - limbs.len()], carry);
             } else {
-                (lo[k], carry) = lo[k].carrying_mul_add(xi, limbs[j], carry);
+                (lo[k], carry) = xi.carrying_mul_add(limbs[j], lo[k], carry);
             }
 
             j += 1;
@@ -114,10 +114,10 @@ pub(crate) const fn schoolbook_squaring(limbs: &[Limb], lo: &mut [Limb], hi: &mu
     while i < limbs.len() {
         let xi = limbs[i];
         if (i * 2) < limbs.len() {
-            (lo[i * 2], carry) = lo[i * 2].carrying_mul_add(xi, xi, carry);
+            (lo[i * 2], carry) = xi.carrying_mul_add(xi, lo[i * 2], carry);
         } else {
             (hi[i * 2 - limbs.len()], carry) =
-                hi[i * 2 - limbs.len()].carrying_mul_add(xi, xi, carry);
+                xi.carrying_mul_add(xi, hi[i * 2 - limbs.len()], carry);
         }
 
         if (i * 2 + 1) < limbs.len() {

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -131,18 +131,6 @@ pub(crate) const fn schoolbook_squaring(limbs: &[Limb], lo: &mut [Limb], hi: &mu
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Multiply `self` by `rhs`, returning a concatenated "wide" result.
-    #[deprecated(since = "0.7.0", note = "please use `concatenating_mul` instead")]
-    pub const fn widening_mul<const RHS_LIMBS: usize, const WIDE_LIMBS: usize>(
-        &self,
-        rhs: &Uint<RHS_LIMBS>,
-    ) -> Uint<WIDE_LIMBS>
-    where
-        Self: ConcatMixed<Uint<RHS_LIMBS>, MixedOutput = Uint<WIDE_LIMBS>>,
-    {
-        self.concatenating_mul(rhs)
-    }
-
-    /// Multiply `self` by `rhs`, returning a concatenated "wide" result.
     pub const fn concatenating_mul<const RHS_LIMBS: usize, const WIDE_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
@@ -150,13 +138,23 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     where
         Self: ConcatMixed<Uint<RHS_LIMBS>, MixedOutput = Uint<WIDE_LIMBS>>,
     {
-        let (lo, hi) = self.split_mul(rhs);
+        let (lo, hi) = self.widening_mul(rhs);
         Uint::concat_mixed(&lo, &hi)
     }
 
     /// Compute "wide" multiplication as a 2-tuple containing the `(lo, hi)` components of the product, whose sizes
     /// correspond to the sizes of the operands.
+    #[deprecated(since = "0.7.0", note = "please use `widening_mul` instead")]
     pub const fn split_mul<const RHS_LIMBS: usize>(
+        &self,
+        rhs: &Uint<RHS_LIMBS>,
+    ) -> (Self, Uint<RHS_LIMBS>) {
+        self.widening_mul(rhs)
+    }
+
+    /// Compute "wide" multiplication as a 2-tuple containing the `(lo, hi)` components of the product, whose sizes
+    /// correspond to the sizes of the operands.
+    pub const fn widening_mul<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
     ) -> (Self, Uint<RHS_LIMBS>) {
@@ -185,12 +183,12 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Perform wrapping multiplication, discarding overflow.
     pub const fn wrapping_mul<const H: usize>(&self, rhs: &Uint<H>) -> Self {
-        self.split_mul(rhs).0
+        self.widening_mul(rhs).0
     }
 
     /// Perform saturating multiplication, returning `MAX` on overflow.
     pub const fn saturating_mul<const RHS_LIMBS: usize>(&self, rhs: &Uint<RHS_LIMBS>) -> Self {
-        let (res, overflow) = self.split_mul(rhs);
+        let (res, overflow) = self.widening_mul(rhs);
         Self::select(&res, &Self::MAX, overflow.is_nonzero())
     }
 }
@@ -253,7 +251,7 @@ where
 impl<const LIMBS: usize, const RHS_LIMBS: usize> CheckedMul<Uint<RHS_LIMBS>> for Uint<LIMBS> {
     #[inline]
     fn checked_mul(&self, rhs: &Uint<RHS_LIMBS>) -> CtOption<Self> {
-        let (lo, hi) = self.split_mul(rhs);
+        let (lo, hi) = self.widening_mul(rhs);
         CtOption::new(lo, hi.is_zero())
     }
 }
@@ -404,20 +402,20 @@ mod tests {
     use crate::{CheckedMul, ConstChoice, U64, U128, U192, U256, Zero};
 
     #[test]
-    fn mul_wide_zero_and_one() {
-        assert_eq!(U64::ZERO.split_mul(&U64::ZERO), (U64::ZERO, U64::ZERO));
-        assert_eq!(U64::ZERO.split_mul(&U64::ONE), (U64::ZERO, U64::ZERO));
-        assert_eq!(U64::ONE.split_mul(&U64::ZERO), (U64::ZERO, U64::ZERO));
-        assert_eq!(U64::ONE.split_mul(&U64::ONE), (U64::ONE, U64::ZERO));
+    fn widening_mul_zero_and_one() {
+        assert_eq!(U64::ZERO.widening_mul(&U64::ZERO), (U64::ZERO, U64::ZERO));
+        assert_eq!(U64::ZERO.widening_mul(&U64::ONE), (U64::ZERO, U64::ZERO));
+        assert_eq!(U64::ONE.widening_mul(&U64::ZERO), (U64::ZERO, U64::ZERO));
+        assert_eq!(U64::ONE.widening_mul(&U64::ONE), (U64::ONE, U64::ZERO));
     }
 
     #[test]
-    fn mul_wide_lo_only() {
+    fn widening_mul_lo_only() {
         let primes: &[u32] = &[3, 5, 17, 257, 65537];
 
         for &a_int in primes {
             for &b_int in primes {
-                let (lo, hi) = U64::from_u32(a_int).split_mul(&U64::from_u32(b_int));
+                let (lo, hi) = U64::from_u32(a_int).widening_mul(&U64::from_u32(b_int));
                 let expected = U64::from_u64(a_int as u64 * b_int as u64);
                 assert_eq!(lo, expected);
                 assert!(bool::from(hi.is_zero()));
@@ -527,7 +525,7 @@ mod tests {
 
         for _ in 0..50 {
             let a = U4096::random(&mut rng);
-            assert_eq!(a.split_mul(&a), a.square_wide(), "a = {a}");
+            assert_eq!(a.widening_mul(&a), a.square_wide(), "a = {a}");
         }
     }
 }

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -33,9 +33,9 @@ const fn schoolbook_multiplication(lhs: &[Limb], rhs: &[Limb], lo: &mut [Limb], 
             let k = i + j;
 
             if k >= lhs.len() {
-                (hi[k - lhs.len()], carry) = hi[k - lhs.len()].mac(xi, rhs[j], carry);
+                (hi[k - lhs.len()], carry) = hi[k - lhs.len()].carrying_mul_add(xi, rhs[j], carry);
             } else {
-                (lo[k], carry) = lo[k].mac(xi, rhs[j], carry);
+                (lo[k], carry) = lo[k].carrying_mul_add(xi, rhs[j], carry);
             }
 
             j += 1;
@@ -74,9 +74,10 @@ pub(crate) const fn schoolbook_squaring(limbs: &[Limb], lo: &mut [Limb], hi: &mu
             let k = i + j;
 
             if k >= limbs.len() {
-                (hi[k - limbs.len()], carry) = hi[k - limbs.len()].mac(xi, limbs[j], carry);
+                (hi[k - limbs.len()], carry) =
+                    hi[k - limbs.len()].carrying_mul_add(xi, limbs[j], carry);
             } else {
-                (lo[k], carry) = lo[k].mac(xi, limbs[j], carry);
+                (lo[k], carry) = lo[k].carrying_mul_add(xi, limbs[j], carry);
             }
 
             j += 1;
@@ -113,9 +114,10 @@ pub(crate) const fn schoolbook_squaring(limbs: &[Limb], lo: &mut [Limb], hi: &mu
     while i < limbs.len() {
         let xi = limbs[i];
         if (i * 2) < limbs.len() {
-            (lo[i * 2], carry) = lo[i * 2].mac(xi, xi, carry);
+            (lo[i * 2], carry) = lo[i * 2].carrying_mul_add(xi, xi, carry);
         } else {
-            (hi[i * 2 - limbs.len()], carry) = hi[i * 2 - limbs.len()].mac(xi, xi, carry);
+            (hi[i * 2 - limbs.len()], carry) =
+                hi[i * 2 - limbs.len()].carrying_mul_add(xi, xi, carry);
         }
 
         if (i * 2 + 1) < limbs.len() {

--- a/src/uint/mul/karatsuba.rs
+++ b/src/uint/mul/karatsuba.rs
@@ -403,7 +403,7 @@ fn carrying_add_mul_limbs(lhs: &[Limb], rhs: &[Limb], out: &mut [Limb]) -> Limb 
 
         while j < rhs.len() {
             let k = i + j;
-            (out[k], carry2) = out[k].carrying_mul_add(xi, rhs[j], carry2);
+            (out[k], carry2) = xi.carrying_mul_add(rhs[j], out[k], carry2);
             j += 1;
         }
 

--- a/src/uint/mul/karatsuba.rs
+++ b/src/uint/mul/karatsuba.rs
@@ -403,7 +403,7 @@ fn carrying_add_mul_limbs(lhs: &[Limb], rhs: &[Limb], out: &mut [Limb]) -> Limb 
 
         while j < rhs.len() {
             let k = i + j;
-            (out[k], carry2) = out[k].mac(xi, rhs[j], carry2);
+            (out[k], carry2) = out[k].carrying_mul_add(xi, rhs[j], carry2);
             j += 1;
         }
 

--- a/src/uint/mul/karatsuba.rs
+++ b/src/uint/mul/karatsuba.rs
@@ -52,8 +52,8 @@ macro_rules! impl_uint_karatsuba_multiplication {
                 let mut l1b = Limb::ZERO;
                 let mut i = 0;
                 while i < $half_size {
-                    (l0.limbs[i], l0b) = x0[i].sbb(x1[i], l0b);
-                    (l1.limbs[i], l1b) = y1[i].sbb(y0[i], l1b);
+                    (l0.limbs[i], l0b) = x0[i].borrowing_sub(x1[i], l0b);
+                    (l1.limbs[i], l1b) = y1[i].borrowing_sub(y0[i], l1b);
                     i += 1;
                 }
                 l0 = Uint::select(
@@ -136,7 +136,7 @@ macro_rules! impl_uint_karatsuba_squaring {
                 let mut l0b = Limb::ZERO;
                 let mut i = 0;
                 while i < $half_size {
-                    (l0.limbs[i], l0b) = x0[i].sbb(x1[i], l0b);
+                    (l0.limbs[i], l0b) = x0[i].borrowing_sub(x1[i], l0b);
                     i += 1;
                 }
                 l0 = Uint::select(
@@ -149,9 +149,9 @@ macro_rules! impl_uint_karatsuba_squaring {
 
                 // Subtract z1•b
                 carry = Limb::ZERO;
-                (res.1, carry) = res.1.sbb(&z1.0, carry);
-                (res.2, carry) = res.2.sbb(&z1.1, carry);
-                (res.3, _) = res.3.sbb(&Uint::ZERO, carry);
+                (res.1, carry) = res.1.borrowing_sub(&z1.0, carry);
+                (res.2, carry) = res.2.borrowing_sub(&z1.1, carry);
+                (res.3, _) = res.3.borrowing_sub(&Uint::ZERO, carry);
 
                 (res.0.concat(&res.1), res.2.concat(&res.3))
             }
@@ -211,8 +211,8 @@ pub(crate) fn karatsuba_mul_limbs(
     let mut borrow0 = Limb::ZERO;
     let mut borrow1 = Limb::ZERO;
     while i < half {
-        (scratch[i], borrow0) = x0[i].sbb(x1[i], borrow0);
-        (scratch[i + half], borrow1) = y1[i].sbb(y0[i], borrow1);
+        (scratch[i], borrow0) = x0[i].borrowing_sub(x1[i], borrow0);
+        (scratch[i + half], borrow1) = y1[i].borrowing_sub(y0[i], borrow1);
         i += 1;
     }
     // Conditionally negate terms depending whether they borrowed
@@ -314,7 +314,7 @@ pub(crate) fn karatsuba_square_limbs(limbs: &[Limb], out: &mut [Limb], scratch: 
     let mut i = 0;
     let mut borrow = Limb::ZERO;
     while i < half {
-        (scratch[i], borrow) = x0[i].sbb(x1[i], borrow);
+        (scratch[i], borrow) = x0[i].borrowing_sub(x1[i], borrow);
         i += 1;
     }
     // Conditionally negate depending whether subtraction borrowed

--- a/src/uint/mul/karatsuba.rs
+++ b/src/uint/mul/karatsuba.rs
@@ -84,16 +84,16 @@ macro_rules! impl_uint_karatsuba_multiplication {
 
                 // Add z0 + (z0 + z2)•b + z2•b^2
                 let mut carry = Limb::select(Limb::ZERO, Limb::ONE, z1_neg);
-                (res.0, carry) = res.0.adc(&z0.0, carry);
-                (res.1, carry) = res.1.adc(&z0.1, carry);
+                (res.0, carry) = res.0.carrying_add(&z0.0, carry);
+                (res.1, carry) = res.1.carrying_add(&z0.1, carry);
                 let mut carry2;
-                (res.1, carry2) = res.1.adc(&z0.0, Limb::ZERO);
-                (res.2, carry) = res.2.adc(&z0.1, carry.wrapping_add(carry2));
-                (res.1, carry2) = res.1.adc(&z2.0, Limb::ZERO);
-                (res.2, carry2) = res.2.adc(&z2.1, carry2);
+                (res.1, carry2) = res.1.carrying_add(&z0.0, Limb::ZERO);
+                (res.2, carry) = res.2.carrying_add(&z0.1, carry.wrapping_add(carry2));
+                (res.1, carry2) = res.1.carrying_add(&z2.0, Limb::ZERO);
+                (res.2, carry2) = res.2.carrying_add(&z2.1, carry2);
                 carry = carry.wrapping_add(carry2);
-                (res.2, carry2) = res.2.adc(&z2.0, Limb::ZERO);
-                (res.3, _) = res.3.adc(&z2.1, carry.wrapping_add(carry2));
+                (res.2, carry2) = res.2.carrying_add(&z2.0, Limb::ZERO);
+                (res.3, _) = res.3.carrying_add(&z2.1, carry.wrapping_add(carry2));
 
                 (res.0.concat(&res.1), res.2.concat(&res.3))
             }
@@ -124,12 +124,12 @@ macro_rules! impl_uint_karatsuba_squaring {
                 // Calculate z0 + (z0 + z2)•b + z2•b^2
                 let mut res = (z0.0, z0.1, Uint::<$half_size>::ZERO, Uint::<$half_size>::ZERO);
                 let mut carry;
-                (res.1, carry) = res.1.adc(&z0.0, Limb::ZERO);
-                (res.2, carry) = z0.1.adc(&z2.0, carry);
+                (res.1, carry) = res.1.carrying_add(&z0.0, Limb::ZERO);
+                (res.2, carry) = z0.1.carrying_add(&z2.0, carry);
                 let mut carry2;
-                (res.1, carry2) = res.1.adc(&z2.0, Limb::ZERO);
-                (res.2, carry2) = res.2.adc(&z2.1, carry2);
-                (res.3, _) = z2.1.adc(&Uint::ZERO, carry.wrapping_add(carry2));
+                (res.1, carry2) = res.1.carrying_add(&z2.0, Limb::ZERO);
+                (res.2, carry2) = res.2.carrying_add(&z2.1, carry2);
+                (res.3, _) = z2.1.carrying_add(&Uint::ZERO, carry.wrapping_add(carry2));
 
                 // Calculate z1 = (x0 - x1)^2
                 let mut l0 = Uint::<$half_size>::ZERO;
@@ -189,7 +189,7 @@ pub(crate) fn karatsuba_mul_limbs(
     };
     if size <= KARATSUBA_MAX_REDUCE_LIMBS {
         out.fill(Limb::ZERO);
-        adc_mul_limbs(lhs, rhs, out);
+        carrying_add_mul_limbs(lhs, rhs, out);
         return;
     }
     if lhs.len() + rhs.len() != out.len() || scratch.len() < 2 * size {
@@ -240,17 +240,17 @@ pub(crate) fn karatsuba_mul_limbs(
     let mut carry2 = Limb::ZERO;
     i = 0;
     while i < size {
-        (out[i], carry) = out[i].adc(scratch[i], carry); // add z0
+        (out[i], carry) = out[i].carrying_add(scratch[i], carry); // add z0
         i += 1;
     }
     i = 0;
     while i < half {
-        (out[i + half], carry2) = out[i + half].adc(scratch[i], carry2); // add z0.0
+        (out[i + half], carry2) = out[i + half].carrying_add(scratch[i], carry2); // add z0.0
         i += 1;
     }
     carry = carry.wrapping_add(carry2);
     while i < size {
-        (out[i + half], carry) = out[i + half].adc(scratch[i], carry); // add z0.1
+        (out[i + half], carry) = out[i + half].carrying_add(scratch[i], carry); // add z0.1
         i += 1;
     }
 
@@ -260,32 +260,32 @@ pub(crate) fn karatsuba_mul_limbs(
     carry2 = Limb::ZERO;
     i = 0;
     while i < size {
-        (out[i + half], carry2) = out[i + half].adc(scratch[i], carry2); // add z2
+        (out[i + half], carry2) = out[i + half].carrying_add(scratch[i], carry2); // add z2
         i += 1;
     }
     carry = carry.wrapping_add(carry2);
     carry2 = Limb::ZERO;
     i = 0;
     while i < half {
-        (out[i + size], carry2) = out[i + size].adc(scratch[i], carry2); // add z2.0
+        (out[i + size], carry2) = out[i + size].carrying_add(scratch[i], carry2); // add z2.0
         i += 1;
     }
     carry = carry.wrapping_add(carry2);
     while i < size {
-        (out[i + size], carry) = out[i + size].adc(scratch[i], carry); // add z2.1
+        (out[i + size], carry) = out[i + size].carrying_add(scratch[i], carry); // add z2.1
         i += 1;
     }
 
     // Handle trailing limbs
     if !xt.is_empty() {
-        adc_mul_limbs(xt, rhs, &mut out[size..]);
+        carrying_add_mul_limbs(xt, rhs, &mut out[size..]);
     }
     if !yt.is_empty() {
         let end_pos = 2 * size + yt.len();
-        carry = adc_mul_limbs(yt, x, &mut out[size..end_pos]);
+        carry = carrying_add_mul_limbs(yt, x, &mut out[size..end_pos]);
         i = end_pos;
         while i < out.len() {
-            (out[i], carry) = out[i].adc(Limb::ZERO, carry);
+            (out[i], carry) = out[i].carrying_add(Limb::ZERO, carry);
             i += 1;
         }
     }
@@ -335,17 +335,17 @@ pub(crate) fn karatsuba_square_limbs(limbs: &[Limb], out: &mut [Limb], scratch: 
     let mut carry2 = Limb::ZERO;
     i = 0;
     while i < size {
-        (out[i], carry) = out[i].adc(scratch[i], carry); // add z0
+        (out[i], carry) = out[i].carrying_add(scratch[i], carry); // add z0
         i += 1;
     }
     i = 0;
     while i < half {
-        (out[i + half], carry2) = out[i + half].adc(scratch[i], carry2); // add z0.0
+        (out[i + half], carry2) = out[i + half].carrying_add(scratch[i], carry2); // add z0.0
         i += 1;
     }
     carry = carry.wrapping_add(carry2);
     while i < size {
-        (out[i + half], carry) = out[i + half].adc(scratch[i], carry); // add z0.1
+        (out[i + half], carry) = out[i + half].carrying_add(scratch[i], carry); // add z0.1
         i += 1;
     }
 
@@ -355,19 +355,19 @@ pub(crate) fn karatsuba_square_limbs(limbs: &[Limb], out: &mut [Limb], scratch: 
     carry2 = Limb::ZERO;
     i = 0;
     while i < size {
-        (out[i + half], carry2) = out[i + half].adc(scratch[i], carry2); // add z2
+        (out[i + half], carry2) = out[i + half].carrying_add(scratch[i], carry2); // add z2
         i += 1;
     }
     carry = carry.wrapping_add(carry2);
     carry2 = Limb::ZERO;
     i = 0;
     while i < half {
-        (out[i + size], carry2) = out[i + size].adc(scratch[i], carry2); // add z2.0
+        (out[i + size], carry2) = out[i + size].carrying_add(scratch[i], carry2); // add z2.0
         i += 1;
     }
     carry = carry.wrapping_add(carry2);
     while i < size {
-        (out[i + size], carry) = out[i + size].adc(scratch[i], carry); // add z2.1
+        (out[i + size], carry) = out[i + size].carrying_add(scratch[i], carry); // add z2.1
         i += 1;
     }
 }
@@ -389,9 +389,9 @@ fn conditional_wrapping_neg_assign(limbs: &mut [Limb], choice: ConstChoice) {
 
 /// Add the schoolbook product of two limb slices to a limb slice, returning the carry.
 #[cfg(feature = "alloc")]
-fn adc_mul_limbs(lhs: &[Limb], rhs: &[Limb], out: &mut [Limb]) -> Limb {
+fn carrying_add_mul_limbs(lhs: &[Limb], rhs: &[Limb], out: &mut [Limb]) -> Limb {
     if lhs.len() + rhs.len() != out.len() {
-        panic!("adc_mul_limbs length mismatch");
+        panic!("carrying_add_mul_limbs length mismatch");
     }
 
     let mut carry = Limb::ZERO;
@@ -408,7 +408,7 @@ fn adc_mul_limbs(lhs: &[Limb], rhs: &[Limb], out: &mut [Limb]) -> Limb {
         }
 
         carry = carry.wrapping_add(carry2);
-        (out[i + j], carry) = out[i + j].adc(Limb::ZERO, carry);
+        (out[i + j], carry) = out[i + j].carrying_add(Limb::ZERO, carry);
         i += 1;
     }
 

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -92,7 +92,7 @@ const fn mac_by_limb<const LIMBS: usize>(
     let mut carry = carry;
 
     while i < LIMBS {
-        (a.limbs[i], carry) = a.limbs[i].carrying_mul_add(b.limbs[i], c, carry);
+        (a.limbs[i], carry) = b.limbs[i].carrying_mul_add(c, a.limbs[i], carry);
         i += 1;
     }
 

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -31,7 +31,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes `self * rhs mod p` for odd `p` in variable time with respect to `p`.
     pub fn mul_mod_vartime(&self, rhs: &Uint<LIMBS>, p: &NonZero<Uint<LIMBS>>) -> Uint<LIMBS> {
-        let lo_hi = self.split_mul(rhs);
+        let lo_hi = self.widening_mul(rhs);
         Self::rem_wide_vartime(lo_hi, p)
     }
 
@@ -53,7 +53,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             return Self::from_word(reduced.0);
         }
 
-        let (lo, hi) = self.split_mul(rhs);
+        let (lo, hi) = self.widening_mul(rhs);
 
         // Now use Algorithm 14.47 for the reduction
         let (lo, carry) = mac_by_limb(&lo, &hi, c, Limb::ZERO);
@@ -142,7 +142,7 @@ mod tests {
                         assert!(c < **p, "not reduced: {} >= {} ", c, p);
 
                         let expected = {
-                            let (lo, hi) = a.split_mul(&b);
+                            let (lo, hi) = a.widening_mul(&b);
                             let mut prod = Uint::<{ 2 * $size }>::ZERO;
                             prod.limbs[..$size].clone_from_slice(&lo.limbs);
                             prod.limbs[$size..].clone_from_slice(&hi.limbs);

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -65,7 +65,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         let (lo, _) = {
             let rhs = carry.0.wrapping_sub(1) & c.0;
-            lo.sbb(&Self::from_word(rhs), Limb::ZERO)
+            lo.borrowing_sub(&Self::from_word(rhs), Limb::ZERO)
         };
 
         lo

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -92,7 +92,7 @@ const fn mac_by_limb<const LIMBS: usize>(
     let mut carry = carry;
 
     while i < LIMBS {
-        (a.limbs[i], carry) = a.limbs[i].mac(b.limbs[i], c, carry);
+        (a.limbs[i], carry) = a.limbs[i].carrying_mul_add(b.limbs[i], c, carry);
         i += 1;
     }
 

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -60,7 +60,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         let (lo, carry) = {
             let rhs = (carry.0 + 1) as WideWord * c.0 as WideWord;
-            lo.adc(&Self::from_wide_word(rhs), Limb::ZERO)
+            lo.carrying_add(&Self::from_wide_word(rhs), Limb::ZERO)
         };
 
         let (lo, _) = {

--- a/src/uint/neg_mod.rs
+++ b/src/uint/neg_mod.rs
@@ -7,7 +7,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Assumes `self` is in `[0, p)`.
     pub const fn neg_mod(&self, p: &Self) -> Self {
         let z = self.is_nonzero();
-        let mut ret = p.sbb(self, Limb::ZERO).0;
+        let mut ret = p.borrowing_sub(self, Limb::ZERO).0;
         let mut i = 0;
         while i < LIMBS {
             // Set ret to 0 if the original value was 0, in which

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -310,7 +310,7 @@ mod tests {
     fn shl_wide_max_0_1() {
         assert_eq!(
             Uint::overflowing_shl_vartime_wide((U128::MAX, U128::ZERO), 1).unwrap(),
-            (U128::MAX.sbb(&U128::ONE, Limb::ZERO).0, U128::ONE)
+            (U128::MAX.borrowing_sub(&U128::ONE, Limb::ZERO).0, U128::ONE)
         );
     }
 

--- a/src/uint/sub_mod.rs
+++ b/src/uint/sub_mod.rs
@@ -7,7 +7,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
     pub const fn sub_mod(&self, rhs: &Self, p: &Self) -> Self {
-        let (out, mask) = self.sbb(rhs, Limb::ZERO);
+        let (out, mask) = self.borrowing_sub(rhs, Limb::ZERO);
 
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the modulus.
@@ -20,7 +20,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     pub(crate) const fn sub_mod_with_carry(&self, carry: Limb, rhs: &Self, p: &Self) -> Self {
         debug_assert!(carry.0 <= 1);
 
-        let (out, borrow) = self.sbb(rhs, Limb::ZERO);
+        let (out, borrow) = self.borrowing_sub(rhs, Limb::ZERO);
 
         // The new `borrow = Word::MAX` iff `carry == 0` and `borrow == Word::MAX`.
         let mask = carry.wrapping_neg().not().bitand(borrow);
@@ -35,7 +35,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
     pub const fn sub_mod_special(&self, rhs: &Self, c: Limb) -> Self {
-        let (out, borrow) = self.sbb(rhs, Limb::ZERO);
+        let (out, borrow) = self.borrowing_sub(rhs, Limb::ZERO);
 
         // If underflow occurred, then we need to subtract `c` to account for
         // the underflow. This cannot underflow due to the assumption

--- a/tests/boxed_uint.rs
+++ b/tests/boxed_uint.rs
@@ -195,7 +195,7 @@ proptest! {
     }
 
     #[test]
-    fn mul_wide(a in uint(), b in uint()) {
+    fn widening_mul(a in uint(), b in uint()) {
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);
 

--- a/tests/monty_form.rs
+++ b/tests/monty_form.rs
@@ -150,7 +150,7 @@ proptest! {
         assert_eq!(one_monty.retrieve(), U128::ONE, "a*a⁻¹ ≠ 1 (normal form)");
         // …and when converted back to normal form and used in a widening operation
         let wide_modulus = NonZero::new(Into::<U256>::into(&monty_params.modulus().get())).unwrap();
-        let one = r_monty_inv.retrieve().widening_mul(&r);
+        let one = r_monty_inv.retrieve().concatenating_mul(&r);
         assert_eq!(
             one % wide_modulus,
             U256::ONE,
@@ -189,7 +189,7 @@ proptest! {
         assert_eq!(one_monty.retrieve(), U256::ONE, "a*a⁻¹ ≠ 1 (normal form)");
         // …and when converted back to normal form and used in a widening operation
         let wide_modulus = NonZero::new(Into::<U512>::into(&monty_params.modulus().get())).unwrap();
-        let one = r_monty_inv.retrieve().widening_mul(&r);
+        let one = r_monty_inv.retrieve().concatenating_mul(&r);
         assert_eq!(
             one % wide_modulus,
             U512::ONE,
@@ -228,7 +228,7 @@ proptest! {
         assert_eq!(one_monty.retrieve(), U1024::ONE, "a*a⁻¹ ≠ 1 (normal form)");
         // …and when converted back to normal form and used in a widening operation
         let wide_modulus = NonZero::new(Into::<U2048>::into(&monty_params.modulus().get())).unwrap();
-        let one = r_monty_inv.retrieve().widening_mul(&r);
+        let one = r_monty_inv.retrieve().concatenating_mul(&r);
         assert_eq!(
             one % wide_modulus,
             U2048::ONE,
@@ -267,7 +267,7 @@ proptest! {
         assert_eq!(one_monty.retrieve(), U2048::ONE, "a*a⁻¹ ≠ 1 (normal form)");
         // …and when converted back to normal form and used in a widening operation
         let wide_modulus = NonZero::new(Into::<U4096>::into(&monty_params.modulus().get())).unwrap();
-        let one = r_monty_inv.retrieve().widening_mul(&r);
+        let one = r_monty_inv.retrieve().concatenating_mul(&r);
         assert_eq!(
             one % wide_modulus,
             U4096::ONE,

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -310,7 +310,7 @@ proptest! {
 
         if !c_bi.is_zero() {
             let expected = to_uint(ab_bi.div_rem(&c_bi).1);
-            let (lo, hi) = a.split_mul(&b);
+            let (lo, hi) = a.widening_mul(&b);
             let c_nz = NonZero::new(c).unwrap();
             let actual = Uint::rem_wide_vartime((lo, hi), &c_nz);
             prop_assert_eq!(expected, actual);

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -265,12 +265,12 @@ proptest! {
     }
 
     #[test]
-    fn widening_mul_large(a in uint_large(), b in uint_large()) {
+    fn concatenating_mul_large(a in uint_large(), b in uint_large()) {
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);
 
         let expected = to_uint_xlarge(a_bi * b_bi);
-        let actual = a.widening_mul(&b);
+        let actual = a.concatenating_mul(&b);
 
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
Fixes #693

Public API:
- Rename `WideningMul` -> `ConcatenatingMul`, `widening_mul()` -> `concatenating_mul()`
- Rename `mul_wide()`/`split_mul()` -> `widening_mul()`
- Rename `adc()` -> `carrying_add()`
- Rename `sbb()` -> `borrowing_sub()`
- Rename `mac()` -> `carrying_mul_add()` and change the order of arguments to match the `core` signature

Internal:
- Remove `primitives::mulhilo()` (same as `widening_mul()`)
- Change argument order in `addhilo()` to match the rest of the primitives
- Mark functions in `primitives` as `pub(crate)` (just in case)

Note that `widening_mul()` methods were not marked as deprecated since they had their behavior changed instead. 