### PR TITLE
Have `impl_modulus!` reference itself by `$crate::`

### DIFF
--- a/src/modular/const_monty_form/macros.rs
+++ b/src/modular/const_monty_form/macros.rs
@@ -13,7 +13,7 @@
 #[macro_export]
 macro_rules! impl_modulus {
     ($name:ident, $uint_type:ty, $value:expr) => {
-        impl_modulus!(
+        $crate::impl_modulus!(
             $name,
             $uint_type,
             $value,


### PR DESCRIPTION
This avoids the requirement to have it in scope