### PR TITLE
Fix cargo-checkct action

### DIFF
--- a/.github/workflows/cargo-checkct.yml
+++ b/.github/workflows/cargo-checkct.yml
@@ -18,6 +18,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    uses: Ledger-Donjon/action-cargo-checkct@v1
-    with:
-      directory: .
+    
+    steps:
+      - uses: Ledger-Donjon/action-cargo-checkct@v1
+        with:
+          directory: .

--- a/.github/workflows/cargo-checkct.yml
+++ b/.github/workflows/cargo-checkct.yml
@@ -16,7 +16,8 @@ env:
   RUSTDOCFLAGS: "-Dwarnings"
 
 jobs:
-  build:
+  checkct:
+    name: Run cargo-checkct
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/cargo-checkct.yml
+++ b/.github/workflows/cargo-checkct.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+      - uses: actions/checkout@v4
+      
       - uses: Ledger-Donjon/action-cargo-checkct@v1
         with:
           directory: .

--- a/checkct/driver/Cargo.toml
+++ b/checkct/driver/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 
 [dependencies]
 rand_core = "0.6.4"
-checkct_macros = { path = "../../../../cargo-checkct/checkct_macros" }
+checkct_macros = { path = "../../cargo-checkct/checkct_macros" }
 crypto-bigint = { path = "../.." }


### PR DESCRIPTION
Hello @tarcieri :wave: 

This PR should fix your action. It'll still [fail](https://github.com/bboilot-ledger/crypto-bigint/actions/runs/15332758658/job/43143257617?pr=1) because the driver hasn't been implemented yet.
I am not a fan of the modification I had to do to the manifest in order for the tool to run. I'll discuss this matter with the team.