### PR TITLE
Add `BoxedUint::{from_be_slice_vartime, from_le_slice_vartime}`

### DIFF
--- a/src/uint/boxed/encoding.rs
+++ b/src/uint/boxed/encoding.rs
@@ -39,6 +39,20 @@ impl BoxedUint {
         Ok(ret)
     }
 
+    /// Create a new [`BoxedUint`] from the provided big endian bytes, automatically selecting its
+    /// precision based on the size of the input.
+    ///
+    /// This method is variable-time with respect to all subsequent operations since it chooses the
+    /// limb count based on the input size, and is therefore only suitable for public inputs.
+    ///
+    /// When working with secret values, use [`BoxedUint::from_be_slice`].
+    pub fn from_be_slice_vartime(bytes: &[u8]) -> Self {
+        let bits_precision = bytes.len().saturating_mul(8) as u32;
+
+        // TODO(tarcieri): avoid panic
+        Self::from_be_slice(bytes, bits_precision).expect("precision should be large enough")
+    }
+
     /// Create a new [`BoxedUint`] from the provided little endian bytes.
     ///
     /// The `bits_precision` argument represents the precision of the resulting integer, which is
@@ -70,6 +84,20 @@ impl BoxedUint {
         }
 
         Ok(ret)
+    }
+
+    /// Create a new [`BoxedUint`] from the provided little endian bytes, automatically selecting
+    /// its precision based on the size of the input.
+    ///
+    /// This method is variable-time with respect to all subsequent operations since it chooses the
+    /// limb count based on the input size, and is therefore only suitable for public inputs.
+    ///
+    /// When working with secret values, use [`BoxedUint::from_le_slice`].
+    pub fn from_le_slice_vartime(bytes: &[u8]) -> Self {
+        let bits_precision = bytes.len().saturating_mul(8) as u32;
+
+        // TODO(tarcieri): avoid panic
+        Self::from_le_slice(bytes, bits_precision).expect("precision should be large enough")
     }
 
     /// Serialize this [`BoxedUint`] as big-endian.
@@ -344,6 +372,15 @@ mod tests {
     }
 
     #[test]
+    fn from_be_slice_vartime() {
+        let bytes = hex!(
+            "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111F"
+        );
+        let uint = BoxedUint::from_be_slice_vartime(&bytes);
+        assert_eq!(&*uint.to_be_bytes_trimmed_vartime(), bytes.as_slice());
+    }
+
+    #[test]
     #[cfg(target_pointer_width = "32")]
     fn from_le_slice_eq() {
         let bytes = hex!("7766554433221100");
@@ -434,6 +471,15 @@ mod tests {
             BoxedUint::from_le_slice(&bytes, 121),
             Err(DecodeError::Precision)
         );
+    }
+
+    #[test]
+    fn from_le_slice_vartime() {
+        let bytes = hex!(
+            "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111F"
+        );
+        let uint = BoxedUint::from_le_slice_vartime(&bytes);
+        assert_eq!(&*uint.to_le_bytes_trimmed_vartime(), bytes.as_slice());
     }
 
     #[test]

--- a/tests/boxed_uint.rs
+++ b/tests/boxed_uint.rs
@@ -283,7 +283,6 @@ proptest! {
         }
     }
 
-
     #[test]
     fn shr_vartime(a in uint(), shift in any::<u16>()) {
         let a_bi = to_biguint(&a);
@@ -302,7 +301,6 @@ proptest! {
         }
     }
 
-
     #[test]
     fn radix_encode_vartime(a in uint(), radix in 2u32..=36) {
         let a_bi = to_biguint(&a);
@@ -315,5 +313,19 @@ proptest! {
         let dec_bi = to_biguint(&decoded);
         prop_assert_eq!(dec_bi, a_bi);
 
+    }
+
+    #[test]
+    fn from_be_slice_vartime(a in uint()) {
+        let a_bytes = a.to_be_bytes_trimmed_vartime();
+        let b = BoxedUint::from_be_slice_vartime(&a_bytes);
+        prop_assert_eq!(a, b);
+    }
+
+    #[test]
+    fn from_le_slice_vartime(a in uint()) {
+        let a_bytes = a.to_le_bytes_trimmed_vartime();
+        let b = BoxedUint::from_le_slice_vartime(&a_bytes);
+        prop_assert_eq!(a, b);
     }
 }


### PR DESCRIPTION
Adds methods for decoding `BoxedUint` which infer the precision from the input size.

This is useful for decoding public parameters, especially when the size of other parameters is inferred from some public parameter that needs to be decoded first, e.g. RSA modulus.