### PR TITLE
`Int`-`Uint` conversion

### DIFF
--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -395,7 +395,7 @@ impl<const LIMBS: usize> ConstCtOption<Uint<LIMBS>> {
     /// Returns the contained value, interpreting the underlying [`Uint`] value as an [`Int`].
     #[inline]
     pub const fn as_int(&self) -> ConstCtOption<Int<LIMBS>> {
-        ConstCtOption::new(self.value.as_int(), self.is_some)
+        ConstCtOption::new(*self.value.as_int(), self.is_some)
     }
 }
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -154,9 +154,22 @@ impl<const LIMBS: usize> Int<LIMBS> {
         ConstCtOption::new(Odd(self), self.0.is_odd())
     }
 
-    /// Interpret the data in this type as a [`Uint`] instead.
+    /// Interpret the data in this object as a [Uint] instead.
+    ///
+    /// Note: this is a casting operation. See
+    /// - [Self::to_uint] for the checked equivalent, and
+    /// - [Self::abs] to obtain the absolute value of `self`.
     pub const fn as_uint(&self) -> &Uint<LIMBS> {
         &self.0
+    }
+
+    /// Get a [Uint] equivalent of this value; returns `None` if `self` is negative.
+    ///
+    /// Note: this is a checked conversion operation. See
+    /// - [Self::as_uint] for the unchecked equivalent, and
+    /// - [Self::abs] to obtain the absolute value of `self`.
+    pub const fn to_uint(self) -> ConstCtOption<Uint<LIMBS>> {
+        ConstCtOption::new(self.0, self.is_negative().not())
     }
 
     /// Whether this [`Int`] is equal to `Self::MIN`.
@@ -428,5 +441,14 @@ mod tests {
         assert_eq!(*I128::ZERO.as_uint(), U128::ZERO);
         assert_eq!(*I128::ONE.as_uint(), U128::ONE);
         assert_eq!(*I128::MAX.as_uint(), U128::MAX >> 1);
+    }
+
+    #[test]
+    fn to_uint() {
+        assert!(bool::from(I128::MIN.to_uint().is_none()));
+        assert!(bool::from(I128::MINUS_ONE.to_uint().is_none()));
+        assert_eq!(I128::ZERO.to_uint().unwrap(), U128::ZERO);
+        assert_eq!(I128::ONE.to_uint().unwrap(), U128::ONE);
+        assert_eq!(I128::MAX.to_uint().unwrap(), U128::MAX >> 1);
     }
 }

--- a/src/int.rs
+++ b/src/int.rs
@@ -157,7 +157,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Interpret the data in this object as a [`Uint`] instead.
     ///
     /// Note: this is a casting operation. See
-    /// - [`Self::to_uint`] for the checked equivalent, and
+    /// - [`Self::try_into_uint`] for the checked equivalent, and
     /// - [`Self::abs`] to obtain the absolute value of `self`.
     pub const fn as_uint(&self) -> &Uint<LIMBS> {
         &self.0
@@ -168,7 +168,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Note: this is a checked conversion operation. See
     /// - [`Self::as_uint`] for the unchecked equivalent, and
     /// - [`Self::abs`] to obtain the absolute value of `self`.
-    pub const fn to_uint(self) -> ConstCtOption<Uint<LIMBS>> {
+    pub const fn try_into_uint(self) -> ConstCtOption<Uint<LIMBS>> {
         ConstCtOption::new(self.0, self.is_negative().not())
     }
 
@@ -445,10 +445,10 @@ mod tests {
 
     #[test]
     fn to_uint() {
-        assert!(bool::from(I128::MIN.to_uint().is_none()));
-        assert!(bool::from(I128::MINUS_ONE.to_uint().is_none()));
-        assert_eq!(I128::ZERO.to_uint().unwrap(), U128::ZERO);
-        assert_eq!(I128::ONE.to_uint().unwrap(), U128::ONE);
-        assert_eq!(I128::MAX.to_uint().unwrap(), U128::MAX >> 1);
+        assert!(bool::from(I128::MIN.try_into_uint().is_none()));
+        assert!(bool::from(I128::MINUS_ONE.try_into_uint().is_none()));
+        assert_eq!(I128::ZERO.try_into_uint().unwrap(), U128::ZERO);
+        assert_eq!(I128::ONE.try_into_uint().unwrap(), U128::ONE);
+        assert_eq!(I128::MAX.try_into_uint().unwrap(), U128::MAX >> 1);
     }
 }

--- a/src/int.rs
+++ b/src/int.rs
@@ -154,20 +154,20 @@ impl<const LIMBS: usize> Int<LIMBS> {
         ConstCtOption::new(Odd(self), self.0.is_odd())
     }
 
-    /// Interpret the data in this object as a [Uint] instead.
+    /// Interpret the data in this object as a [`Uint`] instead.
     ///
     /// Note: this is a casting operation. See
-    /// - [Self::to_uint] for the checked equivalent, and
-    /// - [Self::abs] to obtain the absolute value of `self`.
+    /// - [`Self::to_uint`] for the checked equivalent, and
+    /// - [`Self::abs`] to obtain the absolute value of `self`.
     pub const fn as_uint(&self) -> &Uint<LIMBS> {
         &self.0
     }
 
-    /// Get a [Uint] equivalent of this value; returns `None` if `self` is negative.
+    /// Get a [`Uint`] equivalent of this value; returns `None` if `self` is negative.
     ///
     /// Note: this is a checked conversion operation. See
-    /// - [Self::as_uint] for the unchecked equivalent, and
-    /// - [Self::abs] to obtain the absolute value of `self`.
+    /// - [`Self::as_uint`] for the unchecked equivalent, and
+    /// - [`Self::abs`] to obtain the absolute value of `self`.
     pub const fn to_uint(self) -> ConstCtOption<Uint<LIMBS>> {
         ConstCtOption::new(self.0, self.is_negative().not())
     }

--- a/src/int.rs
+++ b/src/int.rs
@@ -42,6 +42,7 @@ mod rand;
 /// Created as a [`Uint`] newtype.
 #[allow(clippy::derived_hash_with_manual_eq)]
 #[derive(Copy, Clone, Hash)]
+#[repr(transparent)]
 pub struct Int<const LIMBS: usize>(Uint<LIMBS>);
 
 impl<const LIMBS: usize> Int<LIMBS> {

--- a/src/int/mul_uint.rs
+++ b/src/int/mul_uint.rs
@@ -78,7 +78,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
         let product_abs = lhs_abs.concatenating_mul(rhs);
 
         // always fits
-        product_abs.wrapping_neg_if(lhs_sign).as_int()
+        *product_abs.wrapping_neg_if(lhs_sign).as_int()
     }
 
     /// Checked multiplication of self with an `Uint<RHS_LIMBS>`, where the result is to be stored

--- a/src/int/resize.rs
+++ b/src/int/resize.rs
@@ -12,7 +12,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
             limbs[i] = self.0.limbs[i];
             i += 1;
         }
-        Uint { limbs }.as_int()
+        *Uint { limbs }.as_int()
     }
 }
 
@@ -43,7 +43,7 @@ mod tests {
         assert_eq!(I128::ONE.resize::<{ I256::LIMBS }>(), I256::ONE);
         assert_eq!(
             I128::MAX.resize::<{ I256::LIMBS }>(),
-            I128::MAX.0.resize().as_int()
+            *I128::MAX.0.resize().as_int()
         );
     }
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -215,8 +215,11 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Interpret this object as an [`Int`] instead.
     ///
     /// Note: this is a casting operation. See [`Self::try_into_int`] for the checked equivalent.
-    pub const fn as_int(&self) -> Int<LIMBS> {
-        Int::from_bits(*self)
+    pub const fn as_int(&self) -> &Int<LIMBS> {
+        #[allow(trivial_casts, unsafe_code)]
+        unsafe {
+            &*(self as *const Uint<LIMBS> as *const Int<LIMBS>)
+        }
     }
 
     /// Convert this type into an [`Int`]; returns `None` if this value is greater than `Int::MAX`.
@@ -677,9 +680,9 @@ mod tests {
 
     #[test]
     fn as_int() {
-        assert_eq!(U128::ZERO.as_int(), Int::ZERO);
-        assert_eq!(U128::ONE.as_int(), Int::ONE);
-        assert_eq!(U128::MAX.as_int(), Int::MINUS_ONE);
+        assert_eq!(*U128::ZERO.as_int(), Int::ZERO);
+        assert_eq!(*U128::ONE.as_int(), Int::ONE);
+        assert_eq!(*U128::MAX.as_int(), Int::MINUS_ONE);
     }
 
     #[test]

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -212,16 +212,16 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         ConstCtOption::new(Odd(self), self.is_odd())
     }
 
-    /// Interpret this object as an [Int] instead.
+    /// Interpret this object as an [`Int`] instead.
     ///
-    /// Note: this is a casting operation. See [Self::to_int] for the checked equivalent.
+    /// Note: this is a casting operation. See [`Self::to_int`] for the checked equivalent.
     pub const fn as_int(&self) -> Int<LIMBS> {
         Int::from_bits(*self)
     }
 
-    /// Convert this type into an [Int]; returns `None` if this value is greater than `Int::MAX`.
+    /// Convert this type into an [`Int`]; returns `None` if this value is greater than `Int::MAX`.
     ///
-    /// Note: this is the conversion operation. See [Self::as_int] for the unchecked equivalent.
+    /// Note: this is the conversion operation. See [`Self::as_int`] for the unchecked equivalent.
     pub const fn to_int(self) -> ConstCtOption<Int<LIMBS>> {
         Int::new_from_abs_sign(self, ConstChoice::FALSE)
     }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -214,7 +214,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Interpret this object as an [`Int`] instead.
     ///
-    /// Note: this is a casting operation. See [`Self::to_int`] for the checked equivalent.
+    /// Note: this is a casting operation. See [`Self::try_into_int`] for the checked equivalent.
     pub const fn as_int(&self) -> Int<LIMBS> {
         Int::from_bits(*self)
     }
@@ -222,7 +222,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Convert this type into an [`Int`]; returns `None` if this value is greater than `Int::MAX`.
     ///
     /// Note: this is the conversion operation. See [`Self::as_int`] for the unchecked equivalent.
-    pub const fn to_int(self) -> ConstCtOption<Int<LIMBS>> {
+    pub const fn try_into_int(self) -> ConstCtOption<Int<LIMBS>> {
         Int::new_from_abs_sign(self, ConstChoice::FALSE)
     }
 }
@@ -684,9 +684,9 @@ mod tests {
 
     #[test]
     fn to_int() {
-        assert_eq!(U128::ZERO.to_int().unwrap(), Int::ZERO);
-        assert_eq!(U128::ONE.to_int().unwrap(), Int::ONE);
-        assert_eq!(I128::MAX.as_uint().to_int().unwrap(), Int::MAX);
-        assert!(bool::from(U128::MAX.to_int().is_none()));
+        assert_eq!(U128::ZERO.try_into_int().unwrap(), Int::ZERO);
+        assert_eq!(U128::ONE.try_into_int().unwrap(), Int::ONE);
+        assert_eq!(I128::MAX.as_uint().try_into_int().unwrap(), Int::MAX);
+        assert!(bool::from(U128::MAX.try_into_int().is_none()));
     }
 }

--- a/src/uint/bingcd/extension.rs
+++ b/src/uint/bingcd/extension.rs
@@ -105,9 +105,9 @@ impl<const LIMBS: usize, const EXTRA: usize> ExtendedInt<LIMBS, EXTRA> {
         // should succeed when
         // - extension is ZERO, or
         // - extension is MAX, and the top bit in base is set.
-        let proper_positive = Int::eq(&self.1.as_int(), &Int::ZERO);
+        let proper_positive = Int::eq(self.1.as_int(), &Int::ZERO);
         let proper_negative =
-            Int::eq(&self.1.as_int(), &Int::MINUS_ONE).and(self.0.as_int().is_negative());
+            Int::eq(self.1.as_int(), &Int::MINUS_ONE).and(self.0.as_int().is_negative());
         ConstCtOption::new(self.abs().0, proper_negative.or(proper_positive))
     }
 

--- a/src/uint/mul_int.rs
+++ b/src/uint/mul_int.rs
@@ -28,7 +28,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let product_abs = self.concatenating_mul(&rhs_abs);
 
         // always fits
-        product_abs.wrapping_neg_if(rhs_sign).as_int()
+        *product_abs.wrapping_neg_if(rhs_sign).as_int()
     }
 
     /// Checked multiplication of `self` with [`Int`] `rhs`.


### PR DESCRIPTION
This PR introduces `Int::to_uint` and `Uint::to_int`, allowing better conversion between these types.