### PR TITLE
Improve `Int::abs`

### DIFF
--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -171,11 +171,16 @@ impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
 }
 
 impl<const LIMBS: usize> NonZero<Int<LIMBS>> {
-    /// Convert a [`NonZero<Int>`] to its sign and [`NonZero<Uint>`] magnitude.
+    /// The sign and magnitude of this [`NonZero<Int<{LIMBS}>>`].
     pub const fn abs_sign(&self) -> (NonZero<Uint<LIMBS>>, ConstChoice) {
         let (abs, sign) = self.0.abs_sign();
-        // Note: a NonZero<Int> always has a non-zero magnitude, so it is safe to unwrap.
-        (NonZero::<Uint<LIMBS>>::new_unwrap(abs), sign)
+        // Absolute value of a non-zero value is non-zero
+        (NonZero(abs), sign)
+    }
+
+    /// The magnitude of this [`NonZero<Int<{LIMBS}>>`].
+    pub const fn abs(&self) -> NonZero<Uint<LIMBS>> {
+        self.abs_sign().0
     }
 }
 

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -1,6 +1,6 @@
 //! Wrapper type for non-zero integers.
 
-use crate::{Integer, Limb, NonZero, Uint};
+use crate::{ConstChoice, Int, Integer, Limb, NonZero, Uint};
 use core::{cmp::Ordering, fmt, ops::Deref};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
@@ -74,6 +74,20 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
         let uint = Uint::<LIMBS>::from_be_hex(hex);
         assert!(uint.is_odd().is_true_vartime(), "number must be odd");
         Odd(uint)
+    }
+}
+
+impl<const LIMBS: usize> Odd<Int<LIMBS>> {
+    /// The sign and magnitude of this [`Odd<Int<{LIMBS}>>`].
+    pub const fn abs_sign(&self) -> (Odd<Uint<LIMBS>>, ConstChoice) {
+        // Absolute value of an odd value is odd
+        let (abs, sgn) = Int::abs_sign(self.as_ref());
+        (Odd(abs), sgn)
+    }
+
+    /// The magnitude of this [`Odd<Int<{LIMBS}>>`].
+    pub const fn abs(&self) -> Odd<Uint<LIMBS>> {
+        self.abs_sign().0
     }
 }
 


### PR DESCRIPTION
Make 
- `Odd::<Int>::abs() -> Odd<Uint>`, and 
- `NonZero::<Int>::abs() -> NonZero<Uint>`
 
instead of `-> Uint`.