### PR TITLE
Add `NonZero` and `Odd` type aliases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,11 +187,10 @@ pub use crate::{
     int::types::*,
     int::*,
     limb::{Limb, WideWord, Word},
-    non_zero::NonZero,
-    odd::Odd,
+    non_zero::*,
+    odd::*,
     traits::*,
-    uint::div_limb::Reciprocal,
-    uint::*,
+    uint::{div_limb::Reciprocal, *},
     wrapping::Wrapping,
 };
 

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -8,6 +8,9 @@ use core::{
 };
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
+#[cfg(feature = "alloc")]
+use crate::BoxedUint;
+
 #[cfg(feature = "hybrid-array")]
 use crate::{ArrayEncoding, ByteArray};
 
@@ -19,6 +22,13 @@ use serdect::serde::{
     Deserialize, Deserializer, Serialize, Serializer,
     de::{Error, Unexpected},
 };
+
+/// Non-zero unsigned integer.
+pub type NonZeroUint<const LIMBS: usize> = NonZero<Uint<LIMBS>>;
+
+/// Non-zero boxed unsigned integer.
+#[cfg(feature = "alloc")]
+pub type NonZeroBoxedUint = NonZero<BoxedUint>;
 
 /// Wrapper type for non-zero integers.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -21,6 +21,13 @@ use serdect::serde::{
     de::{Error, Unexpected},
 };
 
+/// Non-zero unsigned integer.
+pub type OddUint<const LIMBS: usize> = Odd<Uint<LIMBS>>;
+
+/// Non-zero boxed unsigned integer.
+#[cfg(feature = "alloc")]
+pub type OddBoxedUint = Odd<BoxedUint>;
+
 /// Wrapper type for odd integers.
 ///
 /// These are frequently used in cryptography, e.g. as a modulus.


### PR DESCRIPTION
Adds the following type aliases:
- `NonZeroUint`
- `NonZeroBoxedUint`
- `OddUint`
- `OddBoxedUint`

This avoids consumers of the crate from having to assemble these themselves.