### PR TITLE
Add `NonZeroInt` and `OddInt` type aliases

### DIFF
--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -26,6 +26,9 @@ use serdect::serde::{
 /// Non-zero unsigned integer.
 pub type NonZeroUint<const LIMBS: usize> = NonZero<Uint<LIMBS>>;
 
+/// Non-zero signed integer
+pub type NonZeroInt<const LIMBS: usize> = NonZero<Int<LIMBS>>;
+
 /// Non-zero boxed unsigned integer.
 #[cfg(feature = "alloc")]
 pub type NonZeroBoxedUint = NonZero<BoxedUint>;

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -24,6 +24,9 @@ use serdect::serde::{
 /// Non-zero unsigned integer.
 pub type OddUint<const LIMBS: usize> = Odd<Uint<LIMBS>>;
 
+/// Non-zero signed integer.
+pub type OddInt<const LIMBS: usize> = Odd<Int<LIMBS>>;
+
 /// Non-zero boxed unsigned integer.
 #[cfg(feature = "alloc")]
 pub type OddBoxedUint = Odd<BoxedUint>;


### PR DESCRIPTION
Is there a reason #844 did not include these types? :smiley: 