### PR TITLE
Add `#[ignore]` to bingcd tests

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -94,6 +94,7 @@ jobs:
       - run: cargo test --target ${{ matrix.target }} --no-default-features ${{ matrix.args }}
       - run: cargo test --target ${{ matrix.target }}  ${{ matrix.args }}
       - run: cargo test --target ${{ matrix.target }} --all-features ${{ matrix.args }}
+      - run: cargo test --target ${{ matrix.target }} --all-features ${{ matrix.args }} -- --ignored # slow bingcd tests
 
   # Test using `cargo careful`
   test-careful:

--- a/src/uint/bingcd.rs
+++ b/src/uint/bingcd.rs
@@ -63,6 +63,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // TODO(tarcieri): improve performance
     fn test_bingcd() {
         let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
         bingcd_tests::<{ U256::LIMBS }>(&mut rng);

--- a/src/uint/bingcd/gcd.rs
+++ b/src/uint/bingcd/gcd.rs
@@ -194,6 +194,7 @@ mod tests {
         }
 
         #[test]
+        #[ignore] // TODO(tarcieri): improve performance
         fn test_classic_bingcd() {
             let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
             classic_bingcd_tests::<{ U64::LIMBS }>(&mut rng);
@@ -243,6 +244,7 @@ mod tests {
         }
 
         #[test]
+        #[ignore] // TODO(tarcieri): improve performance
         fn test_optimized_bingcd() {
             let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
 


### PR DESCRIPTION
In their current form these tests take quite awhile to execute.

Adding `#[ignore]` omits them from typical test runs so the test suite still executes quickly.

The main `test` job in CI has been configured to run them with `--ignored`.