### PR TITLE
CI: pin `clippy` version

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -167,7 +167,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.88.0
           components: clippy
       - run: cargo clippy --all-targets --all-features -- -D warnings
 


### PR DESCRIPTION
Pins `clippy` to Rust 1.88, which prevents breaking the build when new lints are introduced in future Rust versions.

See also #859