### PR TITLE
DRY out Monty params between const and non-const forms

### DIFF
--- a/src/modular.rs
+++ b/src/modular.rs
@@ -16,6 +16,8 @@
 //! The [`MontyForm`] and [`MontyParams`] types implement support for modular arithmetic where
 //! the modulus can vary at runtime.
 
+pub mod params;
+
 mod const_monty_form;
 mod lincomb;
 mod monty_form;

--- a/src/modular/const_monty_form/macros.rs
+++ b/src/modular/const_monty_form/macros.rs
@@ -45,34 +45,17 @@ macro_rules! const_monty_params {
 
             // `R mod MODULUS` where `R = 2^BITS`.
             // Represents 1 in Montgomery form.
-            const ONE: $uint_type = $crate::Uint::MAX
-                .rem_vartime(Self::MODULUS.as_nz_ref())
-                .wrapping_add(&$crate::Uint::ONE);
+            const ONE: $uint_type = $crate::modular::params::montgomery_one(&Self::MODULUS);
 
             // `R^2 mod MODULUS`, used to convert integers to Montgomery form.
             const R2: $uint_type =
-                $crate::Uint::rem_wide_vartime(Self::ONE.square_wide(), Self::MODULUS.as_nz_ref());
+                $crate::modular::params::montgomery_r2(&Self::ONE, &Self::MODULUS);
 
-            const MOD_NEG_INV: $crate::Limb = $crate::Limb(
-                $crate::Word::MIN.wrapping_sub(
-                    Self::MODULUS
-                        .as_ref()
-                        .invert_mod2k_vartime($crate::Word::BITS)
-                        .expect("modulus ensured odd")
-                        .as_limbs()[0]
-                        .0,
-                ),
-            );
+            const MOD_NEG_INV: $crate::Limb = $crate::modular::params::mod_neg_inv(&Self::MODULUS);
 
             // Leading zeros in the modulus, used to choose optimized algorithms.
-            const MOD_LEADING_ZEROS: u32 = {
-                let z = Self::MODULUS.as_ref().leading_zeros();
-                if z >= $crate::Word::BITS {
-                    $crate::Word::BITS - 1
-                } else {
-                    z
-                }
-            };
+            const MOD_LEADING_ZEROS: u32 =
+                $crate::modular::params::mod_leading_zeros(&Self::MODULUS);
 
             const R3: $uint_type = $crate::modular::montgomery_reduction(
                 &Self::R2.square_wide(),

--- a/src/modular/params.rs
+++ b/src/modular/params.rs
@@ -1,0 +1,38 @@
+//! Helper functions for computing Montgomery parameters.
+//!
+//! These need to be `pub` as they're used by the `const_monty_params!` macro.
+
+use crate::{Limb, Odd, Uint, Word};
+
+/// Compute `1` in Montgomery form.
+pub const fn montgomery_one<const LIMBS: usize>(modulus: &Odd<Uint<LIMBS>>) -> Uint<LIMBS> {
+    Uint::MAX
+        .rem_vartime(modulus.as_nz_ref())
+        .wrapping_add(&Uint::ONE)
+}
+
+/// Compute `R^2` mod `modulus` in Montgomery form. Used to convert integers to Montgomery form.
+pub const fn montgomery_r2<const LIMBS: usize>(
+    one: &Uint<LIMBS>,
+    modulus: &Odd<Uint<LIMBS>>,
+) -> Uint<LIMBS> {
+    Uint::rem_wide_vartime(one.square_wide(), modulus.as_nz_ref())
+}
+
+/// Compute the lowest limb of `-(modulus^-1) mod R`.
+pub const fn mod_neg_inv<const LIMBS: usize>(modulus: &Odd<Uint<LIMBS>>) -> Limb {
+    // The modular inverse should always exist, because it was ensured odd above, which also ensures
+    // it's non-zero
+    let inv_mod = modulus
+        .as_ref()
+        .invert_mod2k_vartime(Word::BITS)
+        .expect("modular inverse should exist");
+
+    Limb(Word::MIN.wrapping_sub(inv_mod.limbs[0].0))
+}
+
+/// Compute leading zeros in the modulus.
+pub const fn mod_leading_zeros<const LIMBS: usize>(modulus: &Odd<Uint<LIMBS>>) -> u32 {
+    let z = modulus.as_ref().leading_zeros();
+    if z >= Word::BITS { Word::BITS - 1 } else { z }
+}


### PR DESCRIPTION
Creates a `modular::params` module containing a set of `const fn` functions for computing Montgomery params, and uses these functions for both the `const_monty_params!` macro as well as `MontyParams`.

Ideally we could just use `MontyParams` for this (as it has a `const fn` constructor) and eventually this can probably be factored there (i.e. like it was before this PR). However, doing that properly would require `adt_const_params` (rust-lang/rust#95174), which is why we have `const_monty_params!` in the first place, so for now this is the best we can do.