### PR TITLE
Rename `div_by_2` to `shr1`

### DIFF
--- a/benches/monty.rs
+++ b/benches/monty.rs
@@ -180,13 +180,13 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         )
     });
 
-    group.bench_function("div_by_2, U256", |b| {
+    group.bench_function("shr1, MontyForm(U256)", |b| {
         b.iter_batched(
             || {
                 let x = U256::random_mod(&mut rng, params.modulus().as_nz_ref());
                 MontyForm::new(&x, params)
             },
-            |x| black_box(x.div_by_2()),
+            |x| black_box(x.shr1()),
             BatchSize::SmallInput,
         )
     });

--- a/src/modular.rs
+++ b/src/modular.rs
@@ -23,10 +23,10 @@ mod reduction;
 
 mod add;
 pub(crate) mod bingcd;
-mod div_by_2;
 mod mul;
 mod pow;
 pub(crate) mod safegcd;
+mod shr1;
 mod sub;
 
 #[cfg(feature = "alloc")]

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -8,7 +8,7 @@ mod neg;
 mod pow;
 mod sub;
 
-use super::{Retrieve, div_by_2};
+use super::{Retrieve, shr1};
 use mul::BoxedMontyMultiplier;
 
 use crate::{BoxedUint, Limb, Monty, Odd, Resize, Word, modular::MontyParams};
@@ -275,17 +275,29 @@ impl BoxedMontyForm {
     }
 
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
-    pub fn div_by_2(&self) -> Self {
+    pub fn shr1(&self) -> Self {
         Self {
-            montgomery_form: div_by_2::div_by_2_boxed(&self.montgomery_form, self.params.modulus()),
+            montgomery_form: shr1::shr1_boxed(&self.montgomery_form, self.params.modulus()),
             params: self.params.clone(),
         }
     }
 
     /// Performs division by 2 inplace, that is finds `x` such that `x + x = self`
     /// and writes it into `self`.
+    pub fn shr1_assign(&mut self) {
+        shr1::shr1_boxed_assign(&mut self.montgomery_form, self.params.modulus())
+    }
+
+    /// Deprecated equivalent to `shr1`.
+    #[deprecated(since = "0.7.0", note = "please use `Monty::shr1` instead")]
+    pub fn div_by_2(&self) -> Self {
+        self.shr1()
+    }
+
+    /// Deprecated equivalent to `shr1_assign`.
+    #[deprecated(since = "0.7.0", note = "please use `Monty::shr1_assign` instead")]
     pub fn div_by_2_assign(&mut self) {
-        div_by_2::div_by_2_boxed_assign(&mut self.montgomery_form, self.params.modulus())
+        self.shr1_assign()
     }
 }
 
@@ -340,12 +352,12 @@ impl Monty for BoxedMontyForm {
         BoxedMontyForm::double(self)
     }
 
-    fn div_by_2(&self) -> Self {
-        BoxedMontyForm::div_by_2(self)
+    fn shr1(&self) -> Self {
+        BoxedMontyForm::shr1(self)
     }
 
-    fn div_by_2_assign(&mut self) {
-        BoxedMontyForm::div_by_2_assign(self)
+    fn shr1_assign(&mut self) {
+        BoxedMontyForm::shr1_assign(self)
     }
 
     fn lincomb_vartime(products: &[(&Self, &Self)]) -> Self {
@@ -381,14 +393,14 @@ mod tests {
     }
 
     #[test]
-    fn div_by_2() {
+    fn shr1() {
         let modulus = Odd::new(BoxedUint::from(9u8)).unwrap();
         let params = BoxedMontyParams::new(modulus);
         let zero = BoxedMontyForm::zero(params.clone());
         let one = BoxedMontyForm::one(params.clone());
         let two = one.add(&one);
 
-        assert_eq!(zero.div_by_2(), zero);
-        assert_eq!(one.div_by_2().mul(&two), one);
+        assert_eq!(zero.shr1(), zero);
+        assert_eq!(one.shr1().mul(&two), one);
     }
 }

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -9,9 +9,7 @@ mod pow;
 mod sub;
 
 use self::invert::ConstMontyFormInverter;
-use super::{
-    MontyParams, Retrieve, SafeGcdInverter, div_by_2::div_by_2, reduction::montgomery_reduction,
-};
+use super::{MontyParams, Retrieve, SafeGcdInverter, reduction::montgomery_reduction, shr1::shr1};
 use crate::{ConstZero, Odd, PrecomputeInverter, Uint};
 use core::{fmt::Debug, marker::PhantomData};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
@@ -128,12 +126,18 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
         self.montgomery_form
     }
 
-    /// Performs division by 2, that is returns `x` such that `x + x = self`.
-    pub const fn div_by_2(&self) -> Self {
+    /// Performs a 1-bit right shift (division by 2), that is returns `x` such that `x + x = self`.
+    pub const fn shr1(&self) -> Self {
         Self {
-            montgomery_form: div_by_2(&self.montgomery_form, &MOD::PARAMS.modulus),
+            montgomery_form: shr1(&self.montgomery_form, &MOD::PARAMS.modulus),
             phantom: PhantomData,
         }
+    }
+
+    /// Deprecated equivalent to `shr1`.
+    #[deprecated(since = "0.7.0", note = "please use `ConstMontyForm::shr1` instead")]
+    pub const fn div_by_2(&self) -> Self {
+        self.shr1()
     }
 }
 

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -11,8 +11,8 @@ mod sub;
 use super::{
     Retrieve,
     const_monty_form::{ConstMontyForm, ConstMontyParams},
-    div_by_2::div_by_2,
     reduction::montgomery_reduction,
+    shr1::shr1,
 };
 use crate::{Concat, ConstChoice, Limb, Monty, NonZero, Odd, Split, Uint, Word};
 use mul::DynMontyMultiplier;
@@ -241,11 +241,17 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
-    pub const fn div_by_2(&self) -> Self {
+    pub const fn shr1(&self) -> Self {
         Self {
-            montgomery_form: div_by_2(&self.montgomery_form, &self.params.modulus),
+            montgomery_form: shr1(&self.montgomery_form, &self.params.modulus),
             params: self.params,
         }
+    }
+
+    /// Deprecated equivalent to `shr1`.
+    #[deprecated(since = "0.7.0", note = "please use `ConstMontyForm::shr1` instead")]
+    pub const fn div_by_2(&self) -> Self {
+        self.shr1()
     }
 }
 
@@ -294,8 +300,8 @@ impl<const LIMBS: usize> Monty for MontyForm<LIMBS> {
         MontyForm::double(self)
     }
 
-    fn div_by_2(&self) -> Self {
-        MontyForm::div_by_2(self)
+    fn shr1(&self) -> Self {
+        MontyForm::shr1(self)
     }
 
     fn lincomb_vartime(products: &[(&Self, &Self)]) -> Self {

--- a/src/modular/shr1.rs
+++ b/src/modular/shr1.rs
@@ -2,7 +2,7 @@
 use crate::{BoxedUint, Integer};
 use crate::{Limb, Odd, Uint};
 
-pub(crate) const fn div_by_2<const LIMBS: usize>(
+pub(crate) const fn shr1<const LIMBS: usize>(
     a: &Uint<LIMBS>,
     modulus: &Odd<Uint<LIMBS>>,
 ) -> Uint<LIMBS> {
@@ -25,14 +25,14 @@ pub(crate) const fn div_by_2<const LIMBS: usize>(
 }
 
 #[cfg(feature = "alloc")]
-pub(crate) fn div_by_2_boxed(a: &BoxedUint, modulus: &Odd<BoxedUint>) -> BoxedUint {
+pub(crate) fn shr1_boxed(a: &BoxedUint, modulus: &Odd<BoxedUint>) -> BoxedUint {
     let mut result = a.clone();
-    div_by_2_boxed_assign(&mut result, modulus);
+    shr1_boxed_assign(&mut result, modulus);
     result
 }
 
 #[cfg(feature = "alloc")]
-pub(crate) fn div_by_2_boxed_assign(a: &mut BoxedUint, modulus: &Odd<BoxedUint>) {
+pub(crate) fn shr1_boxed_assign(a: &mut BoxedUint, modulus: &Odd<BoxedUint>) {
     debug_assert_eq!(a.bits_precision(), modulus.bits_precision());
 
     let is_odd = a.is_odd();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -999,12 +999,24 @@ pub trait Monty:
     fn double(&self) -> Self;
 
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
-    fn div_by_2(&self) -> Self;
+    fn shr1(&self) -> Self;
 
     /// Performs division by 2 inplace, that is finds `x` such that `x + x = self`
     /// and writes it into `self`.
+    fn shr1_assign(&mut self) {
+        *self = self.shr1()
+    }
+
+    /// Deprecated equivalent to `shr1`.
+    #[deprecated(since = "0.7.0", note = "please use `Monty::shr1` instead")]
+    fn div_by_2(&self) -> Self {
+        self.shr1()
+    }
+
+    /// Deprecated equivalent to `shr1_assign`.
+    #[deprecated(since = "0.7.0", note = "please use `Monty::shr1` instead")]
     fn div_by_2_assign(&mut self) {
-        *self = self.div_by_2()
+        self.shr1_assign()
     }
 
     /// Calculate the sum of products of pairs `(a, b)` in `products`.

--- a/tests/boxed_monty_form.rs
+++ b/tests/boxed_monty_form.rs
@@ -147,10 +147,10 @@ proptest! {
     }
 
     #[test]
-    fn div_by_2(a in monty_form()) {
-        let actual = a.div_by_2();
+    fn shr1(a in monty_form()) {
+        let actual = a.shr1();
         let mut actual_inplace = a.clone();
-        actual_inplace.div_by_2_assign();
+        actual_inplace.shr1_assign();
 
         let p = a.params().modulus();
         let a_bi = retrieve_biguint(&a);

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -566,7 +566,7 @@ proptest! {
     }
 
     #[test]
-    fn monty_form_div_by_2(a in uint_mod_p(P)) {
+    fn monty_form_shr1(a in uint_mod_p(P)) {
         let a_bi = to_biguint(&a);
         let p_bi = to_biguint(&P);
         let two = BigUint::from(2u32);
@@ -581,7 +581,7 @@ proptest! {
 
         let params = MontyParams::new_vartime(P);
         let a_m = MontyForm::new(&a, params);
-        let actual = a_m.div_by_2().retrieve();
+        let actual = a_m.shr1().retrieve();
 
         prop_assert_eq!(expected, actual);
     }


### PR DESCRIPTION
For a few reasons:
- It's more consistent with the existing uses of `shr1` in the codebase
- It's implemented in terms of `shr1` already
- With a little work it can be adapted into a full-fledged `shr`

This preserves the `div_by_2*` names with deprecations