### PR TITLE
`ConstMontyForm`: add `ConstCtOption` support

### DIFF
--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -1,7 +1,8 @@
 use subtle::{Choice, CtOption};
 
 use crate::{
-    Int, Limb, NonZero, NonZeroInt, Odd, OddInt, Uint, WideWord, Word, modular::SafeGcdInverter,
+    Int, Limb, NonZero, NonZeroInt, Odd, OddInt, Uint, WideWord, Word,
+    modular::{ConstMontyForm, ConstMontyParams, SafeGcdInverter},
 };
 
 /// A boolean value returned by constant-time `const fn`s.
@@ -526,6 +527,25 @@ impl<const SAT_LIMBS: usize, const UNSAT_LIMBS: usize>
     /// `msg`.
     #[inline]
     pub const fn expect(self, msg: &str) -> SafeGcdInverter<SAT_LIMBS, UNSAT_LIMBS> {
+        assert!(self.is_some.is_true_vartime(), "{}", msg);
+        self.value
+    }
+}
+
+impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstCtOption<ConstMontyForm<MOD, LIMBS>> {
+    /// This returns the underlying value if it is `Some` or the provided value otherwise.
+    #[inline]
+    pub const fn unwrap_or(self, def: ConstMontyForm<MOD, LIMBS>) -> ConstMontyForm<MOD, LIMBS> {
+        ConstMontyForm::<MOD, LIMBS>::select(&def, &self.value, self.is_some)
+    }
+
+    /// Returns the contained value, consuming the `self` value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is none with a custom panic message provided by `msg`.
+    #[inline]
+    pub const fn expect(self, msg: &str) -> ConstMontyForm<MOD, LIMBS> {
         assert!(self.is_some.is_true_vartime(), "{}", msg);
         self.value
     }

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -10,7 +10,7 @@ mod sub;
 
 use self::invert::ConstMontyFormInverter;
 use super::{MontyParams, Retrieve, SafeGcdInverter, reduction::montgomery_reduction, shr1::shr1};
-use crate::{ConstZero, Odd, PrecomputeInverter, Uint};
+use crate::{ConstChoice, ConstZero, Odd, PrecomputeInverter, Uint};
 use core::{fmt::Debug, marker::PhantomData};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
@@ -138,6 +138,15 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     #[deprecated(since = "0.7.0", note = "please use `ConstMontyForm::shr1` instead")]
     pub const fn div_by_2(&self) -> Self {
         self.shr1()
+    }
+
+    /// Return `b` if `c` is truthy, otherwise return `a`.
+    #[inline]
+    pub(crate) const fn select(a: &Self, b: &Self, choice: ConstChoice) -> Self {
+        ConstMontyForm {
+            montgomery_form: Uint::select(&a.montgomery_form, &b.montgomery_form, choice),
+            phantom: PhantomData,
+        }
     }
 }
 


### PR DESCRIPTION
This is needed to retrieve the results of inversions from a `const fn`.

Computing inversions at compile time is used by the field implementations in https://github.com/RustCrypto/elliptic-curves