### PR TITLE
Revert "Rename `div_by_2` to `shr1`"

### DIFF
--- a/benches/monty.rs
+++ b/benches/monty.rs
@@ -180,13 +180,13 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         )
     });
 
-    group.bench_function("shr1, MontyForm(U256)", |b| {
+    group.bench_function("div_by_2, U256", |b| {
         b.iter_batched(
             || {
                 let x = U256::random_mod(&mut rng, params.modulus().as_nz_ref());
                 MontyForm::new(&x, params)
             },
-            |x| black_box(x.shr1()),
+            |x| black_box(x.div_by_2()),
             BatchSize::SmallInput,
         )
     });

--- a/src/modular.rs
+++ b/src/modular.rs
@@ -23,10 +23,10 @@ mod reduction;
 
 mod add;
 pub(crate) mod bingcd;
+mod div_by_2;
 mod mul;
 mod pow;
 pub(crate) mod safegcd;
-mod shr1;
 mod sub;
 
 #[cfg(feature = "alloc")]

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -8,7 +8,7 @@ mod neg;
 mod pow;
 mod sub;
 
-use super::{Retrieve, shr1};
+use super::{Retrieve, div_by_2};
 use mul::BoxedMontyMultiplier;
 
 use crate::{BoxedUint, Limb, Monty, Odd, Resize, Word, modular::MontyParams};
@@ -275,29 +275,17 @@ impl BoxedMontyForm {
     }
 
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
-    pub fn shr1(&self) -> Self {
+    pub fn div_by_2(&self) -> Self {
         Self {
-            montgomery_form: shr1::shr1_boxed(&self.montgomery_form, self.params.modulus()),
+            montgomery_form: div_by_2::div_by_2_boxed(&self.montgomery_form, self.params.modulus()),
             params: self.params.clone(),
         }
     }
 
     /// Performs division by 2 inplace, that is finds `x` such that `x + x = self`
     /// and writes it into `self`.
-    pub fn shr1_assign(&mut self) {
-        shr1::shr1_boxed_assign(&mut self.montgomery_form, self.params.modulus())
-    }
-
-    /// Deprecated equivalent to `shr1`.
-    #[deprecated(since = "0.7.0", note = "please use `Monty::shr1` instead")]
-    pub fn div_by_2(&self) -> Self {
-        self.shr1()
-    }
-
-    /// Deprecated equivalent to `shr1_assign`.
-    #[deprecated(since = "0.7.0", note = "please use `Monty::shr1_assign` instead")]
     pub fn div_by_2_assign(&mut self) {
-        self.shr1_assign()
+        div_by_2::div_by_2_boxed_assign(&mut self.montgomery_form, self.params.modulus())
     }
 }
 
@@ -352,12 +340,12 @@ impl Monty for BoxedMontyForm {
         BoxedMontyForm::double(self)
     }
 
-    fn shr1(&self) -> Self {
-        BoxedMontyForm::shr1(self)
+    fn div_by_2(&self) -> Self {
+        BoxedMontyForm::div_by_2(self)
     }
 
-    fn shr1_assign(&mut self) {
-        BoxedMontyForm::shr1_assign(self)
+    fn div_by_2_assign(&mut self) {
+        BoxedMontyForm::div_by_2_assign(self)
     }
 
     fn lincomb_vartime(products: &[(&Self, &Self)]) -> Self {
@@ -393,14 +381,14 @@ mod tests {
     }
 
     #[test]
-    fn shr1() {
+    fn div_by_2() {
         let modulus = Odd::new(BoxedUint::from(9u8)).unwrap();
         let params = BoxedMontyParams::new(modulus);
         let zero = BoxedMontyForm::zero(params.clone());
         let one = BoxedMontyForm::one(params.clone());
         let two = one.add(&one);
 
-        assert_eq!(zero.shr1(), zero);
-        assert_eq!(one.shr1().mul(&two), one);
+        assert_eq!(zero.div_by_2(), zero);
+        assert_eq!(one.div_by_2().mul(&two), one);
     }
 }

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -9,7 +9,9 @@ mod pow;
 mod sub;
 
 use self::invert::ConstMontyFormInverter;
-use super::{MontyParams, Retrieve, SafeGcdInverter, reduction::montgomery_reduction, shr1::shr1};
+use super::{
+    MontyParams, Retrieve, SafeGcdInverter, div_by_2::div_by_2, reduction::montgomery_reduction,
+};
 use crate::{ConstChoice, ConstZero, Odd, PrecomputeInverter, Uint};
 use core::{fmt::Debug, marker::PhantomData};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
@@ -126,18 +128,12 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
         self.montgomery_form
     }
 
-    /// Performs a 1-bit right shift (division by 2), that is returns `x` such that `x + x = self`.
-    pub const fn shr1(&self) -> Self {
+    /// Performs division by 2, that is returns `x` such that `x + x = self`.
+    pub const fn div_by_2(&self) -> Self {
         Self {
-            montgomery_form: shr1(&self.montgomery_form, &MOD::PARAMS.modulus),
+            montgomery_form: div_by_2(&self.montgomery_form, &MOD::PARAMS.modulus),
             phantom: PhantomData,
         }
-    }
-
-    /// Deprecated equivalent to `shr1`.
-    #[deprecated(since = "0.7.0", note = "please use `ConstMontyForm::shr1` instead")]
-    pub const fn div_by_2(&self) -> Self {
-        self.shr1()
     }
 
     /// Return `b` if `c` is truthy, otherwise return `a`.

--- a/src/modular/div_by_2.rs
+++ b/src/modular/div_by_2.rs
@@ -2,7 +2,7 @@
 use crate::{BoxedUint, Integer};
 use crate::{Limb, Odd, Uint};
 
-pub(crate) const fn shr1<const LIMBS: usize>(
+pub(crate) const fn div_by_2<const LIMBS: usize>(
     a: &Uint<LIMBS>,
     modulus: &Odd<Uint<LIMBS>>,
 ) -> Uint<LIMBS> {
@@ -25,14 +25,14 @@ pub(crate) const fn shr1<const LIMBS: usize>(
 }
 
 #[cfg(feature = "alloc")]
-pub(crate) fn shr1_boxed(a: &BoxedUint, modulus: &Odd<BoxedUint>) -> BoxedUint {
+pub(crate) fn div_by_2_boxed(a: &BoxedUint, modulus: &Odd<BoxedUint>) -> BoxedUint {
     let mut result = a.clone();
-    shr1_boxed_assign(&mut result, modulus);
+    div_by_2_boxed_assign(&mut result, modulus);
     result
 }
 
 #[cfg(feature = "alloc")]
-pub(crate) fn shr1_boxed_assign(a: &mut BoxedUint, modulus: &Odd<BoxedUint>) {
+pub(crate) fn div_by_2_boxed_assign(a: &mut BoxedUint, modulus: &Odd<BoxedUint>) {
     debug_assert_eq!(a.bits_precision(), modulus.bits_precision());
 
     let is_odd = a.is_odd();

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -11,8 +11,8 @@ mod sub;
 use super::{
     Retrieve,
     const_monty_form::{ConstMontyForm, ConstMontyParams},
+    div_by_2::div_by_2,
     reduction::montgomery_reduction,
-    shr1::shr1,
 };
 use crate::{Concat, ConstChoice, Limb, Monty, NonZero, Odd, Split, Uint, Word};
 use mul::DynMontyMultiplier;
@@ -241,17 +241,11 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
-    pub const fn shr1(&self) -> Self {
+    pub const fn div_by_2(&self) -> Self {
         Self {
-            montgomery_form: shr1(&self.montgomery_form, &self.params.modulus),
+            montgomery_form: div_by_2(&self.montgomery_form, &self.params.modulus),
             params: self.params,
         }
-    }
-
-    /// Deprecated equivalent to `shr1`.
-    #[deprecated(since = "0.7.0", note = "please use `ConstMontyForm::shr1` instead")]
-    pub const fn div_by_2(&self) -> Self {
-        self.shr1()
     }
 }
 
@@ -300,8 +294,8 @@ impl<const LIMBS: usize> Monty for MontyForm<LIMBS> {
         MontyForm::double(self)
     }
 
-    fn shr1(&self) -> Self {
-        MontyForm::shr1(self)
+    fn div_by_2(&self) -> Self {
+        MontyForm::div_by_2(self)
     }
 
     fn lincomb_vartime(products: &[(&Self, &Self)]) -> Self {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -999,24 +999,12 @@ pub trait Monty:
     fn double(&self) -> Self;
 
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
-    fn shr1(&self) -> Self;
+    fn div_by_2(&self) -> Self;
 
     /// Performs division by 2 inplace, that is finds `x` such that `x + x = self`
     /// and writes it into `self`.
-    fn shr1_assign(&mut self) {
-        *self = self.shr1()
-    }
-
-    /// Deprecated equivalent to `shr1`.
-    #[deprecated(since = "0.7.0", note = "please use `Monty::shr1` instead")]
-    fn div_by_2(&self) -> Self {
-        self.shr1()
-    }
-
-    /// Deprecated equivalent to `shr1_assign`.
-    #[deprecated(since = "0.7.0", note = "please use `Monty::shr1` instead")]
     fn div_by_2_assign(&mut self) {
-        self.shr1_assign()
+        *self = self.div_by_2()
     }
 
     /// Calculate the sum of products of pairs `(a, b)` in `products`.

--- a/tests/boxed_monty_form.rs
+++ b/tests/boxed_monty_form.rs
@@ -147,10 +147,10 @@ proptest! {
     }
 
     #[test]
-    fn shr1(a in monty_form()) {
-        let actual = a.shr1();
+    fn div_by_2(a in monty_form()) {
+        let actual = a.div_by_2();
         let mut actual_inplace = a.clone();
-        actual_inplace.shr1_assign();
+        actual_inplace.div_by_2_assign();
 
         let p = a.params().modulus();
         let a_bi = retrieve_biguint(&a);

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -566,7 +566,7 @@ proptest! {
     }
 
     #[test]
-    fn monty_form_shr1(a in uint_mod_p(P)) {
+    fn monty_form_div_by_2(a in uint_mod_p(P)) {
         let a_bi = to_biguint(&a);
         let p_bi = to_biguint(&P);
         let two = BigUint::from(2u32);
@@ -581,7 +581,7 @@ proptest! {
 
         let params = MontyParams::new_vartime(P);
         let a_m = MontyForm::new(&a, params);
-        let actual = a_m.shr1().retrieve();
+        let actual = a_m.div_by_2().retrieve();
 
         prop_assert_eq!(expected, actual);
     }


### PR DESCRIPTION
This reverts commit 5f48318a49b72500af825d1ef0d70c32a3319fc9 (#882).

My original rationale for this was to share code with a larger `shr` implementation. That could be done with repeat applications of `shr1`, though using a Montgomery multiplication would probably be faster.

However, I wound up not needing those, which perhaps makes this change superfluous. Since I noted it's six of one, half dozen of another, it would probably be better to just use the original name in that case.