### PR TITLE
Add `Reduce` trait for fixed modulus reduction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.7.0-pre.5 (2025-06-16)
 _The below list is very much incomplete._
 
+### Added
+- `Reduce` trait for modular reduction with a constant modulus.
+
 ### Changed
 - Replace `Limb::mac` with `::carrying_mul_add` ([#817]).
   - Note: `::carrying_mul_add` requires a different parameter order than `::mac`.

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -6,8 +6,8 @@ mod lincomb;
 mod mul;
 mod neg;
 mod pow;
-mod sub;
 mod reduce;
+mod sub;
 
 use self::invert::ConstMontyFormInverter;
 use super::{

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -7,6 +7,7 @@ mod mul;
 mod neg;
 mod pow;
 mod sub;
+mod reduce;
 
 use self::invert::ConstMontyFormInverter;
 use super::{

--- a/src/modular/const_monty_form/reduce.rs
+++ b/src/modular/const_monty_form/reduce.rs
@@ -1,10 +1,10 @@
-use crate::{modular::ConstMontyForm, Reduce, Uint};
+use crate::{Reduce, Uint, modular::ConstMontyForm};
 
 use super::ConstMontyParams;
 
 impl<const LIMBS: usize, MOD> Reduce<Uint<LIMBS>> for ConstMontyForm<MOD, LIMBS>
 where
-    MOD: ConstMontyParams<LIMBS>
+    MOD: ConstMontyParams<LIMBS>,
 {
     fn reduce(value: Uint<LIMBS>) -> Self {
         Self::new(&value)
@@ -13,7 +13,7 @@ where
 
 impl<const LIMBS: usize, MOD> Reduce<&Uint<LIMBS>> for ConstMontyForm<MOD, LIMBS>
 where
-    MOD: ConstMontyParams<LIMBS>
+    MOD: ConstMontyParams<LIMBS>,
 {
     fn reduce(value: &Uint<LIMBS>) -> Self {
         Self::new(value)

--- a/src/modular/const_monty_form/reduce.rs
+++ b/src/modular/const_monty_form/reduce.rs
@@ -1,0 +1,21 @@
+use crate::{modular::ConstMontyForm, Reduce, Uint};
+
+use super::ConstMontyParams;
+
+impl<const LIMBS: usize, MOD> Reduce<Uint<LIMBS>> for ConstMontyForm<MOD, LIMBS>
+where
+    MOD: ConstMontyParams<LIMBS>
+{
+    fn reduce(value: Uint<LIMBS>) -> Self {
+        Self::new(&value)
+    }
+}
+
+impl<const LIMBS: usize, MOD> Reduce<&Uint<LIMBS>> for ConstMontyForm<MOD, LIMBS>
+where
+    MOD: ConstMontyParams<LIMBS>
+{
+    fn reduce(value: &Uint<LIMBS>) -> Self {
+        Self::new(value)
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -699,6 +699,19 @@ pub trait RemMixed<Reductor>: Sized {
     fn rem_mixed(&self, reductor: &NonZero<Reductor>) -> Reductor;
 }
 
+/// Modular reduction on a fixed modulus.
+///
+/// Used when there is a fixed modulus for which it is natural to reduce the value to.
+///
+/// For modular reduction with a variable modulus, use [`Rem`].
+pub trait Reduce<Modulus> {
+    /// Output type.
+    type Output;
+
+    /// Reduces `self` modulo `Modulus`.
+    fn reduce(&self) -> Self::Output;
+}
+
 /// Division in variable time.
 pub trait DivVartime: Sized {
     /// Computes `self / rhs` in variable time.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -699,17 +699,15 @@ pub trait RemMixed<Reductor>: Sized {
     fn rem_mixed(&self, reductor: &NonZero<Reductor>) -> Reductor;
 }
 
-/// Modular reduction on a fixed modulus.
+/// Modular reduction from a larger value `T`.
 ///
-/// Used when there is a fixed modulus for which it is natural to reduce the value to.
+/// This can be seen as fixed modular reduction, where the modulus is fixed at compile time
+/// by `Self`.
 ///
 /// For modular reduction with a variable modulus, use [`Rem`].
-pub trait Reduce<Modulus> {
-    /// Output type.
-    type Output;
-
+pub trait Reduce<T>: Sized {
     /// Reduces `self` modulo `Modulus`.
-    fn reduce(&self) -> Self::Output;
+    fn reduce(value: T) -> Self;
 }
 
 /// Division in variable time.


### PR DESCRIPTION
This trait comes from [`elliptic_curve::Reduce`](https://docs.rs/elliptic-curve/latest/elliptic_curve/ops/trait.Reduce.html). I thought this would fit better here as `cyrpto-bigint` already hosts a lot of [`modular`](https://docs.rs/crypto-bigint/latest/crypto_bigint/modular/index.html) arithmetic functionality.

Note that it slightly differs from `elliptic_curve::Reduce` because the input type is not bound by `Integer`, and there is no associated `Bytes` (and no `reduce_bytes` function). That is because `Reduce` can be implemented both on the input type and on `Bytes` as separate implementations, if the input type is not bounded by `Integer`.