### PR TITLE
Remove `modular::montgomery_reduction` from public API

### DIFF
--- a/src/modular.rs
+++ b/src/modular.rs
@@ -35,7 +35,6 @@ pub(crate) mod boxed_monty_form;
 pub use self::{
     const_monty_form::{ConstMontyForm, ConstMontyParams, invert::ConstMontyFormInverter},
     monty_form::{MontyForm, MontyParams},
-    reduction::montgomery_reduction,
 };
 
 pub(crate) use self::safegcd::SafeGcdInverter;

--- a/src/modular/reduction.rs
+++ b/src/modular/reduction.rs
@@ -46,7 +46,7 @@ const fn montgomery_reduction_inner(
 }
 
 /// Algorithm 14.32 in Handbook of Applied Cryptography <https://cacr.uwaterloo.ca/hac/about/chap14.pdf>
-pub const fn montgomery_reduction<const LIMBS: usize>(
+pub(crate) const fn montgomery_reduction<const LIMBS: usize>(
     lower_upper: &(Uint<LIMBS>, Uint<LIMBS>),
     modulus: &Odd<Uint<LIMBS>>,
     mod_neg_inv: Limb,


### PR DESCRIPTION
It's an implementation detail. It was originally `pub` because it was used by the `const_monty_params!` nee `impl_modulus!` macro, however that has been changed to use `const fn` constructors instead.