### PR TITLE
Update `BoxedUint::div_rem` to accept mixed sized inputs

### DIFF
--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -12,7 +12,7 @@ use super::{Retrieve, div_by_2};
 use mul::BoxedMontyMultiplier;
 
 use crate::{
-    BoxedUint, Limb, Monty, Odd, Resize, U64, Word,
+    BoxedUint, Limb, Monty, Odd, U64, Word,
     modular::{MontyParams, safegcd::invert_mod_u64},
 };
 use alloc::sync::Arc;
@@ -42,10 +42,8 @@ struct BoxedMontyParamsInner {
 }
 
 impl BoxedMontyParams {
-    /// Instantiates a new set of [`BoxedMontyParams`] representing the given `modulus`, which
-    /// must be odd.
+    /// Instantiates a new set of [`BoxedMontyParams`] representing the given `modulus`.
     ///
-    /// Returns a `CtOption` that is `None` if the provided modulus is not odd.
     /// TODO(tarcieri): DRY out with `MontyParams::new`?
     pub fn new(modulus: Odd<BoxedUint>) -> Self {
         let bits_precision = modulus.bits_precision();
@@ -57,10 +55,7 @@ impl BoxedMontyParams {
             .wrapping_add(&BoxedUint::one());
 
         // `R^2 mod modulus`, used to convert integers to Montgomery form.
-        let r2 = one
-            .square()
-            .rem(&modulus.as_nz_ref().resize_unchecked(bits_precision * 2))
-            .resize_unchecked(bits_precision);
+        let r2 = one.square().rem(modulus.as_nz_ref());
 
         // The inverse of the modulus modulo 2**64
         let mod_inv = U64::from_u64(invert_mod_u64(modulus.as_ref().as_words()));
@@ -79,10 +74,9 @@ impl BoxedMontyParams {
         )
     }
 
-    /// Instantiates a new set of [`BoxedMontyParams`] representing the given `modulus`, which
-    /// must be odd. This version operates in variable-time with respect to the modulus.
+    /// Instantiates a new set of [`BoxedMontyParams`] representing the given `modulus`.
+    /// This version operates in variable-time with respect to the modulus.
     ///
-    /// Returns `None` if the provided modulus is not odd.
     /// TODO(tarcieri): DRY out with `MontyParams::new`?
     pub fn new_vartime(modulus: Odd<BoxedUint>) -> Self {
         let bits_precision = modulus.bits_precision();

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -189,7 +189,17 @@ impl BoxedUint {
         self.limbs.len()
     }
 
-    /// Convert into an [`Odd`].
+    /// Convert to a [`NonZero<BoxedUint>`].
+    ///
+    /// Returns some if the original value is non-zero, and false otherwise.
+    pub fn to_nz(self) -> CtOption<NonZero<Self>> {
+        let is_nz = self.is_nonzero();
+        CtOption::new(NonZero(self), is_nz)
+    }
+
+    /// Convert to an [`Odd<BoxedUint>`].
+    ///
+    /// Returns some if the original value is odd, and false otherwise.
     pub fn to_odd(&self) -> CtOption<Odd<Self>> {
         let is_odd = self.is_odd();
         CtOption::new(Odd(self.clone()), is_odd)

--- a/tests/boxed_monty_form.rs
+++ b/tests/boxed_monty_form.rs
@@ -6,7 +6,7 @@ mod common;
 
 use common::to_biguint;
 use crypto_bigint::{
-    BoxedUint, Integer, Limb, Odd, Resize,
+    BoxedUint, Integer, Limb, Odd,
     modular::{BoxedMontyForm, BoxedMontyParams},
 };
 use num_bigint::BigUint;
@@ -19,9 +19,7 @@ fn retrieve_biguint(monty_form: &BoxedMontyForm) -> BigUint {
 }
 
 fn reduce(n: &BoxedUint, p: BoxedMontyParams) -> BoxedMontyForm {
-    let n_reduced = n
-        .rem_vartime(p.modulus().as_nz_ref())
-        .resize(p.bits_precision());
+    let n_reduced = n.rem_vartime(p.modulus().as_nz_ref());
 
     BoxedMontyForm::new(n_reduced, p)
 }


### PR DESCRIPTION
Allowing mixed size inputs means that `rem` can be performed on 'wide' inputs without resizing the modulus, improving performance. The updated method can also be used to remove restrictions on `BoxedUint::mul_mod` but that's another update.