### PR TITLE
`ConstMontyForm::lincomb_vartime()` is constant-time

### DIFF
--- a/benches/const_monty.rs
+++ b/benches/const_monty.rs
@@ -131,11 +131,11 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         )
     });
 
-    group.bench_function("lincomb_vartime, U256*U256+U256*U256", |b| {
+    group.bench_function("lincomb, U256*U256+U256*U256", |b| {
         b.iter_batched(
             || ConstMontyForm::random(&mut rng),
             |a| {
-                ConstMontyForm::lincomb_vartime(&[
+                ConstMontyForm::lincomb(&[
                     (black_box(a), black_box(a)),
                     (black_box(a), black_box(a)),
                 ])

--- a/src/modular/const_monty_form/lincomb.rs
+++ b/src/modular/const_monty_form/lincomb.rs
@@ -7,10 +7,7 @@ use crate::modular::lincomb::lincomb_const_monty_form;
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Calculate the sum of products of pairs `(a, b)` in `products`.
-    ///
-    /// This method is variable time only with the value of the modulus.
-    /// For a modulus with leading zeros, this method is more efficient than a naive sum of products.
-    pub const fn lincomb_vartime(products: &[(Self, Self)]) -> Self {
+    pub const fn lincomb(products: &[(Self, Self)]) -> Self {
         Self {
             montgomery_form: lincomb_const_monty_form(
                 products,
@@ -51,7 +48,7 @@ mod tests {
                 a.mul_mod(&b, modulus)
                     .add_mod(&c.mul_mod(&d, modulus), modulus)
                     .add_mod(&e.mul_mod(&f, modulus), modulus),
-                ConstMontyForm::<P, { P::LIMBS }>::lincomb_vartime(&[
+                ConstMontyForm::<P, { P::LIMBS }>::lincomb(&[
                     (ConstMontyForm::new(&a), ConstMontyForm::new(&b)),
                     (ConstMontyForm::new(&c), ConstMontyForm::new(&d)),
                     (ConstMontyForm::new(&e), ConstMontyForm::new(&f)),


### PR DESCRIPTION
I'm unsure if I interpreted [this line](https://docs.rs/crypto-bigint/0.7.0-pre.7/crypto_bigint/modular/struct.ConstMontyForm.html#method.lincomb_vartime) correctly:
> This method is variable time only with the value of the modulus.

But it seems to me this is actually constant-time if the modulus is the same.

I'm not sure if this shouldn't actually apply to `MontyForm` and `BoxedMontyForm` as well. Because while they set their modulus during runtime, it still doesn't change between multiple calls to the same instantiation (AFAIU).