### PR TITLE
Have `Reduce` borrow its input

### DIFF
--- a/src/modular/const_monty_form/reduce.rs
+++ b/src/modular/const_monty_form/reduce.rs
@@ -1,17 +1,7 @@
+use super::ConstMontyParams;
 use crate::{Reduce, Uint, modular::ConstMontyForm};
 
-use super::ConstMontyParams;
-
 impl<const LIMBS: usize, MOD> Reduce<Uint<LIMBS>> for ConstMontyForm<MOD, LIMBS>
-where
-    MOD: ConstMontyParams<LIMBS>,
-{
-    fn reduce(value: Uint<LIMBS>) -> Self {
-        Self::new(&value)
-    }
-}
-
-impl<const LIMBS: usize, MOD> Reduce<&Uint<LIMBS>> for ConstMontyForm<MOD, LIMBS>
 where
     MOD: ConstMontyParams<LIMBS>,
 {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -673,7 +673,7 @@ pub trait RemMixed<Reductor>: Sized {
 /// For modular reduction with a variable modulus, use [`Rem`].
 pub trait Reduce<T>: Sized {
     /// Reduces `self` modulo `Modulus`.
-    fn reduce(value: T) -> Self;
+    fn reduce(value: &T) -> Self;
 }
 
 /// Division in variable time.


### PR DESCRIPTION
Impls of `Reduce` only subsequently call functions which borrow, and have no need to actually take ownership of their inputs.

Per the Rust API guidelines, in such a case a function should borrow its input:

https://rust-lang.github.io/api-guidelines/flexibility.html?highlight=clone#caller-decides-where-to-copy-and-place-data-c-caller-control