### PR TITLE
Remove `ConstMontyParams::inverter`

### DIFF
--- a/benches/const_monty.rs
+++ b/benches/const_monty.rs
@@ -87,18 +87,6 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         )
     });
 
-    group.bench_function("Bernstein-Yang invert, U256", |b| {
-        b.iter_batched(
-            || {
-                let x = ConstMontyForm::random(&mut rng);
-                let inverter = Modulus::inverter();
-                (x, inverter)
-            },
-            |(x, inverter)| inverter.invert(&black_box(x)),
-            BatchSize::SmallInput,
-        )
-    });
-
     group.bench_function("multiplication, U256*U256", |b| {
         b.iter_batched(
             || {

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -9,7 +9,6 @@ mod pow;
 mod reduce;
 mod sub;
 
-use self::invert::ConstMontyFormInverter;
 use super::{MontyParams, Retrieve, div_by_2::div_by_2, reduction::montgomery_reduction};
 use crate::{ConstChoice, ConstZero, Uint};
 use core::{fmt::Debug, marker::PhantomData};
@@ -42,13 +41,6 @@ pub trait ConstMontyParams<const LIMBS: usize>:
 
     /// Montgomery parameters constant.
     const PARAMS: MontyParams<LIMBS>;
-
-    /// Precompute a Bernstein-Yang inverter for this modulus.
-    ///
-    /// Use [`ConstMontyFormInverter::new`] if you need `const fn` access.
-    fn inverter() -> ConstMontyFormInverter<Self, LIMBS> {
-        ConstMontyFormInverter::new()
-    }
 }
 
 /// An integer in Montgomery form modulo `MOD`, represented using `LIMBS` limbs.

--- a/src/modular/const_monty_form/invert.rs
+++ b/src/modular/const_monty_form/invert.rs
@@ -202,17 +202,4 @@ mod tests {
 
         assert_eq!(res.retrieve(), U256::ONE);
     }
-
-    #[test]
-    fn test_self_inverse_precomputed() {
-        let x =
-            U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");
-        let x_mod = const_monty_form!(x, Modulus);
-        let inverter = Modulus::inverter();
-
-        let inv = inverter.invert(&x_mod).unwrap();
-        let res = x_mod * inv;
-
-        assert_eq!(res.retrieve(), U256::ONE);
-    }
 }

--- a/tests/const_monty_form.rs
+++ b/tests/const_monty_form.rs
@@ -50,25 +50,4 @@ proptest! {
             (_, _) => panic!("disagreement on if modular inverse exists")
         }
     }
-
-    #[test]
-    fn precomputed_invert(x in uint()) {
-        let x = reduce(&x);
-        let inverter = Modulus::inverter();
-        let actual = Option::<ConstMontyForm>::from(inverter.invert(&x));
-
-        let x_bi = retrieve_biguint(&x);
-        let n_bi = to_biguint(&Modulus::PARAMS.modulus());
-        let expected = x_bi.invm(&n_bi);
-
-        match (expected, actual) {
-            (Some(exp), Some(act)) => {
-                let res = x * act;
-                prop_assert_eq!(res.retrieve(), U256::ONE);
-                prop_assert_eq!(exp, retrieve_biguint(&act));
-            }
-            (None, None) => (),
-            (_, _) => panic!("disagreement on if modular inverse exists")
-        }
-    }
 }


### PR DESCRIPTION
Precomputed inverters are vestiges of the old safegcd implementation, most of which were already removed in #894 and #898