### PR TITLE
Change `const_monty_form!` to define a type alias

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,9 +90,11 @@
 //!
 //! ### Modular arithmetic
 //!
-//! This library has initial support for modular arithmetic in the form of the
-//! [`AddMod`], [`SubMod`], [`NegMod`], and [`MulMod`] traits, as well as the
-//! support for the [`Rem`] trait when used with a [`NonZero`] operand.
+//! See the [`modular`] module for types which implement Montgomery form modular arithmetic.
+//!
+//! This library also has support for performing modular arithmetic on integers in the form of the
+//! [`AddMod`], [`SubMod`], [`NegMod`], and [`MulMod`] traits, as well as the support for the
+//! [`Rem`] trait when used with a [`NonZero`] operand.
 //!
 //! ```
 //! use crypto_bigint::{AddMod, U256};
@@ -109,16 +111,10 @@
 //! assert_eq!(b, U256::ZERO);
 //! ```
 //!
-//! It also supports modular arithmetic over constant moduli using `ConstMontyForm`,
-//! and over moduli set at runtime using `MontyForm`.
-//! That includes modular exponentiation and multiplicative inverses.
-//! These features are described in the [`modular`] module.
-//!
 //! ### Random number generation
 //!
-//! When the `rand_core` or `rand` features of this crate are enabled, it's
-//! possible to generate random numbers using any RNG by using the
-//! [`Random`] trait:
+//! When the `rand_core` feature of this crate are enabled, it's possible to generate random numbers
+//! using any RNG by using the [`Random`] trait:
 //!
 //! ```
 //! # #[cfg(feature = "rand")]

--- a/src/modular.rs
+++ b/src/modular.rs
@@ -55,7 +55,7 @@ pub trait Retrieve {
 #[cfg(test)]
 mod tests {
     use crate::{
-        NonZero, U64, U256, Uint, const_monty_form, const_monty_params,
+        NonZero, U64, U256, Uint, const_monty_params,
         modular::{
             const_monty_form::{ConstMontyForm, ConstMontyParams},
             reduction::montgomery_reduction,
@@ -179,15 +179,5 @@ mod tests {
 
         // Confirm that when creating a Modular and retrieving the value, that it equals the original
         assert_eq!(x, x_mod.retrieve());
-    }
-
-    #[test]
-    fn test_const_monty_form_macro() {
-        let x =
-            U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
-        assert_eq!(
-            ConstMontyForm::<Modulus2, { Modulus2::LIMBS }>::new(&x),
-            const_monty_form!(x, Modulus2)
-        );
     }
 }

--- a/src/modular/const_monty_form/add.rs
+++ b/src/modular/const_monty_form/add.rs
@@ -92,15 +92,17 @@ mod tests {
         "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"
     );
 
+    const_monty_form!(Fe, Modulus);
+
     #[test]
     fn add_overflow() {
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
-        let mut x_mod = const_monty_form!(x, Modulus);
+        let mut x_mod = Fe::new(&x);
 
         let y =
             U256::from_be_hex("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251");
-        let y_mod = const_monty_form!(y, Modulus);
+        let y_mod = Fe::new(&y);
 
         x_mod += &y_mod;
 

--- a/src/modular/const_monty_form/invert.rs
+++ b/src/modular/const_monty_form/invert.rs
@@ -102,11 +102,13 @@ mod tests {
         "15477BCCEFE197328255BFA79A1217899016D927EF460F4FF404029D24FA4409"
     );
 
+    const_monty_form!(Fe, Modulus);
+
     #[test]
     fn test_self_inverse() {
         let x =
             U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");
-        let x_mod = const_monty_form!(x, Modulus);
+        let x_mod = Fe::new(&x);
 
         let inv = x_mod.invert().unwrap();
         let res = x_mod * inv;

--- a/src/modular/const_monty_form/macros.rs
+++ b/src/modular/const_monty_form/macros.rs
@@ -49,8 +49,7 @@ macro_rules! const_monty_params {
     };
 }
 
-/// Creates a [`ConstMontyForm`] with the given value for a specific modulus, i.e. a type which
-/// impls [`ConstMontyParams`].
+/// Creates a type alias to [`ConstMontyForm`] with the given [`ConstMontyParams`].
 ///
 /// # Usage
 ///
@@ -64,12 +63,20 @@ macro_rules! const_monty_params {
 /// #    "Docs for my modulus"
 /// # );
 ///
-/// const_monty_form!(U256::from(105u64), MyModulus);
+/// const_monty_form!(MyFieldElement, MyModulus, "My field element");
 /// ```
 #[macro_export]
 macro_rules! const_monty_form {
-    ($value:expr, $modulus:ident) => {
-        $crate::modular::ConstMontyForm::<$modulus, { $modulus::LIMBS }>::new(&$value)
+    ($name:ident, $modulus:ident) => {
+        $crate::const_monty_form!(
+            $name,
+            $modulus,
+            "Type alias for `ConstMontyForm` specialized for a particular modulus"
+        );
+    };
+    ($name:ident, $modulus:ident, $doc:expr) => {
+        #[doc = $doc]
+        pub type $name = $crate::modular::ConstMontyForm<$modulus, { $modulus::LIMBS }>;
     };
 }
 

--- a/src/modular/const_monty_form/neg.rs
+++ b/src/modular/const_monty_form/neg.rs
@@ -39,11 +39,13 @@ mod tests {
         "15477BCCEFE197328255BFA79A1217899016D927EF460F4FF404029D24FA4409"
     );
 
+    const_monty_form!(Fe, Modulus);
+
     #[test]
     fn test_negate() {
         let x =
             U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");
-        let x_mod = const_monty_form!(x, Modulus);
+        let x_mod = Fe::new(&x);
 
         let res = -x_mod;
         let expected =

--- a/src/modular/const_monty_form/pow.rs
+++ b/src/modular/const_monty_form/pow.rs
@@ -120,10 +120,12 @@ mod tests {
         "9CC24C5DF431A864188AB905AC751B727C9447A8E99E6366E1AD78A21E8D882B"
     );
 
+    const_monty_form!(Fe, Modulus);
+
     #[test]
     fn test_powmod_small_base() {
         let base = U256::from(105u64);
-        let base_mod = const_monty_form!(base, Modulus);
+        let base_mod = Fe::new(&base);
 
         let exponent =
             U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");
@@ -139,7 +141,7 @@ mod tests {
     fn test_powmod_small_exponent() {
         let base =
             U256::from_be_hex("3435D18AA8313EBBE4D20002922225B53F75DC4453BB3EEC0378646F79B524A4");
-        let base_mod = const_monty_form!(base, Modulus);
+        let base_mod = Fe::new(&base);
 
         let exponent = U256::from(105u64);
 
@@ -154,7 +156,7 @@ mod tests {
     fn test_powmod() {
         let base =
             U256::from_be_hex("3435D18AA8313EBBE4D20002922225B53F75DC4453BB3EEC0378646F79B524A4");
-        let base_mod = const_monty_form!(base, Modulus);
+        let base_mod = Fe::new(&base);
 
         let exponent =
             U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");
@@ -169,7 +171,7 @@ mod tests {
     #[test]
     fn test_multi_exp_array() {
         let base = U256::from(2u8);
-        let base_mod = const_monty_form!(base, Modulus);
+        let base_mod = Fe::new(&base);
 
         let exponent = U256::from(33u8);
         let bases_and_exponents = [(base_mod, exponent)];
@@ -184,7 +186,7 @@ mod tests {
 
         let base2 =
             U256::from_be_hex("3435D18AA8313EBBE4D20002922225B53F75DC4453BB3EEC0378646F79B524A4");
-        let base2_mod = const_monty_form!(base2, Modulus);
+        let base2_mod = Fe::new(&base2);
 
         let exponent2 =
             U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");
@@ -202,7 +204,7 @@ mod tests {
     #[test]
     fn test_multi_exp_slice() {
         let base = U256::from(2u8);
-        let base_mod = const_monty_form!(base, Modulus);
+        let base_mod = Fe::new(&base);
 
         let exponent = U256::from(33u8);
         let bases_and_exponents = vec![(base_mod, exponent)];
@@ -217,7 +219,7 @@ mod tests {
 
         let base2 =
             U256::from_be_hex("3435D18AA8313EBBE4D20002922225B53F75DC4453BB3EEC0378646F79B524A4");
-        let base2_mod = const_monty_form!(base2, Modulus);
+        let base2_mod = Fe::new(&base2);
 
         let exponent2 =
             U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");

--- a/src/modular/const_monty_form/sub.rs
+++ b/src/modular/const_monty_form/sub.rs
@@ -84,15 +84,17 @@ mod tests {
         "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"
     );
 
+    const_monty_form!(Fe, Modulus);
+
     #[test]
     fn sub_overflow() {
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
-        let mut x_mod = const_monty_form!(x, Modulus);
+        let mut x_mod = Fe::new(&x);
 
         let y =
             U256::from_be_hex("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251");
-        let y_mod = const_monty_form!(y, Modulus);
+        let y_mod = Fe::new(&y);
 
         x_mod -= &y_mod;
 


### PR DESCRIPTION
Instead of constructing a value, it now defines a type alias, then you can use `MyType::new(&uint)` as the constructor.

Closes #878