### PR TITLE
Update modular operations to use NonZero modulus

### DIFF
--- a/benches/boxed_uint.rs
+++ b/benches/boxed_uint.rs
@@ -281,10 +281,14 @@ fn bench_invert(c: &mut Criterion) {
     group.bench_function("invert_mod", |b| {
         b.iter_batched(
             || {
-                (
+                let (x, mut y) = (
                     BoxedUint::random_bits(&mut OsRng, UINT_BITS),
                     BoxedUint::random_bits(&mut OsRng, UINT_BITS),
-                )
+                );
+                if y.is_zero().into() {
+                    y = BoxedUint::one();
+                }
+                (x, y.to_nz().unwrap())
             },
             |(x, y)| black_box(x.invert_mod(&y)),
             BatchSize::SmallInput,

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -575,7 +575,7 @@ fn bench_invert_mod(c: &mut Criterion) {
                     }
                 }
             },
-            |(x, m)| black_box(x.invert_mod(&m)),
+            |(x, m)| black_box(x.invert_mod(m.as_nz_ref())),
             BatchSize::SmallInput,
         )
     });
@@ -583,7 +583,7 @@ fn bench_invert_mod(c: &mut Criterion) {
     group.bench_function("invert_mod, U256", |b| {
         b.iter_batched(
             || {
-                let m = U256::random(&mut rng);
+                let m = NonZero::<U256>::random(&mut rng);
                 loop {
                     let x = U256::random(&mut rng);
                     let inv_x = x.invert_mod(&m);

--- a/src/int/invert_mod.rs
+++ b/src/int/invert_mod.rs
@@ -21,14 +21,14 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Computes the multiplicative inverse of `self` mod `modulus`.
     ///
     /// Returns some if an inverse exists, otherwise none.
-    pub const fn invert_mod(&self, modulus: &Uint<LIMBS>) -> ConstCtOption<Uint<LIMBS>> {
+    pub const fn invert_mod(&self, modulus: &NonZero<Uint<LIMBS>>) -> ConstCtOption<Uint<LIMBS>> {
         let (abs, sgn) = self.abs_sign();
         let maybe_inv = abs.invert_mod(modulus);
         let (abs_inv, inv_is_some) = maybe_inv.components_ref();
         // Note: when `self` is negative and modulus is non-zero, then
         // self^{-1} % modulus = modulus - |self|^{-1} % modulus
         ConstCtOption::new(
-            Uint::select(abs_inv, &modulus.wrapping_sub(abs_inv), sgn),
+            Uint::select(abs_inv, &modulus.as_ref().wrapping_sub(abs_inv), sgn),
             inv_is_some,
         )
     }
@@ -41,7 +41,7 @@ where
     type Output = Uint<LIMBS>;
 
     fn invert_mod(&self, modulus: &NonZero<Uint<LIMBS>>) -> CtOption<Self::Output> {
-        Self::invert_mod(self, modulus.as_ref()).into()
+        Self::invert_mod(self, modulus).into()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,10 +97,10 @@
 //! [`Rem`] trait when used with a [`NonZero`] operand.
 //!
 //! ```
-//! use crypto_bigint::{AddMod, U256};
+//! use crypto_bigint::{AddMod, NonZero, U256};
 //!
 //! // mod 3
-//! let modulus = U256::from(3u8);
+//! let modulus = NonZero::new(U256::from(3u8)).expect("non-zero");
 //!
 //! // 1 + 1 mod 3 = 2
 //! let a = U256::ONE.add_mod(&U256::ONE, &modulus);

--- a/src/modular/add.rs
+++ b/src/modular/add.rs
@@ -5,7 +5,7 @@ pub(crate) const fn add_montgomery_form<const LIMBS: usize>(
     b: &Uint<LIMBS>,
     modulus: &Odd<Uint<LIMBS>>,
 ) -> Uint<LIMBS> {
-    a.add_mod(b, &modulus.0)
+    a.add_mod(b, modulus.as_nz_ref())
 }
 
 pub(crate) const fn double_montgomery_form<const LIMBS: usize>(

--- a/src/modular/boxed_monty_form/add.rs
+++ b/src/modular/boxed_monty_form/add.rs
@@ -11,7 +11,7 @@ impl BoxedMontyForm {
         Self {
             montgomery_form: self
                 .montgomery_form
-                .add_mod(&rhs.montgomery_form, self.params.modulus()),
+                .add_mod(&rhs.montgomery_form, self.params.modulus().as_nz_ref()),
             params: self.params.clone(),
         }
     }
@@ -19,7 +19,9 @@ impl BoxedMontyForm {
     /// Double `self`.
     pub fn double(&self) -> Self {
         Self {
-            montgomery_form: self.montgomery_form.double_mod(self.params.modulus()),
+            montgomery_form: self
+                .montgomery_form
+                .double_mod(self.params.modulus().as_nz_ref()),
             params: self.params.clone(),
         }
     }
@@ -59,7 +61,7 @@ impl AddAssign<&BoxedMontyForm> for BoxedMontyForm {
     fn add_assign(&mut self, rhs: &BoxedMontyForm) {
         debug_assert_eq!(self.params, rhs.params);
         self.montgomery_form
-            .add_mod_assign(&rhs.montgomery_form, self.params.modulus());
+            .add_mod_assign(&rhs.montgomery_form, self.params.modulus().as_nz_ref());
     }
 }
 

--- a/src/modular/boxed_monty_form/lincomb.rs
+++ b/src/modular/boxed_monty_form/lincomb.rs
@@ -50,9 +50,9 @@ mod tests {
             let f = BoxedUint::random_mod(&mut rng, modulus.as_nz_ref());
 
             let std = a
-                .mul_mod(&b, &modulus)
-                .add_mod(&c.mul_mod(&d, &modulus), &modulus)
-                .add_mod(&e.mul_mod(&f, &modulus), &modulus);
+                .mul_mod(&b, modulus.as_nz_ref())
+                .add_mod(&c.mul_mod(&d, modulus.as_nz_ref()), modulus.as_nz_ref())
+                .add_mod(&e.mul_mod(&f, modulus.as_nz_ref()), modulus.as_nz_ref());
 
             let lincomb = BoxedMontyForm::lincomb_vartime(&[
                 (

--- a/src/modular/boxed_monty_form/neg.rs
+++ b/src/modular/boxed_monty_form/neg.rs
@@ -7,7 +7,9 @@ impl BoxedMontyForm {
     /// Negates the number.
     pub fn neg(&self) -> Self {
         Self {
-            montgomery_form: self.montgomery_form.neg_mod(self.params.modulus()),
+            montgomery_form: self
+                .montgomery_form
+                .neg_mod(self.params.modulus().as_nz_ref()),
             params: self.params.clone(),
         }
     }

--- a/src/modular/boxed_monty_form/sub.rs
+++ b/src/modular/boxed_monty_form/sub.rs
@@ -12,7 +12,7 @@ impl BoxedMontyForm {
         Self {
             montgomery_form: self
                 .montgomery_form
-                .sub_mod(&rhs.montgomery_form, self.params.modulus()),
+                .sub_mod(&rhs.montgomery_form, self.params.modulus().as_nz_ref()),
             params: self.params.clone(),
         }
     }

--- a/src/modular/const_monty_form/neg.rs
+++ b/src/modular/const_monty_form/neg.rs
@@ -7,7 +7,9 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     /// Negates the number.
     pub const fn neg(&self) -> Self {
         Self {
-            montgomery_form: self.montgomery_form.neg_mod(MOD::PARAMS.modulus.as_ref()),
+            montgomery_form: self
+                .montgomery_form
+                .neg_mod(MOD::PARAMS.modulus.as_nz_ref()),
             phantom: self.phantom,
         }
     }

--- a/src/modular/lincomb.rs
+++ b/src/modular/lincomb.rs
@@ -95,7 +95,7 @@ pub const fn lincomb_const_monty_form<MOD: ConstMontyParams<LIMBS>, const LIMBS:
             let carry =
                 impl_longa_monty_lincomb!(window, buf.limbs, modulus.0.limbs, mod_neg_inv, LIMBS);
             buf = buf.sub_mod_with_carry(carry, &modulus.0, &modulus.0);
-            ret = ret.add_mod(&buf, &modulus.0);
+            ret = ret.add_mod(&buf, modulus.as_nz_ref());
             remain -= count;
         }
         ret
@@ -127,7 +127,7 @@ pub const fn lincomb_monty_form<const LIMBS: usize>(
             let carry =
                 impl_longa_monty_lincomb!(window, buf.limbs, modulus.0.limbs, mod_neg_inv, LIMBS);
             buf = buf.sub_mod_with_carry(carry, &modulus.0, &modulus.0);
-            ret = ret.add_mod(&buf, &modulus.0);
+            ret = ret.add_mod(&buf, modulus.as_nz_ref());
             remain -= count;
         }
         ret

--- a/src/modular/monty_form/neg.rs
+++ b/src/modular/monty_form/neg.rs
@@ -7,7 +7,9 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Negates the number.
     pub const fn neg(&self) -> Self {
         Self {
-            montgomery_form: self.montgomery_form.neg_mod(self.params.modulus.as_ref()),
+            montgomery_form: self
+                .montgomery_form
+                .neg_mod(self.params.modulus.as_nz_ref()),
             params: self.params,
         }
     }

--- a/src/modular/sub.rs
+++ b/src/modular/sub.rs
@@ -5,5 +5,5 @@ pub(crate) const fn sub_montgomery_form<const LIMBS: usize>(
     b: &Uint<LIMBS>,
     modulus: &Odd<Uint<LIMBS>>,
 ) -> Uint<LIMBS> {
-    a.sub_mod(b, &modulus.0)
+    a.sub_mod(b, modulus.as_nz_ref())
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -491,7 +491,7 @@ where
 }
 
 /// Compute `1 / self mod p`.
-pub trait InvertMod<Mod = Self>: Sized {
+pub trait InvertMod<Mod = NonZero<Self>>: Sized {
     /// Output type.
     type Output;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -428,44 +428,44 @@ pub trait RandomMod: Sized + Zero {
 }
 
 /// Compute `self + rhs mod p`.
-pub trait AddMod<Rhs = Self> {
+pub trait AddMod<Rhs = Self, Mod = NonZero<Self>> {
     /// Output type.
     type Output;
 
     /// Compute `self + rhs mod p`.
     ///
     /// Assumes `self` and `rhs` are `< p`.
-    fn add_mod(&self, rhs: &Rhs, p: &Self) -> Self::Output;
+    fn add_mod(&self, rhs: &Rhs, p: &Mod) -> Self::Output;
 }
 
 /// Compute `self - rhs mod p`.
-pub trait SubMod<Rhs = Self> {
+pub trait SubMod<Rhs = Self, Mod = NonZero<Self>> {
     /// Output type.
     type Output;
 
     /// Compute `self - rhs mod p`.
     ///
     /// Assumes `self` and `rhs` are `< p`.
-    fn sub_mod(&self, rhs: &Rhs, p: &Self) -> Self::Output;
+    fn sub_mod(&self, rhs: &Rhs, p: &Mod) -> Self::Output;
 }
 
 /// Compute `-self mod p`.
-pub trait NegMod {
+pub trait NegMod<Mod = NonZero<Self>> {
     /// Output type.
     type Output;
 
     /// Compute `-self mod p`.
     #[must_use]
-    fn neg_mod(&self, p: &Self) -> Self::Output;
+    fn neg_mod(&self, p: &Mod) -> Self::Output;
 }
 
 /// Compute `self * rhs mod p`.
-pub trait MulMod<Rhs = Self> {
+pub trait MulMod<Rhs = Self, Mod = NonZero<Self>> {
     /// Output type.
     type Output;
 
     /// Compute `self * rhs mod p`.
-    fn mul_mod(&self, rhs: &Rhs, p: &Self) -> Self::Output;
+    fn mul_mod(&self, rhs: &Rhs, p: &Mod) -> Self::Output;
 }
 
 /// Compute `1 / self mod p`.
@@ -491,12 +491,12 @@ where
 }
 
 /// Compute `1 / self mod p`.
-pub trait InvertMod<Rhs = Self>: Sized {
+pub trait InvertMod<Mod = Self>: Sized {
     /// Output type.
     type Output;
 
     /// Compute `1 / self mod p`.
-    fn invert_mod(&self, p: &Rhs) -> CtOption<Self::Output>;
+    fn invert_mod(&self, p: &Mod) -> CtOption<Self::Output>;
 }
 
 /// Checked addition.

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -1,30 +1,11 @@
 //! [`BoxedUint`] modular multiplication operations.
 
-use crate::{
-    BoxedUint, Limb, MulMod, NonZero, Odd, WideWord, Word,
-    div_limb::mul_rem,
-    modular::{BoxedMontyForm, BoxedMontyParams},
-};
+use crate::{BoxedUint, Limb, MulMod, NonZero, WideWord, Word, div_limb::mul_rem};
 
 impl BoxedUint {
-    /// Computes `self * rhs mod p` for odd `p`.
+    /// Computes `self * rhs mod p` for non-zero `p`.
     pub fn mul_mod(&self, rhs: &BoxedUint, p: &NonZero<BoxedUint>) -> BoxedUint {
-        // NOTE: the overhead of converting to Montgomery form to perform this operation and then
-        // immediately converting out of Montgomery form after just a single operation is likely to
-        // be higher than other possible implementations of this function, such as using a
-        // Barrett reduction instead.
-        //
-        // It's worth potentially exploring other approaches to improve efficiency.
-        match Odd::new(p.as_ref().clone()).into() {
-            Some(p) => {
-                let params = BoxedMontyParams::new(p);
-                let lhs = BoxedMontyForm::new(self.clone(), params.clone());
-                let rhs = BoxedMontyForm::new(rhs.clone(), params);
-                let ret = lhs * rhs;
-                ret.retrieve()
-            }
-            None => todo!("even moduli are currently unsupported"),
-        }
+        self.mul(rhs).rem(p)
     }
 
     /// Computes `self * rhs mod p` for the special modulus

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -8,17 +8,14 @@ use crate::{
 
 impl BoxedUint {
     /// Computes `self * rhs mod p` for odd `p`.
-    ///
-    /// Panics if `p` is even.
-    // TODO(tarcieri): support for even `p`?
-    pub fn mul_mod(&self, rhs: &BoxedUint, p: &BoxedUint) -> BoxedUint {
+    pub fn mul_mod(&self, rhs: &BoxedUint, p: &NonZero<BoxedUint>) -> BoxedUint {
         // NOTE: the overhead of converting to Montgomery form to perform this operation and then
         // immediately converting out of Montgomery form after just a single operation is likely to
         // be higher than other possible implementations of this function, such as using a
         // Barrett reduction instead.
         //
         // It's worth potentially exploring other approaches to improve efficiency.
-        match Odd::new(p.clone()).into() {
+        match Odd::new(p.as_ref().clone()).into() {
             Some(p) => {
                 let params = BoxedMontyParams::new(p);
                 let lhs = BoxedMontyForm::new(self.clone(), params.clone());
@@ -75,7 +72,7 @@ impl BoxedUint {
 impl MulMod for BoxedUint {
     type Output = Self;
 
-    fn mul_mod(&self, rhs: &Self, p: &Self) -> Self {
+    fn mul_mod(&self, rhs: &Self, p: &NonZero<Self>) -> Self {
         self.mul_mod(rhs, p)
     }
 }

--- a/src/uint/boxed/neg_mod.rs
+++ b/src/uint/boxed/neg_mod.rs
@@ -1,12 +1,12 @@
 //! [`BoxedUint`] modular negation operations.
 
-use crate::{BoxedUint, Limb, NegMod};
+use crate::{BoxedUint, Limb, NegMod, NonZero};
 use subtle::ConditionallySelectable;
 
 impl BoxedUint {
     /// Computes `-a mod p`.
     /// Assumes `self` is in `[0, p)`.
-    pub fn neg_mod(&self, p: &Self) -> Self {
+    pub fn neg_mod(&self, p: &NonZero<Self>) -> Self {
         debug_assert_eq!(self.bits_precision(), p.bits_precision());
         let is_zero = self.is_zero();
         let mut ret = p.borrowing_sub(self, Limb::ZERO).0;
@@ -30,8 +30,8 @@ impl BoxedUint {
 impl NegMod for BoxedUint {
     type Output = Self;
 
-    fn neg_mod(&self, p: &Self) -> Self {
-        debug_assert!(self < p);
+    fn neg_mod(&self, p: &NonZero<Self>) -> Self {
+        debug_assert!(self < p.as_ref());
         self.neg_mod(p)
     }
 }
@@ -52,6 +52,8 @@ mod tests {
             &hex!("928334a4e4be0843ec225a4c9c61df34bdc7a81513e4b6f76f2bfa3148e2e1b5"),
             256,
         )
+        .unwrap()
+        .to_nz()
         .unwrap();
 
         let actual = x.neg_mod(&p);
@@ -75,6 +77,8 @@ mod tests {
             &hex!("928334a4e4be0843ec225a4c9c61df34bdc7a81513e4b6f76f2bfa3148e2e1b5"),
             256,
         )
+        .unwrap()
+        .to_nz()
         .unwrap();
 
         let actual = x.neg_mod(&p);

--- a/src/uint/boxed/sub_mod.rs
+++ b/src/uint/boxed/sub_mod.rs
@@ -1,16 +1,16 @@
 //! [`BoxedUint`] modular subtraction operations.
 
-use crate::{BoxedUint, Limb, SubMod, Zero};
+use crate::{BoxedUint, Limb, NonZero, SubMod, Zero};
 
 impl BoxedUint {
     /// Computes `self - rhs mod p`.
     ///
     /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
-    pub fn sub_mod(&self, rhs: &Self, p: &Self) -> Self {
+    pub fn sub_mod(&self, rhs: &Self, p: &NonZero<Self>) -> Self {
         debug_assert_eq!(self.bits_precision(), p.bits_precision());
         debug_assert_eq!(rhs.bits_precision(), p.bits_precision());
-        debug_assert!(self < p);
-        debug_assert!(rhs < p);
+        debug_assert!(self < p.as_ref());
+        debug_assert!(rhs < p.as_ref());
 
         let (mut out, borrow) = self.borrowing_sub(rhs, Limb::ZERO);
 
@@ -54,7 +54,7 @@ impl BoxedUint {
 impl SubMod for BoxedUint {
     type Output = Self;
 
-    fn sub_mod(&self, rhs: &Self, p: &Self) -> Self {
+    fn sub_mod(&self, rhs: &Self, p: &NonZero<Self>) -> Self {
         self.sub_mod(rhs, p)
     }
 }
@@ -80,6 +80,8 @@ mod tests {
             &hex!("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"),
             256,
         )
+        .unwrap()
+        .to_nz()
         .unwrap();
 
         let actual = a.sub_mod(&b, &n);

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -55,8 +55,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 impl<const LIMBS: usize> MulMod for Uint<LIMBS> {
     type Output = Self;
 
-    fn mul_mod(&self, rhs: &Self, p: &Self) -> Self {
-        self.mul_mod_vartime(rhs, &NonZero::new(*p).expect("p should be non-zero"))
+    fn mul_mod(&self, rhs: &Self, p: &NonZero<Self>) -> Self {
+        self.mul_mod(rhs, p)
     }
 }
 

--- a/src/uint/neg_mod.rs
+++ b/src/uint/neg_mod.rs
@@ -1,13 +1,13 @@
 //! [`Uint`] modular negation operations.
 
-use crate::{Limb, NegMod, Uint};
+use crate::{Limb, NegMod, NonZero, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `-a mod p`.
     /// Assumes `self` is in `[0, p)`.
-    pub const fn neg_mod(&self, p: &Self) -> Self {
+    pub const fn neg_mod(&self, p: &NonZero<Self>) -> Self {
         let z = self.is_nonzero();
-        let mut ret = p.borrowing_sub(self, Limb::ZERO).0;
+        let mut ret = p.as_ref().borrowing_sub(self, Limb::ZERO).0;
         let mut i = 0;
         while i < LIMBS {
             // Set ret to 0 if the original value was 0, in which
@@ -28,8 +28,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 impl<const LIMBS: usize> NegMod for Uint<LIMBS> {
     type Output = Self;
 
-    fn neg_mod(&self, p: &Self) -> Self {
-        debug_assert!(self < p);
+    fn neg_mod(&self, p: &NonZero<Self>) -> Self {
+        debug_assert!(self < p.as_ref());
         self.neg_mod(p)
     }
 }
@@ -43,7 +43,9 @@ mod tests {
         let x =
             U256::from_be_hex("8d16e171674b4e6d8529edba4593802bf30b8cb161dd30aa8e550d41380007c2");
         let p =
-            U256::from_be_hex("928334a4e4be0843ec225a4c9c61df34bdc7a81513e4b6f76f2bfa3148e2e1b5");
+            U256::from_be_hex("928334a4e4be0843ec225a4c9c61df34bdc7a81513e4b6f76f2bfa3148e2e1b5")
+                .to_nz()
+                .unwrap();
 
         let actual = x.neg_mod(&p);
         let expected =
@@ -57,7 +59,9 @@ mod tests {
         let x =
             U256::from_be_hex("0000000000000000000000000000000000000000000000000000000000000000");
         let p =
-            U256::from_be_hex("928334a4e4be0843ec225a4c9c61df34bdc7a81513e4b6f76f2bfa3148e2e1b5");
+            U256::from_be_hex("928334a4e4be0843ec225a4c9c61df34bdc7a81513e4b6f76f2bfa3148e2e1b5")
+                .to_nz()
+                .unwrap();
 
         let actual = x.neg_mod(&p);
         let expected =

--- a/tests/boxed_uint.rs
+++ b/tests/boxed_uint.rs
@@ -192,7 +192,7 @@ proptest! {
         let n_bi = to_biguint(&n);
 
         let expected = to_uint((a_bi * b_bi) % n_bi);
-        let actual = a.mul_mod(&b, &n);
+        let actual = a.mul_mod(&b, n.as_nz_ref());
         prop_assert_eq!(expected, actual);
     }
 

--- a/tests/monty_form.rs
+++ b/tests/monty_form.rs
@@ -158,7 +158,7 @@ proptest! {
             "a*a⁻¹ ≠ 1 (normal form, wide)"
         );
         // …and agrees with normal form inversion
-        let normal_form_inv = r.invert_mod(monty_params.modulus()).unwrap();
+        let normal_form_inv = r.invert_mod(monty_params.modulus().as_nz_ref()).unwrap();
         assert_eq!(
             normal_form_inv,
             r_monty_inv.retrieve(),
@@ -197,7 +197,7 @@ proptest! {
             "a*a⁻¹ ≠ 1 (normal form, wide)"
         );
         // …and agrees with normal form inversion
-        let normal_form_inv = r.invert_mod(monty_params.modulus()).unwrap();
+        let normal_form_inv = r.invert_mod(monty_params.modulus().as_nz_ref()).unwrap();
         assert_eq!(
             normal_form_inv,
             r_monty_inv.retrieve(),
@@ -236,7 +236,7 @@ proptest! {
             "a*a⁻¹ ≠ 1 (normal form, wide)"
         );
         // …and agrees with normal form inversion
-        let normal_form_inv = r.invert_mod(monty_params.modulus()).unwrap();
+        let normal_form_inv = r.invert_mod(monty_params.modulus().as_nz_ref()).unwrap();
         assert_eq!(
             normal_form_inv,
             r_monty_inv.retrieve(),
@@ -275,7 +275,7 @@ proptest! {
             "a*a⁻¹ ≠ 1 (normal form, wide)"
         );
         // …and agrees with normal form inversion
-        let normal_form_inv = r.invert_mod(monty_params.modulus()).unwrap();
+        let normal_form_inv = r.invert_mod(monty_params.modulus().as_nz_ref()).unwrap();
         assert_eq!(
             normal_form_inv,
             r_monty_inv.retrieve(),

--- a/tests/safegcd.rs
+++ b/tests/safegcd.rs
@@ -74,7 +74,7 @@ proptest! {
         let p_bi = to_biguint(&P);
 
         let expected_is_some = x_bi.gcd(&p_bi) == BigUint::one();
-        let actual = x.invert_mod(&p);
+        let actual = x.invert_mod(p.as_nz_ref());
 
         prop_assert_eq!(expected_is_some, bool::from(actual.is_some()));
 
@@ -84,7 +84,7 @@ proptest! {
             prop_assert_eq!(res, BigUint::one());
 
             // check vartime implementation equivalence
-            let actual_vartime = x.invert_mod(&p).unwrap();
+            let actual_vartime = x.invert_mod(p.as_nz_ref()).unwrap();
             prop_assert_eq!(actual, actual_vartime);
         }
     }

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -171,7 +171,7 @@ proptest! {
         let p_bi = to_biguint(&P);
 
         let expected = to_uint((a_bi + b_bi) % p_bi);
-        let actual = a.add_mod(&b, &P);
+        let actual = a.add_mod(&b, P.as_nz_ref());
 
         prop_assert!(expected < P);
         prop_assert!(actual < P);
@@ -193,7 +193,7 @@ proptest! {
         let p_bi = to_biguint(&P);
 
         let expected = to_uint((a_bi - b_bi) % p_bi);
-        let actual = a.sub_mod(&b, &P);
+        let actual = a.sub_mod(&b, P.as_nz_ref());
 
         prop_assert!(expected < P);
         prop_assert!(actual < P);

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -432,12 +432,15 @@ proptest! {
     }
 
     #[test]
-    fn invert_mod(a in uint(), b in uint()) {
+    fn invert_mod(a in uint(), mut b in uint()) {
+        if b.is_zero() {
+            b = Uint::ONE;
+        }
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);
 
         let expected_is_some = a_bi.gcd(&b_bi) == BigUint::one();
-        let actual = a.invert_mod(&b);
+        let actual = a.invert_mod(&b.to_nz().unwrap());
         let actual_is_some = bool::from(actual.is_some());
 
         prop_assert_eq!(expected_is_some, actual_is_some);


### PR DESCRIPTION
The modulus type is added as a trait parameter so it can be overridden, allowing implementations for `Odd<Self>` or `NonZero<Limb>` for instance. `BoxedUint::mul_mod` is simplified along the way.

Fixes #903 