### PR TITLE
Simplify `Uint::add_mod`, `Uint::double_mod`

### DIFF
--- a/src/modular/add.rs
+++ b/src/modular/add.rs
@@ -12,5 +12,5 @@ pub(crate) const fn double_montgomery_form<const LIMBS: usize>(
     a: &Uint<LIMBS>,
     modulus: &Odd<Uint<LIMBS>>,
 ) -> Uint<LIMBS> {
-    a.double_mod(&modulus.0)
+    a.double_mod(modulus.as_nz_ref())
 }

--- a/src/uint/sub_mod.rs
+++ b/src/uint/sub_mod.rs
@@ -21,9 +21,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         debug_assert!(carry.0 <= 1);
 
         let (out, borrow) = self.borrowing_sub(rhs, Limb::ZERO);
-
-        // The new `borrow = Word::MAX` iff `carry == 0` and `borrow == Word::MAX`.
-        let mask = carry.wrapping_neg().not().bitand(borrow);
+        let (_, mask) = carry.borrowing_sub(Limb::ZERO, borrow);
 
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the modulus.


### PR DESCRIPTION
This also adjusts the signature of `Uint::double_mod` to require a `NonZero` modulus, consistent with the other operations.

`Uint::sub_mod_with_carry` is changed to match the version previously in `add_mod` and avoid a performance regression.