### PR TITLE
Faster constant time bit shifts

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -95,6 +95,9 @@ impl Limb {
     #[cfg(target_pointer_width = "64")]
     pub const BYTES: usize = 8;
 
+    /// `floor(log2(Self::BITS))`.
+    pub const LOG2_BITS: u32 = u32::BITS - (Self::BITS - 1).leading_zeros();
+
     /// Convert to a [`NonZero<Limb>`].
     ///
     /// Returns some if the original value is non-zero, and false otherwise.

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -151,7 +151,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
 
         (
-            Uint::new(x).wrapping_shr((dwords - 1) * Limb::BITS),
+            Uint::new(x).wrapping_shr_by_limbs(dwords - 1),
             Uint::new(y).shr_limb(lshift).0,
         )
     }

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -55,7 +55,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             let bit = ConstChoice::from_u32_lsb((shift >> i) & 1);
             result = Uint::select(
                 &result,
-                &result.wrapping_shl_by_limbs(1 << (i - Limb::LOG2_BITS)),
+                &result.wrapping_shl_by_limbs_vartime(1 << (i - Limb::LOG2_BITS)),
                 bit,
             );
             i += 1;
@@ -66,7 +66,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self << (shift * Limb::BITS)` in a panic-free manner, returning zero if the
     /// shift exceeds the precision.
     #[inline(always)]
-    pub(crate) const fn wrapping_shl_by_limbs(&self, shift: u32) -> Self {
+    pub(crate) const fn wrapping_shl_by_limbs_vartime(&self, shift: u32) -> Self {
         let shift = shift as usize;
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = shift;
@@ -92,7 +92,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
 
         let shift_num = shift / Limb::BITS;
-        let mut res = self.wrapping_shl_by_limbs(shift_num);
+        let mut res = self.wrapping_shl_by_limbs_vartime(shift_num);
         let rem = shift % Limb::BITS;
 
         if rem > 0 {
@@ -362,13 +362,11 @@ mod tests {
     }
 
     #[test]
-    fn wrapping_shl_by_limbs() {
-        let val = U128::from_be_hex("876543210FEDCBA90123456FEDCBA987");
+    fn wrapping_shl_by_limbs_vartime() {
+        let val = Uint::<2>::from_words([1, 99]);
 
-        for i in 0..3 {
-            let result = val.wrapping_shl_by_limbs(i);
-            let expect = val.wrapping_shl_vartime(Limb::BITS * i);
-            assert_eq!(result, expect);
-        }
+        assert_eq!(val.wrapping_shl_by_limbs_vartime(0).as_words(), &[1, 99]);
+        assert_eq!(val.wrapping_shl_by_limbs_vartime(1).as_words(), &[0, 1]);
+        assert_eq!(val.wrapping_shl_by_limbs_vartime(2).as_words(), &[0, 0]);
     }
 }

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -365,16 +365,10 @@ mod tests {
     fn wrapping_shl_by_limbs() {
         let val = U128::from_be_hex("876543210FEDCBA90123456FEDCBA987");
 
-        let res = val.wrapping_shl_by_limbs(0);
-        assert_eq!(res, val);
-
-        let res = val.wrapping_shl_by_limbs(1);
-        assert_eq!(res, val.shl_vartime(Limb::BITS));
-
-        let res = val.wrapping_shl_by_limbs(2);
-        assert_eq!(res, Uint::ZERO);
-
-        let res = val.wrapping_shl_by_limbs(3);
-        assert_eq!(res, Uint::ZERO);
+        for i in 0..3 {
+            let result = val.wrapping_shl_by_limbs(i);
+            let expect = val.wrapping_shl_vartime(Limb::BITS * i);
+            assert_eq!(result, expect);
+        }
     }
 }

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -360,16 +360,10 @@ mod tests {
     fn wrapping_shr_by_limbs() {
         let val = U128::from_be_hex("876543210FEDCBA90123456FEDCBA987");
 
-        let res = val.wrapping_shr_by_limbs(0);
-        assert_eq!(res, val);
-
-        let res = val.wrapping_shr_by_limbs(1);
-        assert_eq!(res, val.shr_vartime(Limb::BITS));
-
-        let res = val.wrapping_shr_by_limbs(2);
-        assert_eq!(res, Uint::ZERO);
-
-        let res = val.wrapping_shr_by_limbs(3);
-        assert_eq!(res, Uint::ZERO);
+        for i in 0..3 {
+            let result = val.wrapping_shr_by_limbs(i);
+            let expect = val.wrapping_shr_vartime(Limb::BITS * i);
+            assert_eq!(result, expect);
+        }
     }
 }

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -24,27 +24,57 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self >> shift`.
     ///
     /// Returns `None` if `shift >= Self::BITS`.
+    #[inline]
     pub const fn overflowing_shr(&self, shift: u32) -> ConstCtOption<Self> {
+        let overflow = ConstChoice::from_u32_lt(shift, Self::BITS).not();
+        let result = self.bounded_wrapping_shr(shift % Self::BITS, Self::BITS);
+        ConstCtOption::new(Uint::select(&result, &Self::ZERO, overflow), overflow.not())
+    }
+
+    /// Computes `self >> shift` where `shift < `shift_upper_bound`, returning zero
+    /// if the shift exceeds the precision. The runtime is determined by `shift_upper_bound`
+    /// which may be smaller than `Self::BITS`.
+    pub(crate) const fn bounded_wrapping_shr(&self, shift: u32, shift_upper_bound: u32) -> Self {
+        assert!(shift < shift_upper_bound);
         // `floor(log2(BITS - 1))` is the number of bits in the representation of `shift`
         // (which lies in range `0 <= shift < BITS`).
-        let shift_bits = u32::BITS - (Self::BITS - 1).leading_zeros();
-        let overflow = ConstChoice::from_u32_lt(shift, Self::BITS).not();
-        let shift = shift % Self::BITS;
+        let shift_bits = u32::BITS - (shift_upper_bound - 1).leading_zeros();
+        let limb_bits = if shift_bits < Limb::LOG2_BITS {
+            shift_bits
+        } else {
+            Limb::LOG2_BITS
+        };
         let mut result = *self;
         let mut i = 0;
+        while i < limb_bits {
+            let bit = ConstChoice::from_u32_lsb((shift >> i) & 1);
+            result = Uint::select(&result, &result.shr_limb_nonzero(1 << i).0, bit);
+            i += 1;
+        }
         while i < shift_bits {
             let bit = ConstChoice::from_u32_lsb((shift >> i) & 1);
             result = Uint::select(
                 &result,
-                &result
-                    .overflowing_shr_vartime(1 << i)
-                    .expect("shift within range"),
+                &result.wrapping_shr_by_limbs(1 << (i - Limb::LOG2_BITS)),
                 bit,
             );
             i += 1;
         }
+        result
+    }
 
-        ConstCtOption::new(Uint::select(&result, &Self::ZERO, overflow), overflow.not())
+    /// Computes `self >> (shift * Limb::BITS)` in a panic-free manner, returning zero if the
+    /// shift exceeds the precision.
+    #[inline(always)]
+    pub(crate) const fn wrapping_shr_by_limbs(&self, shift: u32) -> Self {
+        let shift = shift as usize;
+        let mut limbs = [Limb::ZERO; LIMBS];
+        let mut i = 0;
+        while i < LIMBS.saturating_sub(shift) {
+            limbs[i] = self.limbs[i + shift];
+            i += 1;
+        }
+        Self { limbs }
     }
 
     /// Computes `self >> shift`.
@@ -57,36 +87,27 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// to `self`.
     #[inline(always)]
     pub const fn overflowing_shr_vartime(&self, shift: u32) -> ConstCtOption<Self> {
-        let mut limbs = [Limb::ZERO; LIMBS];
-
         if shift >= Self::BITS {
             return ConstCtOption::none(Self::ZERO);
         }
 
-        let shift_num = (shift / Limb::BITS) as usize;
+        let shift_num = shift / Limb::BITS;
+        let mut res = self.wrapping_shr_by_limbs(shift_num);
         let rem = shift % Limb::BITS;
 
-        let mut i = 0;
-        while i < LIMBS - shift_num {
-            limbs[i] = self.limbs[i + shift_num];
-            i += 1;
+        if rem > 0 {
+            let mut carry = Limb::ZERO;
+            let mut i = LIMBS - shift_num as usize;
+            while i > 0 {
+                i -= 1;
+                let shifted = res.limbs[i].shr(rem);
+                let new_carry = res.limbs[i].shl(Limb::BITS - rem);
+                res.limbs[i] = shifted.bitor(carry);
+                carry = new_carry;
+            }
         }
 
-        if rem == 0 {
-            return ConstCtOption::some(Self { limbs });
-        }
-
-        let mut carry = Limb::ZERO;
-
-        while i > 0 {
-            i -= 1;
-            let shifted = limbs[i].shr(rem);
-            let new_carry = limbs[i].shl(Limb::BITS - rem);
-            limbs[i] = shifted.bitor(carry);
-            carry = new_carry;
-        }
-
-        ConstCtOption::some(Self { limbs })
+        ConstCtOption::some(res)
     }
 
     /// Computes a right shift on a wide input as `(lo, hi)`.
@@ -162,7 +183,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// returning the result and the carry.
     #[inline(always)]
     pub(crate) const fn shr_limb(&self, shift: u32) -> (Self, Limb) {
-        assert!(shift < Limb::BITS);
         let nz = ConstChoice::from_u32_nonzero(shift);
         let shift = nz.select_u32(1, shift);
         let (res, carry) = self.shr_limb_nonzero(shift);
@@ -186,16 +206,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         let rshift = shift;
         let lshift = Limb::BITS - shift;
-
         let mut carry = Limb::ZERO;
+
         let mut i = LIMBS;
         while i > 0 {
             i -= 1;
-
-            let limb = self.limbs[i].shr(rshift);
-            let new_carry = self.limbs[i].shl(lshift);
-            limbs[i] = limb.bitor(carry);
-            carry = new_carry;
+            limbs[i] = self.limbs[i].shr(rshift).bitor(carry);
+            carry = self.limbs[i].shl(lshift);
         }
 
         (Uint::<LIMBS>::new(limbs), carry)
@@ -337,5 +354,22 @@ mod tests {
         let (res, carry) = val.shr_limb(Limb::BITS - 1);
         assert_eq!(res, val.shr_vartime(Limb::BITS - 1));
         assert_eq!(carry, val.limbs[0].shl(1));
+    }
+
+    #[test]
+    fn wrapping_shr_by_limbs() {
+        let val = U128::from_be_hex("876543210FEDCBA90123456FEDCBA987");
+
+        let res = val.wrapping_shr_by_limbs(0);
+        assert_eq!(res, val);
+
+        let res = val.wrapping_shr_by_limbs(1);
+        assert_eq!(res, val.shr_vartime(Limb::BITS));
+
+        let res = val.wrapping_shr_by_limbs(2);
+        assert_eq!(res, Uint::ZERO);
+
+        let res = val.wrapping_shr_by_limbs(3);
+        assert_eq!(res, Uint::ZERO);
     }
 }

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -97,7 +97,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
         if rem > 0 {
             let mut carry = Limb::ZERO;
-            let mut i = LIMBS - shift_num as usize;
+            let mut i = LIMBS.saturating_sub(shift_num as usize);
             while i > 0 {
                 i -= 1;
                 let shifted = res.limbs[i].shr(rem);


### PR DESCRIPTION
This update adds internal `bounded_wrapping_sh(r/l)` and `wrapping_sh(r/l)_by_limbs` methods and optimizes `shr` and `shl` for `Uint` by applying sub-limb and super-limb shifts in different ways. Performance is generally improved (a lot), with division methods, `sqrt`, `bingcd`, and `MontyParams::new` also being particularly affected.

There is a variant of the bounded-wrapping shr method in `bingcd` which can be updated to use the new methods later.