### PR TITLE
Move bit operations to `UintRef`

### DIFF
--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -453,17 +453,13 @@ fn bench_shl(c: &mut Criterion) {
     let mut group = c.benchmark_group("left shift");
 
     group.bench_function("shl_vartime, small, U2048", |b| {
-        b.iter_batched(
-            || U2048::ONE,
-            |x| x.overflowing_shl_vartime(10),
-            BatchSize::SmallInput,
-        )
+        b.iter_batched(|| U2048::ONE, |x| x.shl_vartime(10), BatchSize::SmallInput)
     });
 
     group.bench_function("shl_vartime, large, U2048", |b| {
         b.iter_batched(
             || U2048::ONE,
-            |x| black_box(x.overflowing_shl_vartime(1024 + 10)),
+            |x| x.shl_vartime(1024 + 10),
             BatchSize::SmallInput,
         )
     });
@@ -477,11 +473,7 @@ fn bench_shl(c: &mut Criterion) {
     });
 
     group.bench_function("shl, U2048", |b| {
-        b.iter_batched(
-            || U2048::ONE,
-            |x| x.overflowing_shl(1024 + 10),
-            BatchSize::SmallInput,
-        )
+        b.iter_batched(|| U2048::ONE, |x| x.shl(1024 + 10), BatchSize::SmallInput)
     });
 
     group.finish();
@@ -491,17 +483,13 @@ fn bench_shr(c: &mut Criterion) {
     let mut group = c.benchmark_group("right shift");
 
     group.bench_function("shr_vartime, small, U2048", |b| {
-        b.iter_batched(
-            || U2048::ONE,
-            |x| x.overflowing_shr_vartime(10),
-            BatchSize::SmallInput,
-        )
+        b.iter_batched(|| U2048::ONE, |x| x.shr_vartime(10), BatchSize::SmallInput)
     });
 
     group.bench_function("shr_vartime, large, U2048", |b| {
         b.iter_batched(
             || U2048::ONE,
-            |x| x.overflowing_shr_vartime(1024 + 10),
+            |x| x.shr_vartime(1024 + 10),
             BatchSize::SmallInput,
         )
     });
@@ -515,11 +503,7 @@ fn bench_shr(c: &mut Criterion) {
     });
 
     group.bench_function("shr, U2048", |b| {
-        b.iter_batched(
-            || U2048::ONE,
-            |x| x.overflowing_shr(1024 + 10),
-            BatchSize::SmallInput,
-        )
+        b.iter_batched(|| U2048::ONE, |x| x.shr(1024 + 10), BatchSize::SmallInput)
     });
 
     group.finish();

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -188,11 +188,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Borrow the limbs of this [`Uint`] as a [`UintRef`].
+    #[inline(always)]
     pub(crate) const fn as_uint_ref(&self) -> &UintRef {
         UintRef::new(&self.limbs)
     }
 
     /// Mutably borrow the limbs of this [`Uint`] as a [`UintRef`].
+    #[inline(always)]
     pub(crate) const fn as_mut_uint_ref(&mut self) -> &mut UintRef {
         UintRef::new_mut(&mut self.limbs)
     }

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -175,16 +175,19 @@ impl BoxedUint {
     }
 
     /// Borrow the limbs of this [`BoxedUint`] as a [`UintRef`].
-    pub(crate) fn as_uint_ref(&self) -> &UintRef {
+    #[inline(always)]
+    pub(crate) const fn as_uint_ref(&self) -> &UintRef {
         UintRef::new(&self.limbs)
     }
 
     /// Mutably borrow the limbs of this [`BoxedUint`] as a [`UintRef`].
-    pub(crate) fn as_mut_uint_ref(&mut self) -> &mut UintRef {
+    #[inline(always)]
+    pub(crate) const fn as_mut_uint_ref(&mut self) -> &mut UintRef {
         UintRef::new_mut(&mut self.limbs)
     }
 
     /// Mutably borrow a subset the limbs of this [`BoxedUint`] as a [`UintRef`].
+    #[inline(always)]
     pub(crate) fn as_mut_uint_ref_range<R>(&mut self, range: R) -> &mut UintRef
     where
         [Limb]: IndexMut<R, Output = [Limb]>,

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -30,8 +30,8 @@ mod rand;
 
 use crate::{Integer, Limb, NonZero, Odd, Resize, UintRef, Word, Zero, modular::BoxedMontyForm};
 use alloc::{boxed::Box, vec, vec::Vec};
-use core::fmt;
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+use core::{fmt, ops::IndexMut};
+use subtle::{Choice, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -184,6 +184,14 @@ impl BoxedUint {
         UintRef::new_mut(&mut self.limbs)
     }
 
+    /// Mutably borrow a subset the limbs of this [`BoxedUint`] as a [`UintRef`].
+    pub(crate) fn as_mut_uint_ref_range<R>(&mut self, range: R) -> &mut UintRef
+    where
+        [Limb]: IndexMut<R, Output = [Limb]>,
+    {
+        UintRef::new_mut(&mut self.limbs[range])
+    }
+
     /// Get the number of limbs in this [`BoxedUint`].
     pub fn nlimbs(&self) -> usize {
         self.limbs.len()
@@ -273,15 +281,6 @@ impl BoxedUint {
         }
 
         limbs.into()
-    }
-
-    /// Set the value of `self` to zero in-place if `choice` is truthy.
-    pub(crate) fn conditional_set_zero(&mut self, choice: Choice) {
-        let nlimbs = self.nlimbs();
-        let limbs = self.limbs.as_mut();
-        for i in 0..nlimbs {
-            limbs[i] = Limb::conditional_select(&limbs[i], &Limb::ZERO, choice);
-        }
     }
 
     /// Returns `true` if the integer's bit size is smaller or equal to `bits`.

--- a/src/uint/boxed/bits.rs
+++ b/src/uint/boxed/bits.rs
@@ -1,19 +1,13 @@
 //! Bit manipulation functions.
 
-use crate::{
-    BitOps, BoxedUint, Limb,
-    uint::bits::{
-        bit, bit_vartime, bits_vartime, leading_zeros, set_bit, set_bit_vartime, trailing_ones,
-        trailing_ones_vartime, trailing_zeros, trailing_zeros_vartime,
-    },
-};
+use crate::{BitOps, BoxedUint, Limb};
 use subtle::Choice;
 
 impl BoxedUint {
     /// Get the value of the bit at position `index`, as a truthy or falsy `Choice`.
     /// Returns the falsy value for indices out of range.
     pub fn bit(&self, index: u32) -> Choice {
-        bit(&self.limbs, index).into()
+        self.as_uint_ref().bit(index).into()
     }
 
     /// Returns `true` if the bit at position `index` is set, `false` otherwise.
@@ -22,7 +16,7 @@ impl BoxedUint {
     /// This operation is variable time with respect to `index` only.
     #[inline(always)]
     pub const fn bit_vartime(&self, index: u32) -> bool {
-        bit_vartime(&self.limbs, index)
+        self.as_uint_ref().bit_vartime(index)
     }
 
     /// Calculate the number of bits needed to represent this number, i.e. the index of the highest
@@ -36,48 +30,49 @@ impl BoxedUint {
     /// Calculate the number of bits needed to represent this number in variable-time with respect
     /// to `self`.
     pub fn bits_vartime(&self) -> u32 {
-        bits_vartime(&self.limbs)
+        self.as_uint_ref().bits_vartime()
     }
 
     /// Calculate the number of leading zeros in the binary representation of this number.
     pub const fn leading_zeros(&self) -> u32 {
-        leading_zeros(&self.limbs)
+        self.as_uint_ref().leading_zeros()
     }
 
     /// Get the precision of this [`BoxedUint`] in bits.
+    #[inline(always)]
     pub fn bits_precision(&self) -> u32 {
         self.limbs.len() as u32 * Limb::BITS
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number.
     pub fn trailing_zeros(&self) -> u32 {
-        trailing_zeros(&self.limbs)
+        self.as_uint_ref().trailing_zeros()
     }
 
     /// Calculate the number of trailing ones in the binary representation of this number.
     pub fn trailing_ones(&self) -> u32 {
-        trailing_ones(&self.limbs)
+        self.as_uint_ref().trailing_ones()
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number in
     /// variable-time with respect to `self`.
     pub fn trailing_zeros_vartime(&self) -> u32 {
-        trailing_zeros_vartime(&self.limbs)
+        self.as_uint_ref().trailing_zeros_vartime()
     }
 
     /// Calculate the number of trailing ones in the binary representation of this number,
     /// variable time in `self`.
     pub fn trailing_ones_vartime(&self) -> u32 {
-        trailing_ones_vartime(&self.limbs)
+        self.as_uint_ref().trailing_ones_vartime()
     }
 
     /// Sets the bit at `index` to 0 or 1 depending on the value of `bit_value`.
     pub(crate) fn set_bit(&mut self, index: u32, bit_value: Choice) {
-        set_bit(&mut self.limbs, index, bit_value.into());
+        self.as_mut_uint_ref().set_bit(index, bit_value.into())
     }
 
     pub(crate) fn set_bit_vartime(&mut self, index: u32, bit_value: bool) {
-        set_bit_vartime(&mut self.limbs, index, bit_value);
+        self.as_mut_uint_ref().set_bit_vartime(index, bit_value)
     }
 }
 

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -68,7 +68,7 @@ impl BoxedUint {
             let q =
                 self.wrapping_div_vartime(&NonZero::<Self>::new(x.clone()).expect("Division by 0"));
             let t = x.wrapping_add(&q);
-            let next_x = t.shr1();
+            let (next_x, _) = t.shr1();
 
             // If `next_x` is the same as `x` or greater, we reached convergence
             // (`x` is guaranteed to either go down or oscillate between

--- a/src/uint/encoding/der.rs
+++ b/src/uint/encoding/der.rs
@@ -1,9 +1,9 @@
 //! Support for decoding/encoding [`Uint`] as an ASN.1 DER `INTEGER`.
 
-use crate::{ArrayEncoding, Encoding, Limb, Uint, hybrid_array::Array, uint::bits::leading_zeros};
+use crate::{ArrayEncoding, Encoding, Limb, Uint, UintRef, hybrid_array::Array};
 use ::der::{
     DecodeValue, EncodeValue, FixedTag, Length, Tag,
-    asn1::{AnyRef, UintRef},
+    asn1::{AnyRef, UintRef as Asn1UintRef},
 };
 
 impl<'a, const LIMBS: usize> TryFrom<AnyRef<'a>> for Uint<LIMBS>
@@ -13,17 +13,17 @@ where
     type Error = der::Error;
 
     fn try_from(any: AnyRef<'a>) -> der::Result<Uint<LIMBS>> {
-        UintRef::try_from(any)?.try_into()
+        Asn1UintRef::try_from(any)?.try_into()
     }
 }
 
-impl<'a, const LIMBS: usize> TryFrom<UintRef<'a>> for Uint<LIMBS>
+impl<'a, const LIMBS: usize> TryFrom<Asn1UintRef<'a>> for Uint<LIMBS>
 where
     Uint<LIMBS>: ArrayEncoding,
 {
     type Error = der::Error;
 
-    fn try_from(bytes: UintRef<'a>) -> der::Result<Uint<LIMBS>> {
+    fn try_from(bytes: Asn1UintRef<'a>) -> der::Result<Uint<LIMBS>> {
         let mut array = Array::default();
         let offset = array.len().saturating_sub(bytes.len().try_into()?);
         array[offset..].copy_from_slice(bytes.as_bytes());
@@ -38,7 +38,7 @@ where
     type Error = der::Error;
 
     fn decode_value<R: der::Reader<'a>>(reader: &mut R, header: der::Header) -> der::Result<Self> {
-        UintRef::decode_value(reader, header)?.try_into()
+        Asn1UintRef::decode_value(reader, header)?.try_into()
     }
 }
 
@@ -52,7 +52,7 @@ where
 
     fn encode_value(&self, encoder: &mut impl der::Writer) -> der::Result<()> {
         let array = self.to_be_byte_array();
-        UintRef::new(&array)?.encode_value(encoder)
+        Asn1UintRef::new(&array)?.encode_value(encoder)
     }
 }
 
@@ -67,7 +67,7 @@ where
 #[inline]
 pub(crate) fn count_der_be_bytes(limbs: &[Limb]) -> u32 {
     // Number of 0x00 bytes (also index of first non-zero byte)
-    let leading_zero_bytes = leading_zeros(limbs) / 8;
+    let leading_zero_bytes = UintRef::new(limbs).leading_zeros() / 8;
 
     // Limbs indexed in reverse
     let limb_index = limbs
@@ -101,7 +101,7 @@ pub(crate) fn count_der_be_bytes(limbs: &[Limb]) -> u32 {
 
 #[cfg(feature = "alloc")]
 pub mod allocating {
-    use der::{DecodeValue, EncodeValue, FixedTag, Length, Tag, asn1::UintRef};
+    use der::{DecodeValue, EncodeValue, FixedTag, Length, Tag, asn1::UintRef as Asn1UintRef};
 
     use crate::{BoxedUint, encoding::der::count_der_be_bytes};
 
@@ -112,7 +112,7 @@ pub mod allocating {
 
         fn encode_value(&self, encoder: &mut impl der::Writer) -> der::Result<()> {
             let array = self.to_be_bytes();
-            UintRef::new(&array)?.encode_value(encoder)
+            Asn1UintRef::new(&array)?.encode_value(encoder)
         }
     }
 
@@ -123,11 +123,11 @@ pub mod allocating {
             reader: &mut R,
             header: der::Header,
         ) -> der::Result<Self> {
-            let value = UintRef::decode_value(reader, header)?;
+            let value = Asn1UintRef::decode_value(reader, header)?;
             let bits_precision = value.as_bytes().len() as u32 * 8;
 
             let value = BoxedUint::from_be_slice(value.as_bytes(), bits_precision)
-                .map_err(|_| UintRef::TAG.value_error())?;
+                .map_err(|_| Asn1UintRef::TAG.value_error())?;
             Ok(value)
         }
     }

--- a/src/uint/ref_type.rs
+++ b/src/uint/ref_type.rs
@@ -5,13 +5,16 @@ use core::{
     fmt,
     ops::{Index, IndexMut},
 };
-use subtle::{Choice, ConditionallySelectable};
 
 #[cfg(feature = "alloc")]
 use crate::Word;
+#[cfg(feature = "alloc")]
+use subtle::{Choice, ConditionallySelectable};
 
 mod bits;
+#[cfg(feature = "alloc")]
 mod shl;
+#[cfg(feature = "alloc")]
 mod shr;
 
 /// Unsigned integer reference type.
@@ -89,6 +92,7 @@ impl UintRef {
         self.0.iter_mut()
     }
 
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn conditional_set_zero(&mut self, choice: Choice) {
         for i in 0..self.0.len() {

--- a/src/uint/ref_type.rs
+++ b/src/uint/ref_type.rs
@@ -5,9 +5,14 @@ use core::{
     fmt,
     ops::{Index, IndexMut},
 };
+use subtle::{Choice, ConditionallySelectable};
 
 #[cfg(feature = "alloc")]
 use crate::Word;
+
+mod bits;
+mod shl;
+mod shr;
 
 /// Unsigned integer reference type.
 ///
@@ -82,6 +87,13 @@ impl UintRef {
     #[allow(dead_code)] // TODO(tarcieri): use this
     pub fn iter_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut Limb> {
         self.0.iter_mut()
+    }
+
+    #[inline]
+    pub fn conditional_set_zero(&mut self, choice: Choice) {
+        for i in 0..self.0.len() {
+            self.0[i] = Limb::conditional_select(&self.0[i], &Limb::ZERO, choice);
+        }
     }
 }
 

--- a/src/uint/ref_type/bits.rs
+++ b/src/uint/ref_type/bits.rs
@@ -1,0 +1,59 @@
+use super::UintRef;
+use crate::uint::bits::{
+    bit, bit_vartime, bits_vartime, leading_zeros, set_bit, set_bit_vartime, trailing_ones,
+    trailing_ones_vartime, trailing_zeros, trailing_zeros_vartime,
+};
+use crate::{Limb, traits::BitOps};
+use subtle::Choice;
+
+impl BitOps for UintRef {
+    #[inline(always)]
+    fn bits_precision(&self) -> u32 {
+        self.0.len() as u32 * Limb::BITS
+    }
+
+    #[inline(always)]
+    fn bytes_precision(&self) -> usize {
+        self.0.len()
+    }
+
+    fn leading_zeros(&self) -> u32 {
+        leading_zeros(self.as_slice())
+    }
+
+    fn bit(&self, index: u32) -> Choice {
+        bit(self.as_slice(), index).into()
+    }
+
+    fn set_bit(&mut self, index: u32, bit_value: Choice) {
+        set_bit(self.as_mut_slice(), index, bit_value.into());
+    }
+
+    fn trailing_zeros(&self) -> u32 {
+        trailing_zeros(self.as_slice())
+    }
+
+    fn trailing_ones(&self) -> u32 {
+        trailing_ones(self.as_slice())
+    }
+
+    fn bit_vartime(&self, index: u32) -> bool {
+        bit_vartime(self.as_slice(), index)
+    }
+
+    fn bits_vartime(&self) -> u32 {
+        bits_vartime(self.as_slice())
+    }
+
+    fn set_bit_vartime(&mut self, index: u32, bit_value: bool) {
+        set_bit_vartime(self.as_mut_slice(), index, bit_value);
+    }
+
+    fn trailing_zeros_vartime(&self) -> u32 {
+        trailing_zeros_vartime(self.as_slice())
+    }
+
+    fn trailing_ones_vartime(&self) -> u32 {
+        trailing_ones_vartime(self.as_slice())
+    }
+}

--- a/src/uint/ref_type/shl.rs
+++ b/src/uint/ref_type/shl.rs
@@ -228,19 +228,19 @@ mod tests {
         let mut val = N;
         let carry = val.as_mut_uint_ref().shl_assign_limb(1);
         assert_eq!(val, N.shl_vartime(1));
-        assert_eq!(carry, N.limbs[3].shr(Limb::BITS - 1));
+        assert_eq!(carry, N.limbs[U256::LIMBS - 1].shr(Limb::BITS - 1));
 
         // Shift by any
         let mut val = N;
         let carry = val.as_mut_uint_ref().shl_assign_limb(13);
         assert_eq!(val, N.shl_vartime(13));
-        assert_eq!(carry, N.limbs[3].shr(Limb::BITS - 13));
+        assert_eq!(carry, N.limbs[U256::LIMBS - 1].shr(Limb::BITS - 13));
 
         // Shift by max
         let mut val = N;
         let carry = val.as_mut_uint_ref().shl_assign_limb(Limb::BITS - 1);
         assert_eq!(val, N.shl_vartime(Limb::BITS - 1));
-        assert_eq!(carry, N.limbs[3].shr(1));
+        assert_eq!(carry, N.limbs[U256::LIMBS - 1].shr(1));
     }
 
     #[test]

--- a/src/uint/ref_type/shl.rs
+++ b/src/uint/ref_type/shl.rs
@@ -1,0 +1,269 @@
+//! [`Uint`] bitwise left shift operations.
+
+use super::UintRef;
+use crate::{BitOps, ConstChoice, Limb};
+use subtle::{Choice, ConstantTimeLess};
+
+impl UintRef {
+    /// Left-shifts by `shift` bits in constant-time.
+    ///
+    /// Produces zero and returns truthy `Choice` if `shift >= self.bits_precision()`,
+    /// or the result and a falsy `Choice` otherwise.
+    #[inline(always)]
+    pub fn overflowing_shl_assign(&mut self, shift: u32) -> Choice {
+        let bits = self.bits_precision();
+        let overflow = !shift.ct_lt(&bits);
+        self.bounded_wrapping_shl_assign(shift % bits, bits);
+        self.conditional_set_zero(overflow);
+        overflow
+    }
+
+    /// Left-shifts by `shift` bits in variable-time.
+    ///
+    /// Produces zero and returns truthy `Choice` if `shift >= self.bits_precision()`,
+    /// or the result and a falsy `Choice` otherwise.
+    ///
+    /// NOTE: this operation is variable time with respect to `shift` *ONLY*.
+    ///
+    /// When used with a fixed `shift`, this function is constant-time with respect to `self`.
+    #[inline(always)]
+    pub fn overflowing_shl_assign_vartime(&mut self, shift: u32) -> Choice {
+        let bits = self.bits_precision();
+        let overflow = !shift.ct_lt(&bits);
+        self.wrapping_shl_assign_vartime(shift);
+        overflow
+    }
+
+    /// Left-shifts by `shift` bits where `shift < `shift_upper_bound`, producing zero if
+    /// the shift exceeds the precision. The runtime is determined by `shift_upper_bound`
+    /// which may be smaller than `self.bits_precision()`.
+    pub(crate) const fn bounded_wrapping_shl_assign(&mut self, shift: u32, shift_upper_bound: u32) {
+        assert!(shift < shift_upper_bound);
+        // `floor(log2(BITS - 1))` is the number of bits in the representation of `shift`
+        // (which lies in range `0 <= shift < BITS`).
+        let shift_bits = u32::BITS - (shift_upper_bound - 1).leading_zeros();
+        let limb_bits = if shift_bits < Limb::LOG2_BITS {
+            shift_bits
+        } else {
+            Limb::LOG2_BITS
+        };
+        let mut i = 0;
+        while i < limb_bits {
+            let bit = ConstChoice::from_u32_lsb((shift >> i) & 1);
+            self.conditional_shl_assign_limb(1 << i, bit);
+            i += 1;
+        }
+        while i < shift_bits {
+            let bit = ConstChoice::from_u32_lsb((shift >> i) & 1);
+            self.conditional_shl_assign_by_limbs_vartime(1 << (i - Limb::LOG2_BITS), bit);
+            i += 1;
+        }
+    }
+
+    /// Conditionally left-shifts by `shift` limbs in a panic-free manner, producing zero
+    /// if the shift exceeds the precision.
+    ///
+    /// NOTE: this operation is variable time with respect to `shift` *ONLY*.
+    ///
+    /// When used with a fixed `shift`, this function is constant-time with respect to `self`.
+    #[inline(always)]
+    pub(crate) const fn conditional_shl_assign_by_limbs_vartime(
+        &mut self,
+        shift: u32,
+        c: ConstChoice,
+    ) {
+        let shift = shift as usize;
+        let mut i = self.0.len();
+        while i > shift {
+            i -= 1;
+            self.0[i] = Limb::select(self.0[i], self.0[i - shift], c);
+        }
+        while i > 0 {
+            i -= 1;
+            self.0[i] = Limb::select(self.0[i], Limb::ZERO, c);
+        }
+    }
+
+    /// Left-shifts by `shift` limbs in a panic-free manner, producing zero if the shift
+    /// exceeds the precision.
+    ///
+    /// NOTE: this operation is variable time with respect to `shift` *ONLY*.
+    ///
+    /// When used with a fixed `shift`, this function is constant-time with respect to `self`.
+    #[inline(always)]
+    pub(crate) const fn wrapping_shl_assign_by_limbs_vartime(&mut self, shift: u32) {
+        let shift = shift as usize;
+        let mut i = self.0.len();
+        while i > shift {
+            i -= 1;
+            self.0[i] = self.0[i - shift];
+        }
+        while i > 0 {
+            i -= 1;
+            self.0[i] = Limb::ZERO;
+        }
+    }
+
+    /// Left-shifts by `shift` bits in a panic-free manner, producing zero if the shift
+    /// exceeds the precision.
+    ///
+    /// NOTE: this operation is variable time with respect to `shift` *ONLY*.
+    ///
+    /// When used with a fixed `shift`, this function is constant-time with respect to `self`.
+    #[inline(always)]
+    pub const fn wrapping_shl_assign_vartime(&mut self, shift: u32) {
+        let shift_limbs = shift / Limb::BITS;
+        let rem = shift % Limb::BITS;
+
+        self.wrapping_shl_assign_by_limbs_vartime(shift_limbs);
+
+        if rem > 0 {
+            let mut carry = Limb::ZERO;
+            let mut i = shift_limbs as usize;
+            while i < self.0.len() {
+                (self.0[i], carry) = (
+                    self.0[i].shl(rem).bitor(carry),
+                    self.0[i].shr(Limb::BITS - rem),
+                );
+                i += 1;
+            }
+        }
+    }
+
+    /// Left-shifts by a single bit in constant-time, returning [`ConstChoice::TRUE`]
+    /// if the least significant bit was set, and [`ConstChoice::FALSE`] otherwise.
+    #[inline(always)]
+    pub const fn shl1_assign(&mut self) -> ConstChoice {
+        let mut carry = Limb::ZERO;
+        let mut i = 0;
+        while i < self.0.len() {
+            let (limb, new_carry) = self.0[i].shl1();
+            self.0[i] = limb.bitor(carry);
+            carry = new_carry;
+            i += 1;
+        }
+        ConstChoice::from_word_lsb(carry.0 >> Limb::HI_BIT)
+    }
+
+    /// Conditionally left-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning
+    /// the carry.
+    #[inline]
+    pub(crate) const fn conditional_shl_assign_limb(&mut self, shift: u32, c: ConstChoice) -> Limb {
+        assert!(shift < Limb::BITS);
+
+        let nz = ConstChoice::from_u32_nonzero(shift);
+        let lshift = shift;
+        let rshift = nz.select_u32(0, Limb::BITS - shift);
+        let apply = c.and(nz);
+        let mut carry = Limb::ZERO;
+
+        let mut i = 0;
+        while i < self.0.len() {
+            (self.0[i], carry) = (
+                Limb::select(self.0[i], self.0[i].shl(lshift).bitor(carry), apply),
+                self.0[i].shr(rshift),
+            );
+            i += 1;
+        }
+
+        Limb::select(Limb::ZERO, carry, apply)
+    }
+
+    /// Left-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning the carry.
+    #[inline(always)]
+    pub const fn shl_assign_limb(&mut self, shift: u32) -> Limb {
+        self.conditional_shl_assign_limb(shift, ConstChoice::TRUE)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Limb, U256, Uint};
+
+    const N: U256 =
+        U256::from_be_hex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
+
+    const TWO_N: U256 =
+        U256::from_be_hex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD755DB9CD5E9140777FA4BD19A06C8282");
+
+    #[test]
+    fn shl_simple() {
+        let mut t = U256::from(1u8);
+        assert_eq!(t << 1, U256::from(2u8));
+        t = U256::from(3u8);
+        assert_eq!(t << 8, U256::from(0x300u16));
+    }
+
+    #[test]
+    fn shl1_assign() {
+        let mut n = N;
+        n.as_mut_uint_ref().shl1_assign();
+        assert_eq!(n, TWO_N);
+    }
+
+    #[test]
+    fn shl256() {
+        let mut n = N;
+        assert!(bool::from(n.as_mut_uint_ref().overflowing_shl_assign(256)));
+        assert!(bool::from(
+            n.as_mut_uint_ref().overflowing_shl_assign_vartime(256)
+        ));
+    }
+
+    #[test]
+    fn shl_assign_limb() {
+        // Shift by zero
+        let mut val = N;
+        let carry = val.as_mut_uint_ref().shl_assign_limb(0);
+        assert_eq!(val, N);
+        assert_eq!(carry, Limb::ZERO);
+
+        // Shift by one
+        let mut val = N;
+        let carry = val.as_mut_uint_ref().shl_assign_limb(1);
+        assert_eq!(val, N.shl_vartime(1));
+        assert_eq!(carry, N.limbs[3].shr(Limb::BITS - 1));
+
+        // Shift by any
+        let mut val = N;
+        let carry = val.as_mut_uint_ref().shl_assign_limb(13);
+        assert_eq!(val, N.shl_vartime(13));
+        assert_eq!(carry, N.limbs[3].shr(Limb::BITS - 13));
+
+        // Shift by max
+        let mut val = N;
+        let carry = val.as_mut_uint_ref().shl_assign_limb(Limb::BITS - 1);
+        assert_eq!(val, N.shl_vartime(Limb::BITS - 1));
+        assert_eq!(carry, N.limbs[3].shr(1));
+    }
+
+    #[test]
+    fn wrapping_shl_by_limbs_vartime() {
+        let refval = Uint::<2>::from_words([1, 99]);
+
+        let mut val = refval;
+        val.as_mut_uint_ref()
+            .wrapping_shl_assign_by_limbs_vartime(0);
+        assert_eq!(val.as_words(), &[1, 99]);
+
+        let mut val = refval;
+        val.as_mut_uint_ref()
+            .wrapping_shl_assign_by_limbs_vartime(1);
+        assert_eq!(val.as_words(), &[0, 1]);
+
+        let mut val = refval;
+        val.as_mut_uint_ref()
+            .wrapping_shl_assign_by_limbs_vartime(2);
+        assert_eq!(val.as_words(), &[0, 0]);
+    }
+
+    #[test]
+    fn compare_shl_assign() {
+        for i in 0..256 {
+            let (mut a, mut b) = (N, N);
+            a.as_mut_uint_ref().bounded_wrapping_shl_assign(i, 256);
+            b.as_mut_uint_ref().wrapping_shl_assign_vartime(i);
+            assert_eq!(a, b);
+        }
+    }
+}

--- a/src/uint/ref_type/shl.rs
+++ b/src/uint/ref_type/shl.rs
@@ -1,7 +1,7 @@
 //! [`Uint`] bitwise left shift operations.
 
 use super::UintRef;
-use crate::{BitOps, ConstChoice, Limb};
+use crate::{BitOps, ConstChoice, Limb, NonZero};
 use subtle::{Choice, ConstantTimeLess};
 
 impl UintRef {
@@ -50,7 +50,7 @@ impl UintRef {
         let mut i = 0;
         while i < limb_bits {
             let bit = ConstChoice::from_u32_lsb((shift >> i) & 1);
-            self.conditional_shl_assign_limb(1 << i, bit);
+            self.conditional_shl_assign_limb_nonzero(NonZero(1 << i), bit);
             i += 1;
         }
         while i < shift_bits {
@@ -147,32 +147,38 @@ impl UintRef {
 
     /// Conditionally left-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning
     /// the carry.
+    ///
+    /// Panics if `shift >= Limb::BITS`.
     #[inline]
-    pub(crate) const fn conditional_shl_assign_limb(&mut self, shift: u32, c: ConstChoice) -> Limb {
-        assert!(shift < Limb::BITS);
+    pub(crate) const fn conditional_shl_assign_limb_nonzero(
+        &mut self,
+        shift: NonZero<u32>,
+        choice: ConstChoice,
+    ) -> Limb {
+        assert!(shift.0 < Limb::BITS);
 
-        let nz = ConstChoice::from_u32_nonzero(shift);
-        let lshift = shift;
-        let rshift = nz.select_u32(0, Limb::BITS - shift);
-        let apply = c.and(nz);
+        let lshift = shift.0;
+        let rshift = Limb::BITS - shift.0;
         let mut carry = Limb::ZERO;
 
         let mut i = 0;
         while i < self.0.len() {
             (self.0[i], carry) = (
-                Limb::select(self.0[i], self.0[i].shl(lshift).bitor(carry), apply),
+                Limb::select(self.0[i], self.0[i].shl(lshift).bitor(carry), choice),
                 self.0[i].shr(rshift),
             );
             i += 1;
         }
 
-        Limb::select(Limb::ZERO, carry, apply)
+        Limb::select(Limb::ZERO, carry, choice)
     }
 
     /// Left-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning the carry.
-    #[inline(always)]
+    ///
+    /// Panics if `shift >= Limb::BITS`.
     pub const fn shl_assign_limb(&mut self, shift: u32) -> Limb {
-        self.conditional_shl_assign_limb(shift, ConstChoice::TRUE)
+        let nz = ConstChoice::from_u32_nonzero(shift);
+        self.conditional_shl_assign_limb_nonzero(NonZero(nz.select_u32(1, shift)), nz)
     }
 }
 

--- a/src/uint/ref_type/shr.rs
+++ b/src/uint/ref_type/shr.rs
@@ -1,0 +1,261 @@
+//! [`UintRef`] bitwise right shift operations.
+
+use super::UintRef;
+use crate::{BitOps, ConstChoice, Limb};
+use subtle::{Choice, ConstantTimeLess};
+
+impl UintRef {
+    /// Right-shifts by `shift` bits in constant-time.
+    ///
+    /// Produces zero and returns truthy `Choice` if `shift >= self.bits_precision()`,
+    /// or the result and a falsy `Choice` otherwise.
+    #[inline(always)]
+    pub fn overflowing_shr_assign(&mut self, shift: u32) -> Choice {
+        let bits = self.bits_precision();
+        let overflow = !shift.ct_lt(&bits);
+        self.bounded_wrapping_shr_assign(shift % bits, bits);
+        self.conditional_set_zero(overflow);
+        overflow
+    }
+
+    /// Right-shifts by `shift` bits in variable-time.
+    ///
+    /// Produces zero and returns truthy `Choice` if `shift >= self.bits_precision()`,
+    /// or the result and a falsy `Choice` otherwise.
+    ///
+    /// NOTE: this operation is variable time with respect to `shift` *ONLY*.
+    ///
+    /// When used with a fixed `shift`, this function is constant-time with respect to `self`.
+    #[inline(always)]
+    pub fn overflowing_shr_assign_vartime(&mut self, shift: u32) -> Choice {
+        let bits = self.bits_precision();
+        let overflow = !shift.ct_lt(&bits);
+        self.wrapping_shr_assign_vartime(shift);
+        overflow
+    }
+
+    /// Right-shifts by `shift` bits where `shift < `shift_upper_bound`, producing zero if
+    /// the shift exceeds the precision. The runtime is determined by `shift_upper_bound`
+    /// which may be smaller than `self.bits_precision()`.
+    pub(crate) const fn bounded_wrapping_shr_assign(&mut self, shift: u32, shift_upper_bound: u32) {
+        assert!(shift < shift_upper_bound);
+        // `floor(log2(BITS - 1))` is the number of bits in the representation of `shift`
+        // (which lies in range `0 <= shift < BITS`).
+        let shift_bits = u32::BITS - (shift_upper_bound - 1).leading_zeros();
+        let limb_bits = if shift_bits < Limb::LOG2_BITS {
+            shift_bits
+        } else {
+            Limb::LOG2_BITS
+        };
+        let mut i = 0;
+        while i < limb_bits {
+            let bit = ConstChoice::from_u32_lsb((shift >> i) & 1);
+            self.conditional_shr_assign_limb(1 << i, bit);
+            i += 1;
+        }
+        while i < shift_bits {
+            let bit = ConstChoice::from_u32_lsb((shift >> i) & 1);
+            self.conditional_shr_assign_by_limbs_vartime(1 << (i - Limb::LOG2_BITS), bit);
+            i += 1;
+        }
+    }
+
+    /// Conditionally right-shifts by `shift` limbs in a panic-free manner, producing zero
+    /// if the shift exceeds the precision.
+    ///
+    /// NOTE: this operation is variable time with respect to `shift` *ONLY*.
+    ///
+    /// When used with a fixed `shift`, this function is constant-time with respect to `self`.
+    #[inline(always)]
+    pub(crate) const fn conditional_shr_assign_by_limbs_vartime(
+        &mut self,
+        shift: u32,
+        c: ConstChoice,
+    ) {
+        let shift = shift as usize;
+        let mut i = 0;
+        while i < self.0.len().saturating_sub(shift) {
+            self.0[i] = Limb::select(self.0[i], self.0[i + shift], c);
+            i += 1;
+        }
+        while i < self.0.len() {
+            self.0[i] = Limb::select(self.0[i], Limb::ZERO, c);
+            i += 1;
+        }
+    }
+
+    /// Right-shifts by `shift` limbs in a panic-free manner, producing zero if the shift
+    /// exceeds the precision.
+    ///
+    /// NOTE: this operation is variable time with respect to `shift` *ONLY*.
+    ///
+    /// When used with a fixed `shift`, this function is constant-time with respect to `self`.
+    #[inline(always)]
+    pub(crate) const fn wrapping_shr_assign_by_limbs_vartime(&mut self, shift: u32) {
+        let shift = shift as usize;
+        let mut i = 0;
+        while i < self.0.len().saturating_sub(shift) {
+            self.0[i] = self.0[i + shift];
+            i += 1;
+        }
+        while i < self.0.len() {
+            self.0[i] = Limb::ZERO;
+            i += 1;
+        }
+    }
+
+    /// Right-shifts by `shift` bits in a panic-free manner, producing zero if the shift
+    /// exceeds the precision.
+    ///
+    /// NOTE: this operation is variable time with respect to `shift` *ONLY*.
+    ///
+    /// When used with a fixed `shift`, this function is constant-time with respect to `self`.
+    #[inline(always)]
+    pub const fn wrapping_shr_assign_vartime(&mut self, shift: u32) {
+        let shift_limbs = shift / Limb::BITS;
+        let rem = shift % Limb::BITS;
+
+        self.wrapping_shr_assign_by_limbs_vartime(shift_limbs);
+
+        if rem > 0 {
+            let mut carry = Limb::ZERO;
+            let mut i = self.0.len().saturating_sub(shift_limbs as usize);
+            while i > 0 {
+                i -= 1;
+                (self.0[i], carry) = (
+                    self.0[i].shr(rem).bitor(carry),
+                    self.0[i].shl(Limb::BITS - rem),
+                );
+            }
+        }
+    }
+
+    /// Right-shifts by a single bit in constant-time, returning [`ConstChoice::TRUE`]
+    /// if the least significant bit was set, and [`ConstChoice::FALSE`] otherwise.
+    #[inline(always)]
+    pub const fn shr1_assign(&mut self) -> ConstChoice {
+        let mut carry = Limb::ZERO;
+        let mut i = self.0.len();
+        while i > 0 {
+            i -= 1;
+            let (limb, new_carry) = self.0[i].shr1();
+            self.0[i] = limb.bitor(carry);
+            carry = new_carry;
+        }
+        ConstChoice::from_word_lsb(carry.0 >> Limb::HI_BIT)
+    }
+
+    /// Conditionally right-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning
+    /// the carry.
+    #[inline]
+    pub(crate) const fn conditional_shr_assign_limb(&mut self, shift: u32, c: ConstChoice) -> Limb {
+        assert!(shift < Limb::BITS);
+
+        let nz = ConstChoice::from_u32_nonzero(shift);
+        let rshift = shift;
+        let lshift = nz.select_u32(0, Limb::BITS - shift);
+        let apply = c.and(nz);
+        let mut carry = Limb::ZERO;
+
+        let mut i = self.0.len();
+        while i > 0 {
+            i -= 1;
+            (self.0[i], carry) = (
+                Limb::select(self.0[i], self.0[i].shr(rshift).bitor(carry), apply),
+                self.0[i].shl(lshift),
+            );
+        }
+
+        Limb::select(Limb::ZERO, carry, apply)
+    }
+
+    /// Right-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning the carry.
+    #[inline(always)]
+    pub const fn shr_assign_limb(&mut self, shift: u32) -> Limb {
+        self.conditional_shr_assign_limb(shift, ConstChoice::TRUE)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Limb, U256, Uint};
+
+    const N: U256 =
+        U256::from_be_hex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
+
+    const N_2: U256 =
+        U256::from_be_hex("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0");
+
+    #[test]
+    fn shr1_assign() {
+        let mut n = N;
+        n.as_mut_uint_ref().shr1_assign();
+        assert_eq!(n, N_2);
+    }
+
+    #[test]
+    fn shr256() {
+        let mut n = N;
+        assert!(bool::from(n.as_mut_uint_ref().overflowing_shr_assign(256)));
+        assert!(bool::from(
+            n.as_mut_uint_ref().overflowing_shr_assign_vartime(256)
+        ));
+    }
+
+    #[test]
+    fn shr_assign_limb() {
+        // Shift by zero
+        let mut val = N;
+        let carry = val.as_mut_uint_ref().shr_assign_limb(0);
+        assert_eq!(val, N);
+        assert_eq!(carry, Limb::ZERO);
+
+        // Shift by one
+        let mut val = N;
+        let carry = val.as_mut_uint_ref().shr_assign_limb(1);
+        assert_eq!(val, N.shr_vartime(1));
+        assert_eq!(carry, N.limbs[0].shl(Limb::BITS - 1));
+
+        // Shift by any
+        let mut val = N;
+        let carry = val.as_mut_uint_ref().shr_assign_limb(13);
+        assert_eq!(val, N.shr_vartime(13));
+        assert_eq!(carry, N.limbs[0].shl(Limb::BITS - 13));
+
+        // Shift by max
+        let mut val = N;
+        let carry = val.as_mut_uint_ref().shr_assign_limb(Limb::BITS - 1);
+        assert_eq!(val, N.shr_vartime(Limb::BITS - 1));
+        assert_eq!(carry, N.limbs[0].shl(1));
+    }
+
+    #[test]
+    fn wrapping_shr_by_limbs_vartime() {
+        let refval = Uint::<2>::from_words([1, 99]);
+
+        let mut val = refval;
+        val.as_mut_uint_ref()
+            .wrapping_shr_assign_by_limbs_vartime(0);
+        assert_eq!(val.as_words(), &[1, 99]);
+
+        let mut val = refval;
+        val.as_mut_uint_ref()
+            .wrapping_shr_assign_by_limbs_vartime(1);
+        assert_eq!(val.as_words(), &[99, 0]);
+
+        let mut val = refval;
+        val.as_mut_uint_ref()
+            .wrapping_shr_assign_by_limbs_vartime(2);
+        assert_eq!(val.as_words(), &[0, 0]);
+    }
+
+    #[test]
+    fn compare_shr_assign() {
+        for i in 0..256 {
+            let (mut a, mut b) = (N, N);
+            a.as_mut_uint_ref().bounded_wrapping_shr_assign(i, 256);
+            b.as_mut_uint_ref().wrapping_shr_assign_vartime(i);
+            assert_eq!(a, b);
+        }
+    }
+}

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -1,6 +1,6 @@
 //! [`Uint`] bitwise right shift operations.
 
-use crate::{ConstChoice, ConstCtOption, Limb, ShrVartime, Uint, WrappingShr};
+use crate::{ConstChoice, ConstCtOption, Limb, NonZero, ShrVartime, Uint, WrappingShr};
 use core::ops::{Shr, ShrAssign};
 use subtle::CtOption;
 
@@ -48,7 +48,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mut i = 0;
         while i < limb_bits {
             let bit = ConstChoice::from_u32_lsb((shift >> i) & 1);
-            result = Uint::select(&result, &result.shr_limb_nonzero(1 << i).0, bit);
+            result = result.conditional_shr_limb_nonzero(NonZero(1 << i), bit).0;
             i += 1;
         }
         while i < shift_bits {
@@ -114,15 +114,15 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let mut res = self.wrapping_shr_by_limbs_vartime(shift_num);
         let rem = shift % Limb::BITS;
 
-        if rem > 0 {
+        if rem != 0 {
             let mut carry = Limb::ZERO;
             let mut i = LIMBS.saturating_sub(shift_num as usize);
             while i > 0 {
                 i -= 1;
-                let shifted = res.limbs[i].shr(rem);
-                let new_carry = res.limbs[i].shl(Limb::BITS - rem);
-                res.limbs[i] = shifted.bitor(carry);
-                carry = new_carry;
+                (res.limbs[i], carry) = (
+                    res.limbs[i].shr(rem).bitor(carry),
+                    res.limbs[i].shl(Limb::BITS - rem),
+                );
             }
         }
 
@@ -198,43 +198,46 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         (ret, ConstChoice::from_word_lsb(carry.0 >> Limb::HI_BIT))
     }
 
-    /// Computes `self >> shift` where `0 <= shift < Limb::BITS`,
-    /// returning the result and the carry.
-    #[inline(always)]
-    pub(crate) const fn shr_limb(&self, shift: u32) -> (Self, Limb) {
-        let nz = ConstChoice::from_u32_nonzero(shift);
-        let shift = nz.select_u32(1, shift);
-        let (res, carry) = self.shr_limb_nonzero(shift);
-        (
-            Uint::select(self, &res, nz),
-            Limb::select(Limb::ZERO, carry, nz),
-        )
-    }
-
-    /// Computes `self >> shift` where `0 < shift < Limb::BITS`, returning the result and the carry.
+    /// Conditionally right-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning
+    /// the carry.
     ///
-    /// Note: this operation should not be used in situations where `shift == 0`; it looks like
-    /// something in the execution pipeline can sometimes sniff this case out and optimize it away,
-    /// possibly leading to variable time behaviour.
+    /// Panics if `shift >= Limb::BITS`.
     #[inline(always)]
-    const fn shr_limb_nonzero(&self, shift: u32) -> (Self, Limb) {
-        assert!(0 < shift);
-        assert!(shift < Limb::BITS);
+    pub(crate) const fn conditional_shr_limb_nonzero(
+        &self,
+        shift: NonZero<u32>,
+        choice: ConstChoice,
+    ) -> (Self, Limb) {
+        assert!(shift.0 < Limb::BITS);
 
         let mut limbs = [Limb::ZERO; LIMBS];
-
-        let rshift = shift;
-        let lshift = Limb::BITS - shift;
+        let rshift = shift.0;
+        let lshift = Limb::BITS - shift.0;
         let mut carry = Limb::ZERO;
 
         let mut i = LIMBS;
         while i > 0 {
             i -= 1;
-            limbs[i] = self.limbs[i].shr(rshift).bitor(carry);
-            carry = self.limbs[i].shl(lshift);
+            (limbs[i], carry) = (
+                Limb::select(
+                    self.limbs[i],
+                    self.limbs[i].shr(rshift).bitor(carry),
+                    choice,
+                ),
+                self.limbs[i].shl(lshift),
+            );
         }
 
-        (Uint::<LIMBS>::new(limbs), carry)
+        (Self { limbs }, Limb::select(Limb::ZERO, carry, choice))
+    }
+
+    /// Computes `self >> shift` where `0 <= shift < Limb::BITS`,
+    /// returning the result and the carry.
+    ///
+    /// Panics if `shift >= Limb::BITS`.
+    pub(crate) const fn shr_limb(&self, shift: u32) -> (Self, Limb) {
+        let nz = ConstChoice::from_u32_nonzero(shift);
+        self.conditional_shr_limb_nonzero(NonZero(nz.select_u32(1, shift)), nz)
     }
 }
 
@@ -342,12 +345,6 @@ mod tests {
     #[should_panic]
     fn shr_limb_shift_too_large() {
         let _ = U128::ONE.shr_limb(Limb::BITS);
-    }
-
-    #[test]
-    #[should_panic]
-    fn shr_limb_nz_panics_at_zero_shift() {
-        let _ = U128::ONE.shr_limb_nonzero(0);
     }
 
     #[test]


### PR DESCRIPTION
This aligns `Uint` and `BoxedUint` bit operations by moving the logic to `UintRef` and removing the free functions.