### PR TITLE
Add Jacobi symbol calculation

### DIFF
--- a/benches/const_monty.rs
+++ b/benches/const_monty.rs
@@ -119,6 +119,22 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         )
     });
 
+    group.bench_function("jacobi_symbol", |b| {
+        b.iter_batched(
+            || ConstMontyForm::random(&mut rng),
+            |a| a.jacobi_symbol(),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("jacobi_symbol_vartime", |b| {
+        b.iter_batched(
+            || ConstMontyForm::random(&mut rng),
+            |a| a.jacobi_symbol_vartime(),
+            BatchSize::SmallInput,
+        )
+    });
+
     group.bench_function("lincomb, U256*U256+U256*U256", |b| {
         b.iter_batched(
             || ConstMontyForm::random(&mut rng),

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -468,6 +468,46 @@ fn bench_gcd(c: &mut Criterion) {
     group.finish();
 }
 
+fn mod_symbols_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: Uint<LIMBS>) {
+    let mut rng = make_rng();
+
+    g.bench_function(BenchmarkId::new("jacobi_symbol", LIMBS), |b| {
+        b.iter_batched(
+            || {
+                (
+                    OddUint::<LIMBS>::random(&mut rng),
+                    Uint::<LIMBS>::random(&mut rng),
+                )
+            },
+            |(f, g)| black_box(g.jacobi_symbol(&f)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    g.bench_function(BenchmarkId::new("jacobi_symbol_vartime", LIMBS), |b| {
+        b.iter_batched(
+            || {
+                (
+                    OddUint::<LIMBS>::random(&mut rng),
+                    Uint::<LIMBS>::random(&mut rng),
+                )
+            },
+            |(f, g)| black_box(g.jacobi_symbol_vartime(&f)),
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+fn bench_mod_symbols(c: &mut Criterion) {
+    let mut group = c.benchmark_group("modular symbols");
+
+    mod_symbols_bench(&mut group, Uint::<1>::ZERO);
+    mod_symbols_bench(&mut group, Uint::<4>::ZERO);
+    mod_symbols_bench(&mut group, Uint::<64>::ZERO);
+
+    group.finish();
+}
+
 fn bench_shl(c: &mut Criterion) {
     let mut group = c.benchmark_group("left shift");
 
@@ -631,6 +671,7 @@ criterion_group!(
     bench_mul,
     bench_division,
     bench_gcd,
+    bench_mod_symbols,
     bench_shl,
     bench_shr,
     bench_invert_mod,

--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -157,6 +157,12 @@ impl ConstChoice {
         Self::from_u32_lsb(bit)
     }
 
+    /// Returns the truthy value if `x == y`, and the falsy value otherwise.
+    #[inline]
+    pub(crate) const fn from_i64_eq(x: i64, y: i64) -> Self {
+        Self::from_word_nonzero(x as Word ^ y as Word).not()
+    }
+
     #[inline]
     pub(crate) const fn not(&self) -> Self {
         Self(!self.0)

--- a/src/int.rs
+++ b/src/int.rs
@@ -23,6 +23,7 @@ mod encoding;
 mod from;
 mod gcd;
 mod invert_mod;
+mod mod_symbol;
 mod mul;
 mod mul_uint;
 mod neg;

--- a/src/int/mod_symbol.rs
+++ b/src/int/mod_symbol.rs
@@ -1,0 +1,101 @@
+//! Support for computing modular symbols.
+
+use crate::{ConstChoice, Int, Odd, Uint};
+
+impl<const LIMBS: usize> Int<LIMBS> {
+    /// Compute the Jacobi symbol `(self|rhs)`.
+    ///
+    /// For prime `rhs`, this corresponds to the Legendre symbol and
+    /// indicates whether `self` is quadratic residue modulo `rhs`.
+    pub const fn jacobi_symbol(&self, rhs: &Odd<Uint<LIMBS>>) -> i8 {
+        let (abs, sign) = self.abs_sign();
+        let jacobi = abs.jacobi_symbol(rhs) as i64;
+        // (-self|rhs) = -(self|rhs) iff rhs = 3 mod 4
+        let swap = sign.and(ConstChoice::from_word_eq(rhs.as_ref().limbs[0].0 & 3, 3));
+        swap.select_i64(jacobi, -jacobi) as i8
+    }
+
+    /// Compute the Jacobi symbol `(self|rhs)`.
+    ///
+    /// For prime `rhs`, this corresponds to the Legendre symbol and
+    /// indicates whether `self` is quadratic residue modulo `rhs`.
+    ///
+    /// This method executes in variable-time for the value of `self`.
+    pub const fn jacobi_symbol_vartime(&self, rhs: &Odd<Uint<LIMBS>>) -> i8 {
+        let (abs, sign) = self.abs_sign();
+        let jacobi = abs.jacobi_symbol(rhs);
+        if sign.is_true_vartime() && rhs.as_ref().limbs[0].0 & 3 == 3 {
+            -jacobi
+        } else {
+            jacobi
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{I256, U256};
+
+    #[test]
+    fn jacobi_quad_residue() {
+        // Two semiprimes with no common factors, and
+        // f is quadratic residue modulo g
+        let f = I256::from(59i32 * 67);
+        let g = U256::from(61u32 * 71).to_odd().unwrap();
+        let res = f.jacobi_symbol(&g);
+        let res_vartime = f.jacobi_symbol_vartime(&g);
+        assert_eq!(res, 1);
+        assert_eq!(res, res_vartime);
+    }
+
+    #[test]
+    fn jacobi_non_quad_residue() {
+        // f and g have no common factors, but
+        // f is not quadratic residue modulo g
+        let f = I256::from(59i32 * 67 + 2);
+        let g = U256::from(61u32 * 71).to_odd().unwrap();
+        let res = f.jacobi_symbol(&g);
+        let res_vartime = f.jacobi_symbol_vartime(&g);
+        assert_eq!(res, -1);
+        assert_eq!(res, res_vartime);
+    }
+
+    #[test]
+    fn jacobi_non_coprime() {
+        let f = I256::from(4391633i32);
+        let g = U256::from(2022161u32).to_odd().unwrap();
+        let res = f.jacobi_symbol(&g);
+        let res_vartime = f.jacobi_symbol_vartime(&g);
+        assert_eq!(res, 0);
+        assert_eq!(res, res_vartime);
+    }
+
+    #[test]
+    fn jacobi_zero() {
+        assert_eq!(I256::ZERO.jacobi_symbol(&U256::ONE.to_odd().unwrap()), 1);
+    }
+
+    #[test]
+    fn jacobi_neg_one() {
+        let f = I256::ONE;
+        assert_eq!(f.jacobi_symbol(&U256::ONE.to_odd().unwrap()), 1);
+        assert_eq!(f.jacobi_symbol(&U256::from(3u8).to_odd().unwrap()), 1);
+    }
+
+    #[test]
+    fn jacobi_int() {
+        // Two semiprimes with no common factors, and
+        // f is quadratic residue modulo g
+        let f = I256::from(59i32 * 67);
+        let g = U256::from(61u32 * 71).to_odd().unwrap();
+        let res = f.jacobi_symbol(&g);
+        let res_vartime = f.jacobi_symbol_vartime(&g);
+        assert_eq!(res, 1);
+        assert_eq!(res, res_vartime);
+
+        // let res = f.checked_neg().unwrap().jacobi_symbol(&g);
+        // let res_vartime = f.jacobi_symbol_vartime(&g);
+        // assert_eq!(res, -1);
+        // assert_eq!(res, res_vartime);
+    }
+}

--- a/src/int/mod_symbol.rs
+++ b/src/int/mod_symbol.rs
@@ -1,18 +1,18 @@
 //! Support for computing modular symbols.
 
-use crate::{ConstChoice, Int, Odd, Uint};
+use crate::{ConstChoice, Int, JacobiSymbol, Odd, Uint};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Compute the Jacobi symbol `(self|rhs)`.
     ///
     /// For prime `rhs`, this corresponds to the Legendre symbol and
     /// indicates whether `self` is quadratic residue modulo `rhs`.
-    pub const fn jacobi_symbol(&self, rhs: &Odd<Uint<LIMBS>>) -> i8 {
+    pub const fn jacobi_symbol(&self, rhs: &Odd<Uint<LIMBS>>) -> JacobiSymbol {
         let (abs, sign) = self.abs_sign();
         let jacobi = abs.jacobi_symbol(rhs) as i64;
         // (-self|rhs) = -(self|rhs) iff rhs = 3 mod 4
         let swap = sign.and(ConstChoice::from_word_eq(rhs.as_ref().limbs[0].0 & 3, 3));
-        swap.select_i64(jacobi, -jacobi) as i8
+        JacobiSymbol::from_i8(swap.select_i64(jacobi, -jacobi) as i8)
     }
 
     /// Compute the Jacobi symbol `(self|rhs)`.
@@ -21,20 +21,22 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// indicates whether `self` is quadratic residue modulo `rhs`.
     ///
     /// This method executes in variable-time for the value of `self`.
-    pub const fn jacobi_symbol_vartime(&self, rhs: &Odd<Uint<LIMBS>>) -> i8 {
+    pub const fn jacobi_symbol_vartime(&self, rhs: &Odd<Uint<LIMBS>>) -> JacobiSymbol {
         let (abs, sign) = self.abs_sign();
-        let jacobi = abs.jacobi_symbol(rhs);
-        if sign.is_true_vartime() && rhs.as_ref().limbs[0].0 & 3 == 3 {
-            -jacobi
-        } else {
-            jacobi
-        }
+        let jacobi = abs.jacobi_symbol_vartime(rhs);
+        JacobiSymbol::from_i8(
+            if sign.is_true_vartime() && rhs.as_ref().limbs[0].0 & 3 == 3 {
+                -(jacobi as i8)
+            } else {
+                jacobi as i8
+            },
+        )
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{I256, U256};
+    use crate::{I256, JacobiSymbol, U256};
 
     #[test]
     fn jacobi_quad_residue() {
@@ -44,7 +46,7 @@ mod tests {
         let g = U256::from(61u32 * 71).to_odd().unwrap();
         let res = f.jacobi_symbol(&g);
         let res_vartime = f.jacobi_symbol_vartime(&g);
-        assert_eq!(res, 1);
+        assert_eq!(res, JacobiSymbol::One);
         assert_eq!(res, res_vartime);
     }
 
@@ -56,7 +58,7 @@ mod tests {
         let g = U256::from(61u32 * 71).to_odd().unwrap();
         let res = f.jacobi_symbol(&g);
         let res_vartime = f.jacobi_symbol_vartime(&g);
-        assert_eq!(res, -1);
+        assert_eq!(res, JacobiSymbol::MinusOne);
         assert_eq!(res, res_vartime);
     }
 
@@ -66,20 +68,29 @@ mod tests {
         let g = U256::from(2022161u32).to_odd().unwrap();
         let res = f.jacobi_symbol(&g);
         let res_vartime = f.jacobi_symbol_vartime(&g);
-        assert_eq!(res, 0);
+        assert_eq!(res, JacobiSymbol::Zero);
         assert_eq!(res, res_vartime);
     }
 
     #[test]
     fn jacobi_zero() {
-        assert_eq!(I256::ZERO.jacobi_symbol(&U256::ONE.to_odd().unwrap()), 1);
+        assert_eq!(
+            I256::ZERO.jacobi_symbol(&U256::ONE.to_odd().unwrap()),
+            JacobiSymbol::One
+        );
     }
 
     #[test]
     fn jacobi_neg_one() {
         let f = I256::ONE;
-        assert_eq!(f.jacobi_symbol(&U256::ONE.to_odd().unwrap()), 1);
-        assert_eq!(f.jacobi_symbol(&U256::from(3u8).to_odd().unwrap()), 1);
+        assert_eq!(
+            f.jacobi_symbol(&U256::ONE.to_odd().unwrap()),
+            JacobiSymbol::One
+        );
+        assert_eq!(
+            f.jacobi_symbol(&U256::from(3u8).to_odd().unwrap()),
+            JacobiSymbol::One
+        );
     }
 
     #[test]
@@ -90,12 +101,12 @@ mod tests {
         let g = U256::from(61u32 * 71).to_odd().unwrap();
         let res = f.jacobi_symbol(&g);
         let res_vartime = f.jacobi_symbol_vartime(&g);
-        assert_eq!(res, 1);
+        assert_eq!(res, JacobiSymbol::One);
         assert_eq!(res, res_vartime);
 
-        // let res = f.checked_neg().unwrap().jacobi_symbol(&g);
-        // let res_vartime = f.jacobi_symbol_vartime(&g);
-        // assert_eq!(res, -1);
-        // assert_eq!(res, res_vartime);
+        let res = f.checked_neg().unwrap().jacobi_symbol(&g);
+        let res_vartime = f.checked_neg().unwrap().jacobi_symbol_vartime(&g);
+        assert_eq!(res, JacobiSymbol::MinusOne);
+        assert_eq!(res, res_vartime);
     }
 }

--- a/src/modular/bingcd/compact.rs
+++ b/src/modular/bingcd/compact.rs
@@ -53,8 +53,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             .bitand(&mask)
     }
 
-    /// Compact `self` to a form containing the concatenation of its bit ranges `[0, K-1)`
-    /// and `[n-K-1, n)`.
+    /// Compact `self` to a form containing the concatenation of its bit ranges `[0, K)`
+    /// and `[n-K, n)`.
     ///
     /// Assumes `K ≤ Uint::<SUMMARY_LIMBS>::BITS`, `n ≤ Self::BITS` and `n ≥ 2K`.
     #[inline(always)]
@@ -67,13 +67,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         debug_assert!(n >= 2 * K);
 
         // safe to vartime; this function is vartime in length only, which is a public constant
-        let hi = self.section_vartime_length(n - K - 1, K + 1);
+        let hi = self.section_vartime_length(n - K, K);
         // safe to vartime; this function is vartime in idx and length only, which are both public
         // constants
-        let lo = self.section_vartime(0, K - 1);
+        let lo = self.section_vartime(0, K);
         // safe to vartime; shl_vartime is variable in the value of shift only. Since this shift
         // is a public constant, the constant time property of this algorithm is not impacted.
-        hi.shl_vartime(K - 1).bitxor(&lo)
+        hi.shl_vartime(K).bitxor(&lo)
     }
 
     /// Vartime equivalent of [`Self::compact`].
@@ -87,13 +87,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         debug_assert!(n >= 2 * K);
 
         // safe to vartime; this function is vartime in length only, which is a public constant
-        let hi = self.section_vartime(n - K - 1, K + 1);
+        let hi = self.section_vartime(n - K, K);
         // safe to vartime; this function is vartime in idx and length only, which are both public
         // constants
-        let lo = self.section_vartime(0, K - 1);
+        let lo = self.section_vartime(0, K);
         // safe to vartime; shl_vartime is variable in the value of shift only. Since this shift
         // is a public constant, the constant time property of this algorithm is not impacted.
-        hi.shl_vartime(K - 1).bitxor(&lo)
+        hi.shl_vartime(K).bitxor(&lo)
     }
 }
 
@@ -105,7 +105,7 @@ mod tests {
     fn test_compact() {
         let val =
             U256::from_be_hex("CFCF1535CEBE19BBF289933AB8645189397450A32BFEC57579FB7EB14E27D101");
-        let target = U128::from_be_hex("BBF289933AB86451F9FB7EB14E27D101");
+        let target = U128::from_be_hex("BBF289933AB8645179FB7EB14E27D101");
 
         let compact = val.compact::<64, { U128::LIMBS }>(200);
         assert_eq!(compact, target);

--- a/src/modular/bingcd/gcd.rs
+++ b/src/modular/bingcd/gcd.rs
@@ -51,7 +51,7 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
     /// Ref: Pornin, Optimized Binary GCD for Modular Inversion, Algorithm 1.
     /// <https://eprint.iacr.org/2020/972.pdf>
     #[inline]
-    pub const fn classic_bingcd(&self, rhs: &Uint<LIMBS>) -> Self {
+    pub(crate) const fn classic_bingcd(&self, rhs: &Uint<LIMBS>) -> Self {
         self.classic_bingcd_(rhs).0
     }
 
@@ -66,7 +66,7 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
     /// This method returns a pair consisting of the GCD and the sign of the Jacobi symbol,
     /// 0 for positive and 1 for negative.
     #[inline(always)]
-    pub const fn classic_bingcd_(&self, rhs: &Uint<LIMBS>) -> (Self, Word) {
+    pub(crate) const fn classic_bingcd_(&self, rhs: &Uint<LIMBS>) -> (Self, Word) {
         // (self, rhs) corresponds to (m, y) in the Algorithm 1 notation.
         let (mut a, mut b) = (*rhs, *self.as_ref());
         let mut i = 0;
@@ -84,13 +84,13 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
 
     /// Variable time equivalent of [`Self::classic_bingcd`].
     #[inline]
-    pub const fn classic_bingcd_vartime(&self, rhs: &Uint<LIMBS>) -> Self {
+    pub(crate) const fn classic_bingcd_vartime(&self, rhs: &Uint<LIMBS>) -> Self {
         self.classic_bingcd_vartime_(rhs).0
     }
 
     /// Variable time equivalent of [`Self::classic_bingcd_`].
     #[inline(always)]
-    pub const fn classic_bingcd_vartime_(&self, rhs: &Uint<LIMBS>) -> (Self, Word) {
+    pub(crate) const fn classic_bingcd_vartime_(&self, rhs: &Uint<LIMBS>) -> (Self, Word) {
         // (self, rhs) corresponds to (m, y) in the Algorithm 1 notation.
         let (mut a, mut b) = (*rhs, *self.as_ref());
         let mut jacobi_neg = 0;
@@ -116,7 +116,7 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
     /// Ref: Pornin, Optimized Binary GCD for Modular Inversion, Algorithm 2.
     /// <https://eprint.iacr.org/2020/972.pdf>
     #[inline(always)]
-    pub const fn optimized_bingcd(&self, rhs: &Uint<LIMBS>) -> Self {
+    pub(crate) const fn optimized_bingcd(&self, rhs: &Uint<LIMBS>) -> Self {
         self.optimized_bingcd_::<{ U64::BITS }, { U64::LIMBS }, { U128::LIMBS }>(rhs, U64::BITS - 1)
             .0
     }
@@ -140,7 +140,11 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
     /// This method returns a pair consisting of the GCD and the sign of the Jacobi symbol,
     /// 0 for positive and 1 for negative.
     #[inline(always)]
-    pub const fn optimized_bingcd_<const K: u32, const LIMBS_K: usize, const LIMBS_2K: usize>(
+    pub(crate) const fn optimized_bingcd_<
+        const K: u32,
+        const LIMBS_K: usize,
+        const LIMBS_2K: usize,
+    >(
         &self,
         rhs: &Uint<LIMBS>,
         batch_max: u32,
@@ -181,7 +185,7 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
 
     /// Variable time equivalent of [`Self::optimized_bingcd`].
     #[inline(always)]
-    pub const fn optimized_bingcd_vartime(&self, rhs: &Uint<LIMBS>) -> Self {
+    pub(crate) const fn optimized_bingcd_vartime(&self, rhs: &Uint<LIMBS>) -> Self {
         self.optimized_bingcd_vartime_::<{ U64::BITS }, { U64::LIMBS }, { U128::LIMBS }>(
             rhs,
             U64::BITS - 1,
@@ -191,7 +195,7 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
 
     /// Variable time equivalent of [`Self::optimized_bingcd_`].
     #[inline(always)]
-    pub const fn optimized_bingcd_vartime_<
+    pub(crate) const fn optimized_bingcd_vartime_<
         const K: u32,
         const LIMBS_K: usize,
         const LIMBS_2K: usize,

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -3,6 +3,7 @@
 mod add;
 pub(super) mod invert;
 mod lincomb;
+mod mod_symbol;
 mod mul;
 mod neg;
 mod pow;

--- a/src/modular/const_monty_form/mod_symbol.rs
+++ b/src/modular/const_monty_form/mod_symbol.rs
@@ -1,0 +1,61 @@
+//! Modular symbol calculation for integers in Montgomery form with a constant modulus.
+
+use super::{ConstMontyForm, ConstMontyParams};
+
+impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
+    /// Compute the Jacobi symbol `(self|modulus)`.
+    ///
+    /// For a prime modulus, this corresponds to the Legendre symbol and indicates
+    /// whether `self` is quadratic residue.
+    pub const fn jacobi_symbol(&self) -> i8 {
+        self.retrieve().jacobi_symbol(MOD::PARAMS.modulus())
+    }
+
+    /// Compute the Jacobi symbol `(self|modulus)`.
+    ///
+    /// For a prime modulus, this corresponds to the Legendre symbol and indicates
+    /// whether `self` is quadratic residue.
+    ///
+    /// This method is variable-time with respect to the value of `self`.
+    pub const fn jacobi_symbol_vartime(&self) -> i8 {
+        self.retrieve().jacobi_symbol_vartime(MOD::PARAMS.modulus())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        U256, const_monty_form, const_monty_params, modular::const_monty_form::ConstMontyParams,
+    };
+
+    const_monty_params!(
+        Modulus,
+        U256,
+        "2523648240000001BA344D80000000086121000000000013A700000000000013"
+    );
+    const_monty_form!(Fe, Modulus);
+
+    #[test]
+    fn jacobi_quad_residue() {
+        let x =
+            U256::from_be_hex("14BFAE46F4026E97C7A3FCD889B379A5F025719911C994A594FC6C5092AC58B1");
+        let x_mod = Fe::new(&x);
+
+        let jac = x_mod.jacobi_symbol();
+        let jac_vartime = x_mod.jacobi_symbol_vartime();
+        assert_eq!(jac, 1);
+        assert_eq!(jac, jac_vartime);
+    }
+
+    #[test]
+    fn jacobi_quad_nonresidue() {
+        let x =
+            U256::from_be_hex("1D2EFB21D283A2DDE77004B9DE9A9624F7B15CEEF055CD02E9EF1A9F1B76F253");
+        let x_mod = Fe::new(&x);
+
+        let jac = x_mod.jacobi_symbol();
+        let jac_vartime = x_mod.jacobi_symbol_vartime();
+        assert_eq!(jac, -1);
+        assert_eq!(jac, jac_vartime);
+    }
+}

--- a/src/modular/const_monty_form/mod_symbol.rs
+++ b/src/modular/const_monty_form/mod_symbol.rs
@@ -1,5 +1,7 @@
 //! Modular symbol calculation for integers in Montgomery form with a constant modulus.
 
+use crate::JacobiSymbol;
+
 use super::{ConstMontyForm, ConstMontyParams};
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
@@ -7,7 +9,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     ///
     /// For a prime modulus, this corresponds to the Legendre symbol and indicates
     /// whether `self` is quadratic residue.
-    pub const fn jacobi_symbol(&self) -> i8 {
+    pub const fn jacobi_symbol(&self) -> JacobiSymbol {
         self.retrieve().jacobi_symbol(MOD::PARAMS.modulus())
     }
 
@@ -17,7 +19,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     /// whether `self` is quadratic residue.
     ///
     /// This method is variable-time with respect to the value of `self`.
-    pub const fn jacobi_symbol_vartime(&self) -> i8 {
+    pub const fn jacobi_symbol_vartime(&self) -> JacobiSymbol {
         self.retrieve().jacobi_symbol_vartime(MOD::PARAMS.modulus())
     }
 }
@@ -25,7 +27,8 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
 #[cfg(test)]
 mod tests {
     use crate::{
-        U256, const_monty_form, const_monty_params, modular::const_monty_form::ConstMontyParams,
+        JacobiSymbol, U256, const_monty_form, const_monty_params,
+        modular::const_monty_form::ConstMontyParams,
     };
 
     const_monty_params!(
@@ -43,7 +46,7 @@ mod tests {
 
         let jac = x_mod.jacobi_symbol();
         let jac_vartime = x_mod.jacobi_symbol_vartime();
-        assert_eq!(jac, 1);
+        assert_eq!(jac, JacobiSymbol::One);
         assert_eq!(jac, jac_vartime);
     }
 
@@ -55,7 +58,7 @@ mod tests {
 
         let jac = x_mod.jacobi_symbol();
         let jac_vartime = x_mod.jacobi_symbol_vartime();
-        assert_eq!(jac, -1);
+        assert_eq!(jac, JacobiSymbol::MinusOne);
         assert_eq!(jac, jac_vartime);
     }
 }

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -3,6 +3,7 @@
 mod add;
 pub(super) mod invert;
 mod lincomb;
+mod mod_symbol;
 mod mul;
 mod neg;
 mod pow;

--- a/src/modular/monty_form/mod_symbol.rs
+++ b/src/modular/monty_form/mod_symbol.rs
@@ -1,0 +1,61 @@
+//! Modular symbol calculation for integers in Montgomery form with a constant modulus.
+
+use super::MontyForm;
+
+impl<const LIMBS: usize> MontyForm<LIMBS> {
+    /// Compute the Jacobi symbol `(self|modulus)`.
+    ///
+    /// For a prime modulus, this corresponds to the Legendre symbol and indicates
+    /// whether `self` is quadratic residue.
+    pub const fn jacobi_symbol(&self) -> i8 {
+        self.retrieve().jacobi_symbol(self.params().modulus())
+    }
+
+    /// Compute the Jacobi symbol `(self|modulus)`.
+    ///
+    /// For a prime modulus, this corresponds to the Legendre symbol and indicates
+    /// whether `self` is quadratic residue.
+    ///
+    /// This method is variable-time with respect to the value of `self`.
+    pub const fn jacobi_symbol_vartime(&self) -> i8 {
+        self.retrieve()
+            .jacobi_symbol_vartime(self.params().modulus())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        Odd, U256,
+        modular::{MontyForm, MontyParams},
+    };
+
+    const PARAMS: MontyParams<{ U256::LIMBS }> =
+        MontyParams::new_vartime(Odd::<U256>::from_be_hex(
+            "2523648240000001BA344D80000000086121000000000013A700000000000013",
+        ));
+
+    #[test]
+    fn jacobi_quad_residue() {
+        let x =
+            U256::from_be_hex("14BFAE46F4026E97C7A3FCD889B379A5F025719911C994A594FC6C5092AC58B1");
+        let x_mod = MontyForm::new(&x, PARAMS);
+
+        let jac = x_mod.jacobi_symbol();
+        let jac_vartime = x_mod.jacobi_symbol_vartime();
+        assert_eq!(jac, 1);
+        assert_eq!(jac, jac_vartime);
+    }
+
+    #[test]
+    fn jacobi_quad_nonresidue() {
+        let x =
+            U256::from_be_hex("1D2EFB21D283A2DDE77004B9DE9A9624F7B15CEEF055CD02E9EF1A9F1B76F253");
+        let x_mod = MontyForm::new(&x, PARAMS);
+
+        let jac = x_mod.jacobi_symbol();
+        let jac_vartime = x_mod.jacobi_symbol_vartime();
+        assert_eq!(jac, -1);
+        assert_eq!(jac, jac_vartime);
+    }
+}

--- a/src/modular/monty_form/mod_symbol.rs
+++ b/src/modular/monty_form/mod_symbol.rs
@@ -1,5 +1,7 @@
 //! Modular symbol calculation for integers in Montgomery form with a constant modulus.
 
+use crate::JacobiSymbol;
+
 use super::MontyForm;
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
@@ -7,7 +9,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     ///
     /// For a prime modulus, this corresponds to the Legendre symbol and indicates
     /// whether `self` is quadratic residue.
-    pub const fn jacobi_symbol(&self) -> i8 {
+    pub const fn jacobi_symbol(&self) -> JacobiSymbol {
         self.retrieve().jacobi_symbol(self.params().modulus())
     }
 
@@ -17,7 +19,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// whether `self` is quadratic residue.
     ///
     /// This method is variable-time with respect to the value of `self`.
-    pub const fn jacobi_symbol_vartime(&self) -> i8 {
+    pub const fn jacobi_symbol_vartime(&self) -> JacobiSymbol {
         self.retrieve()
             .jacobi_symbol_vartime(self.params().modulus())
     }
@@ -26,7 +28,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        Odd, U256,
+        JacobiSymbol, Odd, U256,
         modular::{MontyForm, MontyParams},
     };
 
@@ -43,7 +45,7 @@ mod tests {
 
         let jac = x_mod.jacobi_symbol();
         let jac_vartime = x_mod.jacobi_symbol_vartime();
-        assert_eq!(jac, 1);
+        assert_eq!(jac, JacobiSymbol::One);
         assert_eq!(jac, jac_vartime);
     }
 
@@ -55,7 +57,7 @@ mod tests {
 
         let jac = x_mod.jacobi_symbol();
         let jac_vartime = x_mod.jacobi_symbol_vartime();
-        assert_eq!(jac, -1);
+        assert_eq!(jac, JacobiSymbol::MinusOne);
         assert_eq!(jac, jac_vartime);
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -4,6 +4,7 @@ pub use num_traits::{
     ConstZero, WrappingAdd, WrappingMul, WrappingNeg, WrappingShl, WrappingShr, WrappingSub,
 };
 
+use crate::ConstChoice;
 use crate::{Limb, NonZero, Odd, Reciprocal, modular::Retrieve};
 use core::fmt::{self, Debug};
 use core::ops::{
@@ -1021,3 +1022,58 @@ pub trait MontyMultiplier<'a>: From<&'a <Self::Monty as Monty>::Params> {
     /// Performs a Montgomery squaring, assigning a fully reduced result to `lhs`.
     fn square_assign(&mut self, lhs: &mut Self::Monty);
 }
+
+/// Possible return values for Jacobi symbol calculations.
+#[derive(Debug, Copy, Clone)]
+#[repr(i8)]
+pub enum JacobiSymbol {
+    /// The two arguments are not coprime, they have a common divisor apart from 1.
+    Zero = 0,
+    /// The two arguments are coprime. If the lower argument is prime, then the upper argument
+    /// is quadratic residue modulo the lower argument. Otherwise, the upper argument is known to
+    /// be quadratic nonresidue for an even number of prime factors of the lower argument.
+    One = 1,
+    /// The two terms are coprime, and the upper argument is a quadratic nonresidue modulo the
+    /// lower argument.
+    MinusOne = -1,
+}
+
+impl JacobiSymbol {
+    /// Determine if the symbol is zero.
+    pub const fn is_zero(&self) -> ConstChoice {
+        ConstChoice::from_i64_eq(*self as i8 as i64, 0)
+    }
+
+    /// Determine if the symbol is one.
+    pub const fn is_one(&self) -> ConstChoice {
+        ConstChoice::from_i64_eq(*self as i8 as i64, 1)
+    }
+
+    /// Determine if the symbol is minus one.
+    pub const fn is_minus_one(&self) -> ConstChoice {
+        ConstChoice::from_i64_eq(*self as i8 as i64, -1)
+    }
+
+    pub(crate) const fn from_i8(value: i8) -> Self {
+        match value {
+            0 => Self::Zero,
+            1 => Self::One,
+            -1 => Self::MinusOne,
+            _ => panic!("invalid value for Jacobi symbol"),
+        }
+    }
+}
+
+impl ConstantTimeEq for JacobiSymbol {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        (*self as i8).ct_eq(&(*other as i8))
+    }
+}
+
+impl PartialEq for JacobiSymbol {
+    fn eq(&self, other: &Self) -> bool {
+        bool::from(self.ct_eq(other))
+    }
+}
+
+impl Eq for JacobiSymbol {}

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -38,6 +38,7 @@ pub(crate) mod encoding;
 mod from;
 pub(crate) mod gcd;
 mod invert_mod;
+mod mod_symbol;
 pub(crate) mod mul;
 mod mul_mod;
 mod neg;

--- a/src/uint/mod_symbol.rs
+++ b/src/uint/mod_symbol.rs
@@ -1,0 +1,105 @@
+//! Support for computing modular symbols.
+
+use crate::{Odd, U64, U128, Uint};
+
+impl<const LIMBS: usize> Uint<LIMBS> {
+    /// Compute the Jacobi symbol `(self|rhs)`.
+    ///
+    /// For prime `rhs`, this corresponds to the Legendre symbol and
+    /// indicates whether `self` is quadratic residue modulo `rhs`.
+    pub const fn jacobi_symbol(&self, rhs: &Odd<Uint<LIMBS>>) -> i8 {
+        let (gcd, jacobi_neg) = if LIMBS < 4 {
+            rhs.classic_bingcd_(self)
+        } else {
+            rhs.optimized_bingcd_::<{ U64::BITS }, { U64::LIMBS }, { U128::LIMBS }>(
+                self,
+                U64::BITS - 2,
+            )
+        };
+        // The sign of the Jacobi symbol is represented by jacobi_neg. We select 0 as the
+        // symbol when the GCD is not one, otherwise 1 or -1.
+        let jacobi = (jacobi_neg as i8 * -2 + 1) as i64;
+        Uint::eq(gcd.as_ref(), &Uint::ONE).select_i64(0, jacobi) as i8
+    }
+
+    /// Compute the Jacobi symbol `(self|rhs)`.
+    ///
+    /// For prime `rhs`, this corresponds to the Legendre symbol and
+    /// indicates whether `self` is quadratic residue modulo `rhs`.
+    ///
+    /// This method executes in variable-time for both inputs.
+    pub const fn jacobi_symbol_vartime(&self, rhs: &Odd<Uint<LIMBS>>) -> i8 {
+        let (gcd, jacobi_neg) = if LIMBS < 4 {
+            rhs.classic_bingcd_vartime_(self)
+        } else {
+            rhs.optimized_bingcd_vartime_::<{ U64::BITS }, { U64::LIMBS }, { U128::LIMBS }>(
+                self,
+                U64::BITS - 2,
+            )
+        };
+        if gcd.as_ref().cmp_vartime(&Uint::ONE).is_eq() {
+            jacobi_neg as i8 * -2 + 1
+        } else {
+            0
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::U256;
+
+    #[test]
+    fn jacobi_quad_residue() {
+        // Two semiprimes with no common factors, and
+        // f is quadratic residue modulo g
+        let f = U256::from(59u32 * 67);
+        let g = U256::from(61u32 * 71).to_odd().unwrap();
+        let res = f.jacobi_symbol(&g);
+        let res_vartime = f.jacobi_symbol_vartime(&g);
+        assert_eq!(res, 1);
+        assert_eq!(res, res_vartime);
+    }
+
+    #[test]
+    fn jacobi_non_quad_residue() {
+        // f and g have no common factors, but
+        // f is not quadratic residue modulo g
+        let f = U256::from(59u32 * 67 + 2);
+        let g = U256::from(61u32 * 71).to_odd().unwrap();
+        let res = f.jacobi_symbol(&g);
+        let res_vartime = f.jacobi_symbol_vartime(&g);
+        assert_eq!(res, -1);
+        assert_eq!(res, res_vartime);
+    }
+
+    #[test]
+    fn jacobi_non_coprime() {
+        let f = U256::from(4391633u32);
+        let g = U256::from(2022161u32).to_odd().unwrap();
+        let res = f.jacobi_symbol(&g);
+        let res_vartime = f.jacobi_symbol_vartime(&g);
+        assert_eq!(res, 0);
+        assert_eq!(res, res_vartime);
+    }
+
+    #[test]
+    fn jacobi_zero() {
+        let f = U256::ZERO;
+        let g = U256::ONE.to_odd().unwrap();
+        let res = f.jacobi_symbol(&g);
+        let res_vartime = f.jacobi_symbol_vartime(&g);
+        assert_eq!(res, 1);
+        assert_eq!(res, res_vartime);
+    }
+
+    #[test]
+    fn jacobi_one() {
+        let f = U256::ONE;
+        let g = U256::ONE.to_odd().unwrap();
+        let res = f.jacobi_symbol(&g);
+        let res_vartime = f.jacobi_symbol_vartime(&g);
+        assert_eq!(res, 1);
+        assert_eq!(res, res_vartime);
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,7 +4,21 @@
 #![allow(dead_code)]
 
 use crypto_bigint::{Encoding, Limb};
-use num_bigint::BigUint;
+use num_bigint::{BigInt, BigUint};
+
+/// [`Int`] to [`num_bigint::BigInt`]
+pub fn to_bigint<T>(int: &T) -> BigInt
+where
+    T: AsRef<[Limb]>,
+{
+    let mut bytes = Vec::with_capacity(int.as_ref().len() * Limb::BYTES);
+
+    for limb in int.as_ref() {
+        bytes.extend_from_slice(&limb.to_le_bytes());
+    }
+
+    BigInt::from_signed_bytes_le(&bytes)
+}
 
 /// [`Uint`] to [`num_bigint::BigUint`]
 pub fn to_biguint<T>(uint: &T) -> BigUint

--- a/tests/int.rs
+++ b/tests/int.rs
@@ -1,0 +1,53 @@
+//! Equivalence tests between `crypto_bigint::Int` and `num_bigint::BigInt`.
+
+mod common;
+
+use common::{to_bigint, to_biguint};
+use crypto_bigint::{I256, Odd, U256};
+use num_bigint::{BigInt, Sign, ToBigInt};
+use num_modular::ModularSymbols;
+use proptest::prelude::*;
+
+fn to_int(big_int: BigInt) -> I256 {
+    let mut input = [0u8; U256::BYTES];
+    let (sign, encoded) = big_int.to_bytes_le();
+    let l = encoded.len().min(U256::BYTES);
+    input[..l].copy_from_slice(&encoded[..l]);
+    let abs = *U256::from_le_slice(&input).as_int();
+    if let Sign::Minus = sign {
+        abs.wrapping_neg()
+    } else {
+        abs
+    }
+}
+
+prop_compose! {
+    fn int()(bytes in any::<[u8; 32]>()) -> I256 {
+        *U256::from_le_slice(&bytes).as_int()
+    }
+}
+prop_compose! {
+    fn odd_uint()(mut bytes in any::<[u8; 32]>()) -> Odd<U256> {
+        bytes[0] |= 1;
+        U256::from_le_slice(&bytes).to_odd().unwrap()
+    }
+}
+
+proptest! {
+    #[test]
+    fn roundtrip(a in int()) {
+        prop_assert_eq!(a, to_int(to_bigint(&a)));
+    }
+
+    #[test]
+    fn jacobi_symbol(f in odd_uint(), g in int()) {
+        let f_bi = to_biguint(&f).to_bigint().unwrap();
+        let g_bi = to_bigint(&g);
+
+        let expected = g_bi.jacobi(&f_bi);
+        let actual = g.jacobi_symbol(&f);
+        let actual_vartime = g.jacobi_symbol_vartime(&f);
+        prop_assert_eq!(expected, actual);
+        prop_assert_eq!(expected, actual_vartime);
+    }
+}

--- a/tests/int.rs
+++ b/tests/int.rs
@@ -45,8 +45,8 @@ proptest! {
         let g_bi = to_bigint(&g);
 
         let expected = g_bi.jacobi(&f_bi);
-        let actual = g.jacobi_symbol(&f);
-        let actual_vartime = g.jacobi_symbol_vartime(&f);
+        let actual = g.jacobi_symbol(&f) as i8;
+        let actual_vartime = g.jacobi_symbol_vartime(&f) as i8;
         prop_assert_eq!(expected, actual);
         prop_assert_eq!(expected, actual_vartime);
     }

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -391,8 +391,8 @@ proptest! {
         let g_bi = to_biguint(&g);
 
         let expected = g_bi.jacobi(&f_bi);
-        let actual = g.jacobi_symbol(&f);
-        let actual_vartime = g.jacobi_symbol_vartime(&f);
+        let actual = g.jacobi_symbol(&f) as i8;
+        let actual_vartime = g.jacobi_symbol_vartime(&f) as i8;
         prop_assert_eq!(expected, actual);
         prop_assert_eq!(expected, actual_vartime);
     }

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -9,6 +9,7 @@ use crypto_bigint::{
 };
 use num_bigint::BigUint;
 use num_integer::Integer as _;
+use num_modular::ModularSymbols;
 use num_traits::identities::{One, Zero};
 use proptest::prelude::*;
 use std::mem;
@@ -47,6 +48,12 @@ fn to_uint_xlarge(big_uint: BigUint) -> U8192 {
 prop_compose! {
     fn uint()(bytes in any::<[u8; 32]>()) -> U256 {
         U256::from_le_slice(&bytes)
+    }
+}
+prop_compose! {
+    fn odd_uint()(mut bytes in any::<[u8; 32]>()) -> Odd<U256> {
+        bytes[0] |= 1;
+        U256::from_le_slice(&bytes).to_odd().unwrap()
     }
 }
 prop_compose! {
@@ -378,6 +385,17 @@ proptest! {
         prop_assert_eq!(expected, actual_vartime);
     }
 
+    #[test]
+    fn jacobi_symbol(f in odd_uint(), g in uint()) {
+        let f_bi = to_biguint(&f);
+        let g_bi = to_biguint(&g);
+
+        let expected = g_bi.jacobi(&f_bi);
+        let actual = g.jacobi_symbol(&f);
+        let actual_vartime = g.jacobi_symbol_vartime(&f);
+        prop_assert_eq!(expected, actual);
+        prop_assert_eq!(expected, actual_vartime);
+    }
 
     #[test]
     fn invert_mod2k(a in uint(), k in any::<u32>()) {


### PR DESCRIPTION
This implementation is based on `bingcd`. It does not appear to affect the GCD performance, being optimized away when it is not needed. This would be useful in `primefield` for adding `is_square`/`is_square_vartime` methods which should be faster than `sqrt`.