### PR TITLE
Add `NonZero::<Uint>::{from_be_hex, from_le_hex}`

### DIFF
--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -139,10 +139,12 @@ impl NonZero<Limb> {
 
 impl<const LIMBS: usize> NonZeroUint<LIMBS> {
     /// Creates a new non-zero integer in a const context.
-    /// Panics if the value is zero.
     ///
     /// In future versions of Rust it should be possible to replace this with
     /// `NonZero::new(…).unwrap()`
+    ///
+    /// # Panics
+    /// - if the value is zero.
     // TODO: Remove when `Self::new` and `CtOption::unwrap` support `const fn`
     pub const fn new_unwrap(n: Uint<LIMBS>) -> Self {
         if n.is_nonzero().is_true_vartime() {
@@ -150,6 +152,22 @@ impl<const LIMBS: usize> NonZeroUint<LIMBS> {
         } else {
             panic!("Invalid value: zero")
         }
+    }
+
+    /// Create a new [`NonZero<Uint>`] from the provided big endian hex string.
+    ///
+    /// # Panics
+    /// - if the hex is zero, malformed, or not zero-padded accordingly for the size.
+    pub const fn from_be_hex(hex: &str) -> Self {
+        Self::new_unwrap(Uint::from_be_hex(hex))
+    }
+
+    /// Create a new [`NonZero<Uint>`] from the provided little endian hex string.
+    ///
+    /// # Panics
+    /// - if the hex is zero, malformed, or not zero-padded accordingly for the size.
+    pub const fn from_le_hex(hex: &str) -> Self {
+        Self::new_unwrap(Uint::from_le_hex(hex))
     }
 
     /// Create a [`NonZeroUint`] from a [`NonZeroU8`] (const-friendly)

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -55,7 +55,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Create a new [`Uint`] from the provided big endian hex string.
     ///
-    /// Panics if the hex is malformed or not zero-padded accordingly for the size.
+    /// # Panics
+    /// - if the hex is malformed or not zero-padded accordingly for the size.
     pub const fn from_be_hex(hex: &str) -> Self {
         let bytes = hex.as_bytes();
 
@@ -113,7 +114,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Create a new [`Uint`] from the provided little endian hex string.
     ///
-    /// Panics if the hex is malformed or not zero-padded accordingly for the size.
+    /// # Panics
+    /// - if the hex is malformed or not zero-padded accordingly for the size.
     pub const fn from_le_hex(hex: &str) -> Self {
         let bytes = hex.as_bytes();
 


### PR DESCRIPTION
Adds panicking `const fn` constructors which are useful for defining `NonZero` constants.

We need these for the `elliptic-curve` crate after #917, because we previously didn't store the curve's order as `NonZero` (since the associated constant long, long predates `NonZero` in `crypto-bigint`)