### PR TITLE
Faster retrieval from Montygomery form

### DIFF
--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -10,7 +10,11 @@ mod pow;
 mod reduce;
 mod sub;
 
-use super::{MontyParams, Retrieve, div_by_2::div_by_2, reduction::montgomery_reduction};
+use super::{
+    MontyParams, Retrieve,
+    div_by_2::div_by_2,
+    reduction::{montgomery_reduction, montgomery_retrieve},
+};
 use crate::{ConstChoice, ConstZero, Uint};
 use core::{fmt::Debug, marker::PhantomData};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
@@ -90,8 +94,8 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
 
     /// Retrieves the integer currently encoded in this [`ConstMontyForm`], guaranteed to be reduced.
     pub const fn retrieve(&self) -> Uint<LIMBS> {
-        montgomery_reduction::<LIMBS>(
-            &(self.montgomery_form, Uint::ZERO),
+        montgomery_retrieve(
+            &self.montgomery_form,
             &MOD::PARAMS.modulus,
             MOD::PARAMS.mod_neg_inv(),
         )

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -13,7 +13,7 @@ use super::{
     Retrieve,
     const_monty_form::{ConstMontyForm, ConstMontyParams},
     div_by_2::div_by_2,
-    reduction::montgomery_reduction,
+    reduction::{montgomery_reduction, montgomery_retrieve},
     safegcd::invert_mod_u64,
 };
 use crate::{ConstChoice, Limb, Monty, Odd, U64, Uint, Word};
@@ -166,8 +166,8 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
 
     /// Retrieves the integer currently encoded in this `MontyForm`, guaranteed to be reduced.
     pub const fn retrieve(&self) -> Uint<LIMBS> {
-        montgomery_reduction(
-            &(self.montgomery_form, Uint::ZERO),
+        montgomery_retrieve(
+            &self.montgomery_form,
             &self.params.modulus,
             self.params.mod_neg_inv(),
         )


### PR DESCRIPTION
This optimizes the `retrieve` methods of Montygomery forms by implementing a specialized Montgomery multiplication. This corresponds to the `almost_montgomery_mul_by_one` method (which is removed). In my tests performance is about 7% better for `BoxedMontyForm` at 4096 bits, and about 30-50% better for most `MontyForm` sizes.