### PR TITLE
Add `Signed` and `Unsigned` marker traits

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -240,6 +240,8 @@ impl<const LIMBS: usize> Default for Int<LIMBS> {
 
 // TODO: impl Integer
 
+// TODO: impl Signed
+
 impl<const LIMBS: usize> ConstZero for Int<LIMBS> {
     const ZERO: Self = Self::ZERO;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -198,10 +198,13 @@ pub trait Integer:
     }
 }
 
-/// Marker trait for signed integers.
-pub trait Signed: Integer {}
+/// Signed integers.
+pub trait Signed: Integer {
+    /// Corresponding unsigned integer type.
+    type Unsigned: Unsigned;
+}
 
-/// Marker trait for unsigned integers.
+/// Unsigned integers.
 pub trait Unsigned: Integer {}
 
 /// Fixed-width integers.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -198,6 +198,12 @@ pub trait Integer:
     }
 }
 
+/// Marker trait for signed integers.
+pub trait Signed: Integer {}
+
+/// Marker trait for unsigned integers.
+pub trait Unsigned: Integer {}
+
 /// Fixed-width integers.
 pub trait FixedInteger: Bounded + ConditionallySelectable + Constants + Copy + Integer {
     /// The number of limbs used on this platform.

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -17,7 +17,7 @@ pub(crate) use ref_type::UintRef;
 
 use crate::{
     Bounded, ConstChoice, ConstCtOption, ConstZero, Constants, Encoding, FixedInteger, Int,
-    Integer, Limb, NonZero, Odd, Word, modular::MontyForm,
+    Integer, Limb, NonZero, Odd, Unsigned, Word, modular::MontyForm,
 };
 
 #[macro_use]
@@ -315,6 +315,8 @@ impl<const LIMBS: usize> Integer for Uint<LIMBS> {
         Self::LIMBS
     }
 }
+
+impl<const LIMBS: usize> Unsigned for Uint<LIMBS> {}
 
 impl<const LIMBS: usize> num_traits::Num for Uint<LIMBS> {
     type FromStrRadixErr = crate::DecodeError;

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -28,7 +28,9 @@ mod sub_mod;
 #[cfg(feature = "rand_core")]
 mod rand;
 
-use crate::{Integer, Limb, NonZero, Odd, Resize, UintRef, Word, Zero, modular::BoxedMontyForm};
+use crate::{
+    Integer, Limb, NonZero, Odd, Resize, UintRef, Unsigned, Word, Zero, modular::BoxedMontyForm,
+};
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::{fmt, ops::IndexMut};
 use subtle::{Choice, ConstantTimeEq, CtOption};
@@ -431,6 +433,8 @@ impl Zero for BoxedUint {
         self.limbs.as_mut().fill(Limb::ZERO)
     }
 }
+
+impl Unsigned for BoxedUint {}
 
 impl num_traits::Zero for BoxedUint {
     fn zero() -> Self {


### PR DESCRIPTION
These are notably bounded on `Integer` and thus usable in place of `Integer` anywhere a signed or unsigned integer specifically is expected

I note there's TODOs to impl `Integer` and `FixedInteger` for `Int`. I went ahead and added another TODO to impl `Signed`.