### PR TITLE
Extract `jacobi` module; add `Neg` impl

### DIFF
--- a/src/jacobi.rs
+++ b/src/jacobi.rs
@@ -1,0 +1,87 @@
+use crate::ConstChoice;
+use core::ops::Neg;
+use subtle::{Choice, ConstantTimeEq};
+
+/// Possible return values for Jacobi symbol calculations.
+#[derive(Debug, Copy, Clone)]
+#[repr(i8)]
+pub enum JacobiSymbol {
+    /// The two arguments are not coprime, they have a common divisor apart from 1.
+    Zero = 0,
+
+    /// The two arguments are coprime. If the lower argument is prime, then the upper argument
+    /// is quadratic residue modulo the lower argument. Otherwise, the upper argument is known to
+    /// be quadratic nonresidue for an even number of prime factors of the lower argument.
+    One = 1,
+
+    /// The two terms are coprime, and the upper argument is a quadratic nonresidue modulo the
+    /// lower argument.
+    MinusOne = -1,
+}
+
+impl JacobiSymbol {
+    /// Determine if the symbol is zero.
+    pub const fn is_zero(&self) -> ConstChoice {
+        ConstChoice::from_i64_eq(*self as i8 as i64, 0)
+    }
+
+    /// Determine if the symbol is one.
+    pub const fn is_one(&self) -> ConstChoice {
+        ConstChoice::from_i64_eq(*self as i8 as i64, 1)
+    }
+
+    /// Determine if the symbol is minus one.
+    pub const fn is_minus_one(&self) -> ConstChoice {
+        ConstChoice::from_i64_eq(*self as i8 as i64, -1)
+    }
+
+    /// Negate the symbol.
+    pub const fn neg(self) -> Self {
+        match self {
+            Self::Zero => Self::Zero,
+            Self::One => Self::MinusOne,
+            Self::MinusOne => Self::One,
+        }
+    }
+
+    pub(crate) const fn from_i8(value: i8) -> Self {
+        match value {
+            0 => Self::Zero,
+            1 => Self::One,
+            -1 => Self::MinusOne,
+            _ => panic!("invalid value for Jacobi symbol"),
+        }
+    }
+}
+
+impl ConstantTimeEq for JacobiSymbol {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        (*self as i8).ct_eq(&(*other as i8))
+    }
+}
+
+impl Eq for JacobiSymbol {}
+
+impl PartialEq for JacobiSymbol {
+    fn eq(&self, other: &Self) -> bool {
+        bool::from(self.ct_eq(other))
+    }
+}
+
+impl From<JacobiSymbol> for i8 {
+    fn from(symbol: JacobiSymbol) -> i8 {
+        symbol as i8
+    }
+}
+
+impl Neg for JacobiSymbol {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        match self {
+            Self::Zero => Self::Zero,
+            Self::One => Self::MinusOne,
+            Self::MinusOne => Self::One,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,8 +186,8 @@ pub use crate::uint::boxed::BoxedUint;
 pub use crate::{
     checked::Checked,
     const_choice::{ConstChoice, ConstCtOption},
-    int::types::*,
-    int::*,
+    int::{types::*, *},
+    jacobi::JacobiSymbol,
     limb::{Limb, WideWord, Word},
     non_zero::*,
     odd::*,
@@ -206,6 +206,7 @@ mod array;
 mod checked;
 mod const_choice;
 mod int;
+mod jacobi;
 mod limb;
 mod non_zero;
 mod odd;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,7 +5,6 @@ pub use num_traits::{
     WrappingSub,
 };
 
-use crate::ConstChoice;
 use crate::{Limb, NonZero, Odd, Reciprocal, modular::Retrieve};
 use core::fmt::{self, Debug};
 use core::ops::{
@@ -1047,58 +1046,3 @@ pub trait MontyMultiplier<'a>: From<&'a <Self::Monty as Monty>::Params> {
     /// Performs a Montgomery squaring, assigning a fully reduced result to `lhs`.
     fn square_assign(&mut self, lhs: &mut Self::Monty);
 }
-
-/// Possible return values for Jacobi symbol calculations.
-#[derive(Debug, Copy, Clone)]
-#[repr(i8)]
-pub enum JacobiSymbol {
-    /// The two arguments are not coprime, they have a common divisor apart from 1.
-    Zero = 0,
-    /// The two arguments are coprime. If the lower argument is prime, then the upper argument
-    /// is quadratic residue modulo the lower argument. Otherwise, the upper argument is known to
-    /// be quadratic nonresidue for an even number of prime factors of the lower argument.
-    One = 1,
-    /// The two terms are coprime, and the upper argument is a quadratic nonresidue modulo the
-    /// lower argument.
-    MinusOne = -1,
-}
-
-impl JacobiSymbol {
-    /// Determine if the symbol is zero.
-    pub const fn is_zero(&self) -> ConstChoice {
-        ConstChoice::from_i64_eq(*self as i8 as i64, 0)
-    }
-
-    /// Determine if the symbol is one.
-    pub const fn is_one(&self) -> ConstChoice {
-        ConstChoice::from_i64_eq(*self as i8 as i64, 1)
-    }
-
-    /// Determine if the symbol is minus one.
-    pub const fn is_minus_one(&self) -> ConstChoice {
-        ConstChoice::from_i64_eq(*self as i8 as i64, -1)
-    }
-
-    pub(crate) const fn from_i8(value: i8) -> Self {
-        match value {
-            0 => Self::Zero,
-            1 => Self::One,
-            -1 => Self::MinusOne,
-            _ => panic!("invalid value for Jacobi symbol"),
-        }
-    }
-}
-
-impl ConstantTimeEq for JacobiSymbol {
-    fn ct_eq(&self, other: &Self) -> Choice {
-        (*self as i8).ct_eq(&(*other as i8))
-    }
-}
-
-impl PartialEq for JacobiSymbol {
-    fn eq(&self, other: &Self) -> bool {
-        bool::from(self.ct_eq(other))
-    }
-}
-
-impl Eq for JacobiSymbol {}


### PR DESCRIPTION
Factors `JacobiSymbol` out of the `traits` module and into its own `jacobi` module.

Also adds a `Neg` impl, adapted from the one in `crypto-primes`, which seems to be the one thing missing for `crypto-primes` to switch to it for its Jacobi symbol type.

cc @andrewwhitehead @fjarri 