### PR TITLE
Bump `hybrid-array` to v0.4.4; enable `subtle` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,10 +302,11 @@ checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7c10d9cd8b8e0733111482917f4f7e188cf6f57fc8eb0ff9b26a51db9fbd3c"
+checksum = "2bad028b20a90afcdb5e28a53392562f1db2bdfa238aa1a978b911461bfffb92"
 dependencies = [
+ "subtle",
  "typenum",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ subtle = { version = "2.6", default-features = false }
 
 # optional dependencies
 der = { version = "0.8.0-rc.9", optional = true, default-features = false }
-hybrid-array = { version = "0.4", optional = true }
+hybrid-array = { version = "0.4.4", optional = true, features = ["subtle"] }
 num-traits = { version = "0.2.19", default-features = false }
 rand_core = { version = "0.9.2", optional = true, default-features = false }
 rlp = { version = "0.6", optional = true, default-features = false }


### PR DESCRIPTION
Notably this release also enables the `const-generics` feature, which only incurs an MSRV bump to a much earlier version than our current MSRV so enabling it is more functionality for effectively free