### PR TITLE
Use 64-bit words on wasm targets

### DIFF
--- a/src/const_choice.rs
+++ b/src/const_choice.rs
@@ -25,13 +25,13 @@ impl ConstChoice {
     }
 
     #[inline]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     pub(crate) const fn as_u64_mask(&self) -> u64 {
         ((self.0 as u64) << 32) | (self.0 as u64)
     }
 
     #[inline]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     pub(crate) const fn as_u64_mask(&self) -> u64 {
         self.0
     }

--- a/src/int.rs
+++ b/src/int.rs
@@ -373,14 +373,14 @@ mod tests {
 
     use crate::{ConstChoice, I128, U128};
 
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     #[test]
     fn as_words() {
         let n = I128::from_be_hex("AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
         assert_eq!(n.as_words(), &[0xCCCCCCCCDDDDDDDD, 0xAAAAAAAABBBBBBBB]);
     }
 
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     #[test]
     fn as_words_mut() {
         let mut n = I128::from_be_hex("AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");

--- a/src/int/from.rs
+++ b/src/int/from.rs
@@ -26,14 +26,14 @@ impl<const LIMBS: usize> Int<LIMBS> {
 
     /// Create a [`Int`] from an `i64` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<i64>` when stable
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     pub const fn from_i64(n: i64) -> Self {
         Uint::<{ I64::LIMBS }>::from_u64(n as u64).as_int().resize()
     }
 
     /// Create a [`Int`] from an `i64` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<i64>` when stable
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     pub const fn from_i64(n: i64) -> Self {
         assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         Uint::new([Limb(n as Word)]).as_int().resize()
@@ -108,9 +108,9 @@ impl<const LIMBS: usize, const LIMBS2: usize> From<&Int<LIMBS>> for Int<LIMBS2> 
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     use crate::I64 as IntEx;
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     use crate::I128 as IntEx;
     use crate::{I128, Limb};
 

--- a/src/int/types.rs
+++ b/src/int/types.rs
@@ -3,58 +3,58 @@
 
 use crate::Int;
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
 /// Signed bit integer.
 pub type I64 = Int<1>;
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
 /// Signed bit integer.
 pub type I128 = Int<2>;
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
 /// Signed bit integer.
 pub type I256 = Int<4>;
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
 /// Signed bit integer.
 pub type I512 = Int<8>;
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
 /// Signed bit integer.
 pub type I1024 = Int<16>;
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
 /// Signed bit integer.
 pub type I2048 = Int<32>;
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
 /// Signed bit integer.
 pub type I4096 = Int<64>;
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
 /// Signed bit integer.
 pub type I64 = Int<2>;
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
 /// Signed bit integer.
 pub type I128 = Int<4>;
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
 /// Signed bit integer.
 pub type I256 = Int<8>;
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
 /// Signed bit integer.
 pub type I512 = Int<16>;
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
 /// Signed bit integer.
 pub type I1024 = Int<32>;
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
 /// Signed bit integer.
 pub type I2048 = Int<64>;
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
 /// Signed bit integer.
 pub type I4096 = Int<128>;

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -34,11 +34,11 @@ compile_error!("this crate builds on 32-bit and 64-bit platforms only");
 //
 
 /// Inner integer type that the [`Limb`] newtype wraps.
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
 pub type Word = u32;
 
 /// Unsigned wide integer type: double the width of [`Word`].
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
 pub type WideWord = u64;
 
 //
@@ -46,11 +46,11 @@ pub type WideWord = u64;
 //
 
 /// Unsigned integer type that the [`Limb`] newtype wraps.
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
 pub type Word = u64;
 
 /// Wide integer type: double the width of [`Word`].
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
 pub type WideWord = u128;
 
 /// Big integers are represented as an array/vector of smaller CPU word-size integers called
@@ -80,19 +80,19 @@ impl Limb {
     // 32-bit
 
     /// Size of the inner integer in bits.
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     pub const BITS: u32 = 32;
     /// Size of the inner integer in bytes.
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     pub const BYTES: usize = 4;
 
     // 64-bit
 
     /// Size of the inner integer in bits.
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     pub const BITS: u32 = 64;
     /// Size of the inner integer in bytes.
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     pub const BYTES: usize = 8;
 
     /// `floor(log2(Self::BITS))`.
@@ -239,10 +239,10 @@ mod tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn debug() {
-        #[cfg(target_pointer_width = "32")]
+        #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
         assert_eq!(format!("{:?}", Limb(42)), "Limb(0x0000002A)");
 
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
         assert_eq!(format!("{:?}", Limb(42)), "Limb(0x000000000000002A)");
     }
 }

--- a/src/limb/encoding.rs
+++ b/src/limb/encoding.rs
@@ -4,9 +4,9 @@ use super::{Limb, Word};
 use crate::Encoding;
 
 impl Encoding for Limb {
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     type Repr = [u8; 4];
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     type Repr = [u8; 8];
 
     #[inline]
@@ -65,10 +65,10 @@ impl Limb {
 mod test {
     use super::*;
 
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     const LIMB: Limb = Limb(0x7654_3210);
 
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     const LIMB: Limb = Limb(0xFEDCBA9876543210);
 
     #[test]

--- a/src/limb/from.rs
+++ b/src/limb/from.rs
@@ -24,7 +24,7 @@ impl Limb {
 
     /// Create a [`Limb`] from a `u64` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u64>` when stable
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     pub const fn from_u64(n: u64) -> Self {
         Limb(n)
     }
@@ -51,7 +51,7 @@ impl From<u32> for Limb {
     }
 }
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
 impl From<u64> for Limb {
     #[inline]
     fn from(n: u64) -> Limb {

--- a/src/limb/mul.rs
+++ b/src/limb/mul.rs
@@ -129,14 +129,14 @@ mod tests {
     use super::{CheckedMul, Limb};
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn checked_mul_ok() {
         let n = Limb::from_u16(0xffff);
         assert_eq!(n.checked_mul(&n).unwrap(), Limb::from_u32(0xfffe_0001));
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn checked_mul_ok() {
         let n = Limb::from_u32(0xffff_ffff);
         assert_eq!(

--- a/src/limb/rand.rs
+++ b/src/limb/rand.rs
@@ -7,9 +7,9 @@ use subtle::ConstantTimeLess;
 
 impl Random for Limb {
     fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        #[cfg(target_pointer_width = "32")]
+        #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
         let val = rng.try_next_u32()?;
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
         let val = rng.try_next_u64()?;
 
         Ok(Self(val))

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,7 +11,7 @@ macro_rules! nlimbs {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     #[test]
     fn nlimbs_for_bits_macro() {
         assert_eq!(nlimbs!(64), 2);
@@ -20,7 +20,7 @@ mod tests {
         assert_eq!(nlimbs!(256), 8);
     }
 
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     #[test]
     fn nlimbs_for_bits_macro() {
         assert_eq!(nlimbs!(64), 1);

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -179,7 +179,7 @@ impl NonZero<Limb> {
 
     /// Create a [`NonZero<Limb>`] from a [`NonZeroU64`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU64>` when stable
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     pub const fn from_u64(n: NonZeroU64) -> Self {
         Self(Limb::from_u64(n.get()))
     }
@@ -367,7 +367,7 @@ impl From<NonZeroU32> for NonZero<Limb> {
     }
 }
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
 impl From<NonZeroU64> for NonZero<Limb> {
     fn from(integer: NonZeroU64) -> Self {
         Self::from_u64(integer)

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -461,13 +461,13 @@ impl_uint_aliases! {
     (U32768, 32768, "32768-bit")
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
 impl_uint_aliases! {
     (U224, 224, "224-bit"), // For NIST P-224
     (U544, 544, "544-bit")  // For NIST P-521
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
 impl_uint_concat_split_even! {
     U64,
 }
@@ -533,14 +533,14 @@ mod tests {
     #[cfg(feature = "alloc")]
     use alloc::format;
 
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     #[test]
     fn as_words() {
         let n = U128::from_be_hex("AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");
         assert_eq!(n.as_words(), &[0xCCCCCCCCDDDDDDDD, 0xAAAAAAAABBBBBBBB]);
     }
 
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     #[test]
     fn as_words_mut() {
         let mut n = U128::from_be_hex("AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDD");

--- a/src/uint/array.rs
+++ b/src/uint/array.rs
@@ -74,7 +74,7 @@ impl_uint_array_encoding! {
     (U8192, typenum::U1024)
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
 impl_uint_array_encoding! {
     (U224, typenum::U28), // For NIST P-224
     (U544, typenum::U68)  // For NIST P-521
@@ -85,24 +85,24 @@ mod tests {
     use crate::{ArrayDecoding, ArrayEncoding, Limb};
     use hex_literal::hex;
 
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     use crate::U64 as UintEx;
 
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     use crate::U128 as UintEx;
 
     /// Byte array that corresponds to `UintEx`
     type ByteArray = crate::ByteArray<UintEx>;
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn from_be_byte_array() {
         let n = UintEx::from_be_byte_array(hex!("0011223344556677").into());
         assert_eq!(n.as_limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn from_be_byte_array() {
         let n = UintEx::from_be_byte_array(hex!("00112233445566778899aabbccddeeff").into());
         assert_eq!(
@@ -112,14 +112,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn from_le_byte_array() {
         let n = UintEx::from_le_byte_array(hex!("7766554433221100").into());
         assert_eq!(n.as_limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn from_le_byte_array() {
         let n = UintEx::from_le_byte_array(hex!("ffeeddccbbaa99887766554433221100").into());
         assert_eq!(
@@ -129,7 +129,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn to_be_byte_array() {
         let expected_bytes = ByteArray::from(hex!("0011223344556677"));
         let actual_bytes = UintEx::from_be_byte_array(expected_bytes).to_be_byte_array();
@@ -137,7 +137,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn to_be_byte_array() {
         let expected_bytes = ByteArray::from(hex!("00112233445566778899aabbccddeeff"));
         let actual_bytes = UintEx::from_be_byte_array(expected_bytes).to_be_byte_array();
@@ -145,7 +145,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn to_le_byte_array() {
         let expected_bytes = ByteArray::from(hex!("7766554433221100"));
         let actual_bytes = UintEx::from_le_byte_array(expected_bytes).to_le_byte_array();
@@ -153,7 +153,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn to_le_byte_array() {
         let expected_bytes = ByteArray::from(hex!("ffeeddccbbaa99887766554433221100"));
         let actual_bytes = UintEx::from_le_byte_array(expected_bytes).to_le_byte_array();
@@ -161,7 +161,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn into_uint_be() {
         let expected_bytes = ByteArray::from(hex!("0011223344556677"));
         let actual_bytes = expected_bytes.into_uint_be().to_be_byte_array();
@@ -169,7 +169,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn into_uint_be() {
         let expected_bytes = ByteArray::from(hex!("00112233445566778899aabbccddeeff"));
         let actual_bytes = expected_bytes.into_uint_be().to_be_byte_array();
@@ -177,7 +177,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn into_uint_le() {
         let expected_bytes = ByteArray::from(hex!("7766554433221100"));
         let actual_bytes = expected_bytes.into_uint_le().to_le_byte_array();
@@ -185,7 +185,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn into_uint_le() {
         let expected_bytes = ByteArray::from(hex!("ffeeddccbbaa99887766554433221100"));
         let actual_bytes = expected_bytes.into_uint_le().to_le_byte_array();

--- a/src/uint/boxed/encoding.rs
+++ b/src/uint/boxed/encoding.rs
@@ -271,7 +271,7 @@ mod tests {
     use hex_literal::hex;
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn from_be_slice_eq() {
         let bytes = hex!("0011223344556677");
         let n = BoxedUint::from_be_slice(&bytes, 64).unwrap();
@@ -279,7 +279,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn from_be_slice_eq() {
         let bytes = hex!("00112233445566778899aabbccddeeff");
         let n = BoxedUint::from_be_slice(&bytes, 128).unwrap();
@@ -290,7 +290,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn from_be_hex_eq() {
         let hex = "00112233445566778899aabbccddeeff";
         let n = BoxedUint::from_be_hex(hex, 128).unwrap();
@@ -301,7 +301,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn from_be_slice_short() {
         let bytes = hex!("0011223344556677");
         let n = BoxedUint::from_be_slice(&bytes, 128).unwrap();
@@ -312,7 +312,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn from_be_slice_short() {
         let bytes = hex!("00112233445566778899aabbccddeeff");
         let n = BoxedUint::from_be_slice(&bytes, 256).unwrap();
@@ -337,7 +337,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn from_be_slice_not_word_sized() {
         let bytes = hex!("112233445566778899aabbccddeeff");
         let n = BoxedUint::from_be_slice(&bytes, 127).unwrap();
@@ -354,7 +354,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn from_be_slice_not_word_sized() {
         let bytes = hex!("112233445566778899aabbccddeeff");
         let n = BoxedUint::from_be_slice(&bytes, 127).unwrap();
@@ -384,7 +384,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn from_le_slice_eq() {
         let bytes = hex!("7766554433221100");
         let n = BoxedUint::from_le_slice(&bytes, 64).unwrap();
@@ -392,7 +392,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn from_le_slice_eq() {
         let bytes = hex!("ffeeddccbbaa99887766554433221100");
         let n = BoxedUint::from_le_slice(&bytes, 128).unwrap();
@@ -403,7 +403,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn from_le_slice_short() {
         let bytes = hex!("7766554433221100");
         let n = BoxedUint::from_le_slice(&bytes, 128).unwrap();
@@ -414,7 +414,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn from_le_slice_short() {
         let bytes = hex!("ffeeddccbbaa99887766554433221100");
         let n = BoxedUint::from_le_slice(&bytes, 256).unwrap();
@@ -439,7 +439,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn from_le_slice_not_word_sized() {
         let bytes = hex!("ffeeddccbbaa998877665544332211");
         let n = BoxedUint::from_le_slice(&bytes, 127).unwrap();
@@ -456,7 +456,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn from_le_slice_not_word_sized() {
         let bytes = hex!("ffeeddccbbaa998877665544332211");
         let n = BoxedUint::from_le_slice(&bytes, 127).unwrap();

--- a/src/uint/boxed/encoding/serde.rs
+++ b/src/uint/boxed/encoding/serde.rs
@@ -27,13 +27,13 @@ impl Serialize for BoxedUint {
 #[cfg(test)]
 mod tests {
     use super::BoxedUint;
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     use crate::Limb;
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     use hex_literal::hex;
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn serde() {
         let test: BoxedUint = BoxedUint::from_be_hex("7711223344556600", 64).unwrap();
 
@@ -47,7 +47,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn from_le_slice_eq_test() {
         let bytes = hex!("7766554433221100");
         let box_uint = BoxedUint::from_le_slice(&bytes, 64).unwrap();

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Calculates the reciprocal of the given 32-bit divisor with the highmost bit set.
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
 pub const fn reciprocal(d: Word) -> Word {
     debug_assert!(d >= (1 << (Word::BITS - 1)));
 
@@ -42,7 +42,7 @@ pub const fn reciprocal(d: Word) -> Word {
 }
 
 /// Calculates the reciprocal of the given 64-bit divisor with the highmost bit set.
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
 pub const fn reciprocal(d: Word) -> Word {
     debug_assert!(d >= (1 << (Word::BITS - 1)));
 

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -798,14 +798,14 @@ mod tests {
     #[cfg(feature = "alloc")]
     use {super::radix_encode_limbs_to_string, alloc::format};
 
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     use crate::U64 as UintEx;
 
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     use crate::U128 as UintEx;
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn from_be_slice() {
         let bytes = hex!("0011223344556677");
         let n = UintEx::from_be_slice(&bytes);
@@ -813,7 +813,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn from_be_slice() {
         let bytes = hex!("00112233445566778899aabbccddeeff");
         let n = UintEx::from_be_slice(&bytes);
@@ -824,7 +824,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn from_le_slice() {
         let bytes = hex!("7766554433221100");
         let n = UintEx::from_le_slice(&bytes);
@@ -832,7 +832,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn from_le_slice() {
         let bytes = hex!("ffeeddccbbaa99887766554433221100");
         let n = UintEx::from_le_slice(&bytes);
@@ -843,14 +843,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn from_be_hex() {
         let n = UintEx::from_be_hex("0011223344556677");
         assert_eq!(n.as_limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn from_be_hex() {
         let n = UintEx::from_be_hex("00112233445566778899aabbccddeeff");
         assert_eq!(
@@ -860,14 +860,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn from_le_hex() {
         let n = UintEx::from_le_hex("7766554433221100");
         assert_eq!(n.as_limbs(), &[Limb(0x44556677), Limb(0x00112233)]);
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn from_le_hex() {
         let n = UintEx::from_le_hex("ffeeddccbbaa99887766554433221100");
         assert_eq!(
@@ -1041,7 +1041,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     fn encode_be_hex() {
         let n = UintEx::from_be_hex("0011223344556677");
 
@@ -1053,7 +1053,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     fn encode_be_hex() {
         let n = UintEx::from_be_hex("00112233445566778899aabbccddeeff");
 

--- a/src/uint/from.rs
+++ b/src/uint/from.rs
@@ -33,7 +33,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Create a [`Uint`] from a `u64` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u64>` when stable
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     pub const fn from_u64(n: u64) -> Self {
         assert!(LIMBS >= 2, "number of limbs must be two or greater");
         let mut limbs = [Limb::ZERO; LIMBS];
@@ -44,7 +44,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Create a [`Uint`] from a `u64` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u64>` when stable
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     pub const fn from_u64(n: u64) -> Self {
         assert!(LIMBS >= 1, "number of limbs must be greater than zero");
         let mut limbs = [Limb::ZERO; LIMBS];
@@ -140,14 +140,14 @@ impl<const LIMBS: usize> From<u128> for Uint<LIMBS> {
     }
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
 impl From<U64> for u64 {
     fn from(n: U64) -> u64 {
         (n.limbs[0].0 as u64) | ((n.limbs[1].0 as u64) << 32)
     }
 }
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
 impl From<U64> for u64 {
     fn from(n: U64) -> u64 {
         n.limbs[0].into()
@@ -233,10 +233,10 @@ impl<const LIMBS: usize, const LIMBS2: usize> From<&Uint<LIMBS>> for Uint<LIMBS2
 mod tests {
     use crate::{Limb, U128, Word};
 
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     use crate::U64 as UintEx;
 
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     use crate::U128 as UintEx;
 
     #[test]

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -128,9 +128,9 @@ pub(super) fn random_mod_core<T, R: TryRngCore + ?Sized>(
 where
     T: AsMut<[Limb]> + AsRef<[Limb]> + ConstantTimeLess + Zero,
 {
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     let mut next_word = || rng.try_next_u64();
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
     let mut next_word = || rng.try_next_u32();
 
     let n_limbs = n_bits.div_ceil(Limb::BITS) as usize;

--- a/src/uint/ref_type/invert_mod.rs
+++ b/src/uint/ref_type/invert_mod.rs
@@ -25,7 +25,7 @@ impl Odd<UintRef> {
 impl UintRef {
     #[inline(always)]
     pub const fn lowest_u64(&self) -> u64 {
-        #[cfg(target_pointer_width = "32")]
+        #[cfg(all(target_pointer_width = "32", not(target_family = "wasm")))]
         {
             debug_assert!(self.nlimbs() >= 1);
             let mut ret = self.0[0].0 as u64;
@@ -37,7 +37,7 @@ impl UintRef {
             ret
         }
 
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
         {
             self.0[0].0
         }

--- a/src/uint/sub_mod.rs
+++ b/src/uint/sub_mod.rs
@@ -173,7 +173,7 @@ mod tests {
     }
 
     // Test requires 1-limb is capable of representing a 64-bit integer
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_pointer_width = "64", target_family = "wasm"))]
     test_sub_mod!(1, sub1);
 
     test_sub_mod!(2, sub2);


### PR DESCRIPTION
wasm is a 64-bit architecture with a 32-bit address space. We should be able to use 64-bit words for it without issue. I have not reviewed the u128 codegen to confirm it's non-branching on wasm, yet we already assume u128 codegen is non-branching for 64-bit platforms.

https://users.rust-lang.org/t/are-there-any-negative-implications-of-using-u64-in-wasm32/57419 seems to casually discuss the premise of 64-bit integers within WASM decently.