### PR TITLE
CI: add codecov integration

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -151,6 +151,22 @@ jobs:
       - run: rustup component add miri && cargo miri setup
       - run: cargo miri test --target ${{ matrix.target }} --no-default-features --lib
 
+  # Generate code coverage and report to codecov.io
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+        env:
+          CARGO_HUSKY_DONT_INSTALL_HOOKS: true
+      - uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: true
+
   minimal-versions:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Attempt to collect code coverage information and report to https://codecov.io

I've waffled on the value of this over the years, especially as maintaining the integration can be high maintenance and the reports often contain false negatives which limits their value, but for this crate in particular, due to its sensitive nature, complexity, and use as a dependency for multiple other crates, I think it would be good if we could start getting some coverage information and use that to inform additional testing.