### PR TITLE
README.md: add codecov.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 [![Build Status][build-image]][build-link]
+[![codecov][coverage-image]][coverage-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
@@ -60,6 +61,8 @@ dual licensed as above, without any additional terms or conditions.
 [docs-link]: https://docs.rs/crypto-bigint/
 [build-image]: https://github.com/RustCrypto/crypto-bigint/actions/workflows/crypto-bigint.yml/badge.svg?branch=master
 [build-link]: https://github.com/RustCrypto/crypto-bigint/actions/workflows/crypto-bigint.yml?query=branch:master
+[coverage-image]: https://codecov.io/gh/RustCrypto/crypto-bigint/graph/badge.svg?token=B4J72KDXXJ
+[coverage-link]: https://codecov.io/gh/RustCrypto/crypto-bigint
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg


### PR DESCRIPTION
Currently at 80%, but a public badge is also motivation to get coverage up higher