### PR TITLE
Make AMM-based modular `pow` function generic

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -242,6 +242,14 @@ impl<const LIMBS: usize> FixedInteger for Int<LIMBS> {
 }
 
 impl<const LIMBS: usize> Integer for Int<LIMBS> {
+    fn as_limbs(&self) -> &[Limb] {
+        self.0.as_limbs()
+    }
+
+    fn as_mut_limbs(&mut self) -> &mut [Limb] {
+        self.0.as_mut_limbs()
+    }
+
     fn nlimbs(&self) -> usize {
         self.0.nlimbs()
     }

--- a/src/modular/boxed_monty_form/pow.rs
+++ b/src/modular/boxed_monty_form/pow.rs
@@ -1,9 +1,7 @@
 //! Modular exponentiation support for [`BoxedMontyForm`].
 
-use super::{BoxedMontyForm, BoxedMontyParams, mul::BoxedMontyMultiplier};
-use crate::{BoxedUint, ConstantTimeSelect, Limb, PowBoundedExp, Word};
-use core::{array, mem};
-use subtle::{ConstantTimeEq, ConstantTimeLess};
+use super::BoxedMontyForm;
+use crate::{BoxedUint, PowBoundedExp, modular::pow::pow_montgomery_form_amm};
 
 impl BoxedMontyForm {
     /// Raises to the `exponent` power.
@@ -17,18 +15,10 @@ impl BoxedMontyForm {
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
     pub fn pow_bounded_exp(&self, exponent: &BoxedUint, exponent_bits: u32) -> Self {
-        let ret = Self {
-            montgomery_form: pow_montgomery_form(
-                &self.montgomery_form,
-                exponent,
-                exponent_bits,
-                &self.params,
-            ),
-            params: self.params.clone(),
-        };
+        let z =
+            pow_montgomery_form_amm(&self.montgomery_form, exponent, exponent_bits, &self.params);
 
-        debug_assert!(&ret.retrieve() < self.params.modulus());
-        ret
+        Self::from_amm(z, self.params.clone())
     }
 }
 
@@ -36,100 +26,4 @@ impl PowBoundedExp<BoxedUint> for BoxedMontyForm {
     fn pow_bounded_exp(&self, exponent: &BoxedUint, exponent_bits: u32) -> Self {
         self.pow_bounded_exp(exponent, exponent_bits)
     }
-}
-
-/// Performs modular exponentiation using Montgomery's ladder.
-///
-/// `exponent_bits` represents the length of the exponent in bits.
-///
-/// NOTE: `exponent_bits` is leaked in the time pattern.
-fn pow_montgomery_form(
-    x: &BoxedUint,
-    exponent: &BoxedUint,
-    exponent_bits: u32,
-    params: &BoxedMontyParams,
-) -> BoxedUint {
-    let one = params.one();
-
-    if exponent_bits == 0 {
-        return one.clone(); // 1 in Montgomery form
-    }
-
-    const WINDOW: u32 = 4;
-    const WINDOW_MASK: Word = (1 << WINDOW) - 1;
-
-    let mut multiplier = BoxedMontyMultiplier::from(params);
-    let mut power = x.clone();
-
-    // powers[i] contains x^i
-    let powers: [BoxedUint; 1 << WINDOW] = array::from_fn(|n| {
-        if n == 0 {
-            one.clone()
-        } else {
-            let mut new_power = multiplier.mul_amm(&power, x);
-            mem::swap(&mut power, &mut new_power);
-            new_power
-        }
-    });
-
-    let starting_limb = ((exponent_bits - 1) / Limb::BITS) as usize;
-    let starting_bit_in_limb = (exponent_bits - 1) % Limb::BITS;
-    let starting_window = starting_bit_in_limb / WINDOW;
-    let starting_window_mask = (1 << (starting_bit_in_limb % WINDOW + 1)) - 1;
-
-    let mut z = one.clone(); // 1 in Montgomery form
-    let mut power = powers[0].clone();
-
-    for limb_num in (0..=starting_limb).rev() {
-        let w = exponent.as_limbs()[limb_num].0;
-
-        let mut window_num = if limb_num == starting_limb {
-            starting_window + 1
-        } else {
-            Limb::BITS / WINDOW
-        };
-
-        while window_num > 0 {
-            window_num -= 1;
-
-            let mut idx = (w >> (window_num * WINDOW)) & WINDOW_MASK;
-
-            if limb_num == starting_limb && window_num == starting_window {
-                idx &= starting_window_mask;
-            } else {
-                for _ in 1..=WINDOW {
-                    multiplier.square_amm_assign(&mut z);
-                }
-            }
-
-            // Constant-time lookup in the array of powers
-            power.limbs.copy_from_slice(&powers[0].limbs);
-            for i in 1..(1 << WINDOW) {
-                power.ct_assign(&powers[i as usize], i.ct_eq(&idx));
-            }
-
-            multiplier.mul_amm_assign(&mut z, &power);
-        }
-    }
-
-    // Ensure the output is properly reduced.
-    //
-    // Using the properties of `almost_montgomery_mul()` (see its documentation):
-    // - We have an incoming `x` which is fully reduced (`floor(x / modulus) = 0`).
-    // - We build an array of `powers` which are produced by multiplying the previous power by `x`,
-    //   so for each power `floor(power / modulus) <= 1`.
-    // - Then we take turns squaring the accumulator `z` (bringing `floor(z / modulus)` to 1
-    //   regardless of the previous reduction level) and multiplying by a power of `x`
-    //   (bringing `floor(z / modulus)` to at most 2).
-    // - Then we either exit the loop, or square again, which brings `floor(z / modulus)` back to 1.
-    //
-    // Now that we exited the loop, we need to reduce `z` at most twice
-    // to bring it within `[0, modulus)`.
-
-    let modulus = params.modulus();
-    z.conditional_borrowing_sub_assign(modulus, !z.ct_lt(modulus));
-    z.conditional_borrowing_sub_assign(modulus, !z.ct_lt(modulus));
-    debug_assert!(&z < modulus);
-
-    z
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -300,6 +300,14 @@ impl<const LIMBS: usize> FixedInteger for Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize> Integer for Uint<LIMBS> {
+    fn as_limbs(&self) -> &[Limb] {
+        &self.limbs
+    }
+
+    fn as_mut_limbs(&mut self) -> &mut [Limb] {
+        &mut self.limbs
+    }
+
     fn nlimbs(&self) -> usize {
         Self::LIMBS
     }

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -422,6 +422,14 @@ impl Default for BoxedUint {
 }
 
 impl Integer for BoxedUint {
+    fn as_limbs(&self) -> &[Limb] {
+        &self.limbs
+    }
+
+    fn as_mut_limbs(&mut self) -> &mut [Limb] {
+        &mut self.limbs
+    }
+
     fn nlimbs(&self) -> usize {
         self.nlimbs()
     }


### PR DESCRIPTION
The AMM modpow implementation was previously specialized to `BoxedMontyForm`. This extracts the implementation into the toplevel `pow` module and makes it generic.

Note it doesn't yet add support for using it with `MontyForm`, but that should be a straightforward next step after this.

Making this work involved defining a `MontyMultiplier` extension trait which I've called `AmmMultiplier`, however it's marked `pub(crate)` and is otherwise entirely internal.

Constructing `BoxedMontyForm` from an AMM now has an internal helper function called `BoxedMontyForm::from_amm`, both to permit reuse and because the methods needed to implement it with optimum performance aren't defined on the `Integer`/`Unsigned` traits.

This has no impact on benchmarks:

```
Boxed Montgomery arithmetic/modpow, BoxedUint^BoxedUint
                        time:   [30.203 ms 30.263 ms 30.325 ms]
                        change: [−0.1536% +0.2861% +0.6654%] (p = 0.17 > 0.05)
                        No change in performance detected.
```

cc @andrewwhitehead 