### PR TITLE
Bump `rand_core` to v0.10.0-rc-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3585020fc6766ef7ff5c58d69819dbca16a19008ae347bb5d3e4e145c495eb38"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.0-rc-2",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +162,15 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "criterion"
@@ -221,6 +241,7 @@ name = "crypto-bigint"
 version = "0.7.0-rc.9"
 dependencies = [
  "bincode",
+ "chacha20",
  "criterion",
  "der",
  "hex-literal",
@@ -230,8 +251,7 @@ dependencies = [
  "num-modular",
  "num-traits",
  "proptest",
- "rand_chacha",
- "rand_core",
+ "rand_core 0.10.0-rc-2",
  "rlp",
  "serdect",
  "subtle",
@@ -503,7 +523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -513,7 +533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -526,12 +546,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.0-rc-2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104a23e4e8b77312a823b6b5613edbac78397e2f34320bc7ac4277013ec4478e"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,21 +23,21 @@ subtle = { version = "2.6", default-features = false }
 der = { version = "0.8.0-rc.9", optional = true, default-features = false }
 hybrid-array = { version = "0.4.5", optional = true, features = ["subtle"] }
 num-traits = { version = "0.2.19", default-features = false }
-rand_core = { version = "0.9.2", optional = true, default-features = false }
+rand_core = { version = "0.10.0-rc-2", optional = true, default-features = false }
 rlp = { version = "0.6", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 bincode = { version = "2", features = ["serde"] }
+chacha20 = { version = "0.10.0-rc.3", default-features = false, features = ["rng"] }
 criterion = { version = "0.7", features = ["html_reports"] }
 hex-literal = "1"
 num-bigint = "0.4"
 num-integer = "0.1"
 num-modular = { version = "0.6", features = ["num-bigint", "num-integer", "num-traits"] }
 proptest = "1.9"
-rand_core = { version = "0.9", features = ["std", "os_rng"] }
-rand_chacha = "0.9"
+rand_core = "0.10.0-rc-2"
 
 [features]
 default = ["rand"]

--- a/benches/boxed_monty.rs
+++ b/benches/boxed_monty.rs
@@ -1,3 +1,4 @@
+use chacha20::ChaCha8Rng;
 use criterion::{
     BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
@@ -6,7 +7,6 @@ use crypto_bigint::{
     modular::{BoxedMontyForm, BoxedMontyParams},
 };
 use num_bigint::BigUint;
-use rand_chacha::ChaChaRng;
 use rand_core::SeedableRng;
 use std::hint::black_box;
 
@@ -18,7 +18,7 @@ fn to_biguint(uint: &BoxedUint) -> BigUint {
 }
 
 fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let mut rng = ChaChaRng::from_os_rng();
+    let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
     let params = BoxedMontyParams::new(Odd::<BoxedUint>::random(&mut rng, UINT_BITS));
 
     group.bench_function(format!("add, {UINT_BITS}-bit"), |b| {
@@ -182,7 +182,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 }
 
 fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let mut rng = ChaChaRng::from_os_rng();
+    let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
     group.bench_function("BoxedMontyParams::new", |b| {
         b.iter_batched(
             || Odd::<BoxedUint>::random(&mut rng, UINT_BITS),

--- a/benches/const_monty.rs
+++ b/benches/const_monty.rs
@@ -1,8 +1,8 @@
+use chacha20::ChaCha8Rng;
 use criterion::{
     BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
 use crypto_bigint::{Random, RandomMod, U256, const_monty_params, modular::ConstMontyParams};
-use rand_chacha::ChaChaRng;
 use rand_core::SeedableRng;
 use std::hint::black_box;
 
@@ -18,7 +18,7 @@ const_monty_params!(
 type ConstMontyForm = crypto_bigint::modular::ConstMontyForm<Modulus, { U256::LIMBS }>;
 
 fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let mut rng = ChaChaRng::from_os_rng();
+    let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
     group.bench_function("ConstMontyForm creation", |b| {
         b.iter_batched(
             || U256::random_mod(&mut rng, Modulus::PARAMS.modulus().as_nz_ref()),
@@ -37,7 +37,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
 }
 
 fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let mut rng = ChaChaRng::from_os_rng();
+    let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
 
     group.bench_function("add, U256", |b| {
         b.iter_batched(

--- a/benches/int.rs
+++ b/benches/int.rs
@@ -1,5 +1,5 @@
+use chacha20::ChaCha8Rng;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use rand_chacha::ChaChaRng;
 use rand_core::SeedableRng;
 use std::hint::black_box;
 use std::ops::Div;
@@ -7,7 +7,7 @@ use std::ops::Div;
 use crypto_bigint::{I128, I256, I512, I1024, I2048, I4096, NonZero, Random};
 
 fn bench_mul(c: &mut Criterion) {
-    let mut rng = ChaChaRng::from_os_rng();
+    let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
     let mut group = c.benchmark_group("wrapping ops");
 
     group.bench_function("widening_mul, I128xI128", |b| {
@@ -60,7 +60,7 @@ fn bench_mul(c: &mut Criterion) {
 }
 
 fn bench_concatenating_mul(c: &mut Criterion) {
-    let mut rng = ChaChaRng::from_os_rng();
+    let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
     let mut group = c.benchmark_group("widening ops");
 
     group.bench_function("concatenating_mul, I128xI128", |b| {
@@ -113,7 +113,7 @@ fn bench_concatenating_mul(c: &mut Criterion) {
 }
 
 fn bench_div(c: &mut Criterion) {
-    let mut rng = ChaChaRng::from_os_rng();
+    let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
     let mut group = c.benchmark_group("wrapping ops");
 
     group.bench_function("div, I256/I128, full size", |b| {
@@ -180,7 +180,7 @@ fn bench_div(c: &mut Criterion) {
 }
 
 fn bench_add(c: &mut Criterion) {
-    let mut rng = ChaChaRng::from_os_rng();
+    let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
     let mut group = c.benchmark_group("wrapping ops");
 
     group.bench_function("add, I128+I128", |b| {
@@ -259,7 +259,7 @@ fn bench_add(c: &mut Criterion) {
 }
 
 fn bench_sub(c: &mut Criterion) {
-    let mut rng = ChaChaRng::from_os_rng();
+    let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
     let mut group = c.benchmark_group("wrapping ops");
 
     group.bench_function("sub, I128-I128", |b| {

--- a/benches/limb.rs
+++ b/benches/limb.rs
@@ -1,14 +1,14 @@
+use chacha20::ChaCha8Rng;
 use criterion::{
     BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
 use crypto_bigint::{Limb, Random};
-use rand_chacha::ChaChaRng;
 use rand_core::SeedableRng;
 use std::hint::black_box;
 use subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
 fn bench_cmp<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let mut rng = ChaChaRng::from_os_rng();
+    let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
     group.bench_function("ct_lt", |b| {
         b.iter_batched(
             || {

--- a/benches/monty.rs
+++ b/benches/monty.rs
@@ -1,3 +1,4 @@
+use chacha20::ChaCha8Rng;
 use criterion::{
     BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
@@ -5,7 +6,6 @@ use crypto_bigint::{
     Odd, Random, RandomMod, U256,
     modular::{MontyForm, MontyParams},
 };
-use rand_chacha::ChaChaRng;
 use rand_core::SeedableRng;
 use std::hint::black_box;
 
@@ -13,7 +13,7 @@ use std::hint::black_box;
 use crypto_bigint::MultiExponentiate;
 
 fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let mut rng = ChaChaRng::from_os_rng();
+    let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
     group.bench_function("MontyParams::new", |b| {
         b.iter_batched(
             || Odd::<U256>::random(&mut rng),
@@ -55,7 +55,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
 }
 
 fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let mut rng = ChaChaRng::from_os_rng();
+    let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
     let params = MontyParams::new_vartime(Odd::<U256>::random(&mut rng));
 
     group.bench_function("add, U256", |b| {

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -1,3 +1,4 @@
+use chacha20::ChaCha8Rng;
 use criterion::measurement::WallTime;
 use criterion::{
     BatchSize, BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main,
@@ -6,7 +7,6 @@ use crypto_bigint::{
     Gcd, Limb, NonZero, Odd, OddUint, Random, RandomBits, RandomMod, Reciprocal, U128, U256, U512,
     U1024, U2048, U4096, U8192, Uint,
 };
-use rand_chacha::ChaCha8Rng;
 use rand_core::{RngCore, SeedableRng};
 use std::hint::black_box;
 

--- a/src/int/div_uint.rs
+++ b/src/int/div_uint.rs
@@ -456,7 +456,7 @@ mod tests {
     #[cfg(feature = "rand_core")]
     use {
         crate::{I1024, Random, U512, U1024},
-        rand_chacha::ChaChaRng,
+        chacha20::ChaCha8Rng,
         rand_core::SeedableRng,
     };
 
@@ -488,10 +488,11 @@ mod tests {
         assert_eq!(I128::MAX / U128::MAX.to_nz().unwrap(), I128::ZERO);
     }
 
+    // TODO(tarcieri): use proptest
     #[cfg(feature = "rand_core")]
     #[test]
     fn test_div_ct_vs_vt() {
-        let mut rng = ChaChaRng::from_os_rng();
+        let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
         for _ in 0..50 {
             let num = I1024::random(&mut rng);
             let denom = U1024::from(&U512::random(&mut rng)).to_nz().unwrap();
@@ -556,10 +557,11 @@ mod tests {
         );
     }
 
+    // TODO(tarcieri): use proptest
     #[cfg(feature = "rand_core")]
     #[test]
     fn test_div_floor_ct_vs_vt() {
-        let mut rng = ChaChaRng::from_os_rng();
+        let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
         for _ in 0..50 {
             let num = I1024::random(&mut rng);
             let denom = U1024::from(&U512::random(&mut rng)).to_nz().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@
 //! ```
 //! # #[cfg(feature = "rand")]
 //! # {
-//! # use rand_chacha::ChaCha8Rng;
+//! # use chacha20::ChaCha8Rng;
 //! # use rand_core::SeedableRng;
 //! # fn rng() -> ChaCha8Rng {
 //! #     ChaCha8Rng::from_seed(*b"01234567890123456789012345678901")
@@ -138,7 +138,7 @@
 //! ```
 //! # #[cfg(feature = "rand")]
 //! # {
-//! # use rand_chacha::ChaCha8Rng;
+//! # use chacha20::ChaCha8Rng;
 //! # use rand_core::SeedableRng;
 //! # fn rng() -> ChaCha8Rng {
 //! #     ChaCha8Rng::from_seed(*b"01234567890123456789012345678901")

--- a/src/modular/boxed_monty_form/lincomb.rs
+++ b/src/modular/boxed_monty_form/lincomb.rs
@@ -38,7 +38,7 @@ mod tests {
 
         const SIZE: u32 = 511;
 
-        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+        let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
         for n in 0..100 {
             let modulus = Odd::<BoxedUint>::random(&mut rng, SIZE);
             let params = BoxedMontyParams::new(modulus.clone());

--- a/src/modular/const_monty_form/lincomb.rs
+++ b/src/modular/const_monty_form/lincomb.rs
@@ -35,7 +35,7 @@ mod tests {
         );
         let modulus = P::PARAMS.modulus.as_nz_ref();
 
-        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+        let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
         for n in 0..1000 {
             let a = U256::random_mod(&mut rng, modulus);
             let b = U256::random_mod(&mut rng, modulus);

--- a/src/modular/monty_form/lincomb.rs
+++ b/src/modular/monty_form/lincomb.rs
@@ -38,7 +38,7 @@ mod tests {
         };
         use rand_core::SeedableRng;
 
-        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+        let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
         for n in 0..1500 {
             let modulus = Odd::<U256>::random(&mut rng);
             let params = MontyParams::new_vartime(modulus);

--- a/src/uint/add_mod.rs
+++ b/src/uint/add_mod.rs
@@ -84,7 +84,7 @@ mod tests {
         ($size:expr, $test_name:ident) => {
             #[test]
             fn $test_name() {
-                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+                let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
                 let moduli = [
                     NonZero::<Limb>::random(&mut rng),
                     NonZero::<Limb>::random(&mut rng),

--- a/src/uint/boxed/encoding.rs
+++ b/src/uint/boxed/encoding.rs
@@ -589,7 +589,7 @@ mod tests {
     fn encode_radix_round_trip() {
         use crate::RandomBits;
         use rand_core::SeedableRng;
-        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+        let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
 
         for _ in 0..100 {
             let uint = BoxedUint::random_bits(&mut rng, 4096);

--- a/src/uint/boxed/mul.rs
+++ b/src/uint/boxed/mul.rs
@@ -221,7 +221,7 @@ mod tests {
     fn mul_cmp() {
         use crate::{RandomBits, Resize};
         use rand_core::SeedableRng;
-        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+        let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
 
         for i in 0..50 {
             let a = BoxedUint::random_bits(&mut rng, 4096);

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -99,7 +99,7 @@ mod tests {
         ($size:expr, $test_name:ident) => {
             #[test]
             fn $test_name() {
-                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+                let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
                 let moduli = [
                     NonZero::<Limb>::random(&mut rng),
                     NonZero::<Limb>::random(&mut rng),

--- a/src/uint/boxed/rand.rs
+++ b/src/uint/boxed/rand.rs
@@ -57,7 +57,7 @@ mod tests {
 
     #[test]
     fn random() {
-        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+        let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
 
         let r = BoxedUint::random_bits(&mut rng, 256);
         assert!(r.bits_precision() == 256);
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn random_mod() {
-        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+        let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
 
         // Ensure `random_mod` runs in a reasonable amount of time
         let modulus = NonZero::new(BoxedUint::from(42u8)).unwrap();

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -138,7 +138,7 @@ mod tests {
     #[cfg(feature = "rand")]
     use {
         crate::RandomBits,
-        rand_chacha::ChaChaRng,
+        chacha20::ChaCha8Rng,
         rand_core::{RngCore, SeedableRng},
     };
 
@@ -291,7 +291,7 @@ mod tests {
     #[cfg(feature = "rand")]
     #[test]
     fn fuzz() {
-        let mut rng = ChaChaRng::from_seed([7u8; 32]);
+        let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
         for _ in 0..50 {
             let t = rng.next_u32() as u64;
             let s = BoxedUint::from(t);

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -673,7 +673,7 @@ mod tests {
     };
 
     #[cfg(feature = "rand")]
-    use {crate::Random, rand_chacha::ChaChaRng, rand_core::RngCore, rand_core::SeedableRng};
+    use {crate::Random, chacha20::ChaCha8Rng, rand_core::RngCore, rand_core::SeedableRng};
 
     #[test]
     fn div_word() {
@@ -703,7 +703,7 @@ mod tests {
     #[cfg(feature = "rand")]
     #[test]
     fn div() {
-        let mut rng = ChaChaRng::from_seed([7u8; 32]);
+        let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
         for _ in 0..25 {
             let num = U256::random(&mut rng).overflowing_shr_vartime(128).unwrap();
             let den =
@@ -898,7 +898,7 @@ mod tests {
     #[cfg(feature = "rand")]
     #[test]
     fn rem2krand() {
-        let mut rng = ChaChaRng::from_seed([7u8; 32]);
+        let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
         for _ in 0..25 {
             let num = U256::random(&mut rng);
             let k = rng.next_u32() % 256;

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -1036,7 +1036,7 @@ mod tests {
     fn encode_radix_round_trip() {
         use crate::{Random, U256};
         use rand_core::SeedableRng;
-        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+        let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
 
         for _ in 0..100 {
             let uint = U256::random(&mut rng);

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -398,7 +398,7 @@ mod tests {
     fn mul_cmp() {
         use crate::{Random, U4096};
         use rand_core::SeedableRng;
-        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+        let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
 
         for _ in 0..50 {
             let a = U4096::random(&mut rng);

--- a/src/uint/mul/karatsuba.rs
+++ b/src/uint/mul/karatsuba.rs
@@ -559,7 +559,7 @@ mod tests {
     #[test]
     fn wrapping_mul_sizes() {
         const SIZE: usize = 200;
-        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+        let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
         for n in 0..100 {
             let a = Uint::<SIZE>::random(&mut rng);
             let b = Uint::<SIZE>::random(&mut rng);
@@ -585,7 +585,7 @@ mod tests {
     #[test]
     fn wrapping_square_sizes() {
         const SIZE: usize = 200;
-        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+        let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
         for n in 0..100 {
             let a = Uint::<SIZE>::random(&mut rng);
             let size_a = rng.next_u32() as usize % SIZE;

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -108,7 +108,7 @@ mod tests {
         ($size:expr, $test_name:ident) => {
             #[test]
             fn $test_name() {
-                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+                let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
                 let moduli = [
                     NonZero::<Limb>::random(&mut rng),
                     NonZero::<Limb>::random(&mut rng),

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -166,7 +166,7 @@ where
 mod tests {
     use crate::uint::rand::random_bits_core;
     use crate::{Limb, NonZero, Random, RandomBits, RandomMod, U256, U1024, Uint};
-    use rand_chacha::ChaCha8Rng;
+    use chacha20::ChaCha8Rng;
     use rand_core::{RngCore, SeedableRng};
 
     const RANDOM_OUTPUT: U1024 = Uint::from_be_hex(concat![

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -125,7 +125,7 @@ mod tests {
     #[cfg(feature = "rand")]
     use {
         crate::{Random, U512},
-        rand_chacha::ChaChaRng,
+        chacha20::ChaCha8Rng,
         rand_core::{RngCore, SeedableRng},
     };
 
@@ -236,7 +236,7 @@ mod tests {
     #[cfg(feature = "rand")]
     #[test]
     fn fuzz() {
-        let mut rng = ChaChaRng::from_seed([7u8; 32]);
+        let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
         for _ in 0..50 {
             let t = rng.next_u32() as u64;
             let s = U256::from(t);

--- a/src/uint/sub_mod.rs
+++ b/src/uint/sub_mod.rs
@@ -80,7 +80,7 @@ mod tests {
         ($size:expr, $test_name:ident) => {
             #[test]
             fn $test_name() {
-                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+                let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
                 let moduli = [
                     NonZero::<Uint<$size>>::random(&mut rng),
                     NonZero::<Uint<$size>>::random(&mut rng),
@@ -133,7 +133,7 @@ mod tests {
         ($size:expr, $test_name:ident) => {
             #[test]
             fn $test_name() {
-                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+                let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
                 let moduli = [
                     NonZero::<Limb>::random(&mut rng),
                     NonZero::<Limb>::random(&mut rng),


### PR DESCRIPTION
Also migrates from `rand_chacha` to `chacha20` for an RNG