### PR TITLE
Add `U8320` and `U12288`

### DIFF
--- a/src/uint/extra_sizes.rs
+++ b/src/uint/extra_sizes.rs
@@ -110,7 +110,7 @@ impl_uint_aliases! {
     (U8064, 8064, "8064-bit"),
     (U8128, 8128, "8128-bit"),
     (U8320, 8320, "8320-bit"),
-    (U12288, 12288, "12288-bit"),
+    (U12288, 12288, "12288-bit")
 }
 
 impl_uint_concat_split_even! {
@@ -160,5 +160,5 @@ impl_uint_concat_split_even! {
     U7936,
     U8064,
     U8320,
-    U12288
+    U12288,
 }


### PR DESCRIPTION
In https://github.com/RustCrypto/crypto-bigint/issues/228 and https://github.com/RustCrypto/crypto-bigint/pull/229 extra sizes up to 8k were implemented. In some usages, we need the extra sizes to go up to 16k (for example when two 6k numbers are multiplied).

For our use-case `U12288` and `8320` in addition to extra-sizes would be enough, but for completeness, I added all values in 64 bit increments to a new feature `extra-sizes-16k`.

Let me know if you would rather prefer if we only add these two extra-sizes we need to `extra-sizes` feature.