### PR TITLE
Revert "BREAKING: Make random_mod platform-independent"

### DIFF
--- a/src/uint/boxed/rand.rs
+++ b/src/uint/boxed/rand.rs
@@ -28,7 +28,7 @@ impl RandomBits for BoxedUint {
         }
 
         let mut ret = BoxedUint::zero_with_precision(bits_precision);
-        random_bits_core(rng, &mut ret.limbs, bit_length).map_err(RandomBitsError::RandCore)?;
+        random_bits_core(rng, &mut ret.limbs, bit_length)?;
         Ok(ret)
     }
 }


### PR DESCRIPTION
This reverts commit 62b90b8b39263d4970853e2ecfada62646bc8428 (#1010)

We're noticing CI failures on cross which seem to be related to this
change, e.g.

https://github.com/RustCrypto/crypto-bigint/actions/runs/19647957432/job/56267760132

It looks like it's potentially getting stuck in an infinite loop.

cc @mrdomino @fjarri 