### PR TITLE
BREAKING: Make `random_mod_core` platform-independent (take 2)

### DIFF
--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -147,7 +147,7 @@ where
             // Read entropy in 64-bit blocks, even on 32-bit platforms.
             let _ = rng.try_next_u32()?;
         }
-        // Do a manual, variable-time comparison loop here to avoid a copiler bug that causes a
+        // Do a manual, variable-time comparison loop here to avoid a compiler bug that causes a
         // hang on linux-aarch64 under `--release` with `Uint` of 5 or more limbs using `ct_lt`.
         let x = x.as_ref();
         let n = n.as_ref().as_ref();


### PR DESCRIPTION
This introduces a fairly robust platform-independence test for `random_mod_core`. The test exercises the rejection sampling and also the way multi-word `Uint`s are constructed, which changed in this PR, as you can see in commit d2f4b89:
```diff
-            U256::from_be_hex("C54302F2EB1E2F69C3B919AE0D16DF2259CD1A8A9B8EA8E0862878227D4B40A3")
+            U256::from_be_hex("C3B919AE0D16DF2259CD1A8A9B8EA8E0862878227D4B40A3C54302F2EB1E2F69")
```

The difference, under most circumstances, is just that word order will be rotated; the old entropy gathering approach independently rejection-sampled the high word first, then built up the rest, so the resulting `Uint` was sort of like `(MSW, LSW, LSW+1, …, MSW-1)` over the raw entropy stream, except in cases where the high-word rejection sample triggered, in which case it was a trickier transform. The new interpretation is simply little-endian, both bytewise and wordwise, aligned to 64-bit word boundaries.

I elected to make this change for two reasons:
1. It is more aesthetically pleasing to me personally.
2. More importantly, with this change we actually _are_ changing the way we sample entropy in `random_mod`, particularly in rare cases of multiple rejection samples over the most significant word. Rather than make this a rare, subtle, difficult-to-detect change that will bite people unexpectedly, I elected to make this a big, obvious, easy-to-detect change that people will usually notice.

To work around the apparent compiler bug that required #1010 to be reverted (See #1018 for exploration of the bug), I also elected to make the comparison loop variable-time rather than using `ct_lt`, since the latter is what seems to trigger the bug. My defense is that `random_mod` is already variable-time; it leaks RNG state via timing information every time it rejection-samples. (It might be a good idea to rename it to `random_mod_vartime`, since AFAICT leaking this timing information is unavoidable in the general case.)

By making this change, we are able to carry through the prior copy-elision optimization from master, resulting in an implementation that performs about at parity with master in the benchmarks I ran.

One other note: I elected to take 64-bit rather than 32-bit words as primary here, i.e., 32-bit platforms need to adjust by sampling and discarding an extra word in odd cases rather than 64-bit platforms needing to adjust by only sampling half a word in those cases. Both are doable, but operating in terms of 64-bit word sizes frees us from the constraint of our RNG needing to be "4-byte sequential."

Fixes #1009