### PR TITLE
BREAKING: Write `random_mod` in terms of new `random_bits`

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -641,7 +641,6 @@ pub trait Encoding: Sized {
     /// Byte array representation.
     type Repr: AsRef<[u8]>
         + AsMut<[u8]>
-        + Copy
         + Clone
         + Sized
         + for<'a> TryFrom<&'a [u8], Error: core::error::Error>;

--- a/src/uint/boxed/encoding.rs
+++ b/src/uint/boxed/encoding.rs
@@ -1,7 +1,7 @@
 //! Const-friendly decoding operations for [`BoxedUint`].
 
 use super::BoxedUint;
-use crate::{DecodeError, Limb, Word, uint::encoding};
+use crate::{DecodeError, Encoding, Limb, Word, uint::encoding};
 use alloc::{boxed::Box, string::String, vec::Vec};
 use subtle::{Choice, CtOption};
 
@@ -242,6 +242,28 @@ impl BoxedUint {
     /// Panics if `radix` is not in the range from 2 to 36.
     pub fn to_string_radix_vartime(&self, radix: u32) -> String {
         encoding::radix_encode_limbs_to_string(radix, &self.limbs)
+    }
+}
+
+impl Encoding for BoxedUint {
+    type Repr = Box<[u8]>;
+
+    fn to_be_bytes(&self) -> Self::Repr {
+        BoxedUint::to_be_bytes(self)
+    }
+
+    fn to_le_bytes(&self) -> Self::Repr {
+        BoxedUint::to_le_bytes(self)
+    }
+
+    fn from_be_bytes(bytes: Self::Repr) -> Self {
+        BoxedUint::from_be_slice(&bytes, (bytes.len() * 8).try_into().expect("overflow"))
+            .expect("decode error")
+    }
+
+    fn from_le_bytes(bytes: Self::Repr) -> Self {
+        BoxedUint::from_le_slice(&bytes, (bytes.len() * 8).try_into().expect("overflow"))
+            .expect("decode error")
     }
 }
 

--- a/src/uint/boxed/rand.rs
+++ b/src/uint/boxed/rand.rs
@@ -28,7 +28,7 @@ impl RandomBits for BoxedUint {
         }
 
         let mut ret = BoxedUint::zero_with_precision(bits_precision);
-        random_bits_core(rng, &mut ret.limbs, bit_length)?;
+        random_bits_core(rng, &mut ret, bit_length).map_err(RandomBitsError::RandCore)?;
         Ok(ret)
     }
 }

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -1,7 +1,7 @@
 //! Random number generator support
 
-use super::{Uint, Word};
-use crate::{Encoding, Limb, NonZero, Random, RandomBits, RandomBitsError, RandomMod, Zero};
+use super::Uint;
+use crate::{Encoding, Limb, NonZero, Random, RandomBits, RandomBitsError, RandomMod};
 use rand_core::{RngCore, TryRngCore};
 use subtle::ConstantTimeLess;
 
@@ -26,45 +26,26 @@ impl<const LIMBS: usize> Random for Uint<LIMBS> {
 /// `rng.fill_bytes(&mut bytes[..i]); rng.fill_bytes(&mut bytes[i..])` constructs the same `bytes`,
 /// as long as `i` is a multiple of `X`.
 /// Note that the `TryRngCore` trait does _not_ require this behaviour from `rng`.
-pub(crate) fn random_bits_core<R: TryRngCore + ?Sized>(
+pub(crate) fn random_bits_core<T, R: TryRngCore + ?Sized>(
     rng: &mut R,
-    zeroed_limbs: &mut [Limb],
-    bit_length: u32,
-) -> Result<(), RandomBitsError<R::Error>> {
-    if bit_length == 0 {
+    x: &mut T,
+    n_bits: u32,
+) -> Result<(), R::Error>
+where
+    T: Encoding,
+{
+    if n_bits == 0 {
         return Ok(());
     }
 
-    let buffer: Word = 0;
-    let mut buffer = buffer.to_be_bytes();
+    let n_bytes = n_bits.div_ceil(u8::BITS) as usize;
+    let hi_mask = u8::MAX >> ((u8::BITS - (n_bits % u8::BITS)) % u8::BITS);
 
-    let nonzero_limbs = bit_length.div_ceil(Limb::BITS) as usize;
-    let partial_limb = bit_length % Limb::BITS;
-    let mask = Word::MAX >> ((Word::BITS - partial_limb) % Word::BITS);
-
-    for i in 0..nonzero_limbs - 1 {
-        rng.try_fill_bytes(&mut buffer)
-            .map_err(RandomBitsError::RandCore)?;
-        zeroed_limbs[i] = Limb(Word::from_le_bytes(buffer));
-    }
-
-    // This algorithm should sample the same number of random bytes, regardless of the pointer width
-    // of the target platform. To this end, special attention has to be paid to the case where
-    // bit_length - 1 < 32 mod 64. Bit strings of that size can be represented using `2X+1` 32-bit
-    // words or `X+1` 64-bit words. Note that 64*(X+1) - 32*(2X+1) = 32. Hence, if we sample full
-    // words only, a 64-bit platform will sample 32 bits more than a 32-bit platform. We prevent
-    // this by forcing both platforms to only sample 4 bytes for the last word in this case.
-    let slice = if partial_limb > 0 && partial_limb <= 32 {
-        // Note: we do not have to zeroize the second half of the buffer, as the mask will take
-        // care of this in the end.
-        &mut buffer[0..4]
-    } else {
-        buffer.as_mut_slice()
-    };
-
-    rng.try_fill_bytes(slice)
-        .map_err(RandomBitsError::RandCore)?;
-    zeroed_limbs[nonzero_limbs - 1] = Limb(Word::from_le_bytes(buffer) & mask);
+    let mut buffer = x.to_le_bytes();
+    let slice = buffer.as_mut();
+    rng.try_fill_bytes(&mut slice[..n_bytes])?;
+    slice[n_bytes - 1] &= hi_mask;
+    *x = T::from_le_bytes(buffer);
 
     Ok(())
 }
@@ -94,26 +75,26 @@ impl<const LIMBS: usize> RandomBits for Uint<LIMBS> {
                 bits_precision,
             });
         }
-        let mut limbs = [Limb::ZERO; LIMBS];
-        random_bits_core(rng, &mut limbs, bit_length)?;
-        Ok(Self::from(limbs))
+        let mut x = Self::ZERO;
+        random_bits_core(rng, &mut x, bit_length).map_err(RandomBitsError::RandCore)?;
+        Ok(x)
     }
 }
 
 impl<const LIMBS: usize> RandomMod for Uint<LIMBS> {
     fn random_mod<R: RngCore + ?Sized>(rng: &mut R, modulus: &NonZero<Self>) -> Self {
-        let mut n = Self::ZERO;
-        let Ok(()) = random_mod_core(rng, &mut n, modulus, modulus.bits_vartime());
-        n
+        let mut x = Self::ZERO;
+        let Ok(()) = random_mod_core(rng, &mut x, modulus, modulus.bits_vartime());
+        x
     }
 
     fn try_random_mod<R: TryRngCore + ?Sized>(
         rng: &mut R,
         modulus: &NonZero<Self>,
     ) -> Result<Self, R::Error> {
-        let mut n = Self::ZERO;
-        random_mod_core(rng, &mut n, modulus, modulus.bits_vartime())?;
-        Ok(n)
+        let mut x = Self::ZERO;
+        random_mod_core(rng, &mut x, modulus, modulus.bits_vartime())?;
+        Ok(x)
     }
 }
 
@@ -121,45 +102,19 @@ impl<const LIMBS: usize> RandomMod for Uint<LIMBS> {
 // TODO(tarcieri): obtain `n_bits` via a trait like `Integer`
 pub(super) fn random_mod_core<T, R: TryRngCore + ?Sized>(
     rng: &mut R,
-    n: &mut T,
+    x: &mut T,
     modulus: &NonZero<T>,
     n_bits: u32,
 ) -> Result<(), R::Error>
 where
-    T: AsMut<[Limb]> + AsRef<[Limb]> + ConstantTimeLess + Zero,
+    T: Encoding + ConstantTimeLess,
 {
-    #[cfg(target_pointer_width = "64")]
-    let mut next_word = || rng.try_next_u64();
-    #[cfg(target_pointer_width = "32")]
-    let mut next_word = || rng.try_next_u32();
-
-    let n_limbs = n_bits.div_ceil(Limb::BITS) as usize;
-
-    let hi_word_modulus = modulus.as_ref().as_ref()[n_limbs - 1].0;
-    let mask = !0 >> hi_word_modulus.leading_zeros();
-    let mut hi_word = next_word()? & mask;
-
     loop {
-        while hi_word > hi_word_modulus {
-            hi_word = next_word()? & mask;
+        random_bits_core(rng, x, n_bits)?;
+        if x.ct_lt(modulus).into() {
+            return Ok(());
         }
-        // Set high limb
-        n.as_mut()[n_limbs - 1] = Limb::from_le_bytes(hi_word.to_le_bytes());
-        // Set low limbs
-        for i in 0..n_limbs - 1 {
-            // Need to deserialize from little-endian to make sure that two 32-bit limbs
-            // deserialized sequentially are equal to one 64-bit limb produced from the same
-            // byte stream.
-            n.as_mut()[i] = Limb::from_le_bytes(next_word()?.to_le_bytes());
-        }
-        // If the high limb is equal to the modulus' high limb, it's still possible
-        // that the full uint is too big so we check and repeat if it is.
-        if n.ct_lt(modulus).into() {
-            break;
-        }
-        hi_word = next_word()? & mask;
     }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -269,7 +224,7 @@ mod tests {
 
         let bit_length = 989;
         let mut val = U1024::ZERO;
-        random_bits_core(&mut rng, val.as_mut_limbs(), bit_length).expect("safe");
+        random_bits_core(&mut rng, &mut val, bit_length).expect("safe");
 
         assert_eq!(
             val,
@@ -298,7 +253,7 @@ mod tests {
         for val in &mut vals {
             *val = U256::random_mod(&mut rng, &modulus);
         }
-        let expected = [55, 2172, 1657, 4668, 7688];
+        let expected = [55, 3378, 2172, 1657, 5323];
         for (want, got) in expected.into_iter().zip(vals.into_iter()) {
             // assert_eq!(got.as_words()[0], want);
             assert_eq!(got, U256::from_u32(want));
@@ -309,7 +264,7 @@ mod tests {
         let val = U256::random_mod(&mut rng, &modulus);
         assert_eq!(
             val,
-            U256::from_be_hex("C54302F2EB1E2F69C3B919AE0D16DF2259CD1A8A9B8EA8E0862878227D4B40A3")
+            U256::from_be_hex("E17653A37F1BCC44277FA208E6B31E08CDC4A23A7E88E660EF781C7DD2D368BA")
         );
 
         let mut state = [0u8; 16];
@@ -318,7 +273,7 @@ mod tests {
         assert_eq!(
             state,
             [
-                71, 204, 238, 147, 198, 196, 132, 164, 240, 211, 223, 12, 36, 189, 139, 48,
+                105, 47, 30, 235, 242, 2, 67, 197, 163, 64, 75, 125, 34, 120, 40, 134,
             ],
         );
     }
@@ -333,9 +288,8 @@ mod tests {
             let mut rng = get_four_sequential_rng();
             let mut first = U1024::ZERO;
             let mut second = U1024::ZERO;
-            random_bits_core(&mut rng, first.as_mut_limbs(), bit_length).expect("safe");
-            random_bits_core(&mut rng, second.as_mut_limbs(), U1024::BITS - bit_length)
-                .expect("safe");
+            random_bits_core(&mut rng, &mut first, bit_length).expect("safe");
+            random_bits_core(&mut rng, &mut second, U1024::BITS - bit_length).expect("safe");
             assert_eq!(second.shl(bit_length).bitor(&first), RANDOM_OUTPUT);
         }
     }

--- a/tests/monty_form.rs
+++ b/tests/monty_form.rs
@@ -53,7 +53,7 @@ where
     T: Unsigned + Bounded + Encoding,
     <T as Unsigned>::Monty: Invert<Output = CtOption<T::Monty>>,
 {
-    let r = T::from_be_bytes(bytes);
+    let r = T::from_be_bytes(bytes.clone());
     let rm = <T as Unsigned>::Monty::new(r.clone(), monty_params);
     let rm_inv = rm.invert();
     prop_assume!(bool::from(rm_inv.is_some()), "r={:?} is not invertible", r);


### PR DESCRIPTION
## Breaking changes

- `Encoding::Repr` is no longer required to implement `Copy`, so consumers of `Encoding::Repr` will need to explicitly call `clone`.

- The numbers produced by both `random_bits` and `random_mod` will generally be different, and calling these functions will leave the RNG in a different state, than before.

## Fixes

- Adds a mitigation for rust-lang/rust#149522, modifying `Word::borrowing_sub` to use `overflowing_sub` instead of `WideWord` casts.

## Summary

This essentially applies https://github.com/RustCrypto/crypto-bigint/pull/285 to `random_bits` as well as `random_mod`. Both functions behave the same way now, with the only difference being that `random_mod` adds rejection sampling; otherwise both will produce the same numbers over the same entropy stream.

Questions of platform dependence are now easy; we do not define these algorithms in terms of sequences of machine words but of bytes. Randomly sampled `Uint`s are now always constructed little-endian over the entropy stream. This does not preclude future machine-specific optimizations, but given how perilous the landscape has been (e.g. #1018), I’ve elected to err in the direction of parsimony rather than performance for this change.

This leverages the existing work making `Uint` implement `Encoding`. It additionally needs `Encoding` on `BoxedUint` to make `RandomMod` and `RandomBits` work there; this is implemented, but requires dropping the `Copy` constraint on `Encoding::Repr`.

Fixes #1009

[0]: https://github.com/rust-lang/rust/issues/149522