### PR TITLE
Rename `random_mod` ↦ `random_mod_vartime`

### DIFF
--- a/benches/boxed_monty.rs
+++ b/benches/boxed_monty.rs
@@ -25,11 +25,11 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 let a = BoxedMontyForm::new(
-                    BoxedUint::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params.clone(),
                 );
                 let b = BoxedMontyForm::new(
-                    BoxedUint::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params.clone(),
                 );
                 (a, b)
@@ -43,7 +43,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 BoxedMontyForm::new(
-                    BoxedUint::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params.clone(),
                 )
             },
@@ -56,11 +56,11 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 let a = BoxedMontyForm::new(
-                    BoxedUint::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params.clone(),
                 );
                 let b = BoxedMontyForm::new(
-                    BoxedUint::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params.clone(),
                 );
                 (a, b)
@@ -74,7 +74,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 BoxedMontyForm::new(
-                    BoxedUint::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params.clone(),
                 )
             },
@@ -87,7 +87,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 BoxedMontyForm::new(
-                    BoxedUint::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params.clone(),
                 )
             },
@@ -100,11 +100,11 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 let x = BoxedMontyForm::new(
-                    BoxedUint::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params.clone(),
                 );
                 let y = BoxedMontyForm::new(
-                    BoxedUint::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params.clone(),
                 );
                 (x, y)
@@ -165,7 +165,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             b.iter_batched(
                 || {
                     BoxedMontyForm::new(
-                        BoxedUint::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                        BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                         params.clone(),
                     )
                 },

--- a/benches/const_monty.rs
+++ b/benches/const_monty.rs
@@ -21,7 +21,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
     let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
     group.bench_function("ConstMontyForm creation", |b| {
         b.iter_batched(
-            || U256::random_mod(&mut rng, Modulus::PARAMS.modulus().as_nz_ref()),
+            || U256::random_mod_vartime(&mut rng, Modulus::PARAMS.modulus().as_nz_ref()),
             |x| black_box(ConstMontyForm::new(&x)),
             BatchSize::SmallInput,
         )

--- a/benches/monty.rs
+++ b/benches/monty.rs
@@ -33,7 +33,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
     let params = MontyParams::new_vartime(Odd::<U256>::random(&mut rng));
     group.bench_function("MontyForm::new", |b| {
         b.iter_batched(
-            || U256::random_mod(&mut rng, params.modulus().as_nz_ref()),
+            || U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
             |x| black_box(MontyForm::new(&x, params)),
             BatchSize::SmallInput,
         )
@@ -44,7 +44,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
         b.iter_batched(
             || {
                 MontyForm::new(
-                    &U256::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params,
                 )
             },
@@ -62,11 +62,11 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 let a = MontyForm::new(
-                    &U256::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params,
                 );
                 let b = MontyForm::new(
-                    &U256::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params,
                 );
                 (a, b)
@@ -80,7 +80,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 MontyForm::new(
-                    &U256::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params,
                 )
             },
@@ -93,11 +93,11 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 let a = MontyForm::new(
-                    &U256::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params,
                 );
                 let b = MontyForm::new(
-                    &U256::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params,
                 );
                 (a, b)
@@ -111,7 +111,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 MontyForm::new(
-                    &U256::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params,
                 )
             },
@@ -124,7 +124,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 MontyForm::new(
-                    &U256::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params,
                 )
             },
@@ -137,11 +137,11 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 let x = MontyForm::new(
-                    &U256::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params,
                 );
                 let y = MontyForm::new(
-                    &U256::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params,
                 );
                 (x, y)
@@ -155,7 +155,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 MontyForm::new(
-                    &U256::random_mod(&mut rng, params.modulus().as_nz_ref()),
+                    &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
                     params,
                 )
             },
@@ -167,9 +167,9 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("modpow, U256^U256", |b| {
         b.iter_batched(
             || {
-                let x = U256::random_mod(&mut rng, params.modulus().as_nz_ref());
+                let x = U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref());
                 let x_m = MontyForm::new(&x, params);
-                let p = U256::random_mod(&mut rng, params.modulus().as_nz_ref())
+                let p = U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref())
                     | (U256::ONE << (U256::BITS - 1));
                 (x_m, p)
             },
@@ -181,7 +181,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("div_by_2, U256", |b| {
         b.iter_batched(
             || {
-                let x = U256::random_mod(&mut rng, params.modulus().as_nz_ref());
+                let x = U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref());
                 MontyForm::new(&x, params)
             },
             |x| black_box(x.div_by_2()),
@@ -198,10 +198,15 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                     || {
                         let bases_and_exponents: Vec<(MontyForm<{ U256::LIMBS }>, U256)> = (1..=i)
                             .map(|_| {
-                                let x = U256::random_mod(&mut rng, params.modulus().as_nz_ref());
+                                let x = U256::random_mod_vartime(
+                                    &mut rng,
+                                    params.modulus().as_nz_ref(),
+                                );
                                 let x_m = MontyForm::new(&x, params);
-                                let p = U256::random_mod(&mut rng, params.modulus().as_nz_ref())
-                                    | (U256::ONE << (U256::BITS - 1));
+                                let p = U256::random_mod_vartime(
+                                    &mut rng,
+                                    params.modulus().as_nz_ref(),
+                                ) | (U256::ONE << (U256::BITS - 1));
                                 (x_m, p)
                             })
                             .collect();

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -18,10 +18,10 @@ fn bench_random(c: &mut Criterion) {
     let mut group = c.benchmark_group("bounded random");
 
     let mut rng = make_rng();
-    group.bench_function("random_mod, U1024", |b| {
+    group.bench_function("random_mod_vartime, U1024", |b| {
         let bound = U1024::random(&mut rng);
         let bound_nz = NonZero::new(bound).unwrap();
-        b.iter(|| black_box(U1024::random_mod(&mut rng, &bound_nz)));
+        b.iter(|| black_box(U1024::random_mod_vartime(&mut rng, &bound_nz)));
     });
 
     let mut rng = make_rng();
@@ -38,10 +38,10 @@ fn bench_random(c: &mut Criterion) {
     });
 
     let mut rng = make_rng();
-    group.bench_function("random_mod, U1024, small bound", |b| {
+    group.bench_function("random_mod_vartime, U1024, small bound", |b| {
         let bound = U1024::from_u64(rng.next_u64());
         let bound_nz = NonZero::new(bound).unwrap();
-        b.iter(|| black_box(U1024::random_mod(&mut rng, &bound_nz)));
+        b.iter(|| black_box(U1024::random_mod_vartime(&mut rng, &bound_nz)));
     });
 
     let mut rng = make_rng();
@@ -58,11 +58,11 @@ fn bench_random(c: &mut Criterion) {
     });
 
     let mut rng = make_rng();
-    group.bench_function("random_mod, U1024, 512 bit bound low", |b| {
+    group.bench_function("random_mod_vartime, U1024, 512 bit bound low", |b| {
         let bound = U512::random(&mut rng);
         let bound = U1024::from((bound, U512::ZERO));
         let bound_nz = NonZero::new(bound).unwrap();
-        b.iter(|| black_box(U1024::random_mod(&mut rng, &bound_nz)));
+        b.iter(|| black_box(U1024::random_mod_vartime(&mut rng, &bound_nz)));
     });
 
     let mut rng = make_rng();
@@ -80,11 +80,11 @@ fn bench_random(c: &mut Criterion) {
     });
 
     let mut rng = make_rng();
-    group.bench_function("random_mod, U1024, 512 bit bound hi", |b| {
+    group.bench_function("random_mod_vartime, U1024, 512 bit bound hi", |b| {
         let bound = U512::random(&mut rng);
         let bound = U1024::from((U512::ZERO, bound));
         let bound_nz = NonZero::new(bound).unwrap();
-        b.iter(|| black_box(U1024::random_mod(&mut rng, &bound_nz)));
+        b.iter(|| black_box(U1024::random_mod_vartime(&mut rng, &bound_nz)));
     });
 
     let mut rng = make_rng();
@@ -103,11 +103,11 @@ fn bench_random(c: &mut Criterion) {
 
     // Slow case: the hi limb is just `2`
     let mut rng = make_rng();
-    group.bench_function("random_mod, U1024, tiny high limb", |b| {
+    group.bench_function("random_mod_vartime, U1024, tiny high limb", |b| {
         let hex_1024 = "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000291A6B42D1C7D2A7184D13E36F65773BBEFB4FA7996101300D49F09962A361F00";
         let modulus = U1024::from_be_hex(hex_1024);
         let modulus_nz = NonZero::new(modulus).unwrap();
-        b.iter(|| black_box(U1024::random_mod(&mut rng, &modulus_nz)));
+        b.iter(|| black_box(U1024::random_mod_vartime(&mut rng, &modulus_nz)));
     });
 
     // Slow case: the hi limb is just `2`
@@ -250,7 +250,7 @@ fn bench_mul(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let m = Odd::<U256>::random(&mut rng);
-                let x = U256::random_mod(&mut rng, m.as_nz_ref());
+                let x = U256::random_mod_vartime(&mut rng, m.as_nz_ref());
                 (m.to_nz().unwrap(), x)
             },
             |(m, x)| black_box(x).mul_mod(black_box(&x), &m),
@@ -262,7 +262,7 @@ fn bench_mul(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let m = Odd::<U256>::random(&mut rng);
-                let x = U256::random_mod(&mut rng, m.as_nz_ref());
+                let x = U256::random_mod_vartime(&mut rng, m.as_nz_ref());
                 (m.to_nz().unwrap(), x)
             },
             |(m, x)| black_box(x).mul_mod_vartime(black_box(&x), &m),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@
 //! use crypto_bigint::{NonZero, RandomMod, U256};
 //!
 //! let modulus = NonZero::new(U256::from(3u8)).unwrap();
-//! let n = U256::random_mod(&mut rng(), &modulus);
+//! let n = U256::random_mod_vartime(&mut rng(), &modulus);
 //! # }
 //! ```
 //!

--- a/src/limb/rand.rs
+++ b/src/limb/rand.rs
@@ -17,7 +17,7 @@ impl Random for Limb {
 }
 
 impl RandomMod for Limb {
-    fn try_random_mod<R: TryRngCore + ?Sized>(
+    fn try_random_mod_vartime<R: TryRngCore + ?Sized>(
         rng: &mut R,
         modulus: &NonZero<Self>,
     ) -> Result<Self, R::Error> {

--- a/src/modular/boxed_monty_form/lincomb.rs
+++ b/src/modular/boxed_monty_form/lincomb.rs
@@ -42,12 +42,12 @@ mod tests {
         for n in 0..100 {
             let modulus = Odd::<BoxedUint>::random(&mut rng, SIZE);
             let params = BoxedMontyParams::new(modulus.clone());
-            let a = BoxedUint::random_mod(&mut rng, modulus.as_nz_ref());
-            let b = BoxedUint::random_mod(&mut rng, modulus.as_nz_ref());
-            let c = BoxedUint::random_mod(&mut rng, modulus.as_nz_ref());
-            let d = BoxedUint::random_mod(&mut rng, modulus.as_nz_ref());
-            let e = BoxedUint::random_mod(&mut rng, modulus.as_nz_ref());
-            let f = BoxedUint::random_mod(&mut rng, modulus.as_nz_ref());
+            let a = BoxedUint::random_mod_vartime(&mut rng, modulus.as_nz_ref());
+            let b = BoxedUint::random_mod_vartime(&mut rng, modulus.as_nz_ref());
+            let c = BoxedUint::random_mod_vartime(&mut rng, modulus.as_nz_ref());
+            let d = BoxedUint::random_mod_vartime(&mut rng, modulus.as_nz_ref());
+            let e = BoxedUint::random_mod_vartime(&mut rng, modulus.as_nz_ref());
+            let f = BoxedUint::random_mod_vartime(&mut rng, modulus.as_nz_ref());
 
             let std = a
                 .mul_mod(&b, modulus.as_nz_ref())

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -226,7 +226,7 @@ where
 {
     #[inline]
     fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        Ok(Self::new(&Uint::try_random_mod(
+        Ok(Self::new(&Uint::try_random_mod_vartime(
             rng,
             MOD::PARAMS.modulus.as_nz_ref(),
         )?))

--- a/src/modular/const_monty_form/lincomb.rs
+++ b/src/modular/const_monty_form/lincomb.rs
@@ -37,12 +37,12 @@ mod tests {
 
         let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
         for n in 0..1000 {
-            let a = U256::random_mod(&mut rng, modulus);
-            let b = U256::random_mod(&mut rng, modulus);
-            let c = U256::random_mod(&mut rng, modulus);
-            let d = U256::random_mod(&mut rng, modulus);
-            let e = U256::random_mod(&mut rng, modulus);
-            let f = U256::random_mod(&mut rng, modulus);
+            let a = U256::random_mod_vartime(&mut rng, modulus);
+            let b = U256::random_mod_vartime(&mut rng, modulus);
+            let c = U256::random_mod_vartime(&mut rng, modulus);
+            let d = U256::random_mod_vartime(&mut rng, modulus);
+            let e = U256::random_mod_vartime(&mut rng, modulus);
+            let f = U256::random_mod_vartime(&mut rng, modulus);
 
             assert_eq!(
                 a.mul_mod(&b, modulus)

--- a/src/modular/monty_form/lincomb.rs
+++ b/src/modular/monty_form/lincomb.rs
@@ -43,10 +43,10 @@ mod tests {
             let modulus = Odd::<U256>::random(&mut rng);
             let params = MontyParams::new_vartime(modulus);
             let m = modulus.as_nz_ref();
-            let a = U256::random_mod(&mut rng, m);
-            let b = U256::random_mod(&mut rng, m);
-            let c = U256::random_mod(&mut rng, m);
-            let d = U256::random_mod(&mut rng, m);
+            let a = U256::random_mod_vartime(&mut rng, m);
+            let b = U256::random_mod_vartime(&mut rng, m);
+            let c = U256::random_mod_vartime(&mut rng, m);
+            let d = U256::random_mod_vartime(&mut rng, m);
 
             assert_eq!(
                 a.mul_mod(&b, m).add_mod(&c.mul_mod(&d, m), m),

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -466,8 +466,8 @@ pub trait RandomMod: Sized + Zero {
     /// example, it implements `CryptoRng`), then this is guaranteed not to
     /// leak anything about the output value aside from it being less than
     /// `modulus`.
-    fn random_mod<R: RngCore + ?Sized>(rng: &mut R, modulus: &NonZero<Self>) -> Self {
-        let Ok(out) = Self::try_random_mod(rng, modulus);
+    fn random_mod_vartime<R: RngCore + ?Sized>(rng: &mut R, modulus: &NonZero<Self>) -> Self {
+        let Ok(out) = Self::try_random_mod_vartime(rng, modulus);
         out
     }
 
@@ -480,10 +480,41 @@ pub trait RandomMod: Sized + Zero {
     /// example, it implements `CryptoRng`), then this is guaranteed not to
     /// leak anything about the output value aside from it being less than
     /// `modulus`.
-    fn try_random_mod<R: TryRngCore + ?Sized>(
+    fn try_random_mod_vartime<R: TryRngCore + ?Sized>(
         rng: &mut R,
         modulus: &NonZero<Self>,
     ) -> Result<Self, R::Error>;
+
+    /// Generate a random number which is less than a given `modulus`.
+    ///
+    /// This uses rejection sampling.
+    ///
+    /// As a result, it runs in variable time that depends in part on
+    /// `modulus`. If the generator `rng` is cryptographically secure (for
+    /// example, it implements `CryptoRng`), then this is guaranteed not to
+    /// leak anything about the output value aside from it being less than
+    /// `modulus`.
+    #[deprecated(since = "0.7.0", note = "please use `random_mod_vartime` instead")]
+    fn random_mod<R: RngCore + ?Sized>(rng: &mut R, modulus: &NonZero<Self>) -> Self {
+        Self::random_mod_vartime(rng, modulus)
+    }
+
+    /// Generate a random number which is less than a given `modulus`.
+    ///
+    /// This uses rejection sampling.
+    ///
+    /// As a result, it runs in variable time that depends in part on
+    /// `modulus`. If the generator `rng` is cryptographically secure (for
+    /// example, it implements `CryptoRng`), then this is guaranteed not to
+    /// leak anything about the output value aside from it being less than
+    /// `modulus`.
+    #[deprecated(since = "0.7.0", note = "please use `try_random_mod_vartime` instead")]
+    fn try_random_mod<R: TryRngCore + ?Sized>(
+        rng: &mut R,
+        modulus: &NonZero<Self>,
+    ) -> Result<Self, R::Error> {
+        Self::try_random_mod_vartime(rng, modulus)
+    }
 }
 
 /// Compute `self + rhs mod p`.

--- a/src/uint/add_mod.rs
+++ b/src/uint/add_mod.rs
@@ -109,8 +109,8 @@ mod tests {
                     }
 
                     for _i in 0..100 {
-                        let a = Uint::<$size>::random_mod(&mut rng, p);
-                        let b = Uint::<$size>::random_mod(&mut rng, p);
+                        let a = Uint::<$size>::random_mod_vartime(&mut rng, p);
+                        let b = Uint::<$size>::random_mod_vartime(&mut rng, p);
 
                         let c = a.add_mod_special(&b, *special.as_ref());
                         assert!(c < **p, "not reduced: {} >= {} ", c, p);

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -126,8 +126,8 @@ mod tests {
                     }
 
                     for _i in 0..100 {
-                        let a = Uint::<$size>::random_mod(&mut rng, p);
-                        let b = Uint::<$size>::random_mod(&mut rng, p);
+                        let a = Uint::<$size>::random_mod_vartime(&mut rng, p);
+                        let b = Uint::<$size>::random_mod_vartime(&mut rng, p);
 
                         let c = a.mul_mod_special(&b, *special.as_ref());
                         assert!(c < **p, "not reduced: {} >= {} ", c, p);

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -135,8 +135,8 @@ mod tests {
                     }
 
                     for _i in 0..100 {
-                        let a = Uint::<$size>::random_mod(&mut rng, p);
-                        let b = Uint::<$size>::random_mod(&mut rng, p);
+                        let a = Uint::<$size>::random_mod_vartime(&mut rng, p);
+                        let b = Uint::<$size>::random_mod_vartime(&mut rng, p);
 
                         let c = a.mul_mod_special(&b, *special.as_ref());
                         assert!(c < **p, "not reduced: {} >= {} ", c, p);

--- a/src/uint/sub_mod.rs
+++ b/src/uint/sub_mod.rs
@@ -113,8 +113,8 @@ mod tests {
                     }
 
                     for _i in 0..100 {
-                        let a = Uint::<$size>::random_mod(&mut rng, p);
-                        let b = Uint::<$size>::random_mod(&mut rng, p);
+                        let a = Uint::<$size>::random_mod_vartime(&mut rng, p);
+                        let b = Uint::<$size>::random_mod_vartime(&mut rng, p);
 
                         let c = a.sub_mod(&b, p);
                         assert!(c < **p, "not reduced: {} >= {} ", c, p);
@@ -158,8 +158,8 @@ mod tests {
                     }
 
                     for _i in 0..100 {
-                        let a = Uint::<$size>::random_mod(&mut rng, p);
-                        let b = Uint::<$size>::random_mod(&mut rng, p);
+                        let a = Uint::<$size>::random_mod_vartime(&mut rng, p);
+                        let b = Uint::<$size>::random_mod_vartime(&mut rng, p);
 
                         let c = a.sub_mod_special(&b, *special.as_ref());
                         assert!(c < **p, "not reduced: {} >= {} ", c, p);


### PR DESCRIPTION
Rejection sampling means that `random_mod` is inherently variable-time, and the current name violates the contract in the `README`:

> All functions contained in the crate are designed to execute in
> constant time unless explicitly specified otherwise (via a `*_vartime`
> name suffix).

This renames `random_mod` to `random_mod_vartime`, adding in deprecated aliases at the old names for backwards-compatibility. It preserves the `ConstantTimeLess` functionality for good measure and to not needlessly increase the amount of timing information leaked.

Of course, `random_mod` leaks a pretty small amount of timing information; by my reckoning, at worst an average 2 bits per call, and approaching 0 as the modulus approaches `2^n-1`. So this is a bit of an edge case; but I think the `vartime` naming here reduces surprise.