### PR TITLE
word: delegate some ops to `ctutils::Choice`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,8 +246,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.1.1"
-source = "git+https://github.com/RustCrypto/utils#533ac35fb7dec96f935c2b060a0047a93d72e846"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaad015a0138babdf4933e6f6785273ad6a3dcc8133727926ca9485ff159ea55"
 dependencies = [
  "cmov",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-ctutils = { version = "0.1.1", features = ["subtle"] }
+ctutils = { version = "0.1.2", features = ["subtle"] }
 subtle = { version = "2.6", default-features = false }
 
 # optional dependencies
@@ -86,6 +86,3 @@ harness = false
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io.ctutils]
-git = "https://github.com/RustCrypto/utils"


### PR DESCRIPTION
Conditionally calls certain `u32`/`u64`/`u128` bit twiddling operations defined on `ctutils::Choice` based on `target_pointer_width`, rather than duplicating non-trivial implementations in `ctutils`.

This also goes ahead and bumps to the `ctutils` v0.1.2 crate release to pick up the relevant functions.