### PR TITLE
Replace `ConstantTimeSelect` with `ctutils::CtSelect`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ pub use crate::{
 };
 
 // TODO(tarcieri): get rid of `Const*` prefix
-pub use ctutils::{Choice as ConstChoice, CtOption as ConstCtOption};
+pub use ctutils::{Choice as ConstChoice, CtOption as ConstCtOption, CtSelect};
 
 #[cfg(feature = "alloc")]
 pub use crate::uint::boxed::BoxedUint;

--- a/src/modular/pow.rs
+++ b/src/modular/pow.rs
@@ -114,7 +114,7 @@ where
             // Constant-time lookup in the array of powers
             power.as_mut_limbs().copy_from_slice(powers[0].as_limbs());
             for i in 1..(1 << WINDOW) {
-                power.ct_assign(&powers[i], (i as Word).ct_eq(&idx));
+                power.ct_assign(&powers[i], (i as Word).ct_eq(&idx).into());
             }
 
             multiplier.mul_amm_assign(&mut z, &power);

--- a/src/modular/safegcd/boxed.rs
+++ b/src/modular/safegcd/boxed.rs
@@ -5,7 +5,7 @@
 
 use super::{GCD_BATCH_SIZE, Matrix, iterations, jump};
 use crate::{
-    BoxedUint, ConstChoice, ConstantTimeSelect, I64, Int, Limb, NonZero, Odd, Resize, U64, Uint,
+    BoxedUint, ConstChoice, CtSelect, I64, Int, Limb, NonZero, Odd, Resize, U64, Uint,
     primitives::{u32_max, u32_min},
 };
 use core::fmt;
@@ -127,7 +127,7 @@ fn invert_odd_mod_precomp<const VARTIME: bool>(
 
 /// Calculate the greatest common denominator of `f` and `g`.
 pub fn gcd<const VARTIME: bool>(f: &BoxedUint, g: &BoxedUint) -> BoxedUint {
-    let f_is_zero = f.is_zero();
+    let f_is_zero = f.is_zero().into();
     // Note: is non-zero by construction
     let f_nz = NonZero(BoxedUint::ct_select(
         f,
@@ -407,7 +407,7 @@ impl SignedBoxedInt {
 
     /// Normalize the value to a `BoxedUint` in the range `[0, m)`.
     fn norm(&self, f_sign: ConstChoice, m: &BoxedUint) -> BoxedUint {
-        let swap = Choice::from(f_sign.xor(self.sign)) & self.is_nonzero();
+        let swap = f_sign.xor(self.sign) & self.is_nonzero().into();
         BoxedUint::ct_select(&self.magnitude, &m.wrapping_sub(&self.magnitude), swap)
     }
 }

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -1,8 +1,8 @@
 //! [`BoxedUint`] division operations.
 
 use crate::{
-    BoxedUint, CheckedDiv, ConstantTimeSelect, DivRemLimb, DivVartime, Limb, NonZero, Reciprocal,
-    RemLimb, RemMixed, UintRef, Wrapping,
+    BoxedUint, CheckedDiv, CtSelect, DivRemLimb, DivVartime, Limb, NonZero, Reciprocal, RemLimb,
+    RemMixed, UintRef, Wrapping,
 };
 use core::ops::{Div, DivAssign, Rem, RemAssign};
 use subtle::CtOption;
@@ -121,7 +121,7 @@ impl BoxedUint {
         let mut quo = self.clone();
         let is_nz = rhs.is_nonzero();
         let mut rem = Self::one_with_precision(self.bits_precision());
-        rem.ct_assign(rhs, is_nz);
+        rem.ct_assign(rhs, is_nz.into());
         quo.as_mut_uint_ref().div_rem(rem.as_mut_uint_ref());
         CtOption::new(quo, is_nz)
     }

--- a/src/uint/boxed/invert_mod.rs
+++ b/src/uint/boxed/invert_mod.rs
@@ -1,7 +1,7 @@
 //! [`BoxedUint`] modular inverse (i.e. reciprocal) operations.
 
 use crate::{
-    BoxedUint, ConstantTimeSelect, Integer, InvertMod, Limb, NonZero, Odd, U64, modular::safegcd,
+    BoxedUint, CtSelect, Integer, InvertMod, Limb, NonZero, Odd, U64, modular::safegcd,
     uint::invert_mod::expand_invert_mod2k,
 };
 use subtle::{Choice, ConstantTimeEq, ConstantTimeLess, CtOption};
@@ -50,7 +50,7 @@ impl BoxedUint {
             let inv = Odd(Self::ct_select(
                 &Self::one_with_precision(bits),
                 self,
-                is_some,
+                is_some.into(),
             ))
             .invert_mod2k_vartime(k);
             (inv, is_some)
@@ -76,14 +76,14 @@ impl BoxedUint {
         let mut inv = Odd(Self::ct_select(
             &Self::one_with_precision(bits),
             self,
-            is_some,
+            is_some.into(),
         ))
         .invert_mod_precision();
         inv.restrict_bits(k);
         (inv, is_some)
     }
 
-    /// Computes the multiplicaitve inverse of `self` mod `modulus`
+    /// Computes the multiplicative inverse of `self` mod `modulus`
     ///
     /// `self` and `modulus` must have the same number of limbs, or the function will panic
     ///
@@ -94,7 +94,7 @@ impl BoxedUint {
         let m = NonZero(Self::ct_select(
             &Self::one_with_precision(self.bits_precision()),
             modulus,
-            is_nz,
+            is_nz.into(),
         ));
         let inv_mod_s = self.invert_mod(&m);
         let is_some = inv_mod_s.is_some();
@@ -103,7 +103,7 @@ impl BoxedUint {
         CtOption::new(result, is_some & is_nz)
     }
 
-    /// Computes the multiplicaitve inverse of `self` mod `modulus`
+    /// Computes the multiplicative inverse of `self` mod `modulus`
     ///
     /// `self` and `modulus` must have the same number of limbs, or the function will panic
     ///

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -2,7 +2,7 @@
 
 use subtle::{ConstantTimeEq, ConstantTimeGreater, CtOption};
 
-use crate::{BitOps, BoxedUint, ConstantTimeSelect, Limb, SquareRoot};
+use crate::{BitOps, BoxedUint, CtSelect, Limb, SquareRoot};
 
 impl BoxedUint {
     /// Computes √(`self`) in constant time.
@@ -29,7 +29,7 @@ impl BoxedUint {
         // TODO (#378): the tests indicate that just `Self::LOG2_BITS` may be enough.
         while i < self.log2_bits() + 2 {
             let x_nonzero = x.is_nonzero();
-            nz_x.ct_assign(&x, x_nonzero);
+            nz_x.ct_assign(&x, x_nonzero.into());
 
             // Calculate `x_{i+1} = floor((x_i + self / x_i) / 2)`
             quo.limbs.copy_from_slice(&self.limbs);
@@ -44,7 +44,7 @@ impl BoxedUint {
         // At this point `x_prev == x_{n}` and `x == x_{n+1}`
         // where `n == i - 1 == LOG2_BITS + 1 == floor(log2(BITS)) + 1`.
         // Thus, according to Hast, `sqrt(self) = min(x_n, x_{n+1})`.
-        x.ct_assign(&nz_x, Self::ct_gt(&x, &nz_x));
+        x.ct_assign(&nz_x, Self::ct_gt(&x, &nz_x).into());
         x
     }
 


### PR DESCRIPTION
The `ConstantTimeSelect` trait was a workaround for having a trait-based API that works for `Boxed*` and non-boxed types, since we can't impl `subtle::ConditionallySelectable` on `Boxed*` types since it has a `Copy` bound.

`ctutils::CtSelect` accomplishes the same goals by having only a `Sized` bound (since we need to be able to return selected values).

This commit completely replaces the `ConstantTimeSelect` trait with `ctutils::CtSelect`.