### PR TITLE
word: cleanup helper functions

### DIFF
--- a/src/int/mod_symbol.rs
+++ b/src/int/mod_symbol.rs
@@ -11,7 +11,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
         let (abs, sign) = self.abs_sign();
         let jacobi = abs.jacobi_symbol(rhs) as i64;
         // (-self|rhs) = -(self|rhs) iff rhs = 3 mod 4
-        let swap = sign.and(word::from_word_eq(rhs.as_ref().limbs[0].0 & 3, 3));
+        let swap = sign.and(word::choice_from_eq(rhs.as_ref().limbs[0].0 & 3, 3));
         JacobiSymbol::from_i8(swap.select_i64(jacobi, -jacobi) as i8)
     }
 

--- a/src/int/sign.rs
+++ b/src/int/sign.rs
@@ -50,7 +50,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Whether this [`Int`] is negative, as a `ConstChoice`.
     #[inline(always)]
     pub const fn is_negative(&self) -> ConstChoice {
-        word::from_word_msb(self.most_significant_word())
+        word::choice_from_msb(self.most_significant_word())
     }
 
     /// Whether this [`Int`] is positive, as a `ConstChoice`.

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -29,22 +29,22 @@ impl Limb {
     /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
     pub(crate) const fn select(a: Self, b: Self, c: ConstChoice) -> Self {
-        Self(word::select_word(c, a.0, b.0))
+        Self(word::select(a.0, b.0, c))
     }
 
     /// Swap the values of `a` and `b` if `c` is truthy, otherwise do nothing.
     #[inline]
     pub(crate) const fn ct_conditional_swap(a: &mut Self, b: &mut Self, c: ConstChoice) {
         (*a, *b) = (
-            Self(word::select_word(c, a.0, b.0)),
-            Self(word::select_word(c, b.0, a.0)),
+            Self(word::select(a.0, b.0, c)),
+            Self(word::select(b.0, a.0, c)),
         )
     }
 
     /// Returns the truthy value if `self != 0` and the falsy value otherwise.
     #[inline]
     pub(crate) const fn is_nonzero(&self) -> ConstChoice {
-        word::from_word_nonzero(self.0)
+        word::choice_from_nonzero(self.0)
     }
 }
 
@@ -63,14 +63,14 @@ impl ConstantTimeEq for Limb {
 impl ConstantTimeGreater for Limb {
     #[inline]
     fn ct_gt(&self, other: &Self) -> Choice {
-        word::from_word_gt(self.0, other.0).into()
+        word::choice_from_gt(self.0, other.0).into()
     }
 }
 
 impl ConstantTimeLess for Limb {
     #[inline]
     fn ct_lt(&self, other: &Self) -> Choice {
-        word::from_word_lt(self.0, other.0).into()
+        word::choice_from_lt(self.0, other.0).into()
     }
 }
 

--- a/src/modular/bingcd/div_mod_2k.rs
+++ b/src/modular/bingcd/div_mod_2k.rs
@@ -80,7 +80,7 @@ impl Limb {
             let (shifted, carry) = self.shr1();
             self = Self::select(self, shifted, execute);
 
-            let overflow = word::from_word_msb(carry.0);
+            let overflow = word::choice_from_msb(carry.0);
             let add_back_q = overflow.and(execute);
             self = self.wrapping_add(Self::select(Self::ZERO, one_half_mod_q, add_back_q));
             factor = factor.bitxor(Self::select(Self::ZERO, Self::ONE.shl(i), add_back_q));

--- a/src/modular/bingcd/gcd.rs
+++ b/src/modular/bingcd/gcd.rs
@@ -32,7 +32,7 @@ pub(super) const fn bingcd_step<const LIMBS: usize>(
     *a = a_sub_b.wrapping_neg_if(swap).shr1();
 
     // (b|a) = -(a|b) iff a = b = 3 mod 4 (quadratic reciprocity)
-    let mut jacobi_neg = word::select_word(swap, 0, a_b_mod_4 & (a_b_mod_4 >> 1) & 1);
+    let mut jacobi_neg = word::select(0, a_b_mod_4 & (a_b_mod_4 >> 1) & 1, swap);
 
     // (2a|b) = -(a|b) iff b = ±3 mod 8
     // b is always odd, so we ignore the lower bit and check that bits 2 and 3 are '01' or '10'

--- a/src/modular/boxed_monty_form/mul.rs
+++ b/src/modular/boxed_monty_form/mul.rs
@@ -314,7 +314,7 @@ pub(crate) fn almost_montgomery_mul(
         modulus.as_limbs(),
         mod_neg_inv,
     );
-    let overflow = word::from_word_lsb(overflow.0);
+    let overflow = word::choice_from_lsb(overflow.0);
     out.conditional_borrowing_sub_assign(modulus, overflow.into());
 }
 

--- a/src/modular/pow.rs
+++ b/src/modular/pow.rs
@@ -258,7 +258,7 @@ const fn multi_exponentiate_montgomery_form_internal<const LIMBS: usize, const R
                 let mut power = powers[0];
                 let mut j = 1;
                 while j < 1 << WINDOW {
-                    let choice = word::from_word_eq(j, idx);
+                    let choice = word::choice_from_eq(j, idx);
                     power = Uint::<LIMBS>::select(&power, &powers[j as usize], choice);
                     j += 1;
                 }

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -30,7 +30,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Perform saturating addition, returning `MAX` on overflow.
     pub const fn saturating_add(&self, rhs: &Self) -> Self {
         let (res, overflow) = self.carrying_add(rhs, Limb::ZERO);
-        Self::select(&res, &Self::MAX, word::from_word_lsb(overflow.0))
+        Self::select(&res, &Self::MAX, word::choice_from_lsb(overflow.0))
     }
 
     /// Perform wrapping addition, discarding overflow.

--- a/src/uint/boxed/cmp.rs
+++ b/src/uint/boxed/cmp.rs
@@ -59,7 +59,7 @@ impl ConstantTimeGreater for BoxedUint {
     #[inline]
     fn ct_gt(&self, other: &Self) -> Choice {
         let (_, borrow) = other.borrowing_sub(self, Limb::ZERO);
-        word::from_word_mask(borrow.0).into()
+        word::choice_from_mask(borrow.0).into()
     }
 }
 
@@ -67,7 +67,7 @@ impl ConstantTimeLess for BoxedUint {
     #[inline]
     fn ct_lt(&self, other: &Self) -> Choice {
         let (_, borrow) = self.borrowing_sub(other, Limb::ZERO);
-        word::from_word_mask(borrow.0).into()
+        word::choice_from_mask(borrow.0).into()
     }
 }
 

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -67,7 +67,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Returns the truthy value if `self` is odd or the falsy value otherwise.
     pub(crate) const fn is_odd(&self) -> ConstChoice {
-        word::from_word_lsb(self.limbs[0].0 & 1)
+        word::choice_from_lsb(self.limbs[0].0 & 1)
     }
 
     /// Returns the truthy value if `self == rhs` or the falsy value otherwise.
@@ -92,7 +92,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         // but since we have to use Uint::wrapping_sub(), which calls `borrowing_sub()`,
         // there are no savings compared to just calling `borrowing_sub()` directly.
         let (_res, borrow) = lhs.borrowing_sub(rhs, Limb::ZERO);
-        word::from_word_mask(borrow.0)
+        word::choice_from_mask(borrow.0)
     }
 
     /// Returns the truthy value if `self <= rhs` and the falsy value otherwise.
@@ -105,7 +105,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     #[inline]
     pub(crate) const fn gt(lhs: &Self, rhs: &Self) -> ConstChoice {
         let (_res, borrow) = rhs.borrowing_sub(lhs, Limb::ZERO);
-        word::from_word_mask(borrow.0)
+        word::choice_from_mask(borrow.0)
     }
 
     /// Returns the ordering between `self` and `rhs` as an i8.

--- a/src/uint/neg.rs
+++ b/src/uint/neg.rs
@@ -20,7 +20,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             carry = r >> Limb::BITS;
             i += 1;
         }
-        (Uint::new(ret), word::from_word_lsb(carry as Word))
+        (Uint::new(ret), word::choice_from_lsb(carry as Word))
     }
 
     /// Perform wrapping negation, if `negate` is truthy. Otherwise, return `self`.

--- a/src/uint/neg_mod.rs
+++ b/src/uint/neg_mod.rs
@@ -12,7 +12,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         while i < LIMBS {
             // Set ret to 0 if the original value was 0, in which
             // case ret would be p.
-            ret.limbs[i].0 = word::select_word(z, 0, ret.limbs[i].0);
+            ret.limbs[i].0 = word::select(0, ret.limbs[i].0, z);
             i += 1;
         }
         ret

--- a/src/uint/ref_type/bits.rs
+++ b/src/uint/ref_type/bits.rs
@@ -21,11 +21,11 @@ impl UintRef {
         while i < self.0.len() {
             let bit = self.0[i].0 & index_mask;
             let is_right_limb = ConstChoice::from_u32_eq(i as u32, limb_num);
-            result |= word::select_word(is_right_limb, 0, bit);
+            result |= word::select(0, bit, is_right_limb);
             i += 1;
         }
 
-        word::from_word_lsb(result >> index_in_limb)
+        word::choice_from_lsb(result >> index_in_limb)
     }
 
     /// Returns `true` if the bit at position `index` is set, `false` for an unset bit
@@ -77,9 +77,8 @@ impl UintRef {
         while i < self.0.len() {
             let is_right_limb = ConstChoice::from_u32_eq(i as u32, limb_num);
             let old_limb = self.0[i].0;
-            let new_limb =
-                word::select_word(bit_value, old_limb & !index_mask, old_limb | index_mask);
-            self.0[i] = Limb(word::select_word(is_right_limb, old_limb, new_limb));
+            let new_limb = word::select(old_limb & !index_mask, old_limb | index_mask, bit_value);
+            self.0[i] = Limb(word::select(old_limb, new_limb, is_right_limb));
             i += 1;
         }
     }
@@ -108,7 +107,7 @@ impl UintRef {
             let z = l.leading_zeros();
             count += nonzero_limb_not_encountered.select_u32(0, z);
             nonzero_limb_not_encountered =
-                nonzero_limb_not_encountered.and(word::from_word_nonzero(l.0).not());
+                nonzero_limb_not_encountered.and(word::choice_from_nonzero(l.0).not());
         }
 
         count
@@ -125,7 +124,7 @@ impl UintRef {
             let z = l.trailing_zeros();
             count += nonzero_limb_not_encountered.select_u32(0, z);
             nonzero_limb_not_encountered =
-                nonzero_limb_not_encountered.and(word::from_word_nonzero(l.0).not());
+                nonzero_limb_not_encountered.and(word::choice_from_nonzero(l.0).not());
             i += 1;
         }
 
@@ -162,7 +161,7 @@ impl UintRef {
             let z = l.trailing_ones();
             count += nonmax_limb_not_encountered.select_u32(0, z);
             nonmax_limb_not_encountered =
-                nonmax_limb_not_encountered.and(word::from_word_eq(l.0, Limb::MAX.0));
+                nonmax_limb_not_encountered.and(word::choice_from_eq(l.0, Limb::MAX.0));
             i += 1;
         }
 
@@ -197,7 +196,7 @@ impl UintRef {
         while i < self.nlimbs() {
             let apply = ConstChoice::from_u32_eq(i as u32, limb);
             self.0[i] = self.0[i].bitand(Limb::select(
-                Limb(word::choice_to_word_mask(clear.not())),
+                Limb(word::choice_to_mask(clear.not())),
                 limb_mask,
                 apply,
             ));

--- a/src/uint/ref_type/shl.rs
+++ b/src/uint/ref_type/shl.rs
@@ -151,7 +151,7 @@ impl UintRef {
             carry = new_carry;
             i += 1;
         }
-        word::from_word_lsb(carry.0)
+        word::choice_from_lsb(carry.0)
     }
 
     /// Conditionally left-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning

--- a/src/uint/ref_type/shr.rs
+++ b/src/uint/ref_type/shr.rs
@@ -166,7 +166,7 @@ impl UintRef {
             self.0[i] = limb.bitor(carry);
             carry = new_carry;
         }
-        word::from_word_lsb(carry.0 >> Limb::HI_BIT)
+        word::choice_from_lsb(carry.0 >> Limb::HI_BIT)
     }
 
     /// Conditionally right-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -199,7 +199,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             carry = new_carry;
         }
 
-        (ret, word::from_word_lsb(carry.0 >> Limb::HI_BIT))
+        (ret, word::choice_from_lsb(carry.0 >> Limb::HI_BIT))
     }
 
     /// Conditionally right-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -31,7 +31,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Perform saturating subtraction, returning `ZERO` on underflow.
     pub const fn saturating_sub(&self, rhs: &Self) -> Self {
         let (res, underflow) = self.borrowing_sub(rhs, Limb::ZERO);
-        Self::select(&res, &Self::ZERO, word::from_word_mask(underflow.0))
+        Self::select(&res, &Self::ZERO, word::choice_from_mask(underflow.0))
     }
 
     /// Perform wrapping subtraction, discarding underflow and wrapping around

--- a/src/word.rs
+++ b/src/word.rs
@@ -1,7 +1,7 @@
 //! `Word` represents the core integer type we use as the core of `Limb`, and is typically the same
 //! size as a pointer on a particular CPU.
 
-use crate::ConstChoice;
+use ctutils::Choice;
 
 #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
 compile_error!("this crate builds on 32-bit and 64-bit platforms only");
@@ -9,7 +9,7 @@ compile_error!("this crate builds on 32-bit and 64-bit platforms only");
 /// 32-bit definitions
 #[cfg(target_pointer_width = "32")]
 mod word32 {
-    use crate::ConstChoice;
+    use super::Choice;
 
     /// Inner integer type that the [`Limb`] newtype wraps.
     pub type Word = u32;
@@ -19,27 +19,27 @@ mod word32 {
 
     /// Returns the truthy value if `x <= y` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn from_word_le(x: Word, y: Word) -> ConstChoice {
-        ConstChoice::from_u32_le(x, y)
+    pub(crate) const fn choice_from_le(x: Word, y: Word) -> Choice {
+        Choice::from_u32_le(x, y)
     }
 
     /// Returns the truthy value if `x < y`, and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn from_word_lt(x: Word, y: Word) -> ConstChoice {
-        ConstChoice::from_u32_lt(x, y)
+    pub(crate) const fn choice_from_lt(x: Word, y: Word) -> Choice {
+        Choice::from_u32_lt(x, y)
     }
 
     /// Returns the truthy value if `x <= y` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn from_wide_word_le(x: WideWord, y: WideWord) -> ConstChoice {
-        ConstChoice::from_u64_le(x, y)
+    pub(crate) const fn choice_from_wide_le(x: WideWord, y: WideWord) -> Choice {
+        Choice::from_u64_le(x, y)
     }
 }
 
 /// 64-bit definitions
 #[cfg(target_pointer_width = "64")]
 mod word64 {
-    use crate::ConstChoice;
+    use super::Choice;
 
     /// Unsigned integer type that the [`Limb`][`crate::Limb`] newtype wraps.
     pub type Word = u64;
@@ -49,20 +49,20 @@ mod word64 {
 
     /// Returns the truthy value if `x <= y` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn from_word_le(x: Word, y: Word) -> ConstChoice {
-        ConstChoice::from_u64_le(x, y)
+    pub(crate) const fn choice_from_le(x: Word, y: Word) -> Choice {
+        Choice::from_u64_le(x, y)
     }
 
     /// Returns the truthy value if `x < y`, and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn from_word_lt(x: Word, y: Word) -> ConstChoice {
-        ConstChoice::from_u64_lt(x, y)
+    pub(crate) const fn choice_from_lt(x: Word, y: Word) -> Choice {
+        Choice::from_u64_lt(x, y)
     }
 
     /// Returns the truthy value if `x <= y` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn from_wide_word_le(x: WideWord, y: WideWord) -> ConstChoice {
-        ConstChoice::from_u128_le(x, y)
+    pub(crate) const fn choice_from_wide_le(x: WideWord, y: WideWord) -> Choice {
+        Choice::from_u128_le(x, y)
     }
 }
 
@@ -73,113 +73,111 @@ pub use word64::*;
 
 /// Returns the truthy value if `x == y`, and the falsy value otherwise.
 #[inline]
-pub(crate) const fn from_word_eq(x: Word, y: Word) -> ConstChoice {
-    from_word_nonzero(x ^ y).not()
+pub(crate) const fn choice_from_eq(x: Word, y: Word) -> Choice {
+    choice_from_nonzero(x ^ y).not()
 }
 
 /// Returns the truthy value if `x > y`, and the falsy value otherwise.
 #[inline]
-pub(crate) const fn from_word_gt(x: Word, y: Word) -> ConstChoice {
-    from_word_lt(y, x)
+pub(crate) const fn choice_from_gt(x: Word, y: Word) -> Choice {
+    choice_from_lt(y, x)
 }
 
 /// Returns the truthy value if `value == 1`, and the falsy value if `value == 0`.
-/// Panics for other values.
 #[inline]
-pub(crate) const fn from_word_lsb(value: Word) -> ConstChoice {
-    ConstChoice::new((value & 1) as u8)
+pub(crate) const fn choice_from_lsb(value: Word) -> Choice {
+    Choice::new((value & 1) as u8)
 }
 
 /// Returns the truthy value if `value == Word::MAX`, and the falsy value if `value == 0`.
-/// Panics for other values.
 #[inline]
-pub(crate) const fn from_word_mask(value: Word) -> ConstChoice {
-    from_word_eq(value, Word::MAX)
+pub(crate) const fn choice_from_mask(value: Word) -> Choice {
+    choice_from_eq(value, Word::MAX)
 }
 
 /// Returns the truthy value if the most significant bit of `value` is `1`,
 /// and the falsy value if it equals `0`.
 #[inline]
-pub(crate) const fn from_word_msb(value: Word) -> ConstChoice {
-    from_word_lsb(value >> (Word::BITS - 1))
+pub(crate) const fn choice_from_msb(value: Word) -> Choice {
+    choice_from_lsb(value >> (Word::BITS - 1))
 }
 
 /// Returns the truthy value if `value != 0`, and the falsy value otherwise.
 #[inline]
-pub(crate) const fn from_word_nonzero(value: Word) -> ConstChoice {
-    from_word_lsb((value | value.wrapping_neg()) >> (Word::BITS - 1))
+pub(crate) const fn choice_from_nonzero(value: Word) -> Choice {
+    choice_from_lsb((value | value.wrapping_neg()) >> (Word::BITS - 1))
 }
 
 /// Return `b` if `self` is truthy, otherwise return `a`.
 #[inline]
-pub(crate) const fn select_word(choice: ConstChoice, a: Word, b: Word) -> Word {
-    a ^ (choice_to_word_mask(choice) & (a ^ b))
+pub(crate) const fn select(a: Word, b: Word, choice: Choice) -> Word {
+    a ^ (choice_to_mask(choice) & (a ^ b))
 }
 
 /// Return `b` if `self` is truthy, otherwise return `a`.
 #[inline]
-pub(crate) const fn select_wide_word(choice: ConstChoice, a: WideWord, b: WideWord) -> WideWord {
-    a ^ (choice_to_wide_word_mask(choice) & (a ^ b))
+pub(crate) const fn select_wide(a: WideWord, b: WideWord, choice: Choice) -> WideWord {
+    a ^ (choice_to_wide_mask(choice) & (a ^ b))
 }
 
 /// Create a `Word`-sized bitmask.
 ///
 /// # Returns
-/// - `0` for `ConstChoice::FALSE`
-/// - `Word::MAX` for `ConstChoice::TRUE`
+/// - `0` for `Choice::FALSE`
+/// - `Word::MAX` for `Choice::TRUE`
 #[inline]
-pub(crate) const fn choice_to_word_mask(choice: ConstChoice) -> Word {
+pub(crate) const fn choice_to_mask(choice: Choice) -> Word {
     (choice.to_u8_vartime() as Word).wrapping_neg()
 }
 
 /// Create a `WideWord`-sized bitmask.
 ///
 /// # Returns
-/// - `0` for `ConstChoice::FALSE`
-/// - `Word::MAX` for `ConstChoice::TRUE`
+/// - `0` for `Choice::FALSE`
+/// - `Word::MAX` for `Choice::TRUE`
 #[inline]
-pub(crate) const fn choice_to_wide_word_mask(choice: ConstChoice) -> WideWord {
+pub(crate) const fn choice_to_wide_mask(choice: Choice) -> WideWord {
     (choice.to_u8_vartime() as WideWord).wrapping_neg()
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, WideWord, Word};
+    use super::{Choice, WideWord, Word};
 
     #[test]
-    fn from_word_lt() {
-        assert_eq!(super::from_word_lt(4, 5), ConstChoice::TRUE);
-        assert_eq!(super::from_word_lt(5, 5), ConstChoice::FALSE);
-        assert_eq!(super::from_word_lt(6, 5), ConstChoice::FALSE);
+    fn choice_from_lt() {
+        assert_eq!(super::choice_from_lt(4, 5), Choice::TRUE);
+        assert_eq!(super::choice_from_lt(5, 5), Choice::FALSE);
+        assert_eq!(super::choice_from_lt(6, 5), Choice::FALSE);
     }
 
     #[test]
-    fn from_word_gt() {
-        assert_eq!(super::from_word_gt(4, 5), ConstChoice::FALSE);
-        assert_eq!(super::from_word_gt(5, 5), ConstChoice::FALSE);
-        assert_eq!(super::from_word_gt(6, 5), ConstChoice::TRUE);
+    fn choice_from_gt() {
+        assert_eq!(super::choice_from_gt(4, 5), Choice::FALSE);
+        assert_eq!(super::choice_from_gt(5, 5), Choice::FALSE);
+        assert_eq!(super::choice_from_gt(6, 5), Choice::TRUE);
     }
 
     #[test]
-    fn from_wide_word_le() {
-        assert_eq!(super::from_wide_word_le(4, 5), ConstChoice::TRUE);
-        assert_eq!(super::from_wide_word_le(5, 5), ConstChoice::TRUE);
-        assert_eq!(super::from_wide_word_le(6, 5), ConstChoice::FALSE);
+    fn choice_from_wide_le() {
+        assert_eq!(super::choice_from_wide_le(4, 5), Choice::TRUE);
+        assert_eq!(super::choice_from_wide_le(5, 5), Choice::TRUE);
+        assert_eq!(super::choice_from_wide_le(6, 5), Choice::FALSE);
     }
 
     #[test]
-    fn select_word() {
+    fn select() {
         let a: Word = 1;
         let b: Word = 2;
-        assert_eq!(super::select_word(ConstChoice::TRUE, a, b), b);
-        assert_eq!(super::select_word(ConstChoice::FALSE, a, b), a);
+        assert_eq!(super::select(a, b, Choice::FALSE), a);
+        assert_eq!(super::select(a, b, Choice::TRUE), b);
     }
 
     #[test]
-    fn select_wide_word() {
+    fn select_wide() {
         let a: WideWord = (1 << Word::BITS) + 1;
         let b: WideWord = (3 << Word::BITS) + 4;
-        assert_eq!(super::select_wide_word(ConstChoice::TRUE, a, b), b);
-        assert_eq!(super::select_wide_word(ConstChoice::FALSE, a, b), a);
+        assert_eq!(super::select_wide(a, b, Choice::FALSE), a);
+        assert_eq!(super::select_wide(a, b, Choice::TRUE), b);
     }
 }


### PR DESCRIPTION
Cleans up the internal helper functions in the `word` module, adding a `choice_from_*` prefix to functions that return a `Choice`, and getting rid of `*word*` in the function name since it's implicit from the `word::*` prefix which is used ubiquitously when calling these functions.

Also changes the argument order of `select` and `select_wide` (as newly renamed) so the `Choice` is the last argument, which is more consistent with the rest of the codebase.