### PR TITLE
Replace `ConstantTimeEq` with `CtEq` in trait bounds

### DIFF
--- a/src/checked.rs
+++ b/src/checked.rs
@@ -1,6 +1,6 @@
 //! Checked arithmetic.
 
-use crate::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
+use crate::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, ConstChoice, CtEq, CtSelect};
 use core::ops::{Add, Div, Mul, Sub};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
@@ -268,10 +268,33 @@ impl<T: ConditionallySelectable> ConditionallySelectable for Checked<T> {
     }
 }
 
-impl<T: ConstantTimeEq> ConstantTimeEq for Checked<T> {
+impl<T> ConstantTimeEq for Checked<T>
+where
+    T: ConstantTimeEq,
+{
     #[inline]
     fn ct_eq(&self, rhs: &Self) -> Choice {
         self.0.ct_eq(&rhs.0)
+    }
+}
+
+impl<T> CtEq for Checked<T>
+where
+    Self: ConstantTimeEq,
+{
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> ConstChoice {
+        ConstantTimeEq::ct_eq(self, other).into()
+    }
+}
+
+impl<T> CtSelect for Checked<T>
+where
+    Self: ConditionallySelectable,
+{
+    #[inline]
+    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+        Self::conditional_select(self, other, choice.into())
     }
 }
 

--- a/src/int/cmp.rs
+++ b/src/int/cmp.rs
@@ -2,11 +2,9 @@
 //!
 //! By default, these are all constant-time.
 
+use crate::{ConstChoice, CtEq, Int, Uint};
 use core::cmp::Ordering;
-
-use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
-
-use crate::{ConstChoice, Int, Uint};
+use subtle::{Choice, ConstantTimeGreater, ConstantTimeLess};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Return `b` if `c` is truthy, otherwise return `a`.
@@ -61,10 +59,17 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> ConstantTimeEq for Int<LIMBS> {
+impl<const LIMBS: usize> CtEq for Int<LIMBS> {
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> ConstChoice {
+        CtEq::ct_eq(&self.0, &other.0)
+    }
+}
+
+impl<const LIMBS: usize> subtle::ConstantTimeEq for Int<LIMBS> {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
-        Int::eq(self, other).into()
+        CtEq::ct_eq(self, other).into()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ pub use crate::{
 };
 
 // TODO(tarcieri): get rid of `Const*` prefix
-pub use ctutils::{Choice as ConstChoice, CtOption as ConstCtOption, CtSelect};
+pub use ctutils::{Choice as ConstChoice, CtEq, CtOption as ConstCtOption, CtSelect};
 
 #[cfg(feature = "alloc")]
 pub use crate::uint::boxed::BoxedUint;

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -20,12 +20,12 @@ mod sub;
 mod rand;
 
 use crate::{
-    Bounded, ConstChoice, ConstCtOption, ConstOne, ConstZero, Constants, NonZero, One, WideWord,
-    Word, Zero,
+    Bounded, ConstChoice, ConstCtOption, ConstOne, ConstZero, Constants, CtEq, NonZero, One,
+    WideWord, Word, Zero,
 };
 use core::fmt;
 use ctutils::CtSelect;
-use subtle::{Choice, ConstantTimeEq};
+use subtle::Choice;
 
 #[cfg(feature = "serde")]
 use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/src/limb/add.rs
+++ b/src/limb/add.rs
@@ -83,7 +83,7 @@ impl CheckedAdd for Limb {
     #[inline]
     fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
         let (result, carry) = self.overflowing_add(*rhs);
-        CtOption::new(result, carry.is_zero())
+        CtOption::new(result, carry.is_zero().into())
     }
 }
 

--- a/src/limb/mul.rs
+++ b/src/limb/mul.rs
@@ -48,7 +48,7 @@ impl CheckedMul for Limb {
     #[inline]
     fn checked_mul(&self, rhs: &Self) -> CtOption<Self> {
         let (lo, hi) = self.widening_mul(*rhs);
-        CtOption::new(lo, hi.is_zero())
+        CtOption::new(lo, hi.is_zero().into())
     }
 }
 

--- a/src/limb/sub.rs
+++ b/src/limb/sub.rs
@@ -36,7 +36,7 @@ impl CheckedSub for Limb {
     #[inline]
     fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
         let (result, underflow) = self.borrowing_sub(*rhs, Limb::ZERO);
-        CtOption::new(result, underflow.is_zero())
+        CtOption::new(result, underflow.is_zero().into())
     }
 }
 

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -9,11 +9,9 @@ mod pow;
 mod sub;
 
 use super::{MontyParams, Retrieve, div_by_2, reduction::montgomery_retrieve_inner};
-use crate::{BoxedUint, Limb, Monty, Odd, U64, Word};
-use mul::BoxedMontyMultiplier;
-
+use crate::{BoxedUint, ConstChoice, Limb, Monty, Odd, U64, Word};
 use alloc::sync::Arc;
-use subtle::Choice;
+use mul::BoxedMontyMultiplier;
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -217,7 +215,7 @@ impl BoxedMontyForm {
     /// # Returns
     ///
     /// If zero, returns `Choice(1)`. Otherwise, returns `Choice(0)`.
-    pub fn is_zero(&self) -> Choice {
+    pub fn is_zero(&self) -> ConstChoice {
         self.montgomery_form.is_zero()
     }
 
@@ -227,7 +225,7 @@ impl BoxedMontyForm {
     ///
     /// If zero, returns `Choice(0)`. Otherwise, returns `Choice(1)`.
     #[inline]
-    pub fn is_nonzero(&self) -> Choice {
+    pub fn is_nonzero(&self) -> ConstChoice {
         !self.is_zero()
     }
 

--- a/src/modular/boxed_monty_form/invert.rs
+++ b/src/modular/boxed_monty_form/invert.rs
@@ -1,13 +1,13 @@
 //! Multiplicative inverses of boxed integers in Montgomery form.
 
 use super::{BoxedMontyForm, BoxedMontyParams};
-use crate::{Invert, modular::safegcd::boxed::BoxedSafeGcdInverter};
+use crate::{ConstCtOption, Invert, modular::safegcd::boxed::BoxedSafeGcdInverter};
 use subtle::CtOption;
 
 impl BoxedMontyForm {
     /// Computes `self^-1` representing the multiplicative inverse of `self`,
     /// i.e. `self * self^-1 = 1`.
-    pub fn invert(&self) -> CtOption<Self> {
+    pub fn invert(&self) -> ConstCtOption<Self> {
         let montgomery_form = self.params.inverter().invert(&self.montgomery_form);
         let is_some = montgomery_form.is_some();
         let montgomery_form2 = self.montgomery_form.clone();
@@ -16,7 +16,7 @@ impl BoxedMontyForm {
             params: self.params.clone(),
         };
 
-        CtOption::new(ret, is_some)
+        ConstCtOption::new(ret, is_some)
     }
 
     /// Computes `self^-1` representing the multiplicative inverse of `self`,
@@ -24,7 +24,7 @@ impl BoxedMontyForm {
     ///
     /// This version is variable-time with respect to the self of `self`, but constant-time with
     /// respect to `self`'s `params`.
-    pub fn invert_vartime(&self) -> CtOption<Self> {
+    pub fn invert_vartime(&self) -> ConstCtOption<Self> {
         let montgomery_form = self.params.inverter().invert_vartime(&self.montgomery_form);
         let is_some = montgomery_form.is_some();
         let montgomery_form2 = self.montgomery_form.clone();
@@ -33,7 +33,7 @@ impl BoxedMontyForm {
             params: self.params.clone(),
         };
 
-        CtOption::new(ret, is_some)
+        ConstCtOption::new(ret, is_some)
     }
 }
 
@@ -41,11 +41,11 @@ impl Invert for BoxedMontyForm {
     type Output = CtOption<Self>;
 
     fn invert(&self) -> Self::Output {
-        self.invert()
+        self.invert().into()
     }
 
     fn invert_vartime(&self) -> Self::Output {
-        self.invert_vartime()
+        self.invert_vartime().into()
     }
 }
 

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -14,9 +14,9 @@ use super::{
     MontyParams, Retrieve, div_by_2::div_by_2, mul::mul_montgomery_form,
     reduction::montgomery_retrieve,
 };
-use crate::{ConstOne, ConstZero, Odd, One, Uint, Zero};
+use crate::{ConstChoice, ConstOne, ConstZero, CtEq, Odd, One, Uint, Zero};
 use core::{fmt::Debug, marker::PhantomData};
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+use subtle::{Choice, ConditionallySelectable};
 
 #[cfg(feature = "rand_core")]
 use crate::{Random, RandomMod, rand_core::TryRngCore};
@@ -150,11 +150,17 @@ impl<MOD: ConstMontyParams<LIMBS> + Copy, const LIMBS: usize> ConditionallySelec
     }
 }
 
-impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstantTimeEq
+impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> CtEq for ConstMontyForm<MOD, LIMBS> {
+    fn ct_eq(&self, other: &Self) -> ConstChoice {
+        CtEq::ct_eq(&self.montgomery_form, &other.montgomery_form)
+    }
+}
+
+impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> subtle::ConstantTimeEq
     for ConstMontyForm<MOD, LIMBS>
 {
     fn ct_eq(&self, other: &Self) -> Choice {
-        ConstantTimeEq::ct_eq(&self.montgomery_form, &other.montgomery_form)
+        CtEq::ct_eq(&self.montgomery_form, &other.montgomery_form).into()
     }
 }
 

--- a/src/modular/div_by_2.rs
+++ b/src/modular/div_by_2.rs
@@ -36,7 +36,7 @@ pub(crate) fn div_by_2_boxed_assign(a: &mut BoxedUint, modulus: &Odd<BoxedUint>)
     debug_assert_eq!(a.bits_precision(), modulus.bits_precision());
 
     let is_odd = a.is_odd();
-    let carry = a.conditional_carrying_add_assign(modulus, is_odd);
+    let carry = a.conditional_carrying_add_assign(modulus, is_odd.into());
     a.shr1_assign();
     a.set_bit(a.bits_precision() - 1, carry);
 }

--- a/src/modular/safegcd/boxed.rs
+++ b/src/modular/safegcd/boxed.rs
@@ -5,11 +5,11 @@
 
 use super::{GCD_BATCH_SIZE, Matrix, iterations, jump};
 use crate::{
-    BoxedUint, ConstChoice, CtSelect, I64, Int, Limb, NonZero, Odd, Resize, U64, Uint,
+    BoxedUint, ConstChoice, ConstCtOption, CtSelect, I64, Int, Limb, NonZero, Odd, Resize, U64,
+    Uint,
     primitives::{u32_max, u32_min},
 };
 use core::fmt;
-use subtle::{Choice, CtOption};
 
 /// Modular multiplicative inverter based on the Bernstein-Yang method.
 ///
@@ -53,7 +53,7 @@ impl BoxedSafeGcdInverter {
     }
 
     /// Perform constant-time modular inversion.
-    pub(crate) fn invert(&self, value: &BoxedUint) -> CtOption<BoxedUint> {
+    pub(crate) fn invert(&self, value: &BoxedUint) -> ConstCtOption<BoxedUint> {
         invert_odd_mod_precomp::<false>(
             value,
             &self.modulus,
@@ -63,7 +63,7 @@ impl BoxedSafeGcdInverter {
     }
 
     /// Perform variable-time modular inversion.
-    pub(crate) fn invert_vartime(&self, value: &BoxedUint) -> CtOption<BoxedUint> {
+    pub(crate) fn invert_vartime(&self, value: &BoxedUint) -> ConstCtOption<BoxedUint> {
         invert_odd_mod_precomp::<true>(
             value,
             &self.modulus,
@@ -77,7 +77,7 @@ impl BoxedSafeGcdInverter {
 pub fn invert_odd_mod<const VARTIME: bool>(
     a: &BoxedUint,
     m: &Odd<BoxedUint>,
-) -> CtOption<BoxedUint> {
+) -> ConstCtOption<BoxedUint> {
     let mi = m.as_uint_ref().invert_mod_u64();
     invert_odd_mod_precomp::<VARTIME>(a, m, mi, None)
 }
@@ -89,7 +89,7 @@ fn invert_odd_mod_precomp<const VARTIME: bool>(
     m: &Odd<BoxedUint>,
     mi: u64,
     e: Option<BoxedUint>,
-) -> CtOption<BoxedUint> {
+) -> ConstCtOption<BoxedUint> {
     let a_nonzero = a.is_nonzero();
     let bits_precision = u32_max(a.bits_precision(), m.as_ref().bits_precision());
     let m = m.as_ref().resize(bits_precision);
@@ -122,18 +122,21 @@ fn invert_odd_mod_precomp<const VARTIME: bool>(
     let d = d
         .norm(f.is_negative(), &m)
         .resize_unchecked(a.bits_precision());
-    CtOption::new(d, f.magnitude().is_one() & a_nonzero)
+
+    ConstCtOption::new(d, f.magnitude().is_one() & a_nonzero)
 }
 
 /// Calculate the greatest common denominator of `f` and `g`.
 pub fn gcd<const VARTIME: bool>(f: &BoxedUint, g: &BoxedUint) -> BoxedUint {
-    let f_is_zero = f.is_zero().into();
+    let f_is_zero = f.is_zero();
+
     // Note: is non-zero by construction
     let f_nz = NonZero(BoxedUint::ct_select(
         f,
         &BoxedUint::one_with_precision(f.bits_precision()),
         f_is_zero,
     ));
+
     // gcd of (0, g) is g
     let mut r = gcd_nz::<VARTIME>(&f_nz, g).0;
     r.ct_assign(g, f_is_zero);
@@ -277,13 +280,13 @@ impl SignedBoxedInt {
         Self { sign, magnitude }
     }
 
-    /// Obtain the magnitude of the `SignedInt`, ie. its absolute value.
+    /// Obtain the magnitude of the `SignedInt`, i.e. its absolute value.
     pub const fn magnitude(&self) -> &BoxedUint {
         &self.magnitude
     }
 
     /// Determine if the `SignedInt` is non-zero.
-    pub fn is_nonzero(&self) -> Choice {
+    pub fn is_nonzero(&self) -> ConstChoice {
         self.magnitude.is_nonzero()
     }
 
@@ -407,7 +410,7 @@ impl SignedBoxedInt {
 
     /// Normalize the value to a `BoxedUint` in the range `[0, m)`.
     fn norm(&self, f_sign: ConstChoice, m: &BoxedUint) -> BoxedUint {
-        let swap = f_sign.xor(self.sign) & self.is_nonzero().into();
+        let swap = f_sign.xor(self.sign) & self.is_nonzero();
         BoxedUint::ct_select(&self.magnitude, &m.wrapping_sub(&self.magnitude), swap)
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,7 +5,7 @@ pub use num_traits::{
     WrappingSub,
 };
 
-use crate::{CtSelect, Limb, NonZero, Odd, Reciprocal, modular::Retrieve};
+use crate::{ConstChoice, CtEq, CtSelect, Limb, NonZero, Odd, Reciprocal, modular::Retrieve};
 use core::{
     fmt::{self, Debug},
     ops::{
@@ -14,10 +14,7 @@ use core::{
         SubAssign,
     },
 };
-use subtle::{
-    Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
-    CtOption,
-};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeGreater, ConstantTimeLess, CtOption};
 
 #[cfg(feature = "rand_core")]
 use rand_core::{RngCore, TryRngCore};
@@ -56,9 +53,9 @@ pub trait Integer:
     + CheckedMul
     + CheckedDiv
     + Clone
-    + ConstantTimeEq
     + ConstantTimeGreater
     + ConstantTimeLess
+    + CtEq
     + CtSelect
     + Debug
     + Default
@@ -113,12 +110,12 @@ pub trait Integer:
     ///
     /// # Returns
     ///
-    /// If odd, returns `Choice(1)`. Otherwise, returns `Choice(0)`.
-    fn is_odd(&self) -> Choice {
+    /// If odd, returns `Choice::FALSE`. Otherwise, returns `Choice::TRUE`.
+    fn is_odd(&self) -> ConstChoice {
         self.as_ref()
             .first()
             .map(|limb| limb.is_odd())
-            .unwrap_or_else(|| Choice::from(0))
+            .unwrap_or(ConstChoice::FALSE)
     }
 
     /// Is this integer value an even number?
@@ -126,7 +123,7 @@ pub trait Integer:
     /// # Returns
     ///
     /// If even, returns `Choice(1)`. Otherwise, returns `Choice(0)`.
-    fn is_even(&self) -> Choice {
+    fn is_even(&self) -> ConstChoice {
         !self.is_odd()
     }
 }
@@ -188,7 +185,7 @@ pub trait Unsigned:
 }
 
 /// Zero values: additive identity element for `Self`.
-pub trait Zero: ConstantTimeEq + Sized {
+pub trait Zero: CtEq + Sized {
     /// Returns the additive identity element of `Self`, `0`.
     fn zero() -> Self;
 
@@ -198,7 +195,7 @@ pub trait Zero: ConstantTimeEq + Sized {
     ///
     /// If zero, returns `Choice(1)`. Otherwise, returns `Choice(0)`.
     #[inline]
-    fn is_zero(&self) -> Choice {
+    fn is_zero(&self) -> ConstChoice {
         self.ct_eq(&Self::zero())
     }
 
@@ -220,7 +217,7 @@ pub trait Zero: ConstantTimeEq + Sized {
 }
 
 /// One values: multiplicative identity element for `Self`.
-pub trait One: ConstantTimeEq + Sized {
+pub trait One: CtEq + Sized {
     /// Returns the multiplicative identity element of `Self`, `1`.
     fn one() -> Self;
 
@@ -230,7 +227,7 @@ pub trait One: ConstantTimeEq + Sized {
     ///
     /// If one, returns `Choice(1)`. Otherwise, returns `Choice(0)`.
     #[inline]
-    fn is_one(&self) -> Choice {
+    fn is_one(&self) -> ConstChoice {
         self.ct_eq(&Self::one())
     }
 

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -108,7 +108,7 @@ impl<const LIMBS: usize> AddAssign<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS
 impl<const LIMBS: usize> CheckedAdd for Uint<LIMBS> {
     fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
         let (result, carry) = self.carrying_add(rhs, Limb::ZERO);
-        CtOption::new(result, carry.is_zero())
+        CtOption::new(result, carry.is_zero().into())
     }
 }
 

--- a/src/uint/boxed/add.rs
+++ b/src/uint/boxed/add.rs
@@ -107,11 +107,7 @@ impl AddAssign<BoxedUint> for BoxedUint {
 impl AddAssign<&BoxedUint> for BoxedUint {
     fn add_assign(&mut self, rhs: &BoxedUint) {
         let carry = self.carrying_add_assign(rhs, Limb::ZERO);
-        assert_eq!(
-            carry.is_zero().unwrap_u8(),
-            1,
-            "attempted to add with overflow"
-        );
+        assert!(carry.is_zero().to_bool(), "attempted to add with overflow");
     }
 }
 
@@ -176,7 +172,7 @@ impl AddAssign<&Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
 impl CheckedAdd for BoxedUint {
     fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
         let (result, carry) = self.carrying_add(rhs, Limb::ZERO);
-        CtOption::new(result, carry.is_zero())
+        CtOption::new(result, carry.is_zero().into())
     }
 }
 

--- a/src/uint/boxed/cmp.rs
+++ b/src/uint/boxed/cmp.rs
@@ -5,10 +5,8 @@
 pub(super) use core::cmp::{Ordering, max};
 
 use super::BoxedUint;
-use crate::{Limb, Uint, word};
-use subtle::{
-    Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
-};
+use crate::{ConstChoice, CtEq, Limb, Uint, word};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeGreater, ConstantTimeLess};
 
 impl BoxedUint {
     /// Returns the Ordering between `self` and `rhs` in variable time.
@@ -39,11 +37,11 @@ impl BoxedUint {
     }
 }
 
-impl ConstantTimeEq for BoxedUint {
+impl CtEq for BoxedUint {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> Choice {
+    fn ct_eq(&self, other: &Self) -> ConstChoice {
         let limbs = max(self.nlimbs(), other.nlimbs());
-        let mut ret = Choice::from(1u8);
+        let mut ret = ConstChoice::TRUE;
 
         for i in 0..limbs {
             let a = self.limbs.get(i).unwrap_or(&Limb::ZERO);
@@ -52,6 +50,13 @@ impl ConstantTimeEq for BoxedUint {
         }
 
         ret
+    }
+}
+
+impl subtle::ConstantTimeEq for BoxedUint {
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> Choice {
+        CtEq::ct_eq(self, other).into()
     }
 }
 

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -1,8 +1,8 @@
 //! [`BoxedUint`] division operations.
 
 use crate::{
-    BoxedUint, CheckedDiv, CtSelect, DivRemLimb, DivVartime, Limb, NonZero, Reciprocal, RemLimb,
-    RemMixed, UintRef, Wrapping,
+    BoxedUint, CheckedDiv, ConstCtOption, CtSelect, DivRemLimb, DivVartime, Limb, NonZero,
+    Reciprocal, RemLimb, RemMixed, UintRef, Wrapping,
 };
 use core::ops::{Div, DivAssign, Rem, RemAssign};
 use subtle::CtOption;
@@ -117,19 +117,19 @@ impl BoxedUint {
 
     /// Perform checked division, returning a [`CtOption`] which `is_some`
     /// only if the rhs != 0
-    pub fn checked_div(&self, rhs: &Self) -> CtOption<Self> {
+    pub fn checked_div(&self, rhs: &Self) -> ConstCtOption<Self> {
         let mut quo = self.clone();
         let is_nz = rhs.is_nonzero();
         let mut rem = Self::one_with_precision(self.bits_precision());
-        rem.ct_assign(rhs, is_nz.into());
+        rem.ct_assign(rhs, is_nz);
         quo.as_mut_uint_ref().div_rem(rem.as_mut_uint_ref());
-        CtOption::new(quo, is_nz)
+        ConstCtOption::new(quo, is_nz)
     }
 }
 
 impl CheckedDiv for BoxedUint {
     fn checked_div(&self, rhs: &BoxedUint) -> CtOption<Self> {
-        self.checked_div(rhs)
+        self.checked_div(rhs).into()
     }
 }
 

--- a/src/uint/boxed/neg_mod.rs
+++ b/src/uint/boxed/neg_mod.rs
@@ -1,7 +1,6 @@
 //! [`BoxedUint`] modular negation operations.
 
-use crate::{BoxedUint, Limb, NegMod, NonZero};
-use subtle::ConditionallySelectable;
+use crate::{BoxedUint, CtSelect, Limb, NegMod, NonZero};
 
 impl BoxedUint {
     /// Computes `-a mod p`.
@@ -14,7 +13,7 @@ impl BoxedUint {
         for i in 0..self.nlimbs() {
             // Set ret to 0 if the original value was 0, in which
             // case ret would be p.
-            ret.limbs[i].conditional_assign(&Limb::ZERO, is_zero);
+            ret.limbs[i].ct_assign(&Limb::ZERO, is_zero);
         }
 
         ret

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -29,13 +29,13 @@ impl BoxedUint {
         // TODO (#378): the tests indicate that just `Self::LOG2_BITS` may be enough.
         while i < self.log2_bits() + 2 {
             let x_nonzero = x.is_nonzero();
-            nz_x.ct_assign(&x, x_nonzero.into());
+            nz_x.ct_assign(&x, x_nonzero);
 
             // Calculate `x_{i+1} = floor((x_i + self / x_i) / 2)`
             quo.limbs.copy_from_slice(&self.limbs);
             rem.limbs.copy_from_slice(&nz_x.limbs);
             quo.as_mut_uint_ref().div_rem(rem.as_mut_uint_ref());
-            x.conditional_carrying_add_assign(&quo, x_nonzero);
+            x.conditional_carrying_add_assign(&quo, x_nonzero.into());
             x.shr1_assign();
 
             i += 1;

--- a/src/uint/boxed/sub.rs
+++ b/src/uint/boxed/sub.rs
@@ -72,7 +72,7 @@ impl BoxedUint {
 impl CheckedSub for BoxedUint {
     fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
         let (result, carry) = self.borrowing_sub(rhs, Limb::ZERO);
-        CtOption::new(result, carry.is_zero())
+        CtOption::new(result, carry.is_zero().into())
     }
 }
 
@@ -118,9 +118,8 @@ impl SubAssign<BoxedUint> for BoxedUint {
 impl SubAssign<&BoxedUint> for BoxedUint {
     fn sub_assign(&mut self, rhs: &BoxedUint) {
         let carry = self.borrowing_sub_assign(rhs, Limb::ZERO);
-        assert_eq!(
-            carry.is_zero().unwrap_u8(),
-            1,
+        assert!(
+            carry.is_zero().to_bool(),
             "attempted to subtract with underflow"
         );
     }

--- a/src/uint/boxed/sub_mod.rs
+++ b/src/uint/boxed/sub_mod.rs
@@ -1,6 +1,7 @@
 //! [`BoxedUint`] modular subtraction operations.
 
 use crate::{BoxedUint, Limb, NonZero, SubMod, Zero};
+use subtle::Choice;
 
 impl BoxedUint {
     /// Computes `self - rhs mod p`.
@@ -16,7 +17,7 @@ impl BoxedUint {
 
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the modulus.
-        out.conditional_carrying_add_assign(p, !borrow.is_zero());
+        out.conditional_carrying_add_assign(p, !Choice::from(borrow.is_zero()));
         out
     }
 
@@ -33,7 +34,7 @@ impl BoxedUint {
 
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the modulus.
-        self.conditional_carrying_add_assign(p, !mask.is_zero());
+        self.conditional_carrying_add_assign(p, !Choice::from(mask.is_zero()));
     }
 
     /// Computes `self - rhs mod p` for the special modulus

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -3,9 +3,9 @@
 //! By default, these are all constant-time.
 
 use super::Uint;
-use crate::{ConstChoice, Limb, word};
+use crate::{ConstChoice, CtEq, Limb, word};
 use core::cmp::Ordering;
-use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
+use subtle::{Choice, ConstantTimeGreater, ConstantTimeLess};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Return `b` if `c` is truthy, otherwise return `a`.
@@ -149,10 +149,22 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> ConstantTimeEq for Uint<LIMBS> {
+impl<const LIMBS: usize> CtEq for Uint<LIMBS> {
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> ConstChoice {
+        self.limbs.ct_eq(&other.limbs)
+    }
+}
+
+impl<const LIMBS: usize> subtle::ConstantTimeEq for Uint<LIMBS> {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
-        Uint::eq(self, other).into()
+        CtEq::ct_eq(self, other).into()
+    }
+
+    #[inline]
+    fn ct_ne(&self, other: &Self) -> Choice {
+        CtEq::ct_ne(self, other).into()
     }
 }
 

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -728,7 +728,8 @@ mod tests {
         assert_eq!(q, Uint::ZERO);
         a.limbs[a.limbs.len() - 1] = Limb(1 << (Limb::HI_BIT - 7));
         b.limbs[b.limbs.len() - 1] = Limb(0x82 << (Limb::HI_BIT - 7));
-        let q = a.wrapping_div(&NonZero::new(b).unwrap());
+        let b = NonZero::new(b).unwrap();
+        let q = a.wrapping_div(&b);
         assert_eq!(q, Uint::ZERO);
     }
 

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -44,7 +44,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 impl<const LIMBS: usize> CheckedSub for Uint<LIMBS> {
     fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
         let (result, underflow) = self.borrowing_sub(rhs, Limb::ZERO);
-        CtOption::new(result, underflow.is_zero())
+        CtOption::new(result, underflow.is_zero().into())
     }
 }
 


### PR DESCRIPTION
Changes all of the traits in `traits.rs`, most notably the `Integer`, `Zero`, and `One` traits, to use `ctutils::CtEq` instead of `subtle::ConstantTimeEq`, as part of a larger overall migration to `ctutils` (see also #1040, #1043)