### PR TITLE
Impl and bound `Integer` on `CtGt`/`CtLt`

### DIFF
--- a/src/int/cmp.rs
+++ b/src/int/cmp.rs
@@ -2,9 +2,8 @@
 //!
 //! By default, these are all constant-time.
 
-use crate::{ConstChoice, CtEq, Int, Uint};
+use crate::{ConstChoice, CtEq, CtGt, CtLt, Int, Uint};
 use core::cmp::Ordering;
-use subtle::{Choice, ConstantTimeGreater, ConstantTimeLess};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Return `b` if `c` is truthy, otherwise return `a`.
@@ -66,23 +65,37 @@ impl<const LIMBS: usize> CtEq for Int<LIMBS> {
     }
 }
 
+impl<const LIMBS: usize> CtGt for Int<LIMBS> {
+    #[inline]
+    fn ct_gt(&self, other: &Self) -> ConstChoice {
+        Int::gt(self, other)
+    }
+}
+
+impl<const LIMBS: usize> CtLt for Int<LIMBS> {
+    #[inline]
+    fn ct_lt(&self, other: &Self) -> ConstChoice {
+        Int::lt(self, other)
+    }
+}
+
 impl<const LIMBS: usize> subtle::ConstantTimeEq for Int<LIMBS> {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> Choice {
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
         CtEq::ct_eq(self, other).into()
     }
 }
 
-impl<const LIMBS: usize> ConstantTimeGreater for Int<LIMBS> {
+impl<const LIMBS: usize> subtle::ConstantTimeGreater for Int<LIMBS> {
     #[inline]
-    fn ct_gt(&self, other: &Self) -> Choice {
-        Int::gt(self, other).into()
+    fn ct_gt(&self, other: &Self) -> subtle::Choice {
+        CtGt::ct_gt(self, other).into()
     }
 }
 
-impl<const LIMBS: usize> ConstantTimeLess for Int<LIMBS> {
+impl<const LIMBS: usize> subtle::ConstantTimeLess for Int<LIMBS> {
     #[inline]
-    fn ct_lt(&self, other: &Self) -> Choice {
+    fn ct_lt(&self, other: &Self) -> subtle::Choice {
         Int::lt(self, other).into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ pub use crate::{
 };
 
 // TODO(tarcieri): get rid of `Const*` prefix
-pub use ctutils::{Choice as ConstChoice, CtEq, CtOption as ConstCtOption, CtSelect};
+pub use ctutils::{Choice as ConstChoice, CtOption as ConstCtOption};
 
 #[cfg(feature = "alloc")]
 pub use crate::uint::boxed::BoxedUint;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,11 +1,12 @@
 //! Traits provided by this crate
 
+pub use ctutils::{CtEq, CtGt, CtLt, CtSelect};
 pub use num_traits::{
     ConstOne, ConstZero, WrappingAdd, WrappingMul, WrappingNeg, WrappingShl, WrappingShr,
     WrappingSub,
 };
 
-use crate::{ConstChoice, CtEq, CtSelect, Limb, NonZero, Odd, Reciprocal, modular::Retrieve};
+use crate::{ConstChoice, Limb, NonZero, Odd, Reciprocal, modular::Retrieve};
 use core::{
     fmt::{self, Debug},
     ops::{
@@ -14,7 +15,7 @@ use core::{
         SubAssign,
     },
 };
-use subtle::{Choice, ConditionallySelectable, ConstantTimeGreater, ConstantTimeLess, CtOption};
+use subtle::{Choice, ConditionallySelectable, CtOption};
 
 #[cfg(feature = "rand_core")]
 use rand_core::{RngCore, TryRngCore};
@@ -53,9 +54,9 @@ pub trait Integer:
     + CheckedMul
     + CheckedDiv
     + Clone
-    + ConstantTimeGreater
-    + ConstantTimeLess
     + CtEq
+    + CtGt
+    + CtLt
     + CtSelect
     + Debug
     + Default
@@ -136,7 +137,7 @@ pub trait Signed:
     + From<i16>
     + From<i32>
     + From<i64>
-    + Integer
+    + Integer // + CtNeg TODO(tarcieri)
 {
     /// Corresponding unsigned integer type.
     type Unsigned: Unsigned;

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -3,9 +3,8 @@
 //! By default, these are all constant-time.
 
 use super::Uint;
-use crate::{ConstChoice, CtEq, Limb, word};
+use crate::{ConstChoice, CtEq, CtGt, CtLt, Limb, word};
 use core::cmp::Ordering;
-use subtle::{Choice, ConstantTimeGreater, ConstantTimeLess};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Return `b` if `c` is truthy, otherwise return `a`.
@@ -156,28 +155,42 @@ impl<const LIMBS: usize> CtEq for Uint<LIMBS> {
     }
 }
 
+impl<const LIMBS: usize> CtGt for Uint<LIMBS> {
+    #[inline]
+    fn ct_gt(&self, other: &Self) -> ConstChoice {
+        Self::gt(self, other)
+    }
+}
+
+impl<const LIMBS: usize> CtLt for Uint<LIMBS> {
+    #[inline]
+    fn ct_lt(&self, other: &Self) -> ConstChoice {
+        Self::lt(self, other)
+    }
+}
+
 impl<const LIMBS: usize> subtle::ConstantTimeEq for Uint<LIMBS> {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> Choice {
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
         CtEq::ct_eq(self, other).into()
     }
 
     #[inline]
-    fn ct_ne(&self, other: &Self) -> Choice {
+    fn ct_ne(&self, other: &Self) -> subtle::Choice {
         CtEq::ct_ne(self, other).into()
     }
 }
 
-impl<const LIMBS: usize> ConstantTimeGreater for Uint<LIMBS> {
+impl<const LIMBS: usize> subtle::ConstantTimeGreater for Uint<LIMBS> {
     #[inline]
-    fn ct_gt(&self, other: &Self) -> Choice {
-        Uint::gt(self, other).into()
+    fn ct_gt(&self, other: &Self) -> subtle::Choice {
+        CtGt::ct_gt(self, other).into()
     }
 }
 
-impl<const LIMBS: usize> ConstantTimeLess for Uint<LIMBS> {
+impl<const LIMBS: usize> subtle::ConstantTimeLess for Uint<LIMBS> {
     #[inline]
-    fn ct_lt(&self, other: &Self) -> Choice {
+    fn ct_lt(&self, other: &Self) -> subtle::Choice {
         Uint::lt(self, other).into()
     }
 }


### PR DESCRIPTION
Replaces the previous bounds on `subtle::ConstantTimeGreater` and `ConstantTimeLess` with `ctutils::{CtGt, CtLt}`.

The old `subtle` trait impls are retained but no longer used in bounds. One step closer to making `subtle` optional.