### PR TITLE
Use `ConstChoice` for all traits (notably `BitOps`)

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -264,17 +264,16 @@ impl<const LIMBS: usize> Integer for Int<LIMBS> {
 impl<const LIMBS: usize> Signed for Int<LIMBS> {
     type Unsigned = Uint<LIMBS>;
 
-    fn abs_sign(&self) -> (Uint<LIMBS>, Choice) {
-        let (abs, sign) = self.abs_sign();
-        (abs, sign.into())
+    fn abs_sign(&self) -> (Uint<LIMBS>, ConstChoice) {
+        self.abs_sign()
     }
 
-    fn is_negative(&self) -> Choice {
-        self.is_negative().into()
+    fn is_negative(&self) -> ConstChoice {
+        self.is_negative()
     }
 
-    fn is_positive(&self) -> Choice {
-        self.is_positive().into()
+    fn is_positive(&self) -> ConstChoice {
+        self.is_positive()
     }
 }
 

--- a/src/modular/div_by_2.rs
+++ b/src/modular/div_by_2.rs
@@ -38,5 +38,5 @@ pub(crate) fn div_by_2_boxed_assign(a: &mut BoxedUint, modulus: &Odd<BoxedUint>)
     let is_odd = a.is_odd();
     let carry = a.conditional_carrying_add_assign(modulus, is_odd.into());
     a.shr1_assign();
-    a.set_bit(a.bits_precision() - 1, carry);
+    a.set_bit(a.bits_precision() - 1, carry.into());
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,7 +15,7 @@ use core::{
         SubAssign,
     },
 };
-use subtle::{Choice, ConditionallySelectable, CtOption};
+use subtle::CtOption;
 
 #[cfg(feature = "rand_core")]
 use rand_core::{RngCore, TryRngCore};
@@ -143,18 +143,18 @@ pub trait Signed:
     type Unsigned: Unsigned;
 
     /// The sign and magnitude of this [`Signed`].
-    fn abs_sign(&self) -> (Self::Unsigned, Choice);
+    fn abs_sign(&self) -> (Self::Unsigned, ConstChoice);
 
     /// The magnitude of this [`Signed`].
     fn abs(&self) -> Self::Unsigned {
         self.abs_sign().0
     }
 
-    /// Whether this [`Signed`] is negative (and non-zero), as a [`Choice`].
-    fn is_negative(&self) -> Choice;
+    /// Whether this [`Signed`] is negative (and non-zero), as a [`ConstChoice`].
+    fn is_negative(&self) -> ConstChoice;
 
-    /// Whether this [`Signed`] is positive (and non-zero), as a [`Choice`].
-    fn is_positive(&self) -> Choice;
+    /// Whether this [`Signed`] is positive (and non-zero), as a [`ConstChoice`].
+    fn is_positive(&self) -> ConstChoice;
 }
 
 /// Unsigned [`Integer`]s.
@@ -256,7 +256,7 @@ pub trait Constants: ConstZero + ConstOne {
 }
 
 /// Fixed-width [`Integer`]s.
-pub trait FixedInteger: Bounded + ConditionallySelectable + Constants + Copy + Integer {
+pub trait FixedInteger: Bounded + Constants + Copy + Integer {
     /// The number of limbs used on this platform.
     const LIMBS: usize;
 }
@@ -758,10 +758,10 @@ pub trait BitOps {
 
     /// Get the value of the bit at position `index`, as a truthy or falsy `Choice`.
     /// Returns the falsy value for indices out of range.
-    fn bit(&self, index: u32) -> Choice;
+    fn bit(&self, index: u32) -> ConstChoice;
 
     /// Sets the bit at `index` to 0 or 1 depending on the value of `bit_value`.
-    fn set_bit(&mut self, index: u32, bit_value: Choice);
+    fn set_bit(&mut self, index: u32, bit_value: ConstChoice);
 
     /// Calculate the number of bits required to represent a given number.
     fn bits(&self) -> u32 {

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -1,5 +1,3 @@
-use subtle::Choice;
-
 use crate::{BitOps, ConstChoice, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
@@ -98,12 +96,12 @@ impl<const LIMBS: usize> BitOps for Uint<LIMBS> {
         self.leading_zeros()
     }
 
-    fn bit(&self, index: u32) -> Choice {
-        self.bit(index).into()
+    fn bit(&self, index: u32) -> ConstChoice {
+        self.bit(index)
     }
 
-    fn set_bit(&mut self, index: u32, bit_value: Choice) {
-        *self = Self::set_bit(*self, index, bit_value.into());
+    fn set_bit(&mut self, index: u32, bit_value: ConstChoice) {
+        *self = Self::set_bit(*self, index, bit_value);
     }
 
     fn trailing_zeros(&self) -> u32 {

--- a/src/uint/boxed/bits.rs
+++ b/src/uint/boxed/bits.rs
@@ -1,13 +1,12 @@
 //! Bit manipulation functions.
 
-use crate::{BitOps, BoxedUint, Limb};
-use subtle::Choice;
+use crate::{BitOps, BoxedUint, ConstChoice, Limb};
 
 impl BoxedUint {
     /// Get the value of the bit at position `index`, as a truthy or falsy `Choice`.
     /// Returns the falsy value for indices out of range.
-    pub fn bit(&self, index: u32) -> Choice {
-        self.as_uint_ref().bit(index).into()
+    pub fn bit(&self, index: u32) -> ConstChoice {
+        self.as_uint_ref().bit(index)
     }
 
     /// Returns `true` if the bit at position `index` is set, `false` otherwise.
@@ -67,8 +66,8 @@ impl BoxedUint {
     }
 
     /// Sets the bit at `index` to 0 or 1 depending on the value of `bit_value`.
-    pub(crate) fn set_bit(&mut self, index: u32, bit_value: Choice) {
-        self.as_mut_uint_ref().set_bit(index, bit_value.into())
+    pub(crate) fn set_bit(&mut self, index: u32, bit_value: ConstChoice) {
+        self.as_mut_uint_ref().set_bit(index, bit_value)
     }
 
     pub(crate) fn set_bit_vartime(&mut self, index: u32, bit_value: bool) {
@@ -98,11 +97,11 @@ impl BitOps for BoxedUint {
         self.bits()
     }
 
-    fn bit(&self, index: u32) -> Choice {
+    fn bit(&self, index: u32) -> ConstChoice {
         self.bit(index)
     }
 
-    fn set_bit(&mut self, index: u32, bit_value: Choice) {
+    fn set_bit(&mut self, index: u32, bit_value: ConstChoice) {
         self.set_bit(index, bit_value)
     }
 
@@ -138,8 +137,8 @@ impl BitOps for BoxedUint {
 #[cfg(test)]
 mod tests {
     use super::BoxedUint;
+    use crate::ConstChoice;
     use hex_literal::hex;
-    use subtle::Choice;
 
     fn uint_with_bits_at(positions: &[u32]) -> BoxedUint {
         let mut result = BoxedUint::zero_with_precision(256);
@@ -176,19 +175,19 @@ mod tests {
     #[test]
     fn set_bit() {
         let mut u = uint_with_bits_at(&[16, 79, 150]);
-        u.set_bit(127, Choice::from(1));
+        u.set_bit(127, ConstChoice::TRUE);
         assert_eq!(u, uint_with_bits_at(&[16, 79, 127, 150]));
 
         let mut u = uint_with_bits_at(&[16, 79, 150]);
-        u.set_bit(150, Choice::from(1));
+        u.set_bit(150, ConstChoice::TRUE);
         assert_eq!(u, uint_with_bits_at(&[16, 79, 150]));
 
         let mut u = uint_with_bits_at(&[16, 79, 150]);
-        u.set_bit(127, Choice::from(0));
+        u.set_bit(127, ConstChoice::FALSE);
         assert_eq!(u, uint_with_bits_at(&[16, 79, 150]));
 
         let mut u = uint_with_bits_at(&[16, 79, 150]);
-        u.set_bit(150, Choice::from(0));
+        u.set_bit(150, ConstChoice::FALSE);
         assert_eq!(u, uint_with_bits_at(&[16, 79]));
     }
 

--- a/src/uint/ref_type/bits.rs
+++ b/src/uint/ref_type/bits.rs
@@ -1,6 +1,5 @@
 use super::UintRef;
 use crate::{ConstChoice, Limb, traits::BitOps, word};
-use subtle::Choice;
 
 impl UintRef {
     /// Get the precision of this number in bits.
@@ -221,12 +220,12 @@ impl BitOps for UintRef {
         self.leading_zeros()
     }
 
-    fn bit(&self, index: u32) -> Choice {
-        self.bit(index).into()
+    fn bit(&self, index: u32) -> ConstChoice {
+        self.bit(index)
     }
 
-    fn set_bit(&mut self, index: u32, bit_value: Choice) {
-        self.set_bit(index, bit_value.into());
+    fn set_bit(&mut self, index: u32, bit_value: ConstChoice) {
+        self.set_bit(index, bit_value);
     }
 
     fn trailing_zeros(&self) -> u32 {

--- a/tests/boxed_uint.rs
+++ b/tests/boxed_uint.rs
@@ -5,13 +5,14 @@
 mod common;
 
 use common::to_biguint;
-use crypto_bigint::{BitOps, BoxedUint, CheckedAdd, Gcd, Integer, Limb, NonZero, Odd, Resize};
+use crypto_bigint::{
+    BitOps, BoxedUint, CheckedAdd, ConstChoice, Gcd, Integer, Limb, NonZero, Odd, Resize,
+};
 use num_bigint::BigUint;
 use num_integer::Integer as _;
 use num_modular::ModularUnaryOps;
 use num_traits::identities::One;
 use proptest::prelude::*;
-use subtle::Choice;
 
 fn to_uint(big_uint: BigUint) -> BoxedUint {
     let bytes = big_uint.to_bytes_be();
@@ -138,7 +139,7 @@ proptest! {
 
     #[test]
     fn invert_mod2k(mut a in uint(), k in any::<u32>()) {
-        a.set_bit(0, Choice::from(1)); // make odd
+        a.set_bit(0, ConstChoice::TRUE); // make odd
         let k = k % (a.bits() + 1);
         let a_bi = to_biguint(&a);
         let m_bi = BigUint::one() << k as usize;


### PR DESCRIPTION
Gets rid of the lingering usages of `Choice` in the traits this crate defines in `traits.rs`.

(There are still usages of `CtOption` to remove)