### PR TITLE
CI: disable codecov patch coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    patch: off


### PR DESCRIPTION
We just want to use codecov for metrics, not to police PRs