### PR TITLE
Use `ConstCtOption` for checked operations

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -1,13 +1,10 @@
 //! Stack-allocated big signed integers.
 
 use crate::{
-    Bounded, ConstChoice, ConstCtOption, Constants, FixedInteger, Integer, Limb, NonZero, Odd, One,
-    Signed, Uint, Word, Zero,
+    Bounded, ConstChoice, ConstCtOption, ConstOne, ConstZero, Constants, CtEq, CtSelect,
+    FixedInteger, Integer, Limb, NonZero, Odd, One, Signed, Uint, Word, Zero,
 };
 use core::fmt;
-use ctutils::CtSelect;
-use num_traits::{ConstOne, ConstZero};
-use subtle::{Choice, ConstantTimeEq};
 
 #[cfg(feature = "serde")]
 use crate::Encoding;
@@ -184,6 +181,11 @@ impl<const LIMBS: usize> Int<LIMBS> {
         Self::eq(self, &Self::MAX)
     }
 
+    /// Is this [`Int`] equal to zero?
+    pub const fn is_zero(&self) -> ConstChoice {
+        self.0.is_zero()
+    }
+
     /// Invert the most significant bit (msb) of this [`Int`]
     const fn invert_msb(&self) -> Self {
         Self(self.0.bitxor(&Self::SIGN_MASK.0))
@@ -216,7 +218,7 @@ impl<const LIMBS: usize> AsMut<[Limb]> for Int<LIMBS> {
 
 impl<const LIMBS: usize> subtle::ConditionallySelectable for Int<LIMBS> {
     #[inline]
-    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
         a.ct_select(b, choice.into())
     }
 }

--- a/src/int/add.rs
+++ b/src/int/add.rs
@@ -1,11 +1,8 @@
 //! [`Int`] addition operations.
 
-use core::ops::{Add, AddAssign};
-
-use num_traits::WrappingAdd;
-use subtle::CtOption;
-
-use crate::{Checked, CheckedAdd, ConstChoice, ConstCtOption, Int, Wrapping};
+use crate::{
+    Add, AddAssign, Checked, CheckedAdd, ConstChoice, ConstCtOption, Int, Wrapping, WrappingAdd,
+};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Perform checked addition. Returns `none` when the addition overflowed.
@@ -52,7 +49,8 @@ impl<const LIMBS: usize> Add<&Int<LIMBS>> for Int<LIMBS> {
     type Output = Self;
 
     fn add(self, rhs: &Self) -> Self {
-        CtOption::from(self.checked_add(rhs)).expect("attempted to add with overflow")
+        self.checked_add(rhs)
+            .expect("attempted to add with overflow")
     }
 }
 
@@ -93,8 +91,8 @@ impl<const LIMBS: usize> AddAssign<&Checked<Int<LIMBS>>> for Checked<Int<LIMBS>>
 }
 
 impl<const LIMBS: usize> CheckedAdd for Int<LIMBS> {
-    fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
-        self.checked_add(rhs).into()
+    fn checked_add(&self, rhs: &Self) -> ConstCtOption<Self> {
+        self.checked_add(rhs)
     }
 }
 

--- a/src/int/div.rs
+++ b/src/int/div.rs
@@ -1,10 +1,7 @@
 //! [`Int`] division operations.
 
-use core::ops::{Div, DivAssign, Rem, RemAssign};
-
-use subtle::CtOption;
-
 use crate::{CheckedDiv, ConstChoice, ConstCtOption, DivVartime, Int, NonZero, Uint, Wrapping};
+use core::ops::{Div, DivAssign, Rem, RemAssign};
 
 /// Checked division operations.
 impl<const LIMBS: usize> Int<LIMBS> {
@@ -64,13 +61,13 @@ impl<const LIMBS: usize> Int<LIMBS> {
         )
     }
 
-    /// Perform checked division, returning a [`CtOption`] which `is_some` if
+    /// Perform checked division, returning a [`ConstCtOption`] which `is_some` if
     /// - the `rhs != 0`, and
     /// - `self != MIN` or `rhs != MINUS_ONE`.
     ///
     /// Note: this operation rounds towards zero, truncating any fractional part of the exact result.
-    pub fn checked_div<const RHS_LIMBS: usize>(&self, rhs: &Int<RHS_LIMBS>) -> CtOption<Self> {
-        NonZero::new(*rhs).and_then(|rhs| self.checked_div_rem(&rhs).0.into())
+    pub fn checked_div<const RHS_LIMBS: usize>(&self, rhs: &Int<RHS_LIMBS>) -> ConstCtOption<Self> {
+        NonZero::new(*rhs).and_then(|rhs| self.checked_div_rem(&rhs).0)
     }
 
     /// Computes `self` % `rhs`, returns the remainder.
@@ -133,8 +130,8 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub fn checked_div_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
-    ) -> CtOption<Self> {
-        NonZero::new(*rhs).and_then(|rhs| self.checked_div_rem_vartime(&rhs).0.into())
+    ) -> ConstCtOption<Self> {
+        NonZero::new(*rhs).and_then(|rhs| self.checked_div_rem_vartime(&rhs).0)
     }
 
     /// Variable time equivalent of [`Self::rem`]
@@ -196,8 +193,8 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub fn checked_div_floor_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
-    ) -> CtOption<Self> {
-        NonZero::new(*rhs).and_then(|rhs| self.checked_div_rem_floor_vartime(&rhs).0.into())
+    ) -> ConstCtOption<Self> {
+        NonZero::new(*rhs).and_then(|rhs| self.checked_div_rem_floor_vartime(&rhs).0)
     }
 }
 
@@ -232,8 +229,8 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub fn checked_div_floor<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
-    ) -> CtOption<Self> {
-        NonZero::new(*rhs).and_then(|rhs| self.checked_div_rem_floor(&rhs).0.into())
+    ) -> ConstCtOption<Self> {
+        NonZero::new(*rhs).and_then(|rhs| self.checked_div_rem_floor(&rhs).0)
     }
 
     /// Perform checked division and mod, returning the quotient and remainder.
@@ -296,13 +293,13 @@ impl<const LIMBS: usize> Int<LIMBS> {
 }
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> CheckedDiv<Int<RHS_LIMBS>> for Int<LIMBS> {
-    fn checked_div(&self, rhs: &Int<RHS_LIMBS>) -> CtOption<Self> {
+    fn checked_div(&self, rhs: &Int<RHS_LIMBS>) -> ConstCtOption<Self> {
         self.checked_div(rhs)
     }
 }
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<&NonZero<Int<RHS_LIMBS>>> for &Int<LIMBS> {
-    type Output = CtOption<Int<LIMBS>>;
+    type Output = ConstCtOption<Int<LIMBS>>;
 
     fn div(self, rhs: &NonZero<Int<RHS_LIMBS>>) -> Self::Output {
         *self / *rhs
@@ -310,7 +307,7 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<&NonZero<Int<RHS_LIMBS>>> f
 }
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<&NonZero<Int<RHS_LIMBS>>> for Int<LIMBS> {
-    type Output = CtOption<Int<LIMBS>>;
+    type Output = ConstCtOption<Int<LIMBS>>;
 
     fn div(self, rhs: &NonZero<Int<RHS_LIMBS>>) -> Self::Output {
         self / *rhs
@@ -318,7 +315,7 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<&NonZero<Int<RHS_LIMBS>>> f
 }
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<NonZero<Int<RHS_LIMBS>>> for &Int<LIMBS> {
-    type Output = CtOption<Int<LIMBS>>;
+    type Output = ConstCtOption<Int<LIMBS>>;
 
     fn div(self, rhs: NonZero<Int<RHS_LIMBS>>) -> Self::Output {
         *self / rhs
@@ -326,7 +323,7 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<NonZero<Int<RHS_LIMBS>>> fo
 }
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<NonZero<Int<RHS_LIMBS>>> for Int<LIMBS> {
-    type Output = CtOption<Int<LIMBS>>;
+    type Output = ConstCtOption<Int<LIMBS>>;
 
     fn div(self, rhs: NonZero<Int<RHS_LIMBS>>) -> Self::Output {
         self.checked_div(&rhs)
@@ -506,7 +503,7 @@ impl<const LIMBS: usize> RemAssign<&NonZero<Int<LIMBS>>> for Wrapping<Int<LIMBS>
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, DivVartime, I128, Int, NonZero, Zero};
+    use crate::{ConstChoice, CtSelect, DivVartime, I128, Int, NonZero, One, Zero};
 
     #[test]
     #[allow(clippy::init_numbered_fields)]
@@ -631,7 +628,7 @@ mod tests {
 
     #[test]
     fn div_vartime_through_trait() {
-        fn myfn<T: DivVartime + Zero>(x: T, y: T) -> T {
+        fn myfn<T: DivVartime + Zero + One + CtSelect>(x: T, y: T) -> T {
             x.div_vartime(&NonZero::new(y).unwrap())
         }
         assert_eq!(myfn(I128::from(8), I128::from(3)), I128::from(2));

--- a/src/int/gcd.rs
+++ b/src/int/gcd.rs
@@ -317,7 +317,6 @@ impl<const LIMBS: usize> Xgcd for OddInt<LIMBS> {
 mod tests {
     use crate::int::gcd::{IntXgcdOutput, NonZeroIntXgcdOutput, OddIntXgcdOutput};
     use crate::{ConcatMixed, Gcd, Int, Uint};
-    use num_traits::Zero;
 
     impl<const LIMBS: usize> From<NonZeroIntXgcdOutput<LIMBS>> for IntXgcdOutput<LIMBS> {
         fn from(value: NonZeroIntXgcdOutput<LIMBS>) -> Self {
@@ -420,7 +419,8 @@ mod tests {
 
         // Test quotients
         let (lhs_on_gcd, rhs_on_gcd) = output.quotients();
-        if gcd.is_zero() {
+
+        if gcd.is_zero().to_bool() {
             assert_eq!(lhs_on_gcd, Int::ZERO);
             assert_eq!(rhs_on_gcd, Int::ZERO);
         } else {
@@ -430,11 +430,11 @@ mod tests {
 
         // Test the Bezout coefficients on minimality
         let (x, y) = output.bezout_coefficients();
-        assert!(x.abs() <= rhs_on_gcd.abs() || rhs_on_gcd.is_zero());
-        assert!(y.abs() <= lhs_on_gcd.abs() || lhs_on_gcd.is_zero());
+        assert!(x.abs() <= rhs_on_gcd.abs() || rhs_on_gcd.is_zero().to_bool());
+        assert!(y.abs() <= lhs_on_gcd.abs() || lhs_on_gcd.is_zero().to_bool());
         if lhs.abs() != rhs.abs() {
-            assert!(x.abs() <= rhs_on_gcd.abs().shr(1) || rhs_on_gcd.is_zero());
-            assert!(y.abs() <= lhs_on_gcd.abs().shr(1) || lhs_on_gcd.is_zero());
+            assert!(x.abs() <= rhs_on_gcd.abs().shr(1) || rhs_on_gcd.is_zero().to_bool());
+            assert!(y.abs() <= lhs_on_gcd.abs().shr(1) || lhs_on_gcd.is_zero().to_bool());
         }
 
         // Test the Bezout coefficients for correctness

--- a/src/int/invert_mod.rs
+++ b/src/int/invert_mod.rs
@@ -1,7 +1,5 @@
 //! Operations related to computing the inverse of an [`Int`] modulo a [`Uint`].
 
-use subtle::CtOption;
-
 use crate::{ConstCtOption, Int, InvertMod, NonZero, Odd, Uint};
 
 impl<const LIMBS: usize> Int<LIMBS> {
@@ -42,8 +40,8 @@ where
 {
     type Output = Uint<LIMBS>;
 
-    fn invert_mod(&self, modulus: &NonZero<Uint<LIMBS>>) -> CtOption<Self::Output> {
-        Self::invert_mod(self, modulus).into()
+    fn invert_mod(&self, modulus: &NonZero<Uint<LIMBS>>) -> ConstCtOption<Self::Output> {
+        Self::invert_mod(self, modulus)
     }
 }
 

--- a/src/int/mul.rs
+++ b/src/int/mul.rs
@@ -1,10 +1,9 @@
 //! [`Int`] multiplication operations.
 
-use core::ops::{Mul, MulAssign};
-use num_traits::WrappingMul;
-use subtle::CtOption;
-
-use crate::{Checked, CheckedMul, ConcatMixed, ConstChoice, ConstCtOption, Int, Uint};
+use crate::{
+    Checked, CheckedMul, ConcatMixed, ConstChoice, ConstCtOption, Int, Mul, MulAssign, Uint,
+    WrappingMul,
+};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Compute "wide" multiplication as a 3-tuple `(lo, hi, negate)`.
@@ -130,8 +129,8 @@ impl<const LIMBS: usize> Int<LIMBS> {
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> CheckedMul<Int<RHS_LIMBS>> for Int<LIMBS> {
     #[inline]
-    fn checked_mul(&self, rhs: &Int<RHS_LIMBS>) -> CtOption<Self> {
-        self.checked_mul(rhs).into()
+    fn checked_mul(&self, rhs: &Int<RHS_LIMBS>) -> ConstCtOption<Self> {
+        self.checked_mul(rhs)
     }
 }
 

--- a/src/int/mul_uint.rs
+++ b/src/int/mul_uint.rs
@@ -1,7 +1,5 @@
-use core::ops::Mul;
-use subtle::CtOption;
-
 use crate::{CheckedMul, ConcatMixed, ConstChoice, ConstCtOption, Int, Uint};
+use core::ops::Mul;
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Compute "wide" multiplication between an [`Int`] and [`Uint`] as 3-tuple `(lo, hi, negate)`.
@@ -87,8 +85,8 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub fn checked_mul_uint_right<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
-    ) -> CtOption<Int<RHS_LIMBS>> {
-        rhs.checked_mul_int(self).into()
+    ) -> ConstCtOption<Int<RHS_LIMBS>> {
+        rhs.checked_mul_int(self)
     }
 
     /// Checked multiplication with a [`Uint`].
@@ -103,8 +101,8 @@ impl<const LIMBS: usize> Int<LIMBS> {
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> CheckedMul<Uint<RHS_LIMBS>> for Int<LIMBS> {
     #[inline]
-    fn checked_mul(&self, rhs: &Uint<RHS_LIMBS>) -> CtOption<Self> {
-        self.checked_mul_uint(rhs).into()
+    fn checked_mul(&self, rhs: &Uint<RHS_LIMBS>) -> ConstCtOption<Self> {
+        self.checked_mul_uint(rhs)
     }
 }
 

--- a/src/int/neg.rs
+++ b/src/int/neg.rs
@@ -1,7 +1,6 @@
 //! [`Int`] negation-related operations.
 
-use crate::{ConstChoice, ConstCtOption, Int, Uint};
-use num_traits::WrappingNeg;
+use crate::{ConstChoice, ConstCtOption, Int, Uint, WrappingNeg};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Map this [`Int`] to its two's-complement negation:

--- a/src/int/shl.rs
+++ b/src/int/shl.rs
@@ -1,10 +1,7 @@
 //! [`Int`] bitwise left shift operations.
 
-use core::ops::{Shl, ShlAssign};
-
-use subtle::CtOption;
-
 use crate::{ConstCtOption, Int, ShlVartime, Uint, WrappingShl};
+use core::ops::{Shl, ShlAssign};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Computes `self << shift`.
@@ -93,8 +90,8 @@ impl<const LIMBS: usize> WrappingShl for Int<LIMBS> {
 }
 
 impl<const LIMBS: usize> ShlVartime for Int<LIMBS> {
-    fn overflowing_shl_vartime(&self, shift: u32) -> CtOption<Self> {
-        self.overflowing_shl(shift).into()
+    fn overflowing_shl_vartime(&self, shift: u32) -> ConstCtOption<Self> {
+        self.overflowing_shl(shift)
     }
     fn wrapping_shl_vartime(&self, shift: u32) -> Self {
         self.wrapping_shl(shift)

--- a/src/int/shr.rs
+++ b/src/int/shr.rs
@@ -1,10 +1,7 @@
 //! [`Int`] bitwise right shift operations.
 
-use core::ops::{Shr, ShrAssign};
-
-use subtle::CtOption;
-
 use crate::{ConstChoice, ConstCtOption, Int, Limb, ShrVartime, Uint, WrappingShr};
+use core::ops::{Shr, ShrAssign};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Computes `self >> shift`.
@@ -173,8 +170,8 @@ impl<const LIMBS: usize> WrappingShr for Int<LIMBS> {
 }
 
 impl<const LIMBS: usize> ShrVartime for Int<LIMBS> {
-    fn overflowing_shr_vartime(&self, shift: u32) -> CtOption<Self> {
-        self.overflowing_shr(shift).into()
+    fn overflowing_shr_vartime(&self, shift: u32) -> ConstCtOption<Self> {
+        self.overflowing_shr(shift)
     }
     fn wrapping_shr_vartime(&self, shift: u32) -> Self {
         self.wrapping_shr(shift)

--- a/src/int/sign.rs
+++ b/src/int/sign.rs
@@ -1,5 +1,4 @@
-use crate::{ConstChoice, ConstCtOption, Int, Uint, Word, word};
-use num_traits::ConstZero;
+use crate::{ConstChoice, ConstCtOption, ConstZero, Int, Uint, Word, word};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Returns the word of most significant [`Limb`].

--- a/src/int/sub.rs
+++ b/src/int/sub.rs
@@ -1,11 +1,8 @@
 //! [`Int`] subtraction operations.
 
-use core::ops::{Sub, SubAssign};
-
-use num_traits::WrappingSub;
-use subtle::CtOption;
-
-use crate::{Checked, CheckedSub, ConstChoice, ConstCtOption, Int, Wrapping};
+use crate::{
+    Checked, CheckedSub, ConstChoice, ConstCtOption, Int, Sub, SubAssign, Wrapping, WrappingSub,
+};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Perform subtraction, returning the result along with a [`ConstChoice`] which `is_true`
@@ -37,9 +34,9 @@ impl<const LIMBS: usize> Int<LIMBS> {
 }
 
 impl<const LIMBS: usize> CheckedSub for Int<LIMBS> {
-    fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
+    fn checked_sub(&self, rhs: &Self) -> ConstCtOption<Self> {
         let (res, underflow) = Self::underflowing_sub(self, rhs);
-        ConstCtOption::new(res, underflow.not()).into()
+        ConstCtOption::new(res, underflow.not())
     }
 }
 

--- a/src/limb/add.rs
+++ b/src/limb/add.rs
@@ -1,11 +1,9 @@
 //! Limb addition
 
 use crate::{
-    Checked, CheckedAdd, Limb, Wrapping, WrappingAdd, Zero,
+    Add, AddAssign, Checked, CheckedAdd, ConstCtOption, Limb, Wrapping, WrappingAdd,
     primitives::{carrying_add, overflowing_add},
 };
-use core::ops::{Add, AddAssign};
-use subtle::CtOption;
 
 impl Limb {
     /// Computes `self + rhs`, returning the result along with the carry.
@@ -81,9 +79,9 @@ impl AddAssign<&Checked<Limb>> for Checked<Limb> {
 
 impl CheckedAdd for Limb {
     #[inline]
-    fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
+    fn checked_add(&self, rhs: &Self) -> ConstCtOption<Self> {
         let (result, carry) = self.overflowing_add(*rhs);
-        CtOption::new(result, carry.is_zero().into())
+        ConstCtOption::new(result, carry.is_zero())
     }
 }
 

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -41,7 +41,7 @@ impl Limb {
     /// Returns the truthy value if `self != 0` and the falsy value otherwise.
     #[inline]
     pub(crate) const fn is_nonzero(&self) -> ConstChoice {
-        word::choice_from_nonzero(self.0)
+        word::choice_from_nz(self.0)
     }
 }
 
@@ -125,7 +125,7 @@ impl PartialEq for Limb {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, Limb, Zero};
+    use crate::{ConstChoice, Limb};
     use core::cmp::Ordering;
     use subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 

--- a/src/limb/mul.rs
+++ b/src/limb/mul.rs
@@ -1,12 +1,9 @@
 //! Limb multiplication
 
 use crate::{
-    Checked, CheckedMul, Limb, Wrapping, Zero,
+    Checked, CheckedMul, ConstCtOption, Limb, Mul, MulAssign, Wrapping, WrappingMul,
     primitives::{carrying_mul_add, widening_mul},
 };
-use core::ops::{Mul, MulAssign};
-use num_traits::WrappingMul;
-use subtle::CtOption;
 
 impl Limb {
     /// Computes `self + (b * c) + carry`, returning the result along with the new carry.
@@ -46,9 +43,9 @@ impl Limb {
 
 impl CheckedMul for Limb {
     #[inline]
-    fn checked_mul(&self, rhs: &Self) -> CtOption<Self> {
+    fn checked_mul(&self, rhs: &Self) -> ConstCtOption<Self> {
         let (lo, hi) = self.widening_mul(*rhs);
-        CtOption::new(lo, hi.is_zero().into())
+        ConstCtOption::new(lo, hi.is_zero())
     }
 }
 

--- a/src/limb/neg.rs
+++ b/src/limb/neg.rs
@@ -1,7 +1,6 @@
 //! Limb negation
 
-use crate::Limb;
-use num_traits::WrappingNeg;
+use crate::{Limb, WrappingNeg};
 
 impl Limb {
     /// Perform wrapping negation.

--- a/src/limb/shl.rs
+++ b/src/limb/shl.rs
@@ -1,8 +1,6 @@
 //! Limb left bitshift
 
-use crate::Limb;
-use core::ops::{Shl, ShlAssign};
-use num_traits::WrappingShl;
+use crate::{Limb, Shl, ShlAssign, WrappingShl};
 
 impl Limb {
     /// Computes `self << shift`.

--- a/src/limb/sub.rs
+++ b/src/limb/sub.rs
@@ -1,8 +1,9 @@
 //! Limb subtraction
 
-use crate::{Checked, CheckedSub, Limb, Wrapping, WrappingSub, Zero, primitives::borrowing_sub};
-use core::ops::{Sub, SubAssign};
-use subtle::CtOption;
+use crate::{
+    Checked, CheckedSub, ConstCtOption, Limb, Sub, SubAssign, Wrapping, WrappingSub,
+    primitives::borrowing_sub,
+};
 
 impl Limb {
     /// Computes `self - (rhs + borrow)`, returning the result along with the new borrow.
@@ -34,9 +35,9 @@ impl Limb {
 
 impl CheckedSub for Limb {
     #[inline]
-    fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
+    fn checked_sub(&self, rhs: &Self) -> ConstCtOption<Self> {
         let (result, underflow) = self.borrowing_sub(*rhs, Limb::ZERO);
-        CtOption::new(result, underflow.is_zero().into())
+        ConstCtOption::new(result, underflow.is_zero())
     }
 }
 

--- a/src/modular/bingcd/xgcd.rs
+++ b/src/modular/bingcd/xgcd.rs
@@ -371,7 +371,6 @@ mod tests {
     use crate::modular::bingcd::xgcd::PatternXgcdOutput;
     use crate::{ConcatMixed, Gcd, Uint};
     use core::ops::Div;
-    use num_traits::Zero;
 
     mod test_extract_quotients {
         use crate::modular::bingcd::matrix::DividedPatternMatrix;
@@ -605,8 +604,8 @@ mod tests {
         assert!(x.abs() <= rhs.div(output.gcd.as_nz_ref()));
         assert!(y.abs() <= lhs.div(output.gcd.as_nz_ref()));
         if lhs != rhs {
-            assert!(x.abs() <= rhs_on_gcd.shr(1) || rhs_on_gcd.is_zero());
-            assert!(y.abs() <= lhs_on_gcd.shr(1) || lhs_on_gcd.is_zero());
+            assert!(x.abs() <= rhs_on_gcd.shr(1) || rhs_on_gcd.is_zero().to_bool());
+            assert!(y.abs() <= lhs_on_gcd.shr(1) || lhs_on_gcd.is_zero().to_bool());
         }
     }
 

--- a/src/modular/boxed_monty_form/mul.rs
+++ b/src/modular/boxed_monty_form/mul.rs
@@ -7,11 +7,9 @@
 
 use super::{BoxedMontyForm, BoxedMontyParams};
 use crate::{
-    AmmMultiplier, BoxedUint, Limb, MontyMultiplier, Square, SquareAssign,
+    AmmMultiplier, BoxedUint, CtLt, Limb, MontyMultiplier, Mul, MulAssign, Square, SquareAssign,
     modular::mul::montgomery_multiply_inner, word,
 };
-use core::ops::{Mul, MulAssign};
-use subtle::ConstantTimeLess;
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -315,7 +313,7 @@ pub(crate) fn almost_montgomery_mul(
         mod_neg_inv,
     );
     let overflow = word::choice_from_lsb(overflow.0);
-    out.conditional_borrowing_sub_assign(modulus, overflow.into());
+    out.conditional_borrowing_sub_assign(modulus, overflow);
 }
 
 #[cfg(test)]

--- a/src/modular/div_by_2.rs
+++ b/src/modular/div_by_2.rs
@@ -36,7 +36,7 @@ pub(crate) fn div_by_2_boxed_assign(a: &mut BoxedUint, modulus: &Odd<BoxedUint>)
     debug_assert_eq!(a.bits_precision(), modulus.bits_precision());
 
     let is_odd = a.is_odd();
-    let carry = a.conditional_carrying_add_assign(modulus, is_odd.into());
+    let carry = a.conditional_carrying_add_assign(modulus, is_odd);
     a.shr1_assign();
-    a.set_bit(a.bits_precision() - 1, carry.into());
+    a.set_bit(a.bits_precision() - 1, carry);
 }

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -1,14 +1,10 @@
 //! Wrapper type for non-zero integers.
 
 use crate::{
-    Bounded, ConstChoice, CtEq, CtSelect, Int, Integer, Limb, NonZero, One, Uint, UintRef,
+    Bounded, ConstChoice, ConstOne, CtEq, CtSelect, Int, Integer, Limb, Mul, NonZero, One, Uint,
+    UintRef,
 };
-use core::{
-    cmp::Ordering,
-    fmt,
-    ops::{Deref, Mul},
-};
-use num_traits::ConstOne;
+use core::{cmp::Ordering, fmt, ops::Deref};
 use subtle::{Choice, ConditionallySelectable, CtOption};
 
 #[cfg(feature = "alloc")]

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -1,8 +1,8 @@
 //! [`Uint`] addition operations.
 
-use crate::{Checked, CheckedAdd, Limb, Uint, Wrapping, WrappingAdd, Zero, word};
-use core::ops::{Add, AddAssign};
-use subtle::CtOption;
+use crate::{
+    Add, AddAssign, Checked, CheckedAdd, ConstCtOption, Limb, Uint, Wrapping, WrappingAdd, word,
+};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self + rhs + carry`, returning the result along with the new carry.
@@ -106,9 +106,9 @@ impl<const LIMBS: usize> AddAssign<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS
 }
 
 impl<const LIMBS: usize> CheckedAdd for Uint<LIMBS> {
-    fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
+    fn checked_add(&self, rhs: &Self) -> ConstCtOption<Self> {
         let (result, carry) = self.carrying_add(rhs, Limb::ZERO);
-        CtOption::new(result, carry.is_zero().into())
+        ConstCtOption::new(result, carry.is_zero())
     }
 }
 

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -464,6 +464,12 @@ impl One for BoxedUint {
         Self::one()
     }
 
+    fn one_like(other: &Self) -> Self {
+        let mut ret = other.clone();
+        ret.set_one();
+        ret
+    }
+
     fn is_one(&self) -> ConstChoice {
         self.is_one()
     }

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -1,11 +1,9 @@
 //! [`BoxedUint`] division operations.
 
 use crate::{
-    BoxedUint, CheckedDiv, ConstCtOption, CtSelect, DivRemLimb, DivVartime, Limb, NonZero,
-    Reciprocal, RemLimb, RemMixed, UintRef, Wrapping,
+    BoxedUint, CheckedDiv, ConstCtOption, CtSelect, Div, DivAssign, DivRemLimb, DivVartime, Limb,
+    NonZero, Reciprocal, Rem, RemAssign, RemLimb, RemMixed, UintRef, Wrapping,
 };
-use core::ops::{Div, DivAssign, Rem, RemAssign};
-use subtle::CtOption;
 
 impl BoxedUint {
     /// Computes `self / rhs` using a pre-made reciprocal,
@@ -115,7 +113,7 @@ impl BoxedUint {
         self.div_rem_vartime(rhs).0
     }
 
-    /// Perform checked division, returning a [`CtOption`] which `is_some`
+    /// Perform checked division, returning a [`ConstCtOption`] which `is_some`
     /// only if the rhs != 0
     pub fn checked_div(&self, rhs: &Self) -> ConstCtOption<Self> {
         let mut quo = self.clone();
@@ -128,8 +126,8 @@ impl BoxedUint {
 }
 
 impl CheckedDiv for BoxedUint {
-    fn checked_div(&self, rhs: &BoxedUint) -> CtOption<Self> {
-        self.checked_div(rhs).into()
+    fn checked_div(&self, rhs: &BoxedUint) -> ConstCtOption<Self> {
+        self.checked_div(rhs)
     }
 }
 
@@ -295,9 +293,8 @@ impl RemMixed<BoxedUint> for BoxedUint {
 
 #[cfg(test)]
 mod tests {
-    use crate::{DivVartime, Resize, Zero};
-
     use super::{BoxedUint, Limb, NonZero};
+    use crate::{CtSelect, DivVartime, One, Resize, Zero};
 
     #[test]
     fn rem() {
@@ -386,7 +383,7 @@ mod tests {
             x: T,
             y: T,
         }
-        impl<T: DivVartime + Clone + Zero> A<T> {
+        impl<T: DivVartime + Clone + Zero + One + CtSelect> A<T> {
             fn divide_x_by_y(&self) -> T {
                 let rhs = &NonZero::new(self.y.clone()).unwrap();
                 self.x.div_vartime(rhs)

--- a/src/uint/boxed/shl.rs
+++ b/src/uint/boxed/shl.rs
@@ -1,8 +1,6 @@
 //! [`BoxedUint`] bitwise left shift operations.
 
-use crate::{BoxedUint, ConstChoice, Limb, ShlVartime, WrappingShl};
-use core::ops::{Shl, ShlAssign};
-use subtle::{Choice, CtOption};
+use crate::{BoxedUint, ConstChoice, ConstCtOption, Limb, Shl, ShlAssign, ShlVartime, WrappingShl};
 
 impl BoxedUint {
     /// Computes `self << shift`.
@@ -26,38 +24,36 @@ impl BoxedUint {
     ///
     /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
     /// or the result and a falsy `Choice` otherwise.
-    pub fn overflowing_shl(&self, shift: u32) -> (Self, Choice) {
+    pub fn overflowing_shl(&self, shift: u32) -> (Self, ConstChoice) {
         let mut result = self.clone();
         let overflow = result.as_mut_uint_ref().overflowing_shl_assign(shift);
-        (result, overflow.into())
+        (result, overflow)
     }
 
     /// Computes `self << shift` in variable-time.
     ///
     /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
     /// or the result and a falsy `Choice` otherwise.
-    pub fn overflowing_shl_vartime(&self, shift: u32) -> (Self, Choice) {
+    pub fn overflowing_shl_vartime(&self, shift: u32) -> (Self, ConstChoice) {
         let mut result = self.clone();
         let overflow = result
             .as_mut_uint_ref()
             .overflowing_shl_assign_vartime(shift);
-        (result, overflow.into())
+        (result, overflow)
     }
 
     /// Computes `self <<= shift`.
     ///
     /// Returns a truthy `Choice` if `shift >= self.bits_precision()` or a falsy `Choice` otherwise.
-    pub fn overflowing_shl_assign(&mut self, shift: u32) -> Choice {
-        self.as_mut_uint_ref().overflowing_shl_assign(shift).into()
+    pub fn overflowing_shl_assign(&mut self, shift: u32) -> ConstChoice {
+        self.as_mut_uint_ref().overflowing_shl_assign(shift)
     }
 
     /// Computes `self <<= shift` in variable-time.
     ///
     /// Returns a truthy `Choice` if `shift >= self.bits_precision()` or a falsy `Choice` otherwise.
-    pub fn overflowing_shl_assign_vartime(&mut self, shift: u32) -> Choice {
-        self.as_mut_uint_ref()
-            .overflowing_shl_assign_vartime(shift)
-            .into()
+    pub fn overflowing_shl_assign_vartime(&mut self, shift: u32) -> ConstChoice {
+        self.as_mut_uint_ref().overflowing_shl_assign_vartime(shift)
     }
 
     /// Computes `self << shift` in a panic-free manner, masking off bits of `shift` which would cause the shift to
@@ -171,9 +167,9 @@ impl WrappingShl for BoxedUint {
 }
 
 impl ShlVartime for BoxedUint {
-    fn overflowing_shl_vartime(&self, shift: u32) -> CtOption<Self> {
+    fn overflowing_shl_vartime(&self, shift: u32) -> ConstCtOption<Self> {
         let (result, overflow) = self.overflowing_shl(shift);
-        CtOption::new(result, !overflow)
+        ConstCtOption::new(result, !overflow)
     }
     fn wrapping_shl_vartime(&self, shift: u32) -> Self {
         self.wrapping_shl(shift)

--- a/src/uint/boxed/shr.rs
+++ b/src/uint/boxed/shr.rs
@@ -1,8 +1,6 @@
 //! [`BoxedUint`] bitwise right shift operations.
 
-use crate::{BoxedUint, ConstChoice, Limb, ShrVartime, WrappingShr};
-use core::ops::{Shr, ShrAssign};
-use subtle::{Choice, CtOption};
+use crate::{BoxedUint, ConstChoice, ConstCtOption, Limb, Shr, ShrAssign, ShrVartime, WrappingShr};
 
 impl BoxedUint {
     /// Computes `self >> shift`.
@@ -32,7 +30,7 @@ impl BoxedUint {
     ///
     /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
     /// or the result and a falsy `Choice` otherwise.
-    pub fn overflowing_shr(&self, shift: u32) -> (Self, Choice) {
+    pub fn overflowing_shr(&self, shift: u32) -> (Self, ConstChoice) {
         let mut result = self.clone();
         let overflow = result.overflowing_shr_assign(shift);
         (result, overflow)
@@ -42,7 +40,7 @@ impl BoxedUint {
     ///
     /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
     /// or the result and a falsy `Choice` otherwise.
-    pub fn overflowing_shr_vartime(&self, shift: u32) -> (Self, Choice) {
+    pub fn overflowing_shr_vartime(&self, shift: u32) -> (Self, ConstChoice) {
         let mut result = self.clone();
         let overflow = result.overflowing_shr_assign_vartime(shift);
         (result, overflow)
@@ -51,17 +49,15 @@ impl BoxedUint {
     /// Computes `self >>= shift`.
     ///
     /// Returns a truthy `Choice` if `shift >= self.bits_precision()` or a falsy `Choice` otherwise.
-    pub fn overflowing_shr_assign(&mut self, shift: u32) -> Choice {
-        self.as_mut_uint_ref().overflowing_shr_assign(shift).into()
+    pub fn overflowing_shr_assign(&mut self, shift: u32) -> ConstChoice {
+        self.as_mut_uint_ref().overflowing_shr_assign(shift)
     }
 
     /// Computes `self >>= shift` in variable-time.
     ///
     /// Returns a truthy `Choice` if `shift >= self.bits_precision()` or a falsy `Choice` otherwise.
-    pub fn overflowing_shr_assign_vartime(&mut self, shift: u32) -> Choice {
-        self.as_mut_uint_ref()
-            .overflowing_shr_assign_vartime(shift)
-            .into()
+    pub fn overflowing_shr_assign_vartime(&mut self, shift: u32) -> ConstChoice {
+        self.as_mut_uint_ref().overflowing_shr_assign_vartime(shift)
     }
 
     /// Computes `self >> shift` in a panic-free manner, masking off bits of `shift` which would cause the shift to
@@ -168,9 +164,9 @@ impl WrappingShr for BoxedUint {
 }
 
 impl ShrVartime for BoxedUint {
-    fn overflowing_shr_vartime(&self, shift: u32) -> CtOption<Self> {
+    fn overflowing_shr_vartime(&self, shift: u32) -> ConstCtOption<Self> {
         let (result, overflow) = self.overflowing_shr(shift);
-        CtOption::new(result, !overflow)
+        ConstCtOption::new(result, !overflow)
     }
     fn wrapping_shr_vartime(&self, shift: u32) -> Self {
         self.wrapping_shr(shift)

--- a/src/uint/boxed/sub_mod.rs
+++ b/src/uint/boxed/sub_mod.rs
@@ -1,7 +1,6 @@
 //! [`BoxedUint`] modular subtraction operations.
 
-use crate::{BoxedUint, Limb, NonZero, SubMod, Zero};
-use subtle::Choice;
+use crate::{BoxedUint, Limb, NonZero, SubMod};
 
 impl BoxedUint {
     /// Computes `self - rhs mod p`.
@@ -17,7 +16,7 @@ impl BoxedUint {
 
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the modulus.
-        out.conditional_carrying_add_assign(p, !Choice::from(borrow.is_zero()));
+        out.conditional_carrying_add_assign(p, !borrow.is_zero());
         out
     }
 
@@ -34,7 +33,7 @@ impl BoxedUint {
 
         // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
         // borrow = 0x000...000. Thus, we use it as a mask to conditionally add the modulus.
-        self.conditional_carrying_add_assign(p, !Choice::from(mask.is_zero()));
+        self.conditional_carrying_add_assign(p, !mask.is_zero());
     }
 
     /// Computes `self - rhs mod p` for the special modulus

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -222,11 +222,9 @@ impl<const LIMBS: usize> PartialEq for Uint<LIMBS> {
 
 #[cfg(test)]
 mod tests {
+    use crate::{ConstChoice, Integer, U128, Uint};
     use core::cmp::Ordering;
-
     use subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
-
-    use crate::{ConstChoice, Integer, U128, Uint, Zero};
 
     #[test]
     fn is_zero() {

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -67,7 +67,7 @@ pub const fn reciprocal(d: Word) -> Word {
     // Hence the `ct_select()`.
     let x = v3.wrapping_add(1);
     let (_lo, hi) = widening_mul(x, d);
-    let hi = word::select(d, hi, word::choice_from_nonzero(x));
+    let hi = word::select(d, hi, word::choice_from_nz(x));
 
     v3.wrapping_sub(hi).wrapping_sub(d)
 }
@@ -164,8 +164,8 @@ pub(crate) const fn div3by2(
         let qy = (quo as WideWord) * (v0 as WideWord);
         let rx = (rem << Word::BITS) | (u0 as WideWord);
         // If r < b and q*y[-2] > r*x[-1], then set q = q - 1 and r = r + v1
-        let done = word::choice_from_nonzero((rem >> Word::BITS) as Word)
-            .or(word::choice_from_wide_le(qy, rx));
+        let done =
+            word::choice_from_nz((rem >> Word::BITS) as Word).or(word::choice_from_wide_le(qy, rx));
         quo = word::select(quo.wrapping_sub(1), quo, done);
         rem = word::select_wide(
             rem + (v1_reciprocal.divisor_normalized as WideWord),

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -902,7 +902,7 @@ const fn radix_large_divisor(
 
 #[cfg(test)]
 mod tests {
-    use crate::{DecodeError, Limb, U64, U128, Zero};
+    use crate::{DecodeError, Limb, U64, U128};
     use hex_literal::hex;
 
     #[cfg(feature = "alloc")]

--- a/src/uint/invert_mod.rs
+++ b/src/uint/invert_mod.rs
@@ -4,8 +4,6 @@ use crate::{
     mul::karatsuba,
 };
 
-use subtle::CtOption;
-
 /// Perform a modified recursive Hensel quadratic modular inversion to calculate
 /// `a^-1 mod w^p` given `a^-1 mod w^k` where `w` is the size of `Limb`.
 /// For reference see Algorithm 2: <https://arxiv.org/pdf/1209.6626>
@@ -245,8 +243,8 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
 impl<const LIMBS: usize> InvertMod for Uint<LIMBS> {
     type Output = Self;
 
-    fn invert_mod(&self, modulus: &NonZero<Self>) -> CtOption<Self> {
-        self.invert_mod(modulus).into()
+    fn invert_mod(&self, modulus: &NonZero<Self>) -> ConstCtOption<Self> {
+        self.invert_mod(modulus)
     }
 }
 

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -1,12 +1,8 @@
 //! [`Uint`] multiplication operations.
 
-use core::ops::{Mul, MulAssign};
-
-use subtle::CtOption;
-
 use crate::{
     Checked, CheckedMul, Concat, ConcatMixed, ConcatenatingMul, ConstChoice, ConstCtOption, Limb,
-    Uint, UintRef, Wrapping, WrappingMul,
+    Mul, MulAssign, Uint, UintRef, Wrapping, WrappingMul,
 };
 
 pub(crate) mod karatsuba;
@@ -115,8 +111,8 @@ where
 }
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> CheckedMul<Uint<RHS_LIMBS>> for Uint<LIMBS> {
-    fn checked_mul(&self, rhs: &Uint<RHS_LIMBS>) -> CtOption<Self> {
-        self.checked_mul(rhs).into()
+    fn checked_mul(&self, rhs: &Uint<RHS_LIMBS>) -> ConstCtOption<Self> {
+        self.checked_mul(rhs)
     }
 }
 
@@ -252,7 +248,7 @@ pub(crate) const fn wrapping_mul_overflow(
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, U64, U128, U192, U256, Uint, Zero};
+    use crate::{ConstChoice, U64, U128, U192, U256, Uint};
 
     #[test]
     fn widening_mul_zero_and_one() {

--- a/src/uint/ref_type/bits.rs
+++ b/src/uint/ref_type/bits.rs
@@ -106,7 +106,7 @@ impl UintRef {
             let z = l.leading_zeros();
             count += nonzero_limb_not_encountered.select_u32(0, z);
             nonzero_limb_not_encountered =
-                nonzero_limb_not_encountered.and(word::choice_from_nonzero(l.0).not());
+                nonzero_limb_not_encountered.and(word::choice_from_nz(l.0).not());
         }
 
         count
@@ -123,7 +123,7 @@ impl UintRef {
             let z = l.trailing_zeros();
             count += nonzero_limb_not_encountered.select_u32(0, z);
             nonzero_limb_not_encountered =
-                nonzero_limb_not_encountered.and(word::choice_from_nonzero(l.0).not());
+                nonzero_limb_not_encountered.and(word::choice_from_nz(l.0).not());
             i += 1;
         }
 

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -1,8 +1,8 @@
 //! [`Uint`] bitwise left shift operations.
 
-use crate::{ConstChoice, ConstCtOption, Limb, NonZero, ShlVartime, Uint, WrappingShl};
-use core::ops::{Shl, ShlAssign};
-use subtle::CtOption;
+use crate::{
+    ConstChoice, ConstCtOption, Limb, NonZero, Shl, ShlAssign, ShlVartime, Uint, WrappingShl,
+};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self << shift`.
@@ -264,9 +264,10 @@ impl<const LIMBS: usize> WrappingShl for Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize> ShlVartime for Uint<LIMBS> {
-    fn overflowing_shl_vartime(&self, shift: u32) -> CtOption<Self> {
-        self.overflowing_shl(shift).into()
+    fn overflowing_shl_vartime(&self, shift: u32) -> ConstCtOption<Self> {
+        self.overflowing_shl(shift)
     }
+
     fn wrapping_shl_vartime(&self, shift: u32) -> Self {
         self.wrapping_shl(shift)
     }

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -1,8 +1,8 @@
 //! [`Uint`] bitwise right shift operations.
 
-use crate::{ConstChoice, ConstCtOption, Limb, NonZero, ShrVartime, Uint, WrappingShr, word};
-use core::ops::{Shr, ShrAssign};
-use subtle::CtOption;
+use crate::{
+    ConstChoice, ConstCtOption, Limb, NonZero, Shr, ShrAssign, ShrVartime, Uint, WrappingShr, word,
+};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self >> shift`.
@@ -284,8 +284,8 @@ impl<const LIMBS: usize> WrappingShr for Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize> ShrVartime for Uint<LIMBS> {
-    fn overflowing_shr_vartime(&self, shift: u32) -> CtOption<Self> {
-        self.overflowing_shr(shift).into()
+    fn overflowing_shr_vartime(&self, shift: u32) -> ConstCtOption<Self> {
+        self.overflowing_shr(shift)
     }
     fn wrapping_shr_vartime(&self, shift: u32) -> Self {
         self.wrapping_shr(shift)

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -1,9 +1,9 @@
 //! [`Uint`] subtraction operations.
 
 use super::Uint;
-use crate::{Checked, CheckedSub, Limb, Wrapping, WrappingSub, Zero, word};
-use core::ops::{Sub, SubAssign};
-use subtle::CtOption;
+use crate::{
+    Checked, CheckedSub, ConstCtOption, Limb, Sub, SubAssign, Wrapping, WrappingSub, word,
+};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self - (rhs + borrow)`, returning the result along with the new borrow.
@@ -42,9 +42,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize> CheckedSub for Uint<LIMBS> {
-    fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
+    fn checked_sub(&self, rhs: &Self) -> ConstCtOption<Self> {
         let (result, underflow) = self.borrowing_sub(rhs, Limb::ZERO);
-        CtOption::new(result, underflow.is_zero().into())
+        ConstCtOption::new(result, underflow.is_zero())
     }
 }
 

--- a/src/word.rs
+++ b/src/word.rs
@@ -74,7 +74,7 @@ pub use word64::*;
 /// Returns the truthy value if `x == y`, and the falsy value otherwise.
 #[inline]
 pub(crate) const fn choice_from_eq(x: Word, y: Word) -> Choice {
-    choice_from_nonzero(x ^ y).not()
+    choice_from_nz(x ^ y).not()
 }
 
 /// Returns the truthy value if `x > y`, and the falsy value otherwise.
@@ -104,7 +104,7 @@ pub(crate) const fn choice_from_msb(value: Word) -> Choice {
 
 /// Returns the truthy value if `value != 0`, and the falsy value otherwise.
 #[inline]
-pub(crate) const fn choice_from_nonzero(value: Word) -> Choice {
+pub(crate) const fn choice_from_nz(value: Word) -> Choice {
     choice_from_lsb((value | value.wrapping_neg()) >> (Word::BITS - 1))
 }
 

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -451,7 +451,7 @@ proptest! {
 
     #[test]
     fn invert_mod(a in uint(), mut b in uint()) {
-        if b.is_zero() {
+        if b.is_zero().to_bool() {
             b = Uint::ONE;
         }
         let a_bi = to_biguint(&a);


### PR DESCRIPTION
Uses it both as the return type for ops described by `Checked*` traits as well as the inner type for the `Checked` wrapper.

This seemingly uncovered some issues with the division implementation, including the possibility that checked division was somehow short-circuited when using the previous implementation of the `NonZero` type, as with this change it's now invoking a function that panics with a zero divisor, when instead it still needs to always call the same function and get a result without panicking, even if the divisor is zero.

To solve the general problem, `NonZero::new` now also bounds on `One` and `CtSelect` (in addition to `Zero`), and automatically uses `One::one_like` as a placeholder value in the `ConstCtOption` it returns in the event the provided value is equal to zero. That way we never construct an invalid `NonZero` containing an inner `0` value.