### PR TITLE
Convert remaining `subtle` usages to `ctutils`

### DIFF
--- a/src/checked.rs
+++ b/src/checked.rs
@@ -17,8 +17,8 @@ pub struct Checked<T>(pub ConstCtOption<T>);
 
 impl<T> Checked<T> {
     /// Create a new checked arithmetic wrapper for the given value.
-    pub fn new(val: T) -> Self {
-        Self(ConstCtOption::new(val, ConstChoice::TRUE))
+    pub const fn new(val: T) -> Self {
+        Self(ConstCtOption::some(val))
     }
 }
 

--- a/src/int/cmp.rs
+++ b/src/int/cmp.rs
@@ -6,12 +6,6 @@ use crate::{ConstChoice, CtEq, CtGt, CtLt, Int, Uint};
 use core::cmp::Ordering;
 
 impl<const LIMBS: usize> Int<LIMBS> {
-    /// Return `b` if `c` is truthy, otherwise return `a`.
-    #[inline]
-    pub(crate) const fn select(a: &Self, b: &Self, c: ConstChoice) -> Self {
-        Self(Uint::select(&a.0, &b.0, c))
-    }
-
     /// Swap `a` and `b` if `c` is truthy, otherwise, do nothing.
     #[inline]
     pub(crate) const fn conditional_swap(a: &mut Self, b: &mut Self, c: ConstChoice) {
@@ -127,9 +121,7 @@ impl<const LIMBS: usize> PartialEq for Int<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use subtle::{ConstantTimeGreater, ConstantTimeLess};
-
-    use crate::I128;
+    use crate::{CtGt, CtLt, I128};
 
     #[test]
     fn test_is_nonzero() {

--- a/src/int/select.rs
+++ b/src/int/select.rs
@@ -1,0 +1,42 @@
+//! Constant-time selection support.
+
+use crate::{ConstChoice, CtSelect, Int, Uint};
+
+impl<const LIMBS: usize> Int<LIMBS> {
+    /// Return `b` if `c` is truthy, otherwise return `a`.
+    #[inline]
+    pub(crate) const fn select(a: &Self, b: &Self, c: ConstChoice) -> Self {
+        Self(Uint::select(&a.0, &b.0, c))
+    }
+}
+
+impl<const LIMBS: usize> CtSelect for Int<LIMBS> {
+    #[inline]
+    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+        Self(self.0.ct_select(&other.0, choice))
+    }
+}
+
+impl<const LIMBS: usize> subtle::ConditionallySelectable for Int<LIMBS> {
+    #[inline]
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        a.ct_select(b, choice.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ConstChoice, CtSelect, I128};
+
+    #[test]
+    fn ct_select() {
+        let a = I128::from_be_hex("00002222444466668888AAAACCCCEEEE");
+        let b = I128::from_be_hex("11113333555577779999BBBBDDDDFFFF");
+
+        let select_0 = I128::ct_select(&a, &b, ConstChoice::FALSE);
+        assert_eq!(a, select_0);
+
+        let select_1 = I128::ct_select(&a, &b, ConstChoice::TRUE);
+        assert_eq!(b, select_1);
+    }
+}

--- a/src/jacobi.rs
+++ b/src/jacobi.rs
@@ -1,6 +1,5 @@
-use crate::ConstChoice;
+use crate::{ConstChoice, CtEq};
 use core::ops::Neg;
-use subtle::{Choice, ConstantTimeEq};
 
 /// Possible return values for Jacobi symbol calculations.
 #[derive(Debug, Copy, Clone)]
@@ -54,9 +53,15 @@ impl JacobiSymbol {
     }
 }
 
-impl ConstantTimeEq for JacobiSymbol {
-    fn ct_eq(&self, other: &Self) -> Choice {
+impl CtEq for JacobiSymbol {
+    fn ct_eq(&self, other: &Self) -> ConstChoice {
         (*self as i8).ct_eq(&(*other as i8))
+    }
+}
+
+impl subtle::ConstantTimeEq for JacobiSymbol {
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_eq(self, other).into()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,10 +167,8 @@
 #[macro_use]
 extern crate alloc;
 
-pub use uint::encoding::{EncodedUint, TryFromSliceError};
-
 pub use ctutils;
-pub use subtle;
+pub use uint::encoding::{EncodedUint, TryFromSliceError};
 
 #[cfg(feature = "rand_core")]
 pub use rand_core;

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -12,6 +12,7 @@ mod encoding;
 mod from;
 mod mul;
 mod neg;
+mod select;
 mod shl;
 mod shr;
 mod sub;
@@ -24,8 +25,6 @@ use crate::{
     WideWord, Word, Zero, word,
 };
 use core::fmt;
-use ctutils::CtSelect;
-use subtle::Choice;
 
 #[cfg(feature = "serde")]
 use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -99,20 +98,6 @@ impl Bounded for Limb {
 
 impl Constants for Limb {
     const MAX: Self = Self::MAX;
-}
-
-impl subtle::ConditionallySelectable for Limb {
-    #[inline]
-    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        a.ct_select(b, choice.into())
-    }
-}
-
-impl CtSelect for Limb {
-    #[inline]
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
-        Self(self.0.ct_select(&other.0, choice))
-    }
 }
 
 impl ConstZero for Limb {

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -23,21 +23,6 @@ impl Limb {
         self.0 == other.0
     }
 
-    /// Return `b` if `c` is truthy, otherwise return `a`.
-    #[inline]
-    pub(crate) const fn select(a: Self, b: Self, c: ConstChoice) -> Self {
-        Self(word::select(a.0, b.0, c))
-    }
-
-    /// Swap the values of `a` and `b` if `c` is truthy, otherwise do nothing.
-    #[inline]
-    pub(crate) const fn ct_conditional_swap(a: &mut Self, b: &mut Self, c: ConstChoice) {
-        (*a, *b) = (
-            Self(word::select(a.0, b.0, c)),
-            Self(word::select(b.0, a.0, c)),
-        )
-    }
-
     /// Returns the truthy value if `self != 0` and the falsy value otherwise.
     #[inline]
     pub(crate) const fn is_nonzero(&self) -> ConstChoice {
@@ -125,9 +110,8 @@ impl PartialEq for Limb {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, Limb};
+    use crate::{ConstChoice, CtEq, CtGt, CtLt, Limb};
     use core::cmp::Ordering;
-    use subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
     #[test]
     fn is_zero() {

--- a/src/limb/rand.rs
+++ b/src/limb/rand.rs
@@ -1,9 +1,8 @@
 //! Random number generator support
 
 use super::Limb;
-use crate::{Encoding, NonZero, Random, RandomMod};
+use crate::{CtLt, Encoding, NonZero, Random, RandomMod};
 use rand_core::TryRngCore;
-use subtle::ConstantTimeLess;
 
 impl Random for Limb {
     fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {

--- a/src/limb/select.rs
+++ b/src/limb/select.rs
@@ -1,0 +1,34 @@
+//! Constant-time selection support.
+
+use crate::{ConstChoice, CtSelect, Limb, word};
+
+impl Limb {
+    /// Return `b` if `c` is truthy, otherwise return `a`.
+    #[inline]
+    pub(crate) const fn select(a: Self, b: Self, c: ConstChoice) -> Self {
+        Self(word::select(a.0, b.0, c))
+    }
+
+    /// Swap the values of `a` and `b` if `c` is truthy, otherwise do nothing.
+    #[inline]
+    pub(crate) const fn ct_conditional_swap(a: &mut Self, b: &mut Self, c: ConstChoice) {
+        (*a, *b) = (
+            Self(word::select(a.0, b.0, c)),
+            Self(word::select(b.0, a.0, c)),
+        )
+    }
+}
+
+impl CtSelect for Limb {
+    #[inline]
+    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+        Self(self.0.ct_select(&other.0, choice))
+    }
+}
+
+impl subtle::ConditionallySelectable for Limb {
+    #[inline]
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        a.ct_select(b, choice.into())
+    }
+}

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -1,11 +1,13 @@
 //! Implements heap-allocated `BoxedMontyForm`s, supporting modular arithmetic with a modulus set at runtime.
 
 mod add;
+mod cmp;
 mod invert;
 mod lincomb;
 mod mul;
 mod neg;
 mod pow;
+mod select;
 mod sub;
 
 use super::{MontyParams, Retrieve, div_by_2, reduction::montgomery_retrieve_inner};

--- a/src/modular/boxed_monty_form/cmp.rs
+++ b/src/modular/boxed_monty_form/cmp.rs
@@ -1,0 +1,17 @@
+use super::{BoxedMontyForm, BoxedMontyParams};
+use crate::{ConstChoice, CtEq};
+
+impl CtEq for BoxedMontyForm {
+    fn ct_eq(&self, other: &Self) -> ConstChoice {
+        self.montgomery_form.ct_eq(&other.montgomery_form) & self.params.ct_eq(&other.params)
+    }
+}
+
+impl CtEq for BoxedMontyParams {
+    fn ct_eq(&self, other: &Self) -> ConstChoice {
+        self.modulus().ct_eq(other.modulus())
+            & self.one().ct_eq(other.one())
+            & self.r2().ct_eq(other.r2())
+            & self.mod_inv().ct_eq(&other.mod_inv())
+    }
+}

--- a/src/modular/boxed_monty_form/invert.rs
+++ b/src/modular/boxed_monty_form/invert.rs
@@ -2,7 +2,6 @@
 
 use super::{BoxedMontyForm, BoxedMontyParams};
 use crate::{ConstCtOption, Invert, modular::safegcd::boxed::BoxedSafeGcdInverter};
-use subtle::CtOption;
 
 impl BoxedMontyForm {
     /// Computes `self^-1` representing the multiplicative inverse of `self`,
@@ -38,14 +37,14 @@ impl BoxedMontyForm {
 }
 
 impl Invert for BoxedMontyForm {
-    type Output = CtOption<Self>;
+    type Output = ConstCtOption<Self>;
 
     fn invert(&self) -> Self::Output {
-        self.invert().into()
+        self.invert()
     }
 
     fn invert_vartime(&self) -> Self::Output {
-        self.invert_vartime().into()
+        self.invert_vartime()
     }
 }
 

--- a/src/modular/boxed_monty_form/select.rs
+++ b/src/modular/boxed_monty_form/select.rs
@@ -1,0 +1,34 @@
+use super::{BoxedMontyForm, BoxedMontyParams, BoxedMontyParamsInner};
+use crate::{ConstChoice, CtSelect};
+use alloc::sync::Arc;
+
+impl CtSelect for BoxedMontyForm {
+    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+        Self {
+            montgomery_form: self
+                .montgomery_form
+                .ct_select(&other.montgomery_form, choice),
+            params: self.params.ct_select(&other.params, choice),
+        }
+    }
+}
+
+impl CtSelect for BoxedMontyParams {
+    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+        Self(Arc::new(self.0.ct_select(&other.0, choice)))
+    }
+}
+
+impl CtSelect for BoxedMontyParamsInner {
+    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+        Self {
+            modulus: self.modulus.ct_select(&other.modulus, choice),
+            one: self.one.ct_select(&other.one, choice),
+            r2: self.r2.ct_select(&other.r2, choice),
+            mod_inv: self.mod_inv.ct_select(&other.mod_inv, choice),
+            mod_leading_zeros: self
+                .mod_leading_zeros
+                .ct_select(&other.mod_leading_zeros, choice),
+        }
+    }
+}

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -14,9 +14,8 @@ use super::{
     MontyParams, Retrieve, div_by_2::div_by_2, mul::mul_montgomery_form,
     reduction::montgomery_retrieve,
 };
-use crate::{ConstChoice, ConstOne, ConstZero, CtEq, Odd, One, Uint, Zero};
+use crate::{ConstOne, ConstZero, CtEq, Odd, One, Uint, Zero};
 use core::{fmt::Debug, marker::PhantomData};
-use subtle::{Choice, ConditionallySelectable};
 
 #[cfg(feature = "rand_core")]
 use crate::{Random, RandomMod, rand_core::TryRngCore};
@@ -31,6 +30,8 @@ use {
 /// Macros to remove the boilerplate code when dealing with constant moduli.
 #[macro_use]
 mod macros;
+mod cmp;
+mod select;
 
 /// Trait representing a modulus and its associated constants for converting in and out of
 /// Montgomery form.
@@ -132,35 +133,6 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
             montgomery_form: div_by_2(&self.montgomery_form, &MOD::PARAMS.modulus),
             phantom: PhantomData,
         }
-    }
-}
-
-impl<MOD: ConstMontyParams<LIMBS> + Copy, const LIMBS: usize> ConditionallySelectable
-    for ConstMontyForm<MOD, LIMBS>
-{
-    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        ConstMontyForm {
-            montgomery_form: Uint::conditional_select(
-                &a.montgomery_form,
-                &b.montgomery_form,
-                choice,
-            ),
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> CtEq for ConstMontyForm<MOD, LIMBS> {
-    fn ct_eq(&self, other: &Self) -> ConstChoice {
-        CtEq::ct_eq(&self.montgomery_form, &other.montgomery_form)
-    }
-}
-
-impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> subtle::ConstantTimeEq
-    for ConstMontyForm<MOD, LIMBS>
-{
-    fn ct_eq(&self, other: &Self) -> Choice {
-        CtEq::ct_eq(&self.montgomery_form, &other.montgomery_form).into()
     }
 }
 

--- a/src/modular/const_monty_form/cmp.rs
+++ b/src/modular/const_monty_form/cmp.rs
@@ -1,0 +1,20 @@
+use super::{ConstMontyForm, ConstMontyParams};
+use crate::{ConstChoice, CtEq};
+
+impl<MOD, const LIMBS: usize> CtEq for ConstMontyForm<MOD, LIMBS>
+where
+    MOD: ConstMontyParams<LIMBS>,
+{
+    fn ct_eq(&self, other: &Self) -> ConstChoice {
+        CtEq::ct_eq(&self.montgomery_form, &other.montgomery_form)
+    }
+}
+
+impl<MOD, const LIMBS: usize> subtle::ConstantTimeEq for ConstMontyForm<MOD, LIMBS>
+where
+    MOD: ConstMontyParams<LIMBS>,
+{
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_eq(&self.montgomery_form, &other.montgomery_form).into()
+    }
+}

--- a/src/modular/const_monty_form/invert.rs
+++ b/src/modular/const_monty_form/invert.rs
@@ -3,7 +3,6 @@
 use super::{ConstMontyForm, ConstMontyParams};
 use crate::{ConstCtOption, Invert, modular::SafeGcdInverter};
 use core::marker::PhantomData;
-use subtle::CtOption;
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Computes `self^-1` representing the multiplicative inverse of `self`,
@@ -78,14 +77,14 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
 }
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> Invert for ConstMontyForm<MOD, LIMBS> {
-    type Output = CtOption<Self>;
+    type Output = ConstCtOption<Self>;
 
     fn invert(&self) -> Self::Output {
-        self.invert().into()
+        self.invert()
     }
 
     fn invert_vartime(&self) -> Self::Output {
-        self.invert_vartime().into()
+        self.invert_vartime()
     }
 }
 

--- a/src/modular/const_monty_form/select.rs
+++ b/src/modular/const_monty_form/select.rs
@@ -1,0 +1,24 @@
+use super::{ConstMontyForm, ConstMontyParams};
+use crate::{ConstChoice, CtSelect, Uint};
+use core::marker::PhantomData;
+
+impl<MOD, const LIMBS: usize> CtSelect for ConstMontyForm<MOD, LIMBS>
+where
+    MOD: ConstMontyParams<LIMBS>,
+{
+    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+        ConstMontyForm {
+            montgomery_form: Uint::ct_select(&self.montgomery_form, &other.montgomery_form, choice),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<MOD, const LIMBS: usize> subtle::ConditionallySelectable for ConstMontyForm<MOD, LIMBS>
+where
+    MOD: ConstMontyParams<LIMBS> + Copy,
+{
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        CtSelect::ct_select(a, b, choice.into())
+    }
+}

--- a/src/modular/monty_form/cmp.rs
+++ b/src/modular/monty_form/cmp.rs
@@ -1,0 +1,30 @@
+use super::MontyParams;
+use crate::modular::MontyForm;
+use crate::{ConstChoice, CtEq};
+
+impl<const LIMBS: usize> CtEq for MontyForm<LIMBS> {
+    fn ct_eq(&self, other: &Self) -> ConstChoice {
+        self.montgomery_form.ct_eq(&other.montgomery_form) & self.params.ct_eq(&other.params)
+    }
+}
+
+impl<const LIMBS: usize> CtEq for MontyParams<LIMBS> {
+    fn ct_eq(&self, other: &Self) -> ConstChoice {
+        self.modulus.ct_eq(&other.modulus)
+            & self.one.ct_eq(&other.one)
+            & self.r2.ct_eq(&other.r2)
+            & self.mod_inv.ct_eq(&other.mod_inv)
+    }
+}
+
+impl<const LIMBS: usize> subtle::ConstantTimeEq for MontyForm<LIMBS> {
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_eq(self, other).into()
+    }
+}
+
+impl<const LIMBS: usize> subtle::ConstantTimeEq for MontyParams<LIMBS> {
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_eq(self, other).into()
+    }
+}

--- a/src/modular/monty_form/invert.rs
+++ b/src/modular/monty_form/invert.rs
@@ -2,7 +2,6 @@
 
 use super::{MontyForm, MontyParams};
 use crate::{ConstCtOption, modular::SafeGcdInverter, traits::Invert};
-use subtle::CtOption;
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Computes `self^-1` representing the multiplicative inverse of `self`.
@@ -67,14 +66,14 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
 }
 
 impl<const LIMBS: usize> Invert for MontyForm<LIMBS> {
-    type Output = CtOption<Self>;
+    type Output = ConstCtOption<Self>;
 
     fn invert(&self) -> Self::Output {
-        self.invert().into()
+        self.invert()
     }
 
     fn invert_vartime(&self) -> Self::Output {
-        self.invert_vartime().into()
+        self.invert_vartime()
     }
 }
 

--- a/src/modular/monty_form/select.rs
+++ b/src/modular/monty_form/select.rs
@@ -1,0 +1,40 @@
+use super::MontyParams;
+use crate::modular::MontyForm;
+use crate::{ConstChoice, CtSelect, Odd, U64, Uint};
+
+impl<const LIMBS: usize> CtSelect for MontyForm<LIMBS> {
+    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+        Self {
+            montgomery_form: Uint::ct_select(&self.montgomery_form, &other.montgomery_form, choice),
+            params: MontyParams::ct_select(&self.params, &other.params, choice),
+        }
+    }
+}
+
+impl<const LIMBS: usize> CtSelect for MontyParams<LIMBS> {
+    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+        Self {
+            modulus: Odd::ct_select(&self.modulus, &other.modulus, choice),
+            one: Uint::ct_select(&self.one, &other.one, choice),
+            r2: Uint::ct_select(&self.r2, &other.r2, choice),
+            mod_inv: U64::ct_select(&self.mod_inv, &other.mod_inv, choice),
+            mod_leading_zeros: u32::ct_select(
+                &self.mod_leading_zeros,
+                &other.mod_leading_zeros,
+                choice,
+            ),
+        }
+    }
+}
+
+impl<const LIMBS: usize> subtle::ConditionallySelectable for MontyForm<LIMBS> {
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        a.ct_select(b, choice.into())
+    }
+}
+
+impl<const LIMBS: usize> subtle::ConditionallySelectable for MontyParams<LIMBS> {
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        a.ct_select(b, choice.into())
+    }
+}

--- a/src/modular/pow.rs
+++ b/src/modular/pow.rs
@@ -1,10 +1,9 @@
 use super::mul::{mul_montgomery_form, square_montgomery_form};
-use crate::{AmmMultiplier, Limb, Monty, Odd, Uint, Unsigned, Word, word};
+use crate::{AmmMultiplier, CtEq, Limb, Monty, Odd, Uint, Unsigned, Word, word};
+use core::{array, mem};
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-use core::{array, mem};
-use subtle::ConstantTimeEq;
 
 const WINDOW: u32 = 4;
 const WINDOW_MASK: Word = (1 << WINDOW) - 1;
@@ -114,7 +113,7 @@ where
             // Constant-time lookup in the array of powers
             power.as_mut_limbs().copy_from_slice(powers[0].as_limbs());
             for i in 1..(1 << WINDOW) {
-                power.ct_assign(&powers[i], (i as Word).ct_eq(&idx).into());
+                power.ct_assign(&powers[i], (i as Word).ct_eq(&idx));
             }
 
             multiplier.mul_amm_assign(&mut z, &power);

--- a/src/modular/safegcd/boxed.rs
+++ b/src/modular/safegcd/boxed.rs
@@ -327,7 +327,7 @@ impl SignedBoxedInt {
         let odd_neg = x_neg.xor(y_neg);
 
         // Negate y if none or both of the multiplication results are negative.
-        y.conditional_wrapping_neg_assign(odd_neg.not().into());
+        y.conditional_wrapping_neg_assign(odd_neg.not());
 
         let borrow;
         (x, borrow) = x.borrowing_sub(&y, Limb::ZERO);
@@ -335,7 +335,7 @@ impl SignedBoxedInt {
 
         // Negate the result if we did not negate y and there was a borrow,
         // indicating that |y| > |x|.
-        x.conditional_wrapping_neg_assign(swap.into());
+        x.conditional_wrapping_neg_assign(swap);
 
         let sign = x_neg.and(swap.not()).or(y_neg.and(swap));
         Self::from_uint_sign(x, sign)
@@ -393,7 +393,7 @@ impl SignedBoxedInt {
 
         // Negate x if the subtraction borrowed.
         let swap = borrow.is_nonzero();
-        x.conditional_wrapping_neg_assign(swap.into());
+        x.conditional_wrapping_neg_assign(swap);
         x_sign = x_sign.xor(swap);
 
         // Shift the result, eliminating the trailing zeros.

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -42,6 +42,7 @@ pub struct NonZero<T: ?Sized>(pub(crate) T);
 
 impl<T> NonZero<T> {
     /// Create a new non-zero integer.
+    #[inline]
     pub fn new(mut n: T) -> ConstCtOption<Self>
     where
         T: Zero + One + CtSelect,
@@ -56,6 +57,7 @@ impl<T> NonZero<T> {
     }
 
     /// Returns the inner value.
+    #[inline]
     pub fn get(self) -> T {
         self.0
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -4,7 +4,7 @@ pub use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
     Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
 };
-pub use ctutils::{CtEq, CtGt, CtLt, CtSelect};
+pub use ctutils::{CtEq, CtGt, CtLt, CtNeg, CtSelect};
 pub use num_traits::{
     ConstOne, ConstZero, WrappingAdd, WrappingMul, WrappingNeg, WrappingShl, WrappingShr,
     WrappingSub,
@@ -958,6 +958,8 @@ pub trait Resize: Sized {
 pub trait Monty:
     'static
     + Clone
+    + CtEq
+    + CtSelect
     + Debug
     + Eq
     + Sized

--- a/src/uint/bit_and.rs
+++ b/src/uint/bit_and.rs
@@ -1,9 +1,7 @@
 //! [`Uint`] bitwise AND operations.
 
 use super::Uint;
-use crate::{Limb, Wrapping};
-use core::ops::{BitAnd, BitAndAssign};
-use subtle::{Choice, CtOption};
+use crate::{BitAnd, BitAndAssign, ConstCtOption, Limb, Wrapping};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `a & b`.
@@ -42,10 +40,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         self.bitand(rhs)
     }
 
-    /// Perform checked bitwise `AND`, returning a [`CtOption`] which `is_some` always
-    pub fn checked_and(&self, rhs: &Self) -> CtOption<Self> {
-        let result = self.bitand(rhs);
-        CtOption::new(result, Choice::from(1))
+    /// Perform checked bitwise `AND`, returning a [`ConstCtOption`] which `is_some` always
+    pub const fn checked_and(&self, rhs: &Self) -> ConstCtOption<Self> {
+        ConstCtOption::some(self.bitand(rhs))
     }
 }
 

--- a/src/uint/bit_or.rs
+++ b/src/uint/bit_or.rs
@@ -1,9 +1,7 @@
 //! [`Uint`] bitwise OR operations.
 
 use super::Uint;
-use crate::{Limb, Wrapping};
-use core::ops::{BitOr, BitOrAssign};
-use subtle::{Choice, CtOption};
+use crate::{BitOr, BitOrAssign, ConstCtOption, Limb, Wrapping};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `a & b`.
@@ -28,10 +26,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         self.bitor(rhs)
     }
 
-    /// Perform checked bitwise `OR`, returning a [`CtOption`] which `is_some` always
-    pub fn checked_or(&self, rhs: &Self) -> CtOption<Self> {
-        let result = self.bitor(rhs);
-        CtOption::new(result, Choice::from(1))
+    /// Perform checked bitwise `OR`, returning a [`ConstCtOption`] which `is_some` always
+    pub const fn checked_or(&self, rhs: &Self) -> ConstCtOption<Self> {
+        ConstCtOption::some(self.bitor(rhs))
     }
 }
 

--- a/src/uint/bit_xor.rs
+++ b/src/uint/bit_xor.rs
@@ -1,9 +1,7 @@
 //! [`Uint`] bitwise XOR operations.
 
 use super::Uint;
-use crate::{Limb, Wrapping};
-use core::ops::{BitXor, BitXorAssign};
-use subtle::{Choice, CtOption};
+use crate::{BitXor, BitXorAssign, ConstCtOption, Limb, Wrapping};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `a ^ b`.
@@ -28,10 +26,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         self.bitxor(rhs)
     }
 
-    /// Perform checked bitwise `XOR`, returning a [`CtOption`] which `is_some` always
-    pub fn checked_xor(&self, rhs: &Self) -> CtOption<Self> {
-        let result = self.bitxor(rhs);
-        CtOption::new(result, Choice::from(1))
+    /// Perform checked bitwise `XOR`, returning a [`ConstCtOption`] which `is_some` always
+    pub const fn checked_xor(&self, rhs: &Self) -> ConstCtOption<Self> {
+        ConstCtOption::some(self.bitxor(rhs))
     }
 }
 

--- a/src/uint/boxed/bit_and.rs
+++ b/src/uint/boxed/bit_and.rs
@@ -1,9 +1,7 @@
 //! [`BoxedUint`] bitwise AND operations.
 
 use super::BoxedUint;
-use crate::{Limb, Wrapping};
-use core::ops::{BitAnd, BitAndAssign};
-use subtle::{Choice, CtOption};
+use crate::{BitAnd, BitAndAssign, ConstCtOption, Limb, Wrapping};
 
 impl BoxedUint {
     /// Computes bitwise `a & b`.
@@ -28,10 +26,9 @@ impl BoxedUint {
         self.bitand(rhs)
     }
 
-    /// Perform checked bitwise `AND`, returning a [`CtOption`] which `is_some` always
-    pub fn checked_and(&self, rhs: &Self) -> CtOption<Self> {
-        let result = self.bitand(rhs);
-        CtOption::new(result, Choice::from(1))
+    /// Perform checked bitwise `AND`, returning a [`ConstCtOption`] which `is_some` always
+    pub fn checked_and(&self, rhs: &Self) -> ConstCtOption<Self> {
+        ConstCtOption::some(self.bitand(rhs))
     }
 }
 

--- a/src/uint/boxed/bit_or.rs
+++ b/src/uint/boxed/bit_or.rs
@@ -1,8 +1,6 @@
 //! [`BoxedUint`] bitwise OR operations.
 
-use crate::{BoxedUint, Wrapping};
-use core::ops::{BitOr, BitOrAssign};
-use subtle::{Choice, CtOption};
+use crate::{BitOr, BitOrAssign, BoxedUint, ConstCtOption, Wrapping};
 
 impl BoxedUint {
     /// Computes bitwise `a & b`.
@@ -19,10 +17,9 @@ impl BoxedUint {
         self.bitor(rhs)
     }
 
-    /// Perform checked bitwise `OR`, returning a [`CtOption`] which `is_some` always
-    pub fn checked_or(&self, rhs: &Self) -> CtOption<Self> {
-        let result = self.bitor(rhs);
-        CtOption::new(result, Choice::from(1))
+    /// Perform checked bitwise `OR`, returning a [`ConstCtOption`] which `is_some` always
+    pub fn checked_or(&self, rhs: &Self) -> ConstCtOption<Self> {
+        ConstCtOption::some(self.bitor(rhs))
     }
 }
 

--- a/src/uint/boxed/bit_xor.rs
+++ b/src/uint/boxed/bit_xor.rs
@@ -1,9 +1,7 @@
 //! [`BoxedUint`] bitwise XOR operations.
 
 use super::BoxedUint;
-use crate::Wrapping;
-use core::ops::{BitXor, BitXorAssign};
-use subtle::{Choice, CtOption};
+use crate::{BitXor, BitXorAssign, ConstCtOption, Wrapping};
 
 impl BoxedUint {
     /// Computes bitwise `a ^ b`.
@@ -20,10 +18,9 @@ impl BoxedUint {
         self.bitxor(rhs)
     }
 
-    /// Perform checked bitwise `XOR`, returning a [`CtOption`] which `is_some` always
-    pub fn checked_xor(&self, rhs: &Self) -> CtOption<Self> {
-        let result = self.bitxor(rhs);
-        CtOption::new(result, Choice::from(1))
+    /// Perform checked bitwise `XOR`, returning a [`ConstCtOption`] which `is_some` always
+    pub fn checked_xor(&self, rhs: &Self) -> ConstCtOption<Self> {
+        ConstCtOption::some(self.bitxor(rhs))
     }
 }
 

--- a/src/uint/boxed/cmp.rs
+++ b/src/uint/boxed/cmp.rs
@@ -132,18 +132,18 @@ impl<const LIMBS: usize> PartialOrd<Uint<LIMBS>> for BoxedUint {
 #[cfg(test)]
 mod tests {
     use super::BoxedUint;
+    use crate::{CtEq, CtGt, CtLt};
     use core::cmp::Ordering;
-    use subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
     #[test]
     fn ct_eq() {
         let a = BoxedUint::zero();
         let b = BoxedUint::one();
 
-        assert!(bool::from(a.ct_eq(&a)));
-        assert!(!bool::from(a.ct_eq(&b)));
-        assert!(!bool::from(b.ct_eq(&a)));
-        assert!(bool::from(b.ct_eq(&b)));
+        assert!(a.ct_eq(&a).to_bool());
+        assert!(!a.ct_eq(&b).to_bool());
+        assert!(!b.ct_eq(&a).to_bool());
+        assert!(b.ct_eq(&b).to_bool());
     }
 
     #[test]
@@ -152,17 +152,17 @@ mod tests {
         let b = BoxedUint::one();
         let c = BoxedUint::max(64);
 
-        assert!(bool::from(b.ct_gt(&a)));
-        assert!(bool::from(c.ct_gt(&a)));
-        assert!(bool::from(c.ct_gt(&b)));
+        assert!(b.ct_gt(&a).to_bool());
+        assert!(c.ct_gt(&a).to_bool());
+        assert!(c.ct_gt(&b).to_bool());
 
-        assert!(!bool::from(a.ct_gt(&a)));
-        assert!(!bool::from(b.ct_gt(&b)));
-        assert!(!bool::from(c.ct_gt(&c)));
+        assert!(!a.ct_gt(&a).to_bool());
+        assert!(!b.ct_gt(&b).to_bool());
+        assert!(!c.ct_gt(&c).to_bool());
 
-        assert!(!bool::from(a.ct_gt(&b)));
-        assert!(!bool::from(a.ct_gt(&c)));
-        assert!(!bool::from(b.ct_gt(&c)));
+        assert!(!a.ct_gt(&b).to_bool());
+        assert!(!a.ct_gt(&c).to_bool());
+        assert!(!b.ct_gt(&c).to_bool());
     }
 
     #[test]
@@ -171,17 +171,17 @@ mod tests {
         let b = BoxedUint::one();
         let c = BoxedUint::max(64);
 
-        assert!(bool::from(a.ct_lt(&b)));
-        assert!(bool::from(a.ct_lt(&c)));
-        assert!(bool::from(b.ct_lt(&c)));
+        assert!(a.ct_lt(&b).to_bool());
+        assert!(a.ct_lt(&c).to_bool());
+        assert!(b.ct_lt(&c).to_bool());
 
-        assert!(!bool::from(a.ct_lt(&a)));
-        assert!(!bool::from(b.ct_lt(&b)));
-        assert!(!bool::from(c.ct_lt(&c)));
+        assert!(!a.ct_lt(&a).to_bool());
+        assert!(!b.ct_lt(&b).to_bool());
+        assert!(!c.ct_lt(&c).to_bool());
 
-        assert!(!bool::from(b.ct_lt(&a)));
-        assert!(!bool::from(c.ct_lt(&a)));
-        assert!(!bool::from(c.ct_lt(&b)));
+        assert!(!b.ct_lt(&a).to_bool());
+        assert!(!c.ct_lt(&a).to_bool());
+        assert!(!c.ct_lt(&b).to_bool());
     }
 
     #[test]

--- a/src/uint/boxed/encoding.rs
+++ b/src/uint/boxed/encoding.rs
@@ -1,9 +1,8 @@
 //! Const-friendly decoding operations for [`BoxedUint`].
 
 use super::BoxedUint;
-use crate::{DecodeError, Encoding, Limb, Word, uint::encoding};
+use crate::{ConstCtOption, CtEq, DecodeError, Encoding, Limb, Word, uint::encoding};
 use alloc::{boxed::Box, string::String, vec::Vec};
-use subtle::{Choice, CtOption};
 
 #[cfg(feature = "serde")]
 mod serde;
@@ -157,7 +156,7 @@ impl BoxedUint {
     }
 
     /// Create a new [`BoxedUint`] from the provided big endian hex string.
-    pub fn from_be_hex(hex: &str, bits_precision: u32) -> CtOption<Self> {
+    pub fn from_be_hex(hex: &str, bits_precision: u32) -> ConstCtOption<Self> {
         let nlimbs = (bits_precision / Limb::BITS) as usize;
         let bytes = hex.as_bytes();
 
@@ -183,7 +182,8 @@ impl BoxedUint {
             res[nlimbs - i - 1] = Limb(Word::from_be_bytes(buf));
             i += 1;
         }
-        CtOption::new(Self { limbs: res.into() }, Choice::from((err == 0) as u8))
+
+        ConstCtOption::new(Self { limbs: res.into() }, err.ct_eq(&0))
     }
 
     /// Create a new [`BoxedUint`] from a big-endian string in a given base.

--- a/src/uint/boxed/select.rs
+++ b/src/uint/boxed/select.rs
@@ -1,8 +1,7 @@
-//! Constant-time helper functions.
+//! Constant-time selection support.
 
 use super::BoxedUint;
 use crate::{ConstChoice, CtSelect, Limb};
-use subtle::{Choice, ConditionallyNegatable};
 
 impl CtSelect for BoxedUint {
     #[inline]
@@ -36,38 +35,16 @@ impl CtSelect for BoxedUint {
     }
 }
 
-impl ConditionallyNegatable for BoxedUint {
-    #[inline]
-    fn conditional_negate(&mut self, choice: Choice) {
-        let self_neg = self.wrapping_neg();
-        self.ct_assign(&self_neg, choice.into())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::{BoxedUint, ConstChoice, CtSelect};
-    use subtle::ConditionallyNegatable;
 
     #[test]
-    fn conditional_select() {
+    fn ct_select() {
         let a = BoxedUint::zero_with_precision(128);
         let b = BoxedUint::max(128);
 
         assert_eq!(a, BoxedUint::ct_select(&a, &b, ConstChoice::FALSE));
         assert_eq!(b, BoxedUint::ct_select(&a, &b, ConstChoice::TRUE));
-    }
-
-    #[test]
-    fn conditional_negate() {
-        let mut a = BoxedUint::from(123u64);
-        let control = a.clone();
-
-        a.conditional_negate(ConstChoice::FALSE.into());
-        assert_eq!(a, control);
-
-        a.conditional_negate(ConstChoice::TRUE.into());
-        assert_ne!(a, control);
-        assert_eq!(a, control.wrapping_neg());
     }
 }

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -7,38 +7,6 @@ use crate::{ConstChoice, CtEq, CtGt, CtLt, Limb, word};
 use core::cmp::Ordering;
 
 impl<const LIMBS: usize> Uint<LIMBS> {
-    /// Return `b` if `c` is truthy, otherwise return `a`.
-    #[inline]
-    pub(crate) const fn select(a: &Self, b: &Self, c: ConstChoice) -> Self {
-        let mut limbs = [Limb::ZERO; LIMBS];
-
-        let mut i = 0;
-        while i < LIMBS {
-            limbs[i] = Limb::select(a.limbs[i], b.limbs[i], c);
-            i += 1;
-        }
-
-        Uint { limbs }
-    }
-
-    /// Swap `a` and `b` if `c` is truthy, otherwise, do nothing.
-    #[inline]
-    pub(crate) const fn conditional_swap(a: &mut Self, b: &mut Self, c: ConstChoice) {
-        let mut i = 0;
-        let a = a.as_mut_limbs();
-        let b = b.as_mut_limbs();
-        while i < LIMBS {
-            Limb::ct_conditional_swap(&mut a[i], &mut b[i], c);
-            i += 1;
-        }
-    }
-
-    /// Swap `a` and `b`
-    #[inline]
-    pub(crate) const fn swap(a: &mut Self, b: &mut Self) {
-        Self::conditional_swap(a, b, ConstChoice::TRUE)
-    }
-
     /// Returns the truthy value if `self`!=0 or the falsy value otherwise.
     #[inline]
     pub(crate) const fn is_nonzero(&self) -> ConstChoice {
@@ -222,9 +190,8 @@ impl<const LIMBS: usize> PartialEq for Uint<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, Integer, U128, Uint};
+    use crate::{ConstChoice, CtEq, CtGt, CtLt, Integer, U128, Uint};
     use core::cmp::Ordering;
-    use subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
     #[test]
     fn is_zero() {

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -159,7 +159,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// ### Usage:
     /// ```
-    /// use crypto_bigint::{U448, NonZero, subtle::{CtOption, Choice}};
+    /// use crypto_bigint::{U448, NonZero};
     ///
     /// let a = U448::from(8_u64);
     /// let result = NonZero::new(U448::from(4_u64))
@@ -170,7 +170,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// // Check division by zero
     /// let zero = U448::from(0_u64);
-    /// assert!(bool::from(a.checked_div(&zero).is_none()), "Should be None for division by zero");
+    /// assert!(a.checked_div(&zero).is_none().to_bool(), "should be None for division by zero");
     /// ```
     pub fn checked_div<const RHS_LIMBS: usize>(
         &self,
@@ -205,7 +205,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// ### Usage:
     /// ```
-    /// use crypto_bigint::{U448, NonZero, subtle::{Choice,CtOption}};
+    /// use crypto_bigint::{U448, NonZero};
     ///
     /// let a = U448::from(10_u64);
     /// let remainder_option = NonZero::new(U448::from(3_u64))
@@ -216,7 +216,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// // Check reduction by zero
     /// let zero = U448::from(0_u64);
     ///
-    /// assert!(bool::from(a.checked_rem(&zero).is_none()), "Should be None for reduction by zero");
+    /// assert!(a.checked_rem(&zero).is_none().to_bool(), "should be None for reduction by zero");
     /// ```
     pub fn checked_rem<const RHS_LIMBS: usize>(
         &self,

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -3,11 +3,10 @@
 //! (DOI: 10.1109/TC.2010.143, <https://gmplib.org/~tege/division-paper.pdf>).
 
 use crate::{
-    ConstChoice, Limb, NonZero, Uint, WideWord, Word,
+    ConstChoice, CtSelect, Limb, NonZero, Uint, WideWord, Word,
     primitives::{addhilo, widening_mul},
     word,
 };
-use subtle::{Choice, ConditionallySelectable};
 
 /// Calculates the reciprocal of the given 32-bit divisor with the highmost bit set.
 #[cfg(target_pointer_width = "32")]
@@ -226,16 +225,16 @@ impl Reciprocal {
     }
 }
 
-impl ConditionallySelectable for Reciprocal {
-    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+impl CtSelect for Reciprocal {
+    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
         Self {
-            divisor_normalized: Word::conditional_select(
-                &a.divisor_normalized,
-                &b.divisor_normalized,
+            divisor_normalized: Word::ct_select(
+                &self.divisor_normalized,
+                &other.divisor_normalized,
                 choice,
             ),
-            shift: u32::conditional_select(&a.shift, &b.shift, choice),
-            reciprocal: Word::conditional_select(&a.reciprocal, &b.reciprocal, choice),
+            shift: u32::ct_select(&self.shift, &other.shift, choice),
+            reciprocal: Word::ct_select(&self.reciprocal, &other.reciprocal, choice),
         }
     }
 }

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -1,9 +1,8 @@
 //! Random number generator support
 
 use super::Uint;
-use crate::{Encoding, Limb, NonZero, Random, RandomBits, RandomBitsError, RandomMod};
+use crate::{CtLt, Encoding, Limb, NonZero, Random, RandomBits, RandomBitsError, RandomMod};
 use rand_core::{RngCore, TryRngCore};
-use subtle::ConstantTimeLess;
 
 impl<const LIMBS: usize> Random for Uint<LIMBS> {
     fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
@@ -107,7 +106,7 @@ pub(super) fn random_mod_vartime_core<T, R: TryRngCore + ?Sized>(
     n_bits: u32,
 ) -> Result<(), R::Error>
 where
-    T: Encoding + ConstantTimeLess,
+    T: Encoding + CtLt,
 {
     loop {
         random_bits_core(rng, x, n_bits)?;

--- a/src/uint/select.rs
+++ b/src/uint/select.rs
@@ -1,0 +1,70 @@
+//! Constant-time selection support.
+
+use crate::{ConstChoice, CtSelect, Limb, Uint};
+
+impl<const LIMBS: usize> Uint<LIMBS> {
+    /// Return `b` if `c` is truthy, otherwise return `a`.
+    #[inline]
+    pub(crate) const fn select(a: &Self, b: &Self, c: ConstChoice) -> Self {
+        let mut limbs = [Limb::ZERO; LIMBS];
+
+        let mut i = 0;
+        while i < LIMBS {
+            limbs[i] = Limb::select(a.limbs[i], b.limbs[i], c);
+            i += 1;
+        }
+
+        Uint { limbs }
+    }
+
+    /// Swap `a` and `b` if `c` is truthy, otherwise, do nothing.
+    #[inline]
+    pub(crate) const fn conditional_swap(a: &mut Self, b: &mut Self, c: ConstChoice) {
+        let mut i = 0;
+        let a = a.as_mut_limbs();
+        let b = b.as_mut_limbs();
+        while i < LIMBS {
+            Limb::ct_conditional_swap(&mut a[i], &mut b[i], c);
+            i += 1;
+        }
+    }
+
+    /// Swap `a` and `b`
+    #[inline]
+    pub(crate) const fn swap(a: &mut Self, b: &mut Self) {
+        Self::conditional_swap(a, b, ConstChoice::TRUE)
+    }
+}
+
+impl<const LIMBS: usize> CtSelect for Uint<LIMBS> {
+    #[inline]
+    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+        Self {
+            limbs: self.limbs.ct_select(&other.limbs, choice),
+        }
+    }
+}
+
+impl<const LIMBS: usize> subtle::ConditionallySelectable for Uint<LIMBS> {
+    #[inline]
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        a.ct_select(b, choice.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ConstChoice, CtSelect, U128};
+
+    #[test]
+    fn ct_select() {
+        let a = U128::from_be_hex("00002222444466668888AAAACCCCEEEE");
+        let b = U128::from_be_hex("11113333555577779999BBBBDDDDFFFF");
+
+        let select_0 = U128::ct_select(&a, &b, ConstChoice::FALSE);
+        assert_eq!(a, select_0);
+
+        let select_1 = U128::ct_select(&a, &b, ConstChoice::TRUE);
+        assert_eq!(b, select_1);
+    }
+}

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -8,7 +8,6 @@ use core::{
     fmt,
     ops::{Add, Mul, Neg, Shl, Shr, Sub},
 };
-use subtle::{Choice, ConditionallySelectable};
 
 #[cfg(feature = "rand_core")]
 use {crate::Random, rand_core::TryRngCore};
@@ -185,10 +184,14 @@ impl<T: WrappingShr> Shr<u32> for &Wrapping<T> {
     }
 }
 
-impl<T: ConditionallySelectable> ConditionallySelectable for Wrapping<T> {
+impl<T> subtle::ConditionallySelectable for Wrapping<T>
+where
+    T: Copy,
+    Self: CtSelect,
+{
     #[inline]
-    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        Wrapping(T::conditional_select(&a.0, &b.0, choice))
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        a.ct_select(b, choice.into())
     }
 }
 
@@ -197,7 +200,7 @@ where
     Self: CtEq,
 {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> Choice {
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
         CtEq::ct_eq(self, other).into()
     }
 }

--- a/tests/monty_form.rs
+++ b/tests/monty_form.rs
@@ -4,8 +4,8 @@ mod common;
 
 use common::to_biguint;
 use crypto_bigint::{
-    Bounded, Constants, EncodedUint, Encoding, Integer, Invert, Monty, NonZero, Odd, U128, U256,
-    U512, U1024, U2048, U4096, Unsigned,
+    Bounded, ConstCtOption, Constants, EncodedUint, Encoding, Integer, Invert, Monty, NonZero, Odd,
+    U128, U256, U512, U1024, U2048, U4096, Unsigned,
     modular::{MontyForm, MontyParams},
 };
 use num_bigint::BigUint;
@@ -13,7 +13,6 @@ use num_modular::ModularUnaryOps;
 use num_traits::FromBytes;
 use prop::test_runner::TestRng;
 use proptest::prelude::*;
-use subtle::CtOption;
 
 type MontyForm256 = MontyForm<{ U256::LIMBS }>;
 type MontyParams256 = MontyParams<{ U256::LIMBS }>;
@@ -51,7 +50,7 @@ fn random_invertible_uint<T>(
 ) -> Result<(T, <T as Unsigned>::Monty, <T as Unsigned>::Monty, BigUint), TestCaseError>
 where
     T: Unsigned + Bounded + Encoding,
-    <T as Unsigned>::Monty: Invert<Output = CtOption<T::Monty>>,
+    <T as Unsigned>::Monty: Invert<Output = ConstCtOption<T::Monty>>,
 {
     let r = T::from_be_bytes(bytes.clone());
     let rm = <T as Unsigned>::Monty::new(r.clone(), monty_params);


### PR DESCRIPTION
Except for impls of `subtle` traits (which we can make optional), this gets rid of all of the remaining usage of `subtle` in the internals of the library, replacing it with `ctutils`.

After this, we can make `subtle` optional, and rename `ConstChoice` to `Choice` and `ConstCtOption` to `CtOption`, removing the split between the two types.

This commit fills in various trait impls as needed, and also adds `CtEq` and `CtSelect` bounds to the `Monty` trait.