### PR TITLE
Make `subtle` an optional dependency

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -44,8 +44,9 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rand_core
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rlp
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features serde
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features subtle
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features zeroize
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,der,hybrid-array,rand_core,rlp,serde,zeroize
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,der,hybrid-array,rand_core,rlp,serde,subtle,zeroize
 
   build-benchmarks:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,16 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-ctutils = { version = "0.2.1", features = ["subtle"] }
-subtle = { version = "2.6", default-features = false }
+ctutils = "0.2.1"
+num-traits = { version = "0.2.19", default-features = false }
 
 # optional dependencies
 der = { version = "0.8.0-rc.10", optional = true, default-features = false }
-hybrid-array = { version = "0.4.5", optional = true, features = ["subtle"] }
-num-traits = { version = "0.2.19", default-features = false }
+hybrid-array = { version = "0.4.5", optional = true }
 rand_core = { version = "0.10.0-rc-3", optional = true, default-features = false }
 rlp = { version = "0.6", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
+subtle = { version = "2.6", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
@@ -46,6 +46,7 @@ alloc = ["serdect?/alloc"]
 extra-sizes = []
 rand = ["rand_core"]
 serde = ["dep:serdect"]
+subtle = ["dep:subtle", "ctutils/subtle", "hybrid-array?/subtle"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/benches/limb.rs
+++ b/benches/limb.rs
@@ -2,10 +2,9 @@ use chacha20::ChaCha8Rng;
 use criterion::{
     BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
-use crypto_bigint::{Limb, Random};
+use crypto_bigint::{CtEq, CtGt, CtLt, Limb, Random};
 use rand_core::SeedableRng;
 use std::hint::black_box;
-use subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
 fn bench_cmp<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let mut rng = ChaCha8Rng::from_seed([7u8; 32]);

--- a/src/checked.rs
+++ b/src/checked.rs
@@ -278,27 +278,6 @@ where
     }
 }
 
-impl<T> subtle::ConditionallySelectable for Checked<T>
-where
-    T: Copy,
-    Self: CtSelect,
-{
-    #[inline]
-    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
-        a.ct_select(b, choice.into())
-    }
-}
-
-impl<T> subtle::ConstantTimeEq for Checked<T>
-where
-    Self: CtEq,
-{
-    #[inline]
-    fn ct_eq(&self, rhs: &Self) -> subtle::Choice {
-        CtEq::ct_eq(self, rhs).into()
-    }
-}
-
 impl<T> CtEq for Checked<T>
 where
     T: CtEq,
@@ -365,5 +344,28 @@ impl<T: Copy + Serialize> Serialize for Checked<T> {
         S: Serializer,
     {
         self.0.into_option().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<T> subtle::ConditionallySelectable for Checked<T>
+where
+    T: Copy,
+    Self: CtSelect,
+{
+    #[inline]
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        a.ct_select(b, choice.into())
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<T> subtle::ConstantTimeEq for Checked<T>
+where
+    Self: CtEq,
+{
+    #[inline]
+    fn ct_eq(&self, rhs: &Self) -> subtle::Choice {
+        CtEq::ct_eq(self, rhs).into()
     }
 }

--- a/src/int/cmp.rs
+++ b/src/int/cmp.rs
@@ -73,27 +73,6 @@ impl<const LIMBS: usize> CtLt for Int<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> subtle::ConstantTimeEq for Int<LIMBS> {
-    #[inline]
-    fn ct_eq(&self, other: &Self) -> subtle::Choice {
-        CtEq::ct_eq(self, other).into()
-    }
-}
-
-impl<const LIMBS: usize> subtle::ConstantTimeGreater for Int<LIMBS> {
-    #[inline]
-    fn ct_gt(&self, other: &Self) -> subtle::Choice {
-        CtGt::ct_gt(self, other).into()
-    }
-}
-
-impl<const LIMBS: usize> subtle::ConstantTimeLess for Int<LIMBS> {
-    #[inline]
-    fn ct_lt(&self, other: &Self) -> subtle::Choice {
-        Int::lt(self, other).into()
-    }
-}
-
 impl<const LIMBS: usize> Eq for Int<LIMBS> {}
 
 impl<const LIMBS: usize> Ord for Int<LIMBS> {
@@ -116,6 +95,30 @@ impl<const LIMBS: usize> PartialOrd for Int<LIMBS> {
 impl<const LIMBS: usize> PartialEq for Int<LIMBS> {
     fn eq(&self, other: &Self) -> bool {
         self.ct_eq(other).into()
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<const LIMBS: usize> subtle::ConstantTimeEq for Int<LIMBS> {
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_eq(self, other).into()
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<const LIMBS: usize> subtle::ConstantTimeGreater for Int<LIMBS> {
+    #[inline]
+    fn ct_gt(&self, other: &Self) -> subtle::Choice {
+        CtGt::ct_gt(self, other).into()
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<const LIMBS: usize> subtle::ConstantTimeLess for Int<LIMBS> {
+    #[inline]
+    fn ct_lt(&self, other: &Self) -> subtle::Choice {
+        Int::lt(self, other).into()
     }
 }
 

--- a/src/int/select.rs
+++ b/src/int/select.rs
@@ -17,6 +17,7 @@ impl<const LIMBS: usize> CtSelect for Int<LIMBS> {
     }
 }
 
+#[cfg(feature = "subtle")]
 impl<const LIMBS: usize> subtle::ConditionallySelectable for Int<LIMBS> {
     #[inline]
     fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {

--- a/src/jacobi.rs
+++ b/src/jacobi.rs
@@ -59,17 +59,11 @@ impl CtEq for JacobiSymbol {
     }
 }
 
-impl subtle::ConstantTimeEq for JacobiSymbol {
-    fn ct_eq(&self, other: &Self) -> subtle::Choice {
-        CtEq::ct_eq(self, other).into()
-    }
-}
-
 impl Eq for JacobiSymbol {}
 
 impl PartialEq for JacobiSymbol {
     fn eq(&self, other: &Self) -> bool {
-        bool::from(self.ct_eq(other))
+        self.ct_eq(other).to_bool()
     }
 }
 
@@ -88,5 +82,12 @@ impl Neg for JacobiSymbol {
             Self::One => Self::MinusOne,
             Self::MinusOne => Self::One,
         }
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl subtle::ConstantTimeEq for JacobiSymbol {
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_eq(self, other).into()
     }
 }

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -56,32 +56,6 @@ impl CtLt for Limb {
     }
 }
 
-impl subtle::ConstantTimeEq for Limb {
-    #[inline]
-    fn ct_eq(&self, other: &Self) -> subtle::Choice {
-        CtEq::ct_eq(self, other).into()
-    }
-
-    #[inline]
-    fn ct_ne(&self, other: &Self) -> subtle::Choice {
-        CtEq::ct_ne(self, other).into()
-    }
-}
-
-impl subtle::ConstantTimeGreater for Limb {
-    #[inline]
-    fn ct_gt(&self, other: &Self) -> subtle::Choice {
-        CtGt::ct_gt(self, other).into()
-    }
-}
-
-impl subtle::ConstantTimeLess for Limb {
-    #[inline]
-    fn ct_lt(&self, other: &Self) -> subtle::Choice {
-        CtLt::ct_lt(self, other).into()
-    }
-}
-
 impl Eq for Limb {}
 
 impl Ord for Limb {
@@ -105,6 +79,35 @@ impl PartialEq for Limb {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.ct_eq(other).into()
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl subtle::ConstantTimeEq for Limb {
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_eq(self, other).into()
+    }
+
+    #[inline]
+    fn ct_ne(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_ne(self, other).into()
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl subtle::ConstantTimeGreater for Limb {
+    #[inline]
+    fn ct_gt(&self, other: &Self) -> subtle::Choice {
+        CtGt::ct_gt(self, other).into()
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl subtle::ConstantTimeLess for Limb {
+    #[inline]
+    fn ct_lt(&self, other: &Self) -> subtle::Choice {
+        CtLt::ct_lt(self, other).into()
     }
 }
 

--- a/src/limb/select.rs
+++ b/src/limb/select.rs
@@ -26,6 +26,7 @@ impl CtSelect for Limb {
     }
 }
 
+#[cfg(feature = "subtle")]
 impl subtle::ConditionallySelectable for Limb {
     #[inline]
     fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {

--- a/src/modular/const_monty_form/cmp.rs
+++ b/src/modular/const_monty_form/cmp.rs
@@ -10,6 +10,7 @@ where
     }
 }
 
+#[cfg(feature = "subtle")]
 impl<MOD, const LIMBS: usize> subtle::ConstantTimeEq for ConstMontyForm<MOD, LIMBS>
 where
     MOD: ConstMontyParams<LIMBS>,

--- a/src/modular/const_monty_form/select.rs
+++ b/src/modular/const_monty_form/select.rs
@@ -14,6 +14,7 @@ where
     }
 }
 
+#[cfg(feature = "subtle")]
 impl<MOD, const LIMBS: usize> subtle::ConditionallySelectable for ConstMontyForm<MOD, LIMBS>
 where
     MOD: ConstMontyParams<LIMBS> + Copy,

--- a/src/modular/monty_form/cmp.rs
+++ b/src/modular/monty_form/cmp.rs
@@ -17,12 +17,14 @@ impl<const LIMBS: usize> CtEq for MontyParams<LIMBS> {
     }
 }
 
+#[cfg(feature = "subtle")]
 impl<const LIMBS: usize> subtle::ConstantTimeEq for MontyForm<LIMBS> {
     fn ct_eq(&self, other: &Self) -> subtle::Choice {
         CtEq::ct_eq(self, other).into()
     }
 }
 
+#[cfg(feature = "subtle")]
 impl<const LIMBS: usize> subtle::ConstantTimeEq for MontyParams<LIMBS> {
     fn ct_eq(&self, other: &Self) -> subtle::Choice {
         CtEq::ct_eq(self, other).into()

--- a/src/modular/monty_form/select.rs
+++ b/src/modular/monty_form/select.rs
@@ -27,12 +27,14 @@ impl<const LIMBS: usize> CtSelect for MontyParams<LIMBS> {
     }
 }
 
+#[cfg(feature = "subtle")]
 impl<const LIMBS: usize> subtle::ConditionallySelectable for MontyForm<LIMBS> {
     fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
         a.ct_select(b, choice.into())
     }
 }
 
+#[cfg(feature = "subtle")]
 impl<const LIMBS: usize> subtle::ConditionallySelectable for MontyParams<LIMBS> {
     fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
         a.ct_select(b, choice.into())

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -300,27 +300,6 @@ impl<T: ?Sized> AsRef<T> for NonZero<T> {
     }
 }
 
-impl<T> subtle::ConditionallySelectable for NonZero<T>
-where
-    T: Copy,
-    Self: CtSelect,
-{
-    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
-        CtSelect::ct_select(a, b, choice.into())
-    }
-}
-
-impl<T> subtle::ConstantTimeEq for NonZero<T>
-where
-    T: ?Sized,
-    Self: CtEq,
-{
-    #[inline]
-    fn ct_eq(&self, other: &Self) -> subtle::Choice {
-        CtEq::ct_eq(self, other).into()
-    }
-}
-
 impl<T> CtEq for NonZero<T>
 where
     T: CtEq + ?Sized,
@@ -510,6 +489,29 @@ impl<T: Serialize + Zero> Serialize for NonZero<T> {
         S: Serializer,
     {
         self.0.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<T> subtle::ConditionallySelectable for NonZero<T>
+where
+    T: Copy,
+    Self: CtSelect,
+{
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        CtSelect::ct_select(a, b, choice.into())
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<T> subtle::ConstantTimeEq for NonZero<T>
+where
+    T: ?Sized,
+    Self: CtEq,
+{
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_eq(self, other).into()
     }
 }
 

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -160,26 +160,6 @@ impl<T: ?Sized> AsRef<NonZero<T>> for Odd<T> {
     }
 }
 
-impl<T> subtle::ConditionallySelectable for Odd<T>
-where
-    T: Copy,
-    Self: CtSelect,
-{
-    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
-        a.ct_select(b, choice.into())
-    }
-}
-
-impl<T> subtle::ConstantTimeEq for Odd<T>
-where
-    T: ?Sized,
-    Self: CtEq,
-{
-    fn ct_eq(&self, other: &Self) -> subtle::Choice {
-        CtEq::ct_eq(self, other).into()
-    }
-}
-
 impl<T> CtEq for Odd<T>
 where
     T: CtEq + ?Sized,
@@ -412,6 +392,29 @@ impl<T: Serialize + Zero> Serialize for Odd<T> {
         self.0.serialize(serializer)
     }
 }
+
+#[cfg(feature = "subtle")]
+impl<T> subtle::ConditionallySelectable for Odd<T>
+where
+    T: Copy,
+    Self: CtSelect,
+{
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        a.ct_select(b, choice.into())
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<T> subtle::ConstantTimeEq for Odd<T>
+where
+    T: ?Sized,
+    Self: CtEq,
+{
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_eq(self, other).into()
+    }
+}
+
 #[cfg(feature = "zeroize")]
 impl<T: zeroize::Zeroize> zeroize::Zeroize for Odd<T> {
     fn zeroize(&mut self) {

--- a/src/uint/boxed/cmp.rs
+++ b/src/uint/boxed/cmp.rs
@@ -68,27 +68,6 @@ impl CtLt for BoxedUint {
     }
 }
 
-impl subtle::ConstantTimeEq for BoxedUint {
-    #[inline]
-    fn ct_eq(&self, other: &Self) -> subtle::Choice {
-        CtEq::ct_eq(self, other).into()
-    }
-}
-
-impl subtle::ConstantTimeGreater for BoxedUint {
-    #[inline]
-    fn ct_gt(&self, other: &Self) -> subtle::Choice {
-        CtGt::ct_gt(self, other).into()
-    }
-}
-
-impl subtle::ConstantTimeLess for BoxedUint {
-    #[inline]
-    fn ct_lt(&self, other: &Self) -> subtle::Choice {
-        CtLt::ct_lt(self, other).into()
-    }
-}
-
 impl Eq for BoxedUint {}
 impl PartialEq for BoxedUint {
     fn eq(&self, other: &Self) -> bool {
@@ -126,6 +105,30 @@ impl PartialOrd for BoxedUint {
 impl<const LIMBS: usize> PartialOrd<Uint<LIMBS>> for BoxedUint {
     fn partial_cmp(&self, other: &Uint<LIMBS>) -> Option<Ordering> {
         self.partial_cmp(&Self::from(other))
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl subtle::ConstantTimeEq for BoxedUint {
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_eq(self, other).into()
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl subtle::ConstantTimeGreater for BoxedUint {
+    #[inline]
+    fn ct_gt(&self, other: &Self) -> subtle::Choice {
+        CtGt::ct_gt(self, other).into()
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl subtle::ConstantTimeLess for BoxedUint {
+    #[inline]
+    fn ct_lt(&self, other: &Self) -> subtle::Choice {
+        CtLt::ct_lt(self, other).into()
     }
 }
 

--- a/src/uint/boxed/neg.rs
+++ b/src/uint/boxed/neg.rs
@@ -42,16 +42,17 @@ impl CtNeg for BoxedUint {
     }
 }
 
+impl WrappingNeg for BoxedUint {
+    fn wrapping_neg(&self) -> Self {
+        self.wrapping_neg()
+    }
+}
+
+#[cfg(feature = "subtle")]
 impl subtle::ConditionallyNegatable for BoxedUint {
     #[inline]
     fn conditional_negate(&mut self, choice: subtle::Choice) {
         self.ct_neg_assign(choice.into())
-    }
-}
-
-impl WrappingNeg for BoxedUint {
-    fn wrapping_neg(&self) -> Self {
-        self.wrapping_neg()
     }
 }
 
@@ -79,6 +80,7 @@ mod tests {
         assert_eq!(a, control.wrapping_neg());
     }
 
+    #[cfg(feature = "subtle")]
     #[test]
     fn subtle_conditional_negate() {
         use subtle::ConditionallyNegatable;

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -137,32 +137,6 @@ impl<const LIMBS: usize> CtLt for Uint<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> subtle::ConstantTimeEq for Uint<LIMBS> {
-    #[inline]
-    fn ct_eq(&self, other: &Self) -> subtle::Choice {
-        CtEq::ct_eq(self, other).into()
-    }
-
-    #[inline]
-    fn ct_ne(&self, other: &Self) -> subtle::Choice {
-        CtEq::ct_ne(self, other).into()
-    }
-}
-
-impl<const LIMBS: usize> subtle::ConstantTimeGreater for Uint<LIMBS> {
-    #[inline]
-    fn ct_gt(&self, other: &Self) -> subtle::Choice {
-        CtGt::ct_gt(self, other).into()
-    }
-}
-
-impl<const LIMBS: usize> subtle::ConstantTimeLess for Uint<LIMBS> {
-    #[inline]
-    fn ct_lt(&self, other: &Self) -> subtle::Choice {
-        Uint::lt(self, other).into()
-    }
-}
-
 impl<const LIMBS: usize> Eq for Uint<LIMBS> {}
 
 impl<const LIMBS: usize> Ord for Uint<LIMBS> {
@@ -185,6 +159,35 @@ impl<const LIMBS: usize> PartialOrd for Uint<LIMBS> {
 impl<const LIMBS: usize> PartialEq for Uint<LIMBS> {
     fn eq(&self, other: &Self) -> bool {
         self.ct_eq(other).into()
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<const LIMBS: usize> subtle::ConstantTimeEq for Uint<LIMBS> {
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_eq(self, other).into()
+    }
+
+    #[inline]
+    fn ct_ne(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_ne(self, other).into()
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<const LIMBS: usize> subtle::ConstantTimeGreater for Uint<LIMBS> {
+    #[inline]
+    fn ct_gt(&self, other: &Self) -> subtle::Choice {
+        CtGt::ct_gt(self, other).into()
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<const LIMBS: usize> subtle::ConstantTimeLess for Uint<LIMBS> {
+    #[inline]
+    fn ct_lt(&self, other: &Self) -> subtle::Choice {
+        Uint::lt(self, other).into()
     }
 }
 

--- a/src/uint/select.rs
+++ b/src/uint/select.rs
@@ -45,6 +45,7 @@ impl<const LIMBS: usize> CtSelect for Uint<LIMBS> {
     }
 }
 
+#[cfg(feature = "subtle")]
 impl<const LIMBS: usize> subtle::ConditionallySelectable for Uint<LIMBS> {
     #[inline]
     fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -184,27 +184,6 @@ impl<T: WrappingShr> Shr<u32> for &Wrapping<T> {
     }
 }
 
-impl<T> subtle::ConditionallySelectable for Wrapping<T>
-where
-    T: Copy,
-    Self: CtSelect,
-{
-    #[inline]
-    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
-        a.ct_select(b, choice.into())
-    }
-}
-
-impl<T> subtle::ConstantTimeEq for Wrapping<T>
-where
-    Self: CtEq,
-{
-    #[inline]
-    fn ct_eq(&self, other: &Self) -> subtle::Choice {
-        CtEq::ct_eq(self, other).into()
-    }
-}
-
 impl<T> CtEq for Wrapping<T>
 where
     T: CtEq,
@@ -317,5 +296,28 @@ impl<T: Serialize> Serialize for Wrapping<T> {
         S: Serializer,
     {
         self.0.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<T> subtle::ConditionallySelectable for Wrapping<T>
+where
+    T: Copy,
+    Self: CtSelect,
+{
+    #[inline]
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        a.ct_select(b, choice.into())
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<T> subtle::ConstantTimeEq for Wrapping<T>
+where
+    Self: CtEq,
+{
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_eq(self, other).into()
     }
 }


### PR DESCRIPTION
After a long string of PRs to convert all previously `subtle`-based constant-time functionality to `ctutils`, #1054 removed the last of the hard dependencies on `subtle`, and we can now make it optional.

Enabling the feature provides legacy `subtle` trait impls, and also enables the corresponding `subtle` feature on `ctutils`, and if it's enabled, also on `hybrid-array`.