### PR TITLE
Get rid of `Const*` prefix on `Choice` and `CtOption`

### DIFF
--- a/src/checked.rs
+++ b/src/checked.rs
@@ -1,8 +1,6 @@
 //! Checked arithmetic.
 
-use crate::{
-    CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, ConstChoice, ConstCtOption, CtEq, CtSelect,
-};
+use crate::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Choice, CtEq, CtOption, CtSelect};
 use core::ops::{Add, Div, Mul, Sub};
 
 #[cfg(feature = "serde")]
@@ -10,15 +8,15 @@ use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Provides intentionally-checked arithmetic on `T`.
 ///
-/// Internally this leverages the [`ConstCtOption`] type from the [`ctutils`] crate in order to
+/// Internally this leverages the [`CtOption`] type from the [`ctutils`] crate in order to
 /// handle overflows.
 #[derive(Copy, Clone, Debug)]
-pub struct Checked<T>(pub ConstCtOption<T>);
+pub struct Checked<T>(pub CtOption<T>);
 
 impl<T> Checked<T> {
     /// Create a new checked arithmetic wrapper for the given value.
     pub const fn new(val: T) -> Self {
-        Self(ConstCtOption::some(val))
+        Self(CtOption::some(val))
     }
 }
 
@@ -283,7 +281,7 @@ where
     T: CtEq,
 {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> ConstChoice {
+    fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
     }
 }
@@ -293,7 +291,7 @@ where
     T: CtSelect,
 {
     #[inline]
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         Self(self.0.ct_select(&other.0, choice))
     }
 }
@@ -307,14 +305,14 @@ where
     }
 }
 
-impl<T> From<Checked<T>> for ConstCtOption<T> {
-    fn from(checked: Checked<T>) -> ConstCtOption<T> {
+impl<T> From<Checked<T>> for CtOption<T> {
+    fn from(checked: Checked<T>) -> CtOption<T> {
         checked.0
     }
 }
 
-impl<T> From<ConstCtOption<T>> for Checked<T> {
-    fn from(ct_option: ConstCtOption<T>) -> Checked<T> {
+impl<T> From<CtOption<T>> for Checked<T> {
+    fn from(ct_option: CtOption<T>) -> Checked<T> {
         Checked(ct_option)
     }
 }
@@ -332,8 +330,8 @@ impl<'de, T: Default + Deserialize<'de>> Deserialize<'de> for Checked<T> {
         D: Deserializer<'de>,
     {
         let value = Option::<T>::deserialize(deserializer)?;
-        let choice = ConstChoice::new(value.is_some() as u8);
-        Ok(Self(ConstCtOption::new(value.unwrap_or_default(), choice)))
+        let choice = Choice::new(value.is_some() as u8);
+        Ok(Self(CtOption::new(value.unwrap_or_default(), choice)))
     }
 }
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -1,8 +1,8 @@
 //! Stack-allocated big signed integers.
 
 use crate::{
-    Bounded, ConstChoice, ConstCtOption, ConstOne, ConstZero, Constants, CtEq, FixedInteger,
-    Integer, Limb, NonZero, Odd, One, Signed, Uint, Word, Zero,
+    Bounded, Choice, ConstOne, ConstZero, Constants, CtEq, CtOption, FixedInteger, Integer, Limb,
+    NonZero, Odd, One, Signed, Uint, Word, Zero,
 };
 use core::fmt;
 
@@ -143,15 +143,15 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Convert to a [`NonZero<Int<LIMBS>>`].
     ///
     /// Returns some if the original value is non-zero, and false otherwise.
-    pub const fn to_nz(self) -> ConstCtOption<NonZero<Self>> {
-        ConstCtOption::new(NonZero(self), self.0.is_nonzero())
+    pub const fn to_nz(self) -> CtOption<NonZero<Self>> {
+        CtOption::new(NonZero(self), self.0.is_nonzero())
     }
 
     /// Convert to a [`Odd<Int<LIMBS>>`].
     ///
     /// Returns some if the original value is odd, and false otherwise.
-    pub const fn to_odd(self) -> ConstCtOption<Odd<Self>> {
-        ConstCtOption::new(Odd(self), self.0.is_odd())
+    pub const fn to_odd(self) -> CtOption<Odd<Self>> {
+        CtOption::new(Odd(self), self.0.is_odd())
     }
 
     /// Interpret the data in this object as a [`Uint`] instead.
@@ -168,22 +168,22 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Note: this is a checked conversion operation. See
     /// - [`Self::as_uint`] for the unchecked equivalent, and
     /// - [`Self::abs`] to obtain the absolute value of `self`.
-    pub const fn try_into_uint(self) -> ConstCtOption<Uint<LIMBS>> {
-        ConstCtOption::new(self.0, self.is_negative().not())
+    pub const fn try_into_uint(self) -> CtOption<Uint<LIMBS>> {
+        CtOption::new(self.0, self.is_negative().not())
     }
 
     /// Whether this [`Int`] is equal to `Self::MIN`.
-    pub const fn is_min(&self) -> ConstChoice {
+    pub const fn is_min(&self) -> Choice {
         Self::eq(self, &Self::MIN)
     }
 
     /// Whether this [`Int`] is equal to `Self::MAX`.
-    pub const fn is_max(&self) -> ConstChoice {
+    pub const fn is_max(&self) -> Choice {
         Self::eq(self, &Self::MAX)
     }
 
     /// Is this [`Int`] equal to zero?
-    pub const fn is_zero(&self) -> ConstChoice {
+    pub const fn is_zero(&self) -> Choice {
         self.0.is_zero()
     }
 
@@ -253,15 +253,15 @@ impl<const LIMBS: usize> Integer for Int<LIMBS> {
 impl<const LIMBS: usize> Signed for Int<LIMBS> {
     type Unsigned = Uint<LIMBS>;
 
-    fn abs_sign(&self) -> (Uint<LIMBS>, ConstChoice) {
+    fn abs_sign(&self) -> (Uint<LIMBS>, Choice) {
         self.abs_sign()
     }
 
-    fn is_negative(&self) -> ConstChoice {
+    fn is_negative(&self) -> Choice {
         self.is_negative()
     }
 
-    fn is_positive(&self) -> ConstChoice {
+    fn is_positive(&self) -> Choice {
         self.is_positive()
     }
 }
@@ -371,7 +371,7 @@ where
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use crate::{ConstChoice, I128, U128};
+    use crate::{Choice, I128, U128};
 
     #[cfg(target_pointer_width = "64")]
     #[test]
@@ -450,19 +450,19 @@ mod tests {
     #[test]
     fn is_minimal() {
         let min = I128::from_be_hex("80000000000000000000000000000000");
-        assert_eq!(min.is_min(), ConstChoice::TRUE);
+        assert_eq!(min.is_min(), Choice::TRUE);
 
         let random = I128::from_be_hex("11113333555577779999BBBBDDDDFFFF");
-        assert_eq!(random.is_min(), ConstChoice::FALSE);
+        assert_eq!(random.is_min(), Choice::FALSE);
     }
 
     #[test]
     fn is_maximal() {
         let max = I128::from_be_hex("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
-        assert_eq!(max.is_max(), ConstChoice::TRUE);
+        assert_eq!(max.is_max(), Choice::TRUE);
 
         let random = I128::from_be_hex("11113333555577779999BBBBDDDDFFFF");
-        assert_eq!(random.is_max(), ConstChoice::FALSE);
+        assert_eq!(random.is_max(), Choice::FALSE);
     }
 
     #[test]

--- a/src/int/add.rs
+++ b/src/int/add.rs
@@ -1,18 +1,16 @@
 //! [`Int`] addition operations.
 
-use crate::{
-    Add, AddAssign, Checked, CheckedAdd, ConstChoice, ConstCtOption, Int, Wrapping, WrappingAdd,
-};
+use crate::{Add, AddAssign, Checked, CheckedAdd, Choice, CtOption, Int, Wrapping, WrappingAdd};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Perform checked addition. Returns `none` when the addition overflowed.
-    pub const fn checked_add(&self, rhs: &Self) -> ConstCtOption<Self> {
+    pub const fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
         let (value, overflow) = self.overflowing_add(rhs);
-        ConstCtOption::new(value, overflow.not())
+        CtOption::new(value, overflow.not())
     }
 
     /// Perform addition, raising the `overflow` flag on overflow.
-    pub const fn overflowing_add(&self, rhs: &Self) -> (Self, ConstChoice) {
+    pub const fn overflowing_add(&self, rhs: &Self) -> (Self, Choice) {
         // Step 1. add operands
         let res = Self(self.0.wrapping_add(&rhs.0));
 
@@ -91,7 +89,7 @@ impl<const LIMBS: usize> AddAssign<&Checked<Int<LIMBS>>> for Checked<Int<LIMBS>>
 }
 
 impl<const LIMBS: usize> CheckedAdd for Int<LIMBS> {
-    fn checked_add(&self, rhs: &Self) -> ConstCtOption<Self> {
+    fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
         self.checked_add(rhs)
     }
 }
@@ -104,7 +102,7 @@ impl<const LIMBS: usize> WrappingAdd for Int<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, I128, U128};
+    use crate::{Choice, I128, U128};
 
     #[test]
     fn checked_add() {
@@ -219,105 +217,105 @@ mod tests {
         // lhs = MIN
 
         let (_val, overflow) = I128::MIN.overflowing_add(&I128::MIN);
-        assert_eq!(overflow, ConstChoice::TRUE);
+        assert_eq!(overflow, Choice::TRUE);
 
         let (_val, overflow) = I128::MIN.overflowing_add(&I128::MINUS_ONE);
-        assert_eq!(overflow, ConstChoice::TRUE);
+        assert_eq!(overflow, Choice::TRUE);
 
         let (val, overflow) = I128::MIN.overflowing_add(&I128::ZERO);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, I128::MIN);
 
         let (val, overflow) = I128::MIN.overflowing_add(&I128::ONE);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, min_plus_one);
 
         let (val, overflow) = I128::MIN.overflowing_add(&I128::MAX);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, I128::MINUS_ONE);
 
         // lhs = -1
 
         let (_val, overflow) = I128::MINUS_ONE.overflowing_add(&I128::MIN);
-        assert_eq!(overflow, ConstChoice::TRUE);
+        assert_eq!(overflow, Choice::TRUE);
 
         let (val, overflow) = I128::MINUS_ONE.overflowing_add(&I128::MINUS_ONE);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, two.wrapping_neg());
 
         let (val, overflow) = I128::MINUS_ONE.overflowing_add(&I128::ZERO);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, I128::MINUS_ONE);
 
         let (val, overflow) = I128::MINUS_ONE.overflowing_add(&I128::ONE);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, I128::ZERO);
 
         let (val, overflow) = I128::MINUS_ONE.overflowing_add(&I128::MAX);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, max_minus_one);
 
         // lhs = 0
 
         let (val, overflow) = I128::ZERO.overflowing_add(&I128::MIN);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, I128::MIN);
 
         let (val, overflow) = I128::ZERO.overflowing_add(&I128::MINUS_ONE);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, I128::MINUS_ONE);
 
         let (val, overflow) = I128::ZERO.overflowing_add(&I128::ZERO);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, I128::ZERO);
 
         let (val, overflow) = I128::ZERO.overflowing_add(&I128::ONE);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, I128::ONE);
 
         let (val, overflow) = I128::ZERO.overflowing_add(&I128::MAX);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, I128::MAX);
 
         // lhs = 1
 
         let (val, overflow) = I128::ONE.overflowing_add(&I128::MIN);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, min_plus_one);
 
         let (val, overflow) = I128::ONE.overflowing_add(&I128::MINUS_ONE);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, I128::ZERO);
 
         let (val, overflow) = I128::ONE.overflowing_add(&I128::ZERO);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, I128::ONE);
 
         let (val, overflow) = I128::ONE.overflowing_add(&I128::ONE);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, two);
 
         let (_val, overflow) = I128::ONE.overflowing_add(&I128::MAX);
-        assert_eq!(overflow, ConstChoice::TRUE);
+        assert_eq!(overflow, Choice::TRUE);
 
         // lhs = MAX
 
         let (val, overflow) = I128::MAX.overflowing_add(&I128::MIN);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, I128::MINUS_ONE);
 
         let (val, overflow) = I128::MAX.overflowing_add(&I128::MINUS_ONE);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, max_minus_one);
 
         let (val, overflow) = I128::MAX.overflowing_add(&I128::ZERO);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
         assert_eq!(val, I128::MAX);
 
         let (_val, overflow) = I128::MAX.overflowing_add(&I128::ONE);
-        assert_eq!(overflow, ConstChoice::TRUE);
+        assert_eq!(overflow, Choice::TRUE);
 
         let (_val, overflow) = I128::MAX.overflowing_add(&I128::MAX);
-        assert_eq!(overflow, ConstChoice::TRUE);
+        assert_eq!(overflow, Choice::TRUE);
     }
 }

--- a/src/int/bit_and.rs
+++ b/src/int/bit_and.rs
@@ -2,7 +2,7 @@
 
 use core::ops::{BitAnd, BitAndAssign};
 
-use crate::{ConstCtOption, Int, Limb, Uint, Wrapping};
+use crate::{CtOption, Int, Limb, Uint, Wrapping};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Computes bitwise `a & b`.
@@ -25,9 +25,9 @@ impl<const LIMBS: usize> Int<LIMBS> {
         self.bitand(rhs)
     }
 
-    /// Perform checked bitwise `AND`, returning a [`ConstCtOption`] which `is_some` always
-    pub const fn checked_and(&self, rhs: &Self) -> ConstCtOption<Self> {
-        ConstCtOption::some(self.bitand(rhs))
+    /// Perform checked bitwise `AND`, returning a [`CtOption`] which `is_some` always
+    pub const fn checked_and(&self, rhs: &Self) -> CtOption<Self> {
+        CtOption::some(self.bitand(rhs))
     }
 }
 

--- a/src/int/bit_or.rs
+++ b/src/int/bit_or.rs
@@ -2,7 +2,7 @@
 
 use core::ops::{BitOr, BitOrAssign};
 
-use crate::{ConstCtOption, Uint, Wrapping};
+use crate::{CtOption, Uint, Wrapping};
 
 use super::Int;
 
@@ -21,9 +21,9 @@ impl<const LIMBS: usize> Int<LIMBS> {
         self.bitor(rhs)
     }
 
-    /// Perform checked bitwise `OR`, returning a [`ConstCtOption`] which `is_some` always
-    pub const fn checked_or(&self, rhs: &Self) -> ConstCtOption<Self> {
-        ConstCtOption::some(self.bitor(rhs))
+    /// Perform checked bitwise `OR`, returning a [`CtOption`] which `is_some` always
+    pub const fn checked_or(&self, rhs: &Self) -> CtOption<Self> {
+        CtOption::some(self.bitor(rhs))
     }
 }
 

--- a/src/int/bit_xor.rs
+++ b/src/int/bit_xor.rs
@@ -2,7 +2,7 @@
 
 use core::ops::{BitXor, BitXorAssign};
 
-use crate::{ConstCtOption, Uint, Wrapping};
+use crate::{CtOption, Uint, Wrapping};
 
 use super::Int;
 
@@ -21,9 +21,9 @@ impl<const LIMBS: usize> Int<LIMBS> {
         self.bitxor(rhs)
     }
 
-    /// Perform checked bitwise `XOR`, returning a [`ConstCtOption`] which `is_some` always
-    pub fn checked_xor(&self, rhs: &Self) -> ConstCtOption<Self> {
-        ConstCtOption::some(self.bitxor(rhs))
+    /// Perform checked bitwise `XOR`, returning a [`CtOption`] which `is_some` always
+    pub fn checked_xor(&self, rhs: &Self) -> CtOption<Self> {
+        CtOption::some(self.bitxor(rhs))
     }
 }
 

--- a/src/int/cmp.rs
+++ b/src/int/cmp.rs
@@ -2,37 +2,37 @@
 //!
 //! By default, these are all constant-time.
 
-use crate::{ConstChoice, CtEq, CtGt, CtLt, Int, Uint};
+use crate::{Choice, CtEq, CtGt, CtLt, Int, Uint};
 use core::cmp::Ordering;
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Swap `a` and `b` if `c` is truthy, otherwise, do nothing.
     #[inline]
-    pub(crate) const fn conditional_swap(a: &mut Self, b: &mut Self, c: ConstChoice) {
+    pub(crate) const fn conditional_swap(a: &mut Self, b: &mut Self, c: Choice) {
         Uint::conditional_swap(&mut a.0, &mut b.0, c);
     }
 
     /// Returns the truthy value if `self`!=0 or the falsy value otherwise.
     #[inline]
-    pub(crate) const fn is_nonzero(&self) -> ConstChoice {
+    pub(crate) const fn is_nonzero(&self) -> Choice {
         Uint::is_nonzero(&self.0)
     }
 
     /// Returns the truthy value if `self == rhs` or the falsy value otherwise.
     #[inline]
-    pub(crate) const fn eq(lhs: &Self, rhs: &Self) -> ConstChoice {
+    pub(crate) const fn eq(lhs: &Self, rhs: &Self) -> Choice {
         Uint::eq(&lhs.0, &rhs.0)
     }
 
     /// Returns the truthy value if `self < rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn lt(lhs: &Self, rhs: &Self) -> ConstChoice {
+    pub(crate) const fn lt(lhs: &Self, rhs: &Self) -> Choice {
         Uint::lt(&lhs.invert_msb().0, &rhs.invert_msb().0)
     }
 
     /// Returns the truthy value if `self > rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn gt(lhs: &Self, rhs: &Self) -> ConstChoice {
+    pub(crate) const fn gt(lhs: &Self, rhs: &Self) -> Choice {
         Uint::gt(&lhs.invert_msb().0, &rhs.invert_msb().0)
     }
 
@@ -54,21 +54,21 @@ impl<const LIMBS: usize> Int<LIMBS> {
 
 impl<const LIMBS: usize> CtEq for Int<LIMBS> {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> ConstChoice {
+    fn ct_eq(&self, other: &Self) -> Choice {
         CtEq::ct_eq(&self.0, &other.0)
     }
 }
 
 impl<const LIMBS: usize> CtGt for Int<LIMBS> {
     #[inline]
-    fn ct_gt(&self, other: &Self) -> ConstChoice {
+    fn ct_gt(&self, other: &Self) -> Choice {
         Int::gt(self, other)
     }
 }
 
 impl<const LIMBS: usize> CtLt for Int<LIMBS> {
     #[inline]
-    fn ct_lt(&self, other: &Self) -> ConstChoice {
+    fn ct_lt(&self, other: &Self) -> Choice {
         Int::lt(self, other)
     }
 }

--- a/src/int/div.rs
+++ b/src/int/div.rs
@@ -1,6 +1,6 @@
 //! [`Int`] division operations.
 
-use crate::{CheckedDiv, ConstChoice, ConstCtOption, DivVartime, Int, NonZero, Uint, Wrapping};
+use crate::{CheckedDiv, Choice, CtOption, DivVartime, Int, NonZero, Uint, Wrapping};
 use core::ops::{Div, DivAssign, Rem, RemAssign};
 
 /// Checked division operations.
@@ -13,7 +13,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     const fn div_rem_base<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Int<RHS_LIMBS>>,
-    ) -> (Uint<LIMBS>, Uint<RHS_LIMBS>, ConstChoice, ConstChoice) {
+    ) -> (Uint<LIMBS>, Uint<RHS_LIMBS>, Choice, Choice) {
         // Step 1: split operands into signs and magnitudes.
         let (lhs_mag, lhs_sgn) = self.abs_sign();
         let (rhs_mag, rhs_sgn) = rhs.abs_sign();
@@ -52,7 +52,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub const fn checked_div_rem<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Int<RHS_LIMBS>>,
-    ) -> (ConstCtOption<Self>, Int<RHS_LIMBS>) {
+    ) -> (CtOption<Self>, Int<RHS_LIMBS>) {
         let (quotient, remainder, lhs_sgn, rhs_sgn) = self.div_rem_base(rhs);
         let opposing_signs = lhs_sgn.ne(rhs_sgn);
         (
@@ -61,12 +61,12 @@ impl<const LIMBS: usize> Int<LIMBS> {
         )
     }
 
-    /// Perform checked division, returning a [`ConstCtOption`] which `is_some` if
+    /// Perform checked division, returning a [`CtOption`] which `is_some` if
     /// - the `rhs != 0`, and
     /// - `self != MIN` or `rhs != MINUS_ONE`.
     ///
     /// Note: this operation rounds towards zero, truncating any fractional part of the exact result.
-    pub fn checked_div<const RHS_LIMBS: usize>(&self, rhs: &Int<RHS_LIMBS>) -> ConstCtOption<Self> {
+    pub fn checked_div<const RHS_LIMBS: usize>(&self, rhs: &Int<RHS_LIMBS>) -> CtOption<Self> {
         NonZero::new(*rhs).and_then(|rhs| self.checked_div_rem(&rhs).0)
     }
 
@@ -91,7 +91,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     const fn div_rem_base_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Int<RHS_LIMBS>>,
-    ) -> (Uint<LIMBS>, Uint<RHS_LIMBS>, ConstChoice, ConstChoice) {
+    ) -> (Uint<LIMBS>, Uint<RHS_LIMBS>, Choice, Choice) {
         // Step 1: split operands into signs and magnitudes.
         let (lhs_mag, lhs_sgn) = self.abs_sign();
         let (rhs_mag, rhs_sgn) = rhs.abs_sign();
@@ -112,7 +112,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub const fn checked_div_rem_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Int<RHS_LIMBS>>,
-    ) -> (ConstCtOption<Self>, Int<RHS_LIMBS>) {
+    ) -> (CtOption<Self>, Int<RHS_LIMBS>) {
         let (quotient, remainder, lhs_sgn, rhs_sgn) = self.div_rem_base_vartime(rhs);
         let opposing_signs = lhs_sgn.ne(rhs_sgn);
         (
@@ -130,7 +130,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub fn checked_div_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
-    ) -> ConstCtOption<Self> {
+    ) -> CtOption<Self> {
         NonZero::new(*rhs).and_then(|rhs| self.checked_div_rem_vartime(&rhs).0)
     }
 
@@ -159,7 +159,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub const fn checked_div_rem_floor_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Int<RHS_LIMBS>>,
-    ) -> (ConstCtOption<Self>, Int<RHS_LIMBS>) {
+    ) -> (CtOption<Self>, Int<RHS_LIMBS>) {
         let (lhs_mag, lhs_sgn) = self.abs_sign();
         let (rhs_mag, rhs_sgn) = rhs.abs_sign();
         let (quotient, remainder) = lhs_mag.div_rem_vartime(&rhs_mag);
@@ -193,14 +193,14 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub fn checked_div_floor_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
-    ) -> ConstCtOption<Self> {
+    ) -> CtOption<Self> {
         NonZero::new(*rhs).and_then(|rhs| self.checked_div_rem_floor_vartime(&rhs).0)
     }
 }
 
 /// Checked div-floor operations.
 impl<const LIMBS: usize> Int<LIMBS> {
-    /// Perform checked floored division, returning a [`ConstCtOption`] which `is_some` only if
+    /// Perform checked floored division, returning a [`CtOption`] which `is_some` only if
     /// - the `rhs != 0`, and
     /// - `self != MIN` or `rhs != MINUS_ONE`.
     ///
@@ -229,13 +229,13 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub fn checked_div_floor<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
-    ) -> ConstCtOption<Self> {
+    ) -> CtOption<Self> {
         NonZero::new(*rhs).and_then(|rhs| self.checked_div_rem_floor(&rhs).0)
     }
 
     /// Perform checked division and mod, returning the quotient and remainder.
     ///
-    /// The quotient is a [`ConstCtOption`] which `is_some` only if
+    /// The quotient is a [`CtOption`] which `is_some` only if
     /// - the `rhs != 0`, and
     /// - `self != MIN` or `rhs != MINUS_ONE`.
     ///
@@ -266,7 +266,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub const fn checked_div_rem_floor<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Int<RHS_LIMBS>>,
-    ) -> (ConstCtOption<Self>, Int<RHS_LIMBS>) {
+    ) -> (CtOption<Self>, Int<RHS_LIMBS>) {
         let (lhs_mag, lhs_sgn) = self.abs_sign();
         let (rhs_mag, rhs_sgn) = rhs.abs_sign();
         let (quotient, remainder) = lhs_mag.div_rem(&rhs_mag);
@@ -293,13 +293,13 @@ impl<const LIMBS: usize> Int<LIMBS> {
 }
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> CheckedDiv<Int<RHS_LIMBS>> for Int<LIMBS> {
-    fn checked_div(&self, rhs: &Int<RHS_LIMBS>) -> ConstCtOption<Self> {
+    fn checked_div(&self, rhs: &Int<RHS_LIMBS>) -> CtOption<Self> {
         self.checked_div(rhs)
     }
 }
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<&NonZero<Int<RHS_LIMBS>>> for &Int<LIMBS> {
-    type Output = ConstCtOption<Int<LIMBS>>;
+    type Output = CtOption<Int<LIMBS>>;
 
     fn div(self, rhs: &NonZero<Int<RHS_LIMBS>>) -> Self::Output {
         *self / *rhs
@@ -307,7 +307,7 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<&NonZero<Int<RHS_LIMBS>>> f
 }
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<&NonZero<Int<RHS_LIMBS>>> for Int<LIMBS> {
-    type Output = ConstCtOption<Int<LIMBS>>;
+    type Output = CtOption<Int<LIMBS>>;
 
     fn div(self, rhs: &NonZero<Int<RHS_LIMBS>>) -> Self::Output {
         self / *rhs
@@ -315,7 +315,7 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<&NonZero<Int<RHS_LIMBS>>> f
 }
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<NonZero<Int<RHS_LIMBS>>> for &Int<LIMBS> {
-    type Output = ConstCtOption<Int<LIMBS>>;
+    type Output = CtOption<Int<LIMBS>>;
 
     fn div(self, rhs: NonZero<Int<RHS_LIMBS>>) -> Self::Output {
         *self / rhs
@@ -323,7 +323,7 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<NonZero<Int<RHS_LIMBS>>> fo
 }
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<NonZero<Int<RHS_LIMBS>>> for Int<LIMBS> {
-    type Output = ConstCtOption<Int<LIMBS>>;
+    type Output = CtOption<Int<LIMBS>>;
 
     fn div(self, rhs: NonZero<Int<RHS_LIMBS>>) -> Self::Output {
         self.checked_div(&rhs)
@@ -503,7 +503,7 @@ impl<const LIMBS: usize> RemAssign<&NonZero<Int<LIMBS>>> for Wrapping<Int<LIMBS>
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, CtSelect, DivVartime, I128, Int, NonZero, One, Zero};
+    use crate::{Choice, CtSelect, DivVartime, I128, Int, NonZero, One, Zero};
 
     #[test]
     #[allow(clippy::init_numbered_fields)]
@@ -622,7 +622,7 @@ mod tests {
     fn test_checked_div_mod_floor() {
         let (quotient, remainder) =
             I128::MIN.checked_div_rem_floor(&I128::MINUS_ONE.to_nz().unwrap());
-        assert_eq!(quotient.is_some(), ConstChoice::FALSE);
+        assert_eq!(quotient.is_some(), Choice::FALSE);
         assert_eq!(remainder, I128::ZERO);
     }
 

--- a/src/int/div_uint.rs
+++ b/src/int/div_uint.rs
@@ -1,7 +1,7 @@
 //! Operations related to dividing an [`Int`] by a [`Uint`].
 use core::ops::{Div, DivAssign, Rem, RemAssign};
 
-use crate::{ConstChoice, Int, NonZero, Uint, Wrapping};
+use crate::{Choice, Int, NonZero, Uint, Wrapping};
 
 /// Checked division operations.
 impl<const LIMBS: usize> Int<LIMBS> {
@@ -12,7 +12,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     const fn div_rem_base_uint<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
-    ) -> (Uint<LIMBS>, Uint<RHS_LIMBS>, ConstChoice) {
+    ) -> (Uint<LIMBS>, Uint<RHS_LIMBS>, Choice) {
         let (lhs_mag, lhs_sgn) = self.abs_sign();
         let (quotient, remainder) = lhs_mag.div_rem(rhs);
         (quotient, remainder, lhs_sgn)
@@ -71,7 +71,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     const fn div_rem_base_uint_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
-    ) -> (Uint<LIMBS>, Uint<RHS_LIMBS>, ConstChoice) {
+    ) -> (Uint<LIMBS>, Uint<RHS_LIMBS>, Choice) {
         let (lhs_mag, lhs_sgn) = self.abs_sign();
         let (quotient, remainder) = lhs_mag.div_rem_vartime(rhs);
         (quotient, remainder, lhs_sgn)

--- a/src/int/from.rs
+++ b/src/int/from.rs
@@ -1,6 +1,6 @@
 //! `From`-like conversions for [`Int`].
 
-use crate::{ConstCtOption, I64, I128, Int, Limb, Uint, Word};
+use crate::{CtOption, I64, I128, Int, Limb, Uint, Word};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Create a [`Int`] from an `i8` (const-friendly)
@@ -56,8 +56,8 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Convert a `CtOption<Uint<LIMBS>>` to a `CtOption<Int<LIMBS>>`
     // TODO(tarcieri): replace with `const impl From<CtOption<Uint>>` when stable
     #[inline]
-    pub(super) const fn from_uint_opt(opt: ConstCtOption<Uint<LIMBS>>) -> ConstCtOption<Self> {
-        ConstCtOption::new(*opt.as_inner_unchecked().as_int(), opt.is_some())
+    pub(super) const fn from_uint_opt(opt: CtOption<Uint<LIMBS>>) -> CtOption<Self> {
+        CtOption::new(*opt.as_inner_unchecked().as_int(), opt.is_some())
     }
 }
 

--- a/src/int/gcd.rs
+++ b/src/int/gcd.rs
@@ -4,9 +4,7 @@
 
 use crate::primitives::u32_min;
 use crate::uint::gcd::{OddUintXgcdOutput, impl_gcd_uint_lhs, impl_gcd_uint_rhs};
-use crate::{
-    ConstChoice, Gcd, Int, NonZero, NonZeroInt, NonZeroUint, Odd, OddInt, OddUint, Uint, Xgcd,
-};
+use crate::{Choice, Gcd, Int, NonZero, NonZeroInt, NonZeroUint, Odd, OddInt, OddUint, Uint, Xgcd};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Compute the greatest common divisor of `self` and `rhs`.
@@ -102,7 +100,7 @@ impl<const LIMBS: usize> NonZero<Int<LIMBS>> {
 
         // Note: at this point, either lhs or rhs is odd (or both).
         // Swap to make sure lhs is odd.
-        let swap = ConstChoice::from_u32_lt(j, i);
+        let swap = Choice::from_u32_lt(j, i);
         Int::conditional_swap(&mut lhs, &mut rhs, swap);
         let lhs = lhs.to_odd().expect_copied("odd by construction");
         let rhs = rhs.to_nz().expect_copied("non-zero by construction");

--- a/src/int/invert_mod.rs
+++ b/src/int/invert_mod.rs
@@ -1,17 +1,17 @@
 //! Operations related to computing the inverse of an [`Int`] modulo a [`Uint`].
 
-use crate::{ConstCtOption, Int, InvertMod, NonZero, Odd, Uint};
+use crate::{CtOption, Int, InvertMod, NonZero, Odd, Uint};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
-    pub fn invert_odd_mod(&self, modulus: &Odd<Uint<LIMBS>>) -> ConstCtOption<Uint<LIMBS>> {
+    pub fn invert_odd_mod(&self, modulus: &Odd<Uint<LIMBS>>) -> CtOption<Uint<LIMBS>> {
         let (abs, sgn) = self.abs_sign();
         let maybe_inv = abs.invert_odd_mod(modulus);
         let abs_inv = maybe_inv.as_inner_unchecked();
 
         // Note: when `self` is negative and modulus is non-zero, then
         // self^{-1} % modulus = modulus - |self|^{-1} % modulus
-        ConstCtOption::new(
+        CtOption::new(
             Uint::select(abs_inv, &modulus.wrapping_sub(abs_inv), sgn),
             maybe_inv.is_some(),
         )
@@ -20,14 +20,14 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Computes the multiplicative inverse of `self` mod `modulus`.
     ///
     /// Returns some if an inverse exists, otherwise none.
-    pub const fn invert_mod(&self, modulus: &NonZero<Uint<LIMBS>>) -> ConstCtOption<Uint<LIMBS>> {
+    pub const fn invert_mod(&self, modulus: &NonZero<Uint<LIMBS>>) -> CtOption<Uint<LIMBS>> {
         let (abs, sgn) = self.abs_sign();
         let maybe_inv = abs.invert_mod(modulus);
         let abs_inv = maybe_inv.as_inner_unchecked();
 
         // Note: when `self` is negative and modulus is non-zero, then
         // self^{-1} % modulus = modulus - |self|^{-1} % modulus
-        ConstCtOption::new(
+        CtOption::new(
             Uint::select(abs_inv, &modulus.as_ref().wrapping_sub(abs_inv), sgn),
             maybe_inv.is_some(),
         )
@@ -40,7 +40,7 @@ where
 {
     type Output = Uint<LIMBS>;
 
-    fn invert_mod(&self, modulus: &NonZero<Uint<LIMBS>>) -> ConstCtOption<Self::Output> {
+    fn invert_mod(&self, modulus: &NonZero<Uint<LIMBS>>) -> CtOption<Self::Output> {
         Self::invert_mod(self, modulus)
     }
 }

--- a/src/int/mul.rs
+++ b/src/int/mul.rs
@@ -1,8 +1,7 @@
 //! [`Int`] multiplication operations.
 
 use crate::{
-    Checked, CheckedMul, ConcatMixed, ConstChoice, ConstCtOption, Int, Mul, MulAssign, Uint,
-    WrappingMul,
+    Checked, CheckedMul, Choice, ConcatMixed, CtOption, Int, Mul, MulAssign, Uint, WrappingMul,
 };
 
 impl<const LIMBS: usize> Int<LIMBS> {
@@ -16,7 +15,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub const fn split_mul<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
-    ) -> (Uint<{ LIMBS }>, Uint<{ RHS_LIMBS }>, ConstChoice) {
+    ) -> (Uint<{ LIMBS }>, Uint<{ RHS_LIMBS }>, Choice) {
         self.widening_mul(rhs)
     }
 
@@ -29,7 +28,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub const fn widening_mul<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
-    ) -> (Uint<{ LIMBS }>, Uint<{ RHS_LIMBS }>, ConstChoice) {
+    ) -> (Uint<{ LIMBS }>, Uint<{ RHS_LIMBS }>, Choice) {
         // Step 1: split operands into their signs and magnitudes.
         let (lhs_abs, lhs_sgn) = self.abs_sign();
         let (rhs_abs, rhs_sgn) = rhs.abs_sign();
@@ -63,12 +62,12 @@ impl<const LIMBS: usize> Int<LIMBS> {
         Int::from_bits(product_abs.wrapping_neg_if(product_sign))
     }
 
-    /// Multiply `self` by `rhs`, returning a `ConstCtOption` which is `is_some` only if
+    /// Multiply `self` by `rhs`, returning a `CtOption` which is `is_some` only if
     /// overflow did not occur.
     pub const fn checked_mul<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
-    ) -> ConstCtOption<Self> {
+    ) -> CtOption<Self> {
         let (abs_lhs, lhs_sgn) = self.abs_sign();
         let (abs_rhs, rhs_sgn) = rhs.abs_sign();
         let maybe_res = abs_lhs.checked_mul(&abs_rhs);
@@ -112,7 +111,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 
     /// Square self, checking that the result fits in the original [`Uint`] size.
-    pub fn checked_square(&self) -> ConstCtOption<Uint<LIMBS>> {
+    pub fn checked_square(&self) -> CtOption<Uint<LIMBS>> {
         self.abs().checked_square()
     }
 
@@ -129,7 +128,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> CheckedMul<Int<RHS_LIMBS>> for Int<LIMBS> {
     #[inline]
-    fn checked_mul(&self, rhs: &Int<RHS_LIMBS>) -> ConstCtOption<Self> {
+    fn checked_mul(&self, rhs: &Int<RHS_LIMBS>) -> CtOption<Self> {
         self.checked_mul(rhs)
     }
 }
@@ -199,7 +198,7 @@ impl<const LIMBS: usize> MulAssign<&Checked<Int<LIMBS>>> for Checked<Int<LIMBS>>
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, I64, I128, I256, Int, U64, U128, U256};
+    use crate::{Choice, I64, I128, I256, Int, U64, U128, U256};
 
     #[test]
     #[allow(clippy::init_numbered_fields)]
@@ -523,7 +522,7 @@ mod tests {
     #[test]
     fn test_checked_square() {
         let res = I128::from_i64(i64::MIN).checked_square();
-        assert_eq!(res.is_some(), ConstChoice::TRUE);
+        assert_eq!(res.is_some(), Choice::TRUE);
         assert_eq!(
             res.unwrap(),
             U128::from_be_hex("40000000000000000000000000000000")
@@ -531,7 +530,7 @@ mod tests {
 
         let x: I128 = I128::MINUS_ONE << 64;
         let res = x.checked_square();
-        assert_eq!(res.is_none(), ConstChoice::TRUE)
+        assert_eq!(res.is_none(), Choice::TRUE)
     }
 
     #[test]

--- a/src/int/mul_uint.rs
+++ b/src/int/mul_uint.rs
@@ -1,4 +1,4 @@
-use crate::{CheckedMul, ConcatMixed, ConstChoice, ConstCtOption, Int, Uint};
+use crate::{CheckedMul, Choice, ConcatMixed, CtOption, Int, Uint};
 use core::ops::Mul;
 
 impl<const LIMBS: usize> Int<LIMBS> {
@@ -12,7 +12,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub const fn split_mul_uint<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
-    ) -> (Uint<{ LIMBS }>, Uint<{ RHS_LIMBS }>, ConstChoice) {
+    ) -> (Uint<{ LIMBS }>, Uint<{ RHS_LIMBS }>, Choice) {
         self.widening_mul_uint(rhs)
     }
 
@@ -25,7 +25,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub const fn widening_mul_uint<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
-    ) -> (Uint<{ LIMBS }>, Uint<{ RHS_LIMBS }>, ConstChoice) {
+    ) -> (Uint<{ LIMBS }>, Uint<{ RHS_LIMBS }>, Choice) {
         // Step 1. split self into its sign and magnitude.
         let (lhs_abs, lhs_sgn) = self.abs_sign();
 
@@ -46,7 +46,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub const fn split_mul_uint_right<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
-    ) -> (Uint<{ RHS_LIMBS }>, Uint<{ LIMBS }>, ConstChoice) {
+    ) -> (Uint<{ RHS_LIMBS }>, Uint<{ LIMBS }>, Choice) {
         rhs.widening_mul_int(self)
     }
 
@@ -60,7 +60,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub const fn widening_mul_uint_right<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
-    ) -> (Uint<{ RHS_LIMBS }>, Uint<{ LIMBS }>, ConstChoice) {
+    ) -> (Uint<{ RHS_LIMBS }>, Uint<{ LIMBS }>, Choice) {
         rhs.widening_mul_int(self)
     }
 
@@ -85,7 +85,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub fn checked_mul_uint_right<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
-    ) -> ConstCtOption<Int<RHS_LIMBS>> {
+    ) -> CtOption<Int<RHS_LIMBS>> {
         rhs.checked_mul_int(self)
     }
 
@@ -93,7 +93,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub fn checked_mul_uint<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
-    ) -> ConstCtOption<Int<LIMBS>> {
+    ) -> CtOption<Int<LIMBS>> {
         let (abs_lhs, lhs_sgn) = self.abs_sign();
         Self::new_from_abs_opt_sign(abs_lhs.checked_mul(rhs), lhs_sgn)
     }
@@ -101,7 +101,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> CheckedMul<Uint<RHS_LIMBS>> for Int<LIMBS> {
     #[inline]
-    fn checked_mul(&self, rhs: &Uint<RHS_LIMBS>) -> ConstCtOption<Self> {
+    fn checked_mul(&self, rhs: &Uint<RHS_LIMBS>) -> CtOption<Self> {
         self.checked_mul_uint(rhs)
     }
 }

--- a/src/int/neg.rs
+++ b/src/int/neg.rs
@@ -1,6 +1,6 @@
 //! [`Int`] negation-related operations.
 
-use crate::{ConstChoice, ConstCtOption, Int, Uint, WrappingNeg};
+use crate::{Choice, CtOption, Int, Uint, WrappingNeg};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Map this [`Int`] to its two's-complement negation:
@@ -9,7 +9,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Returns the negation, as well as whether the operation overflowed.
     /// The operation overflows when attempting to negate [`Int::MIN`]; the positive counterpart
     /// of this value cannot be represented.
-    pub const fn overflowing_neg(&self) -> (Self, ConstChoice) {
+    pub const fn overflowing_neg(&self) -> (Self, Choice) {
         Self(self.0.bitxor(&Uint::MAX)).overflowing_add(&Int::ONE)
     }
 
@@ -25,7 +25,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// Warning: this operation maps [`Int::MIN`] to itself, since the positive counterpart of this
     /// value cannot be represented.
-    pub const fn wrapping_neg_if(&self, negate: ConstChoice) -> Int<LIMBS> {
+    pub const fn wrapping_neg_if(&self, negate: Choice) -> Int<LIMBS> {
         Self(self.0.wrapping_neg_if(negate))
     }
 
@@ -33,9 +33,9 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// Yields `None` when `self == Self::MIN`, since the positive counterpart of this value cannot
     /// be represented.
-    pub const fn checked_neg(&self) -> ConstCtOption<Self> {
+    pub const fn checked_neg(&self) -> CtOption<Self> {
         let (value, overflow) = self.overflowing_neg();
-        ConstCtOption::new(value, overflow.not())
+        CtOption::new(value, overflow.not())
     }
 }
 
@@ -48,7 +48,7 @@ impl<const LIMBS: usize> WrappingNeg for Int<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, I128};
+    use crate::{Choice, I128};
 
     #[test]
     fn overflowing_neg() {
@@ -58,23 +58,23 @@ mod tests {
 
         let (res, overflow) = I128::MIN.overflowing_neg();
         assert_eq!(res, I128::MIN);
-        assert_eq!(overflow, ConstChoice::TRUE);
+        assert_eq!(overflow, Choice::TRUE);
 
         let (res, overflow) = I128::MINUS_ONE.overflowing_neg();
         assert_eq!(res, I128::ONE);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
 
         let (res, overflow) = I128::ZERO.overflowing_neg();
         assert_eq!(res, I128::ZERO);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
 
         let (res, overflow) = I128::ONE.overflowing_neg();
         assert_eq!(res, I128::MINUS_ONE);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
 
         let (res, overflow) = I128::MAX.overflowing_neg();
         assert_eq!(res, min_plus_one);
-        assert_eq!(overflow, ConstChoice::FALSE);
+        assert_eq!(overflow, Choice::FALSE);
     }
 
     #[test]
@@ -83,14 +83,14 @@ mod tests {
             0: I128::MIN.0.wrapping_add(&I128::ONE.0),
         };
 
-        let do_negate = ConstChoice::TRUE;
+        let do_negate = Choice::TRUE;
         assert_eq!(I128::MIN.wrapping_neg_if(do_negate), I128::MIN);
         assert_eq!(I128::MINUS_ONE.wrapping_neg_if(do_negate), I128::ONE);
         assert_eq!(I128::ZERO.wrapping_neg_if(do_negate), I128::ZERO);
         assert_eq!(I128::ONE.wrapping_neg_if(do_negate), I128::MINUS_ONE);
         assert_eq!(I128::MAX.wrapping_neg_if(do_negate), min_plus_one);
 
-        let do_not_negate = ConstChoice::FALSE;
+        let do_not_negate = Choice::FALSE;
         assert_eq!(I128::MIN.wrapping_neg_if(do_not_negate), I128::MIN);
         assert_eq!(
             I128::MINUS_ONE.wrapping_neg_if(do_not_negate),
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn checked_neg() {
-        assert_eq!(I128::MIN.checked_neg().is_none(), ConstChoice::TRUE);
+        assert_eq!(I128::MIN.checked_neg().is_none(), Choice::TRUE);
         assert_eq!(I128::MINUS_ONE.checked_neg().unwrap(), I128::ONE);
         assert_eq!(I128::ZERO.checked_neg().unwrap(), I128::ZERO);
         assert_eq!(I128::ONE.checked_neg().unwrap(), I128::MINUS_ONE);

--- a/src/int/select.rs
+++ b/src/int/select.rs
@@ -1,18 +1,18 @@
 //! Constant-time selection support.
 
-use crate::{ConstChoice, CtSelect, Int, Uint};
+use crate::{Choice, CtSelect, Int, Uint};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
-    pub(crate) const fn select(a: &Self, b: &Self, c: ConstChoice) -> Self {
+    pub(crate) const fn select(a: &Self, b: &Self, c: Choice) -> Self {
         Self(Uint::select(&a.0, &b.0, c))
     }
 }
 
 impl<const LIMBS: usize> CtSelect for Int<LIMBS> {
     #[inline]
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         Self(self.0.ct_select(&other.0, choice))
     }
 }
@@ -27,17 +27,17 @@ impl<const LIMBS: usize> subtle::ConditionallySelectable for Int<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, CtSelect, I128};
+    use crate::{Choice, CtSelect, I128};
 
     #[test]
     fn ct_select() {
         let a = I128::from_be_hex("00002222444466668888AAAACCCCEEEE");
         let b = I128::from_be_hex("11113333555577779999BBBBDDDDFFFF");
 
-        let select_0 = I128::ct_select(&a, &b, ConstChoice::FALSE);
+        let select_0 = I128::ct_select(&a, &b, Choice::FALSE);
         assert_eq!(a, select_0);
 
-        let select_1 = I128::ct_select(&a, &b, ConstChoice::TRUE);
+        let select_1 = I128::ct_select(&a, &b, Choice::TRUE);
         assert_eq!(b, select_1);
     }
 }

--- a/src/int/shl.rs
+++ b/src/int/shl.rs
@@ -1,6 +1,6 @@
 //! [`Int`] bitwise left shift operations.
 
-use crate::{ConstCtOption, Int, ShlVartime, Uint, WrappingShl};
+use crate::{CtOption, Int, ShlVartime, Uint, WrappingShl};
 use core::ops::{Shl, ShlAssign};
 
 impl<const LIMBS: usize> Int<LIMBS> {
@@ -21,7 +21,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Computes `self << shift`.
     ///
     /// Returns `None` if `shift >= Self::BITS`.
-    pub const fn overflowing_shl(&self, shift: u32) -> ConstCtOption<Self> {
+    pub const fn overflowing_shl(&self, shift: u32) -> CtOption<Self> {
         Self::from_uint_opt(self.0.overflowing_shl(shift))
     }
 
@@ -34,7 +34,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// When used with a fixed `shift`, this function is constant-time with respect
     /// to `self`.
     #[inline(always)]
-    pub const fn overflowing_shl_vartime(&self, shift: u32) -> ConstCtOption<Self> {
+    pub const fn overflowing_shl_vartime(&self, shift: u32) -> CtOption<Self> {
         Self::from_uint_opt(self.0.overflowing_shl_vartime(shift))
     }
 
@@ -90,7 +90,7 @@ impl<const LIMBS: usize> WrappingShl for Int<LIMBS> {
 }
 
 impl<const LIMBS: usize> ShlVartime for Int<LIMBS> {
-    fn overflowing_shl_vartime(&self, shift: u32) -> ConstCtOption<Self> {
+    fn overflowing_shl_vartime(&self, shift: u32) -> CtOption<Self> {
         self.overflowing_shl(shift)
     }
     fn wrapping_shl_vartime(&self, shift: u32) -> Self {

--- a/src/int/sub.rs
+++ b/src/int/sub.rs
@@ -1,13 +1,11 @@
 //! [`Int`] subtraction operations.
 
-use crate::{
-    Checked, CheckedSub, ConstChoice, ConstCtOption, Int, Sub, SubAssign, Wrapping, WrappingSub,
-};
+use crate::{Checked, CheckedSub, Choice, CtOption, Int, Sub, SubAssign, Wrapping, WrappingSub};
 
 impl<const LIMBS: usize> Int<LIMBS> {
-    /// Perform subtraction, returning the result along with a [`ConstChoice`] which `is_true`
+    /// Perform subtraction, returning the result along with a [`Choice`] which `is_true`
     /// only if the operation underflowed.
-    pub const fn underflowing_sub(&self, rhs: &Self) -> (Self, ConstChoice) {
+    pub const fn underflowing_sub(&self, rhs: &Self) -> (Self, Choice) {
         // Step 1. subtract operands
         let res = Self(self.0.wrapping_sub(&rhs.0));
 
@@ -34,9 +32,9 @@ impl<const LIMBS: usize> Int<LIMBS> {
 }
 
 impl<const LIMBS: usize> CheckedSub for Int<LIMBS> {
-    fn checked_sub(&self, rhs: &Self) -> ConstCtOption<Self> {
+    fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
         let (res, underflow) = Self::underflowing_sub(self, rhs);
-        ConstCtOption::new(res, underflow.not())
+        CtOption::new(res, underflow.not())
     }
 }
 

--- a/src/jacobi.rs
+++ b/src/jacobi.rs
@@ -1,4 +1,4 @@
-use crate::{ConstChoice, CtEq};
+use crate::{Choice, CtEq};
 use core::ops::Neg;
 
 /// Possible return values for Jacobi symbol calculations.
@@ -20,18 +20,18 @@ pub enum JacobiSymbol {
 
 impl JacobiSymbol {
     /// Determine if the symbol is zero.
-    pub const fn is_zero(&self) -> ConstChoice {
-        ConstChoice::from_i64_eq(*self as i8 as i64, 0)
+    pub const fn is_zero(&self) -> Choice {
+        Choice::from_i64_eq(*self as i8 as i64, 0)
     }
 
     /// Determine if the symbol is one.
-    pub const fn is_one(&self) -> ConstChoice {
-        ConstChoice::from_i64_eq(*self as i8 as i64, 1)
+    pub const fn is_one(&self) -> Choice {
+        Choice::from_i64_eq(*self as i8 as i64, 1)
     }
 
     /// Determine if the symbol is minus one.
-    pub const fn is_minus_one(&self) -> ConstChoice {
-        ConstChoice::from_i64_eq(*self as i8 as i64, -1)
+    pub const fn is_minus_one(&self) -> Choice {
+        Choice::from_i64_eq(*self as i8 as i64, -1)
     }
 
     /// Negate the symbol.
@@ -54,7 +54,7 @@ impl JacobiSymbol {
 }
 
 impl CtEq for JacobiSymbol {
-    fn ct_eq(&self, other: &Self) -> ConstChoice {
+    fn ct_eq(&self, other: &Self) -> Choice {
         (*self as i8).ct_eq(&(*other as i8))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,16 +167,6 @@
 #[macro_use]
 extern crate alloc;
 
-pub use ctutils;
-pub use uint::encoding::{EncodedUint, TryFromSliceError};
-
-#[cfg(feature = "rand_core")]
-pub use rand_core;
-#[cfg(feature = "rlp")]
-pub use rlp;
-#[cfg(feature = "zeroize")]
-pub use zeroize;
-
 pub use crate::{
     checked::Checked,
     int::{types::*, *},
@@ -185,16 +175,26 @@ pub use crate::{
     non_zero::*,
     odd::*,
     traits::*,
-    uint::{div_limb::Reciprocal, *},
+    uint::{
+        div_limb::Reciprocal,
+        encoding::{EncodedUint, TryFromSliceError},
+        *,
+    },
     word::{WideWord, Word},
     wrapping::Wrapping,
 };
 
-// TODO(tarcieri): get rid of `Const*` prefix
-pub use ctutils::{Choice as ConstChoice, CtOption as ConstCtOption};
+pub use ctutils;
+pub use ctutils::{Choice, CtOption};
 
 #[cfg(feature = "alloc")]
 pub use crate::uint::boxed::BoxedUint;
+#[cfg(feature = "rand_core")]
+pub use rand_core;
+#[cfg(feature = "rlp")]
+pub use rlp;
+#[cfg(feature = "zeroize")]
+pub use zeroize;
 #[cfg(feature = "hybrid-array")]
 pub use {
     crate::array::{ArrayDecoding, ArrayEncoding, ByteArray},
@@ -226,3 +226,11 @@ pub mod prelude {
     pub use crate::array::{ArrayDecoding, ArrayEncoding};
     pub use crate::traits::*;
 }
+
+/// DEPRECATED: legacy type alias for [`Choice`].
+#[deprecated(since = "0.7.0", note = "use `Choice` instead")]
+pub type ConstChoice = Choice;
+
+/// DEPRECATED: legacy type alias for [`CtOption`].
+#[deprecated(since = "0.7.0", note = "use `CtOption` instead")]
+pub type ConstCtOption<T> = CtOption<T>;

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -21,8 +21,8 @@ mod sub;
 mod rand;
 
 use crate::{
-    Bounded, ConstChoice, ConstCtOption, ConstOne, ConstZero, Constants, CtEq, NonZero, One,
-    WideWord, Word, Zero, word,
+    Bounded, Choice, ConstOne, ConstZero, Constants, CtEq, CtOption, NonZero, One, WideWord, Word,
+    Zero, word,
 };
 use core::fmt;
 
@@ -75,19 +75,19 @@ impl Limb {
     pub const LOG2_BITS: u32 = u32::BITS - (Self::BITS - 1).leading_zeros();
 
     /// Is this limb equal to [`Limb::ZERO`]?
-    pub const fn is_zero(&self) -> ConstChoice {
+    pub const fn is_zero(&self) -> Choice {
         word::choice_from_nz(self.0).not()
     }
 
     /// Convert to a [`NonZero<Limb>`].
     ///
     /// Returns some if the original value is non-zero, and false otherwise.
-    pub const fn to_nz(self) -> ConstCtOption<NonZero<Self>> {
+    pub const fn to_nz(self) -> CtOption<NonZero<Self>> {
         let is_nz = self.is_nonzero();
 
         // Use `1` as a placeholder in the event that `self` is `Limb(0)`
         let nz_word = word::select(1, self.0, is_nz);
-        ConstCtOption::new(NonZero(Self(nz_word)), is_nz)
+        CtOption::new(NonZero(Self(nz_word)), is_nz)
     }
 }
 

--- a/src/limb/add.rs
+++ b/src/limb/add.rs
@@ -1,7 +1,7 @@
 //! Limb addition
 
 use crate::{
-    Add, AddAssign, Checked, CheckedAdd, ConstCtOption, Limb, Wrapping, WrappingAdd,
+    Add, AddAssign, Checked, CheckedAdd, CtOption, Limb, Wrapping, WrappingAdd,
     primitives::{carrying_add, overflowing_add},
 };
 
@@ -79,9 +79,9 @@ impl AddAssign<&Checked<Limb>> for Checked<Limb> {
 
 impl CheckedAdd for Limb {
     #[inline]
-    fn checked_add(&self, rhs: &Self) -> ConstCtOption<Self> {
+    fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
         let (result, carry) = self.overflowing_add(*rhs);
-        ConstCtOption::new(result, carry.is_zero())
+        CtOption::new(result, carry.is_zero())
     }
 }
 

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -1,12 +1,12 @@
 //! Limb comparisons
 
-use crate::{ConstChoice, CtEq, CtGt, CtLt, CtSelect, Limb, word};
+use crate::{Choice, CtEq, CtGt, CtLt, CtSelect, Limb, word};
 use core::cmp::Ordering;
 
 impl Limb {
     /// Is this limb an odd number?
     #[inline]
-    pub fn is_odd(&self) -> ConstChoice {
+    pub fn is_odd(&self) -> Choice {
         word::choice_from_lsb(self.0 & 1)
     }
 
@@ -25,33 +25,33 @@ impl Limb {
 
     /// Returns the truthy value if `self != 0` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn is_nonzero(&self) -> ConstChoice {
+    pub(crate) const fn is_nonzero(&self) -> Choice {
         word::choice_from_nz(self.0)
     }
 }
 
 impl CtEq for Limb {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> ConstChoice {
+    fn ct_eq(&self, other: &Self) -> Choice {
         CtEq::ct_eq(&self.0, &other.0)
     }
 
     #[inline]
-    fn ct_ne(&self, other: &Self) -> ConstChoice {
+    fn ct_ne(&self, other: &Self) -> Choice {
         CtEq::ct_ne(&self.0, &other.0)
     }
 }
 
 impl CtGt for Limb {
     #[inline]
-    fn ct_gt(&self, other: &Self) -> ConstChoice {
+    fn ct_gt(&self, other: &Self) -> Choice {
         word::choice_from_gt(self.0, other.0)
     }
 }
 
 impl CtLt for Limb {
     #[inline]
-    fn ct_lt(&self, other: &Self) -> ConstChoice {
+    fn ct_lt(&self, other: &Self) -> Choice {
         word::choice_from_lt(self.0, other.0)
     }
 }
@@ -113,7 +113,7 @@ impl subtle::ConstantTimeLess for Limb {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, CtEq, CtGt, CtLt, Limb};
+    use crate::{Choice, CtEq, CtGt, CtLt, Limb};
     use core::cmp::Ordering;
 
     #[test]
@@ -191,11 +191,11 @@ mod tests {
         let mut a = Limb::MAX;
         let mut b = Limb::ZERO;
 
-        Limb::ct_conditional_swap(&mut a, &mut b, ConstChoice::FALSE);
+        Limb::ct_conditional_swap(&mut a, &mut b, Choice::FALSE);
         assert_eq!(a, Limb::MAX);
         assert_eq!(b, Limb::ZERO);
 
-        Limb::ct_conditional_swap(&mut a, &mut b, ConstChoice::TRUE);
+        Limb::ct_conditional_swap(&mut a, &mut b, Choice::TRUE);
         assert_eq!(a, Limb::ZERO);
         assert_eq!(b, Limb::MAX);
     }

--- a/src/limb/mul.rs
+++ b/src/limb/mul.rs
@@ -1,7 +1,7 @@
 //! Limb multiplication
 
 use crate::{
-    Checked, CheckedMul, ConstCtOption, Limb, Mul, MulAssign, Wrapping, WrappingMul,
+    Checked, CheckedMul, CtOption, Limb, Mul, MulAssign, Wrapping, WrappingMul,
     primitives::{carrying_mul_add, widening_mul},
 };
 
@@ -43,9 +43,9 @@ impl Limb {
 
 impl CheckedMul for Limb {
     #[inline]
-    fn checked_mul(&self, rhs: &Self) -> ConstCtOption<Self> {
+    fn checked_mul(&self, rhs: &Self) -> CtOption<Self> {
         let (lo, hi) = self.widening_mul(*rhs);
-        ConstCtOption::new(lo, hi.is_zero())
+        CtOption::new(lo, hi.is_zero())
     }
 }
 

--- a/src/limb/select.rs
+++ b/src/limb/select.rs
@@ -1,17 +1,17 @@
 //! Constant-time selection support.
 
-use crate::{ConstChoice, CtSelect, Limb, word};
+use crate::{Choice, CtSelect, Limb, word};
 
 impl Limb {
     /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
-    pub(crate) const fn select(a: Self, b: Self, c: ConstChoice) -> Self {
+    pub(crate) const fn select(a: Self, b: Self, c: Choice) -> Self {
         Self(word::select(a.0, b.0, c))
     }
 
     /// Swap the values of `a` and `b` if `c` is truthy, otherwise do nothing.
     #[inline]
-    pub(crate) const fn ct_conditional_swap(a: &mut Self, b: &mut Self, c: ConstChoice) {
+    pub(crate) const fn ct_conditional_swap(a: &mut Self, b: &mut Self, c: Choice) {
         (*a, *b) = (
             Self(word::select(a.0, b.0, c)),
             Self(word::select(b.0, a.0, c)),
@@ -21,7 +21,7 @@ impl Limb {
 
 impl CtSelect for Limb {
     #[inline]
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         Self(self.0.ct_select(&other.0, choice))
     }
 }

--- a/src/limb/sub.rs
+++ b/src/limb/sub.rs
@@ -1,7 +1,7 @@
 //! Limb subtraction
 
 use crate::{
-    Checked, CheckedSub, ConstCtOption, Limb, Sub, SubAssign, Wrapping, WrappingSub,
+    Checked, CheckedSub, CtOption, Limb, Sub, SubAssign, Wrapping, WrappingSub,
     primitives::borrowing_sub,
 };
 
@@ -35,9 +35,9 @@ impl Limb {
 
 impl CheckedSub for Limb {
     #[inline]
-    fn checked_sub(&self, rhs: &Self) -> ConstCtOption<Self> {
+    fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
         let (result, underflow) = self.borrowing_sub(*rhs, Limb::ZERO);
-        ConstCtOption::new(result, underflow.is_zero())
+        CtOption::new(result, underflow.is_zero())
     }
 }
 

--- a/src/modular/bingcd/div_mod_2k.rs
+++ b/src/modular/bingcd/div_mod_2k.rs
@@ -1,6 +1,6 @@
 //! Compute `x / 2^k mod q` for some prime `q`.
 
-use crate::{ConstChoice, Limb, Odd, OddUint, Uint, primitives::u32_min, word};
+use crate::{Choice, Limb, Odd, OddUint, Uint, primitives::u32_min, word};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Compute `self / 2^k mod q`.
@@ -75,7 +75,7 @@ impl Limb {
         let mut factor = Limb::ZERO;
         let mut i = 0;
         while i < k_upper_bound {
-            let execute = ConstChoice::from_u32_lt(i, k);
+            let execute = Choice::from_u32_lt(i, k);
 
             let (shifted, carry) = self.shr1();
             self = Self::select(self, shifted, execute);

--- a/src/modular/bingcd/gcd.rs
+++ b/src/modular/bingcd/gcd.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ConstChoice, Limb, Odd, U64, U128, Uint, Word,
+    Choice, Limb, Odd, U64, U128, Uint, Word,
     primitives::{u32_max, u32_min},
     word,
 };
@@ -22,7 +22,7 @@ use crate::{
 pub(super) const fn bingcd_step<const LIMBS: usize>(
     a: &mut Uint<LIMBS>,
     b: &mut Uint<LIMBS>,
-) -> (ConstChoice, ConstChoice, Word) {
+) -> (Choice, Choice, Word) {
     let a_b_mod_4 = (a.limbs[0].0 & b.limbs[0].0) & 3;
 
     let a_odd = a.is_odd();
@@ -172,7 +172,7 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
             let (.., matrix, j_neg) = a_
                 .to_odd()
                 .expect_copied("a_ is always odd")
-                .partial_binxgcd::<LIMBS_K>(&b_, batch, ConstChoice::FALSE);
+                .partial_binxgcd::<LIMBS_K>(&b_, batch, Choice::FALSE);
             jacobi_neg ^= j_neg;
 
             // Update `a` and `b` using the update matrix.
@@ -234,7 +234,7 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
             let (.., matrix, j_neg) = a_
                 .to_odd()
                 .expect_copied("a_ is always odd")
-                .partial_binxgcd::<LIMBS_K>(&b_, batch_max, ConstChoice::FALSE);
+                .partial_binxgcd::<LIMBS_K>(&b_, batch_max, Choice::FALSE);
             jacobi_neg ^= j_neg;
 
             // Update `a` and `b` using the update matrix.

--- a/src/modular/bingcd/matrix.rs
+++ b/src/modular/bingcd/matrix.rs
@@ -1,5 +1,5 @@
 use crate::modular::bingcd::extension::ExtendedInt;
-use crate::{ConstChoice, Uint};
+use crate::{Choice, Uint};
 
 pub trait Unit: Sized {
     /// The unit matrix.
@@ -38,13 +38,13 @@ impl<const LIMBS: usize> Unit for IntMatrix<LIMBS> {
 
 impl<const LIMBS: usize> IntMatrix<LIMBS> {
     /// Negate the top row of this matrix if `negate`; otherwise do nothing.
-    pub(super) const fn conditional_negate_top_row(&mut self, negate: ConstChoice) {
+    pub(super) const fn conditional_negate_top_row(&mut self, negate: Choice) {
         self.m00 = self.m00.wrapping_neg_if(negate);
         self.m01 = self.m01.wrapping_neg_if(negate);
     }
 
     /// Negate the bottom row of this matrix if `negate`; otherwise do nothing.
-    pub(super) const fn conditional_negate_bottom_row(&mut self, negate: ConstChoice) {
+    pub(super) const fn conditional_negate_bottom_row(&mut self, negate: Choice) {
         self.m10 = self.m10.wrapping_neg_if(negate);
         self.m11 = self.m11.wrapping_neg_if(negate);
     }
@@ -96,7 +96,7 @@ pub(crate) struct PatternMatrix<const LIMBS: usize> {
     pub m01: Uint<LIMBS>,
     pub m10: Uint<LIMBS>,
     pub m11: Uint<LIMBS>,
-    pub pattern: ConstChoice,
+    pub pattern: Choice,
 }
 
 impl<const LIMBS: usize> PatternMatrix<LIMBS> {
@@ -105,7 +105,7 @@ impl<const LIMBS: usize> PatternMatrix<LIMBS> {
         m01: Uint::ZERO,
         m10: Uint::ZERO,
         m11: Uint::ONE,
-        pattern: ConstChoice::TRUE,
+        pattern: Choice::TRUE,
     };
 
     /// Apply this matrix to a vector of [Uint]s, returning the result as a vector of
@@ -153,7 +153,7 @@ impl<const LIMBS: usize> PatternMatrix<LIMBS> {
 
     /// Swap the rows of this matrix if `swap` is truthy. Otherwise, do nothing.
     #[inline]
-    pub(crate) const fn conditional_swap_rows(&mut self, swap: ConstChoice) {
+    pub(crate) const fn conditional_swap_rows(&mut self, swap: Choice) {
         Uint::conditional_swap(&mut self.m00, &mut self.m10, swap);
         Uint::conditional_swap(&mut self.m01, &mut self.m11, swap);
         self.pattern = self.pattern.xor(swap);
@@ -161,7 +161,7 @@ impl<const LIMBS: usize> PatternMatrix<LIMBS> {
 
     /// Subtract the bottom row from the top if `subtract` is truthy. Otherwise, do nothing.
     #[inline]
-    pub(crate) const fn conditional_subtract_bottom_row_from_top(&mut self, subtract: ConstChoice) {
+    pub(crate) const fn conditional_subtract_bottom_row_from_top(&mut self, subtract: Choice) {
         // Note: because the signs of the internal representation are stored in `pattern`,
         // subtracting one row from another involves _adding_ these rows instead.
         self.m00 = Uint::select(&self.m00, &self.m00.wrapping_add(&self.m10), subtract);
@@ -170,10 +170,7 @@ impl<const LIMBS: usize> PatternMatrix<LIMBS> {
 
     /// Subtract the right column from the left if `subtract` is truthy. Otherwise, do nothing.
     #[inline]
-    pub(crate) const fn conditional_subtract_right_column_from_left(
-        &mut self,
-        subtract: ConstChoice,
-    ) {
+    pub(crate) const fn conditional_subtract_right_column_from_left(&mut self, subtract: Choice) {
         // Note: because the signs of the internal representation are stored in `pattern`,
         // subtracting one column from another involves _adding_ these columns instead.
         self.m00 = Uint::select(&self.m00, &self.m00.wrapping_add(&self.m01), subtract);
@@ -182,7 +179,7 @@ impl<const LIMBS: usize> PatternMatrix<LIMBS> {
 
     /// If `add` is truthy, add the right column to the left. Otherwise, do nothing.
     #[inline]
-    pub(crate) const fn conditional_add_right_column_to_left(&mut self, add: ConstChoice) {
+    pub(crate) const fn conditional_add_right_column_to_left(&mut self, add: Choice) {
         // Note: because the signs of the internal representation are stored in `pattern`,
         // subtracting one column from another involves _adding_ these columns instead.
         self.m00 = Uint::select(&self.m00, &self.m01.wrapping_sub(&self.m00), add);
@@ -191,14 +188,14 @@ impl<const LIMBS: usize> PatternMatrix<LIMBS> {
 
     /// Double the bottom row of this matrix if `double` is truthy. Otherwise, do nothing.
     #[inline]
-    pub(crate) const fn conditional_double_bottom_row(&mut self, double: ConstChoice) {
+    pub(crate) const fn conditional_double_bottom_row(&mut self, double: Choice) {
         self.m10 = Uint::select(&self.m10, &self.m10.overflowing_shl1().0, double);
         self.m11 = Uint::select(&self.m11, &self.m11.overflowing_shl1().0, double);
     }
 
     /// Negate the elements in this matrix if `negate` is truthy. Otherwise, do nothing.
     #[inline]
-    pub(crate) const fn conditional_negate(&mut self, negate: ConstChoice) {
+    pub(crate) const fn conditional_negate(&mut self, negate: Choice) {
         self.pattern = self.pattern.xor(negate);
     }
 }
@@ -290,26 +287,26 @@ impl<const LIMBS: usize> DividedPatternMatrix<LIMBS> {
 
     /// Swap the rows of this matrix if `swap` is truthy. Otherwise, do nothing.
     #[inline]
-    pub const fn conditional_swap_rows(&mut self, swap: ConstChoice) {
+    pub const fn conditional_swap_rows(&mut self, swap: Choice) {
         self.inner.conditional_swap_rows(swap);
     }
 
     /// Swap the rows of this matrix.
     #[inline]
     pub const fn swap_rows(&mut self) {
-        self.conditional_swap_rows(ConstChoice::TRUE);
+        self.conditional_swap_rows(Choice::TRUE);
     }
 
     /// Subtract the bottom row from the top if `subtract` is truthy. Otherwise, do nothing.
     #[inline]
-    pub const fn conditional_subtract_bottom_row_from_top(&mut self, subtract: ConstChoice) {
+    pub const fn conditional_subtract_bottom_row_from_top(&mut self, subtract: Choice) {
         self.inner
             .conditional_subtract_bottom_row_from_top(subtract);
     }
 
     /// Double the bottom row of this matrix if `double` is truthy. Otherwise, do nothing.
     #[inline]
-    pub const fn conditional_double_bottom_row(&mut self, double: ConstChoice) {
+    pub const fn conditional_double_bottom_row(&mut self, double: Choice) {
         self.inner.conditional_double_bottom_row(double);
         self.k = double.select_u32(self.k, self.k + 1);
         self.k_upper_bound += 1;
@@ -320,12 +317,12 @@ pub(crate) type DividedIntMatrix<const LIMBS: usize> = DividedMatrix<LIMBS, IntM
 
 impl<const LIMBS: usize> DividedIntMatrix<LIMBS> {
     /// Negate the top row of this matrix if `negate`; otherwise do nothing.
-    pub(super) const fn conditional_negate_top_row(&mut self, negate: ConstChoice) {
+    pub(super) const fn conditional_negate_top_row(&mut self, negate: Choice) {
         self.inner.conditional_negate_top_row(negate);
     }
 
     /// Negate the bottom row of this matrix if `negate`; otherwise do nothing.
-    pub(super) const fn conditional_negate_bottom_row(&mut self, negate: ConstChoice) {
+    pub(super) const fn conditional_negate_bottom_row(&mut self, negate: Choice) {
         self.inner.conditional_negate_bottom_row(negate);
     }
 
@@ -341,10 +338,10 @@ impl<const LIMBS: usize> DividedIntMatrix<LIMBS> {
 #[cfg(test)]
 mod tests {
     use crate::modular::bingcd::matrix::{DividedPatternMatrix, PatternMatrix};
-    use crate::{ConstChoice, U64, U256, Uint};
+    use crate::{Choice, U64, U256, Uint};
 
     impl<const LIMBS: usize> PatternMatrix<LIMBS> {
-        pub(crate) const fn new_u64(matrix: (u64, u64, u64, u64), pattern: ConstChoice) -> Self {
+        pub(crate) const fn new_u64(matrix: (u64, u64, u64, u64), pattern: Choice) -> Self {
             Self {
                 m00: Uint::from_u64(matrix.0),
                 m01: Uint::from_u64(matrix.1),
@@ -358,7 +355,7 @@ mod tests {
     impl<const LIMBS: usize> DividedPatternMatrix<LIMBS> {
         pub(crate) const fn new_u64(
             matrix: (u64, u64, u64, u64),
-            pattern: ConstChoice,
+            pattern: Choice,
             k: u32,
             k_upper_bound: u32,
         ) -> Self {
@@ -371,7 +368,7 @@ mod tests {
     }
 
     const X: DividedPatternMatrix<{ U256::LIMBS }> =
-        DividedPatternMatrix::new_u64((1u64, 7u64, 23u64, 53u64), ConstChoice::TRUE, 6, 8);
+        DividedPatternMatrix::new_u64((1u64, 7u64, 23u64, 53u64), Choice::TRUE, 6, 8);
 
     #[test]
     fn test_wrapping_apply_to() {
@@ -379,7 +376,7 @@ mod tests {
         let b = U64::from_be_hex("AE693BF7BE8E5566");
         let matrix = DividedPatternMatrix::<{ U64::LIMBS }>::new_u64(
             (288, 208, 310, 679),
-            ConstChoice::TRUE,
+            Choice::TRUE,
             17,
             17,
         );
@@ -399,62 +396,61 @@ mod tests {
     fn test_swap() {
         let mut y = X;
         y.swap_rows();
-        let target = DividedPatternMatrix::new_u64((23, 53, 1, 7), ConstChoice::FALSE, 6, 8);
+        let target = DividedPatternMatrix::new_u64((23, 53, 1, 7), Choice::FALSE, 6, 8);
         assert_eq!(y, target);
     }
 
     #[test]
     fn test_conditional_swap() {
         let mut y = X;
-        y.conditional_swap_rows(ConstChoice::FALSE);
+        y.conditional_swap_rows(Choice::FALSE);
         assert_eq!(y, X);
-        y.conditional_swap_rows(ConstChoice::TRUE);
-        let target = DividedPatternMatrix::new_u64((23, 53, 1, 7), ConstChoice::FALSE, 6, 8);
+        y.conditional_swap_rows(Choice::TRUE);
+        let target = DividedPatternMatrix::new_u64((23, 53, 1, 7), Choice::FALSE, 6, 8);
         assert_eq!(y, target);
     }
 
     #[test]
     fn test_conditional_subtract_bottom_row_from_top() {
         let mut y = X;
-        y.conditional_subtract_bottom_row_from_top(ConstChoice::FALSE);
+        y.conditional_subtract_bottom_row_from_top(Choice::FALSE);
         assert_eq!(y, X);
-        y.conditional_subtract_bottom_row_from_top(ConstChoice::TRUE);
+        y.conditional_subtract_bottom_row_from_top(Choice::TRUE);
         let target =
-            DividedPatternMatrix::new_u64((24u64, 60u64, 23u64, 53u64), ConstChoice::TRUE, 6, 8);
+            DividedPatternMatrix::new_u64((24u64, 60u64, 23u64, 53u64), Choice::TRUE, 6, 8);
         assert_eq!(y, target);
     }
 
     #[test]
     fn test_conditional_double() {
         let mut y = X;
-        y.conditional_double_bottom_row(ConstChoice::FALSE);
-        let target =
-            DividedPatternMatrix::new_u64((1u64, 7u64, 23u64, 53u64), ConstChoice::TRUE, 6, 9);
+        y.conditional_double_bottom_row(Choice::FALSE);
+        let target = DividedPatternMatrix::new_u64((1u64, 7u64, 23u64, 53u64), Choice::TRUE, 6, 9);
         assert_eq!(y, target);
-        y.conditional_double_bottom_row(ConstChoice::TRUE);
+        y.conditional_double_bottom_row(Choice::TRUE);
         let target =
-            DividedPatternMatrix::new_u64((1u64, 7u64, 46u64, 106u64), ConstChoice::TRUE, 7, 10);
+            DividedPatternMatrix::new_u64((1u64, 7u64, 46u64, 106u64), Choice::TRUE, 7, 10);
         assert_eq!(y, target);
     }
 
     #[test]
     fn test_conditional_add_right_column_to_left() {
         let mut y = X.inner;
-        y.conditional_add_right_column_to_left(ConstChoice::FALSE);
+        y.conditional_add_right_column_to_left(Choice::FALSE);
         assert_eq!(y, X.inner);
-        y.conditional_add_right_column_to_left(ConstChoice::TRUE);
+        y.conditional_add_right_column_to_left(Choice::TRUE);
 
-        let target = PatternMatrix::new_u64((6u64, 7u64, 30u64, 53u64), ConstChoice::TRUE);
+        let target = PatternMatrix::new_u64((6u64, 7u64, 30u64, 53u64), Choice::TRUE);
         assert_eq!(y, target);
     }
 
     #[test]
     fn test_conditional_subtract_right_column_from_left() {
         let mut y = X.inner;
-        y.conditional_subtract_right_column_from_left(ConstChoice::FALSE);
+        y.conditional_subtract_right_column_from_left(Choice::FALSE);
         assert_eq!(y, X.inner);
-        y.conditional_subtract_right_column_from_left(ConstChoice::TRUE);
-        let target = PatternMatrix::new_u64((8u64, 7u64, 76u64, 53u64), ConstChoice::TRUE);
+        y.conditional_subtract_right_column_from_left(Choice::TRUE);
+        let target = PatternMatrix::new_u64((8u64, 7u64, 76u64, 53u64), Choice::TRUE);
         assert_eq!(y, target);
     }
 }

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -11,7 +11,7 @@ mod select;
 mod sub;
 
 use super::{MontyParams, Retrieve, div_by_2, reduction::montgomery_retrieve_inner};
-use crate::{BoxedUint, ConstChoice, Limb, Monty, Odd, U64, Word};
+use crate::{BoxedUint, Choice, Limb, Monty, Odd, U64, Word};
 use alloc::sync::Arc;
 use mul::BoxedMontyMultiplier;
 
@@ -217,7 +217,7 @@ impl BoxedMontyForm {
     /// # Returns
     ///
     /// If zero, returns `Choice(1)`. Otherwise, returns `Choice(0)`.
-    pub fn is_zero(&self) -> ConstChoice {
+    pub fn is_zero(&self) -> Choice {
         self.montgomery_form.is_zero()
     }
 
@@ -227,7 +227,7 @@ impl BoxedMontyForm {
     ///
     /// If zero, returns `Choice(0)`. Otherwise, returns `Choice(1)`.
     #[inline]
-    pub fn is_nonzero(&self) -> ConstChoice {
+    pub fn is_nonzero(&self) -> Choice {
         !self.is_zero()
     }
 

--- a/src/modular/boxed_monty_form/cmp.rs
+++ b/src/modular/boxed_monty_form/cmp.rs
@@ -1,14 +1,14 @@
 use super::{BoxedMontyForm, BoxedMontyParams};
-use crate::{ConstChoice, CtEq};
+use crate::{Choice, CtEq};
 
 impl CtEq for BoxedMontyForm {
-    fn ct_eq(&self, other: &Self) -> ConstChoice {
+    fn ct_eq(&self, other: &Self) -> Choice {
         self.montgomery_form.ct_eq(&other.montgomery_form) & self.params.ct_eq(&other.params)
     }
 }
 
 impl CtEq for BoxedMontyParams {
-    fn ct_eq(&self, other: &Self) -> ConstChoice {
+    fn ct_eq(&self, other: &Self) -> Choice {
         self.modulus().ct_eq(other.modulus())
             & self.one().ct_eq(other.one())
             & self.r2().ct_eq(other.r2())

--- a/src/modular/boxed_monty_form/invert.rs
+++ b/src/modular/boxed_monty_form/invert.rs
@@ -1,12 +1,12 @@
 //! Multiplicative inverses of boxed integers in Montgomery form.
 
 use super::{BoxedMontyForm, BoxedMontyParams};
-use crate::{ConstCtOption, Invert, modular::safegcd::boxed::BoxedSafeGcdInverter};
+use crate::{CtOption, Invert, modular::safegcd::boxed::BoxedSafeGcdInverter};
 
 impl BoxedMontyForm {
     /// Computes `self^-1` representing the multiplicative inverse of `self`,
     /// i.e. `self * self^-1 = 1`.
-    pub fn invert(&self) -> ConstCtOption<Self> {
+    pub fn invert(&self) -> CtOption<Self> {
         let montgomery_form = self.params.inverter().invert(&self.montgomery_form);
         let is_some = montgomery_form.is_some();
         let montgomery_form2 = self.montgomery_form.clone();
@@ -15,7 +15,7 @@ impl BoxedMontyForm {
             params: self.params.clone(),
         };
 
-        ConstCtOption::new(ret, is_some)
+        CtOption::new(ret, is_some)
     }
 
     /// Computes `self^-1` representing the multiplicative inverse of `self`,
@@ -23,7 +23,7 @@ impl BoxedMontyForm {
     ///
     /// This version is variable-time with respect to the self of `self`, but constant-time with
     /// respect to `self`'s `params`.
-    pub fn invert_vartime(&self) -> ConstCtOption<Self> {
+    pub fn invert_vartime(&self) -> CtOption<Self> {
         let montgomery_form = self.params.inverter().invert_vartime(&self.montgomery_form);
         let is_some = montgomery_form.is_some();
         let montgomery_form2 = self.montgomery_form.clone();
@@ -32,12 +32,12 @@ impl BoxedMontyForm {
             params: self.params.clone(),
         };
 
-        ConstCtOption::new(ret, is_some)
+        CtOption::new(ret, is_some)
     }
 }
 
 impl Invert for BoxedMontyForm {
-    type Output = ConstCtOption<Self>;
+    type Output = CtOption<Self>;
 
     fn invert(&self) -> Self::Output {
         self.invert()

--- a/src/modular/boxed_monty_form/select.rs
+++ b/src/modular/boxed_monty_form/select.rs
@@ -1,9 +1,9 @@
 use super::{BoxedMontyForm, BoxedMontyParams, BoxedMontyParamsInner};
-use crate::{ConstChoice, CtSelect};
+use crate::{Choice, CtSelect};
 use alloc::sync::Arc;
 
 impl CtSelect for BoxedMontyForm {
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         Self {
             montgomery_form: self
                 .montgomery_form
@@ -14,13 +14,13 @@ impl CtSelect for BoxedMontyForm {
 }
 
 impl CtSelect for BoxedMontyParams {
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         Self(Arc::new(self.0.ct_select(&other.0, choice)))
     }
 }
 
 impl CtSelect for BoxedMontyParamsInner {
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         Self {
             modulus: self.modulus.ct_select(&other.modulus, choice),
             one: self.one.ct_select(&other.one, choice),

--- a/src/modular/const_monty_form/cmp.rs
+++ b/src/modular/const_monty_form/cmp.rs
@@ -1,11 +1,11 @@
 use super::{ConstMontyForm, ConstMontyParams};
-use crate::{ConstChoice, CtEq};
+use crate::{Choice, CtEq};
 
 impl<MOD, const LIMBS: usize> CtEq for ConstMontyForm<MOD, LIMBS>
 where
     MOD: ConstMontyParams<LIMBS>,
 {
-    fn ct_eq(&self, other: &Self) -> ConstChoice {
+    fn ct_eq(&self, other: &Self) -> Choice {
         CtEq::ct_eq(&self.montgomery_form, &other.montgomery_form)
     }
 }

--- a/src/modular/const_monty_form/invert.rs
+++ b/src/modular/const_monty_form/invert.rs
@@ -1,7 +1,7 @@
 //! Multiplicative inverses of integers in Montgomery form with a constant modulus.
 
 use super::{ConstMontyForm, ConstMontyParams};
-use crate::{ConstCtOption, Invert, modular::SafeGcdInverter};
+use crate::{CtOption, Invert, modular::SafeGcdInverter};
 use core::marker::PhantomData;
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
@@ -11,7 +11,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
     #[deprecated(since = "0.7.0", note = "please use `invert` instead")]
-    pub const fn inv(&self) -> ConstCtOption<Self> {
+    pub const fn inv(&self) -> CtOption<Self> {
         self.invert()
     }
 
@@ -20,7 +20,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     ///
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
-    pub const fn invert(&self) -> ConstCtOption<Self> {
+    pub const fn invert(&self) -> CtOption<Self> {
         let inverter = SafeGcdInverter::new_with_inverse(
             &MOD::PARAMS.modulus,
             MOD::PARAMS.mod_inv,
@@ -34,7 +34,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
             phantom: PhantomData,
         };
 
-        ConstCtOption::new(ret, maybe_inverse.is_some())
+        CtOption::new(ret, maybe_inverse.is_some())
     }
 
     /// Computes `self^-1` representing the multiplicative inverse of `self`,
@@ -46,7 +46,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     /// This version is variable-time with respect to the value of `self`, but constant-time with
     /// respect to `MOD`.
     #[deprecated(since = "0.7.0", note = "please use `invert_vartime` instead")]
-    pub const fn inv_vartime(&self) -> ConstCtOption<Self> {
+    pub const fn inv_vartime(&self) -> CtOption<Self> {
         self.invert_vartime()
     }
 
@@ -58,7 +58,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     ///
     /// This version is variable-time with respect to the value of `self`, but constant-time with
     /// respect to `MOD`.
-    pub const fn invert_vartime(&self) -> ConstCtOption<Self> {
+    pub const fn invert_vartime(&self) -> CtOption<Self> {
         let inverter = SafeGcdInverter::new_with_inverse(
             &MOD::PARAMS.modulus,
             MOD::PARAMS.mod_inv,
@@ -72,12 +72,12 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
             phantom: PhantomData,
         };
 
-        ConstCtOption::new(ret, maybe_inverse.is_some())
+        CtOption::new(ret, maybe_inverse.is_some())
     }
 }
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> Invert for ConstMontyForm<MOD, LIMBS> {
-    type Output = ConstCtOption<Self>;
+    type Output = CtOption<Self>;
 
     fn invert(&self) -> Self::Output {
         self.invert()

--- a/src/modular/const_monty_form/select.rs
+++ b/src/modular/const_monty_form/select.rs
@@ -1,12 +1,12 @@
 use super::{ConstMontyForm, ConstMontyParams};
-use crate::{ConstChoice, CtSelect, Uint};
+use crate::{Choice, CtSelect, Uint};
 use core::marker::PhantomData;
 
 impl<MOD, const LIMBS: usize> CtSelect for ConstMontyForm<MOD, LIMBS>
 where
     MOD: ConstMontyParams<LIMBS>,
 {
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         ConstMontyForm {
             montgomery_form: Uint::ct_select(&self.montgomery_form, &other.montgomery_form, choice),
             phantom: PhantomData,

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -18,7 +18,7 @@ use super::{
     mul::mul_montgomery_form,
     reduction::montgomery_retrieve,
 };
-use crate::{ConstChoice, Limb, Monty, Odd, U64, Uint, Word};
+use crate::{Choice, Limb, Monty, Odd, U64, Uint, Word};
 use mul::DynMontyMultiplier;
 
 /// Parameters to efficiently go to/from the Montgomery form for an odd modulus provided at runtime.
@@ -53,7 +53,7 @@ impl<const LIMBS: usize> MontyParams<LIMBS> {
         let mod_inv = U64::from_u64(modulus.as_uint_ref().invert_mod_u64());
 
         let mod_leading_zeros = modulus.as_ref().leading_zeros();
-        let mod_leading_zeros = ConstChoice::from_u32_lt(mod_leading_zeros, Word::BITS - 1)
+        let mod_leading_zeros = Choice::from_u32_lt(mod_leading_zeros, Word::BITS - 1)
             .select_u32(Word::BITS - 1, mod_leading_zeros);
 
         Self {

--- a/src/modular/monty_form/cmp.rs
+++ b/src/modular/monty_form/cmp.rs
@@ -1,15 +1,15 @@
 use super::MontyParams;
 use crate::modular::MontyForm;
-use crate::{ConstChoice, CtEq};
+use crate::{Choice, CtEq};
 
 impl<const LIMBS: usize> CtEq for MontyForm<LIMBS> {
-    fn ct_eq(&self, other: &Self) -> ConstChoice {
+    fn ct_eq(&self, other: &Self) -> Choice {
         self.montgomery_form.ct_eq(&other.montgomery_form) & self.params.ct_eq(&other.params)
     }
 }
 
 impl<const LIMBS: usize> CtEq for MontyParams<LIMBS> {
-    fn ct_eq(&self, other: &Self) -> ConstChoice {
+    fn ct_eq(&self, other: &Self) -> Choice {
         self.modulus.ct_eq(&other.modulus)
             & self.one.ct_eq(&other.one)
             & self.r2.ct_eq(&other.r2)

--- a/src/modular/monty_form/invert.rs
+++ b/src/modular/monty_form/invert.rs
@@ -1,7 +1,7 @@
 //! Multiplicative inverses of integers in Montgomery form with a modulus set at runtime.
 
 use super::{MontyForm, MontyParams};
-use crate::{ConstCtOption, modular::SafeGcdInverter, traits::Invert};
+use crate::{CtOption, modular::SafeGcdInverter, traits::Invert};
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Computes `self^-1` representing the multiplicative inverse of `self`.
@@ -10,7 +10,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
     #[deprecated(since = "0.7.0", note = "please use `invert` instead")]
-    pub const fn inv(&self) -> ConstCtOption<Self> {
+    pub const fn inv(&self) -> CtOption<Self> {
         self.invert()
     }
 
@@ -19,7 +19,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     ///
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
-    pub const fn invert(&self) -> ConstCtOption<Self> {
+    pub const fn invert(&self) -> CtOption<Self> {
         let inverter = self.params.inverter();
         let maybe_inverse = inverter.invert(&self.montgomery_form);
 
@@ -28,7 +28,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
             params: self.params,
         };
 
-        ConstCtOption::new(ret, maybe_inverse.is_some())
+        CtOption::new(ret, maybe_inverse.is_some())
     }
 
     /// Computes `self^-1` representing the multiplicative inverse of `self`.
@@ -40,7 +40,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// This version is variable-time with respect to the value of `self`, but constant-time with
     /// respect to `self`'s `params`.
     #[deprecated(since = "0.7.0", note = "please use `invert_vartime` instead")]
-    pub const fn inv_vartime(&self) -> ConstCtOption<Self> {
+    pub const fn inv_vartime(&self) -> CtOption<Self> {
         self.invert_vartime()
     }
 
@@ -52,7 +52,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     ///
     /// This version is variable-time with respect to the value of `self`, but constant-time with
     /// respect to `self`'s `params`.
-    pub const fn invert_vartime(&self) -> ConstCtOption<Self> {
+    pub const fn invert_vartime(&self) -> CtOption<Self> {
         let inverter = self.params.inverter();
         let maybe_inverse = inverter.invert_vartime(&self.montgomery_form);
 
@@ -61,12 +61,12 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
             params: self.params,
         };
 
-        ConstCtOption::new(ret, maybe_inverse.is_some())
+        CtOption::new(ret, maybe_inverse.is_some())
     }
 }
 
 impl<const LIMBS: usize> Invert for MontyForm<LIMBS> {
-    type Output = ConstCtOption<Self>;
+    type Output = CtOption<Self>;
 
     fn invert(&self) -> Self::Output {
         self.invert()

--- a/src/modular/monty_form/select.rs
+++ b/src/modular/monty_form/select.rs
@@ -1,9 +1,9 @@
 use super::MontyParams;
 use crate::modular::MontyForm;
-use crate::{ConstChoice, CtSelect, Odd, U64, Uint};
+use crate::{Choice, CtSelect, Odd, U64, Uint};
 
 impl<const LIMBS: usize> CtSelect for MontyForm<LIMBS> {
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         Self {
             montgomery_form: Uint::ct_select(&self.montgomery_form, &other.montgomery_form, choice),
             params: MontyParams::ct_select(&self.params, &other.params, choice),
@@ -12,7 +12,7 @@ impl<const LIMBS: usize> CtSelect for MontyForm<LIMBS> {
 }
 
 impl<const LIMBS: usize> CtSelect for MontyParams<LIMBS> {
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         Self {
             modulus: Odd::ct_select(&self.modulus, &other.modulus, choice),
             one: Uint::ct_select(&self.one, &other.one, choice),

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -1,8 +1,8 @@
 //! Wrapper type for non-zero integers.
 
 use crate::{
-    Bounded, ConstChoice, ConstCtOption, ConstOne, Constants, CtEq, CtSelect, Encoding, Int, Limb,
-    Mul, Odd, One, Uint, Zero,
+    Bounded, Choice, ConstOne, Constants, CtEq, CtOption, CtSelect, Encoding, Int, Limb, Mul, Odd,
+    One, Uint, Zero,
 };
 use core::{
     fmt,
@@ -43,7 +43,7 @@ pub struct NonZero<T: ?Sized>(pub(crate) T);
 impl<T> NonZero<T> {
     /// Create a new non-zero integer.
     #[inline]
-    pub fn new(mut n: T) -> ConstCtOption<Self>
+    pub fn new(mut n: T) -> CtOption<Self>
     where
         T: Zero + One + CtSelect,
     {
@@ -53,7 +53,7 @@ impl<T> NonZero<T> {
         // `NonZero` values really can expect the value to never be zero, even in the case
         // `CtOption::is_some` is false.
         n.ct_assign(&T::one_like(&n), is_zero);
-        ConstCtOption::new(Self(n), !is_zero)
+        CtOption::new(Self(n), !is_zero)
     }
 
     /// Returns the inner value.
@@ -97,12 +97,12 @@ where
     T: Zero + One + CtSelect + Encoding,
 {
     /// Decode from big endian bytes.
-    pub fn from_be_bytes(bytes: T::Repr) -> ConstCtOption<Self> {
+    pub fn from_be_bytes(bytes: T::Repr) -> CtOption<Self> {
         Self::new(T::from_be_bytes(bytes))
     }
 
     /// Decode from little endian bytes.
-    pub fn from_le_bytes(bytes: T::Repr) -> ConstCtOption<Self> {
+    pub fn from_le_bytes(bytes: T::Repr) -> CtOption<Self> {
         Self::new(T::from_le_bytes(bytes))
     }
 }
@@ -266,7 +266,7 @@ impl<const LIMBS: usize> NonZeroInt<LIMBS> {
     }
 
     /// The sign and magnitude of this [`NonZeroInt`].
-    pub const fn abs_sign(&self) -> (NonZero<Uint<LIMBS>>, ConstChoice) {
+    pub const fn abs_sign(&self) -> (NonZero<Uint<LIMBS>>, Choice) {
         let (abs, sign) = self.0.abs_sign();
         // Absolute value of a non-zero value is non-zero
         (NonZero(abs), sign)
@@ -284,12 +284,12 @@ where
     T: ArrayEncoding + Zero + One + CtSelect,
 {
     /// Decode a non-zero integer from big endian bytes.
-    pub fn from_be_byte_array(bytes: ByteArray<T>) -> ConstCtOption<Self> {
+    pub fn from_be_byte_array(bytes: ByteArray<T>) -> CtOption<Self> {
         Self::new(T::from_be_byte_array(bytes))
     }
 
     /// Decode a non-zero integer from big endian bytes.
-    pub fn from_le_byte_array(bytes: ByteArray<T>) -> ConstCtOption<Self> {
+    pub fn from_le_byte_array(bytes: ByteArray<T>) -> CtOption<Self> {
         Self::new(T::from_be_byte_array(bytes))
     }
 }
@@ -305,7 +305,7 @@ where
     T: CtEq + ?Sized,
 {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> ConstChoice {
+    fn ct_eq(&self, other: &Self) -> Choice {
         CtEq::ct_eq(&self.0, &other.0)
     }
 }
@@ -315,7 +315,7 @@ where
     T: CtSelect,
 {
     #[inline]
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         Self(self.0.ct_select(&other.0, choice))
     }
 }
@@ -524,13 +524,13 @@ impl<T: zeroize::Zeroize + Zero> zeroize::Zeroize for NonZero<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, I128, U128};
+    use crate::{Choice, I128, U128};
 
     #[test]
     fn int_abs_sign() {
         let x = I128::from(-55).to_nz().unwrap();
         let (abs, sgn) = x.abs_sign();
         assert_eq!(abs, U128::from(55u32).to_nz().unwrap());
-        assert_eq!(sgn, ConstChoice::TRUE);
+        assert_eq!(sgn, Choice::TRUE);
     }
 }

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -1,8 +1,8 @@
 //! Wrapper type for non-zero integers.
 
 use crate::{
-    Bounded, ConstChoice, ConstCtOption, ConstOne, CtEq, CtSelect, Int, Integer, Limb, Mul,
-    NonZero, One, Uint, UintRef,
+    Bounded, Choice, ConstOne, CtEq, CtOption, CtSelect, Int, Integer, Limb, Mul, NonZero, One,
+    Uint, UintRef,
 };
 use core::{cmp::Ordering, fmt, ops::Deref};
 
@@ -43,7 +43,7 @@ pub struct Odd<T: ?Sized>(pub(crate) T);
 impl<T> Odd<T> {
     /// Create a new odd integer.
     #[inline]
-    pub fn new(mut n: T) -> ConstCtOption<Self>
+    pub fn new(mut n: T) -> CtOption<Self>
     where
         T: Integer,
     {
@@ -53,7 +53,7 @@ impl<T> Odd<T> {
         // operate on `NonZero` values really can expect the value to never be zero, even in the
         // case `CtOption::is_some` is false.
         n.ct_assign(&T::one_like(&n), !is_odd);
-        ConstCtOption::new(Self(n), is_odd)
+        CtOption::new(Self(n), is_odd)
     }
 
     /// Returns the inner value.
@@ -127,7 +127,7 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
 
 impl<const LIMBS: usize> Odd<Int<LIMBS>> {
     /// The sign and magnitude of this [`Odd<Int<{LIMBS}>>`].
-    pub const fn abs_sign(&self) -> (Odd<Uint<LIMBS>>, ConstChoice) {
+    pub const fn abs_sign(&self) -> (Odd<Uint<LIMBS>>, Choice) {
         // Absolute value of an odd value is odd
         let (abs, sgn) = Int::abs_sign(self.as_ref());
         (Odd(abs), sgn)
@@ -165,7 +165,7 @@ where
     T: CtEq + ?Sized,
 {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> ConstChoice {
+    fn ct_eq(&self, other: &Self) -> Choice {
         CtEq::ct_eq(&self.0, &other.0)
     }
 }
@@ -175,7 +175,7 @@ where
     T: CtSelect,
 {
     #[inline]
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         Self(self.0.ct_select(&other.0, choice))
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,4 +1,4 @@
-use crate::{ConstChoice, WideWord, Word};
+use crate::{Choice, WideWord, Word};
 
 /// Adds wide numbers represented by pairs of (least significant word, most significant word)
 /// and returns the result in the same format `(lo, hi)`.
@@ -73,13 +73,13 @@ pub(crate) const fn carrying_mul_add(
 /// `const fn` equivalent of `u32::max(a, b)`.
 #[inline]
 pub(crate) const fn u32_max(a: u32, b: u32) -> u32 {
-    ConstChoice::from_u32_lt(a, b).select_u32(a, b)
+    Choice::from_u32_lt(a, b).select_u32(a, b)
 }
 
 /// `const` equivalent of `u32::min(a, b)`.
 #[inline]
 pub(crate) const fn u32_min(a: u32, b: u32) -> u32 {
-    ConstChoice::from_u32_lt(a, b).select_u32(b, a)
+    Choice::from_u32_lt(a, b).select_u32(b, a)
 }
 
 #[cfg(test)]

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -8,8 +8,8 @@ pub use extra_sizes::*;
 pub(crate) use ref_type::UintRef;
 
 use crate::{
-    Bounded, ConstChoice, ConstCtOption, ConstOne, ConstZero, Constants, CtEq, FixedInteger, Int,
-    Integer, Limb, NonZero, Odd, One, Unsigned, Word, Zero, modular::MontyForm,
+    Bounded, Choice, ConstOne, ConstZero, Constants, CtEq, CtOption, FixedInteger, Int, Integer,
+    Limb, NonZero, Odd, One, Unsigned, Word, Zero, modular::MontyForm,
 };
 use core::fmt;
 
@@ -209,23 +209,23 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Convert to a [`NonZero<Uint<LIMBS>>`].
     ///
     /// Returns some if the original value is non-zero, and false otherwise.
-    pub const fn to_nz(&self) -> ConstCtOption<NonZero<Self>> {
+    pub const fn to_nz(&self) -> CtOption<NonZero<Self>> {
         let is_nz = self.is_nonzero();
 
         // Use `1` as a placeholder in the event this value is `0`
         let ret = Self::select(&Self::ONE, self, is_nz);
-        ConstCtOption::new(NonZero(ret), is_nz)
+        CtOption::new(NonZero(ret), is_nz)
     }
 
     /// Convert to a [`Odd<Uint<LIMBS>>`].
     ///
     /// Returns some if the original value is odd, and false otherwise.
-    pub const fn to_odd(&self) -> ConstCtOption<Odd<Self>> {
+    pub const fn to_odd(&self) -> CtOption<Odd<Self>> {
         let is_odd = self.is_odd();
 
         // Use `1` as a placeholder in the event this value is even
         let ret = Self::select(&Self::ONE, self, is_odd);
-        ConstCtOption::new(Odd(ret), is_odd)
+        CtOption::new(Odd(ret), is_odd)
     }
 
     /// Interpret this object as an [`Int`] instead.
@@ -241,13 +241,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Convert this type into an [`Int`]; returns `None` if this value is greater than [`Int::MAX`].
     ///
     /// Note: this is the conversion operation. See [`Self::as_int`] for the unchecked equivalent.
-    pub const fn try_into_int(self) -> ConstCtOption<Int<LIMBS>> {
-        Int::new_from_abs_sign(self, ConstChoice::FALSE)
+    pub const fn try_into_int(self) -> CtOption<Int<LIMBS>> {
+        Int::new_from_abs_sign(self, Choice::FALSE)
     }
 
     /// Is this [`Uint`] equal to [`Uint::ZERO`]?
-    pub const fn is_zero(&self) -> ConstChoice {
-        let mut ret = ConstChoice::TRUE;
+    pub const fn is_zero(&self) -> Choice {
+        let mut ret = Choice::TRUE;
         let mut n = 0;
 
         while n < LIMBS {

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -1,7 +1,7 @@
 //! [`Uint`] addition operations.
 
 use crate::{
-    Add, AddAssign, Checked, CheckedAdd, ConstCtOption, Limb, Uint, Wrapping, WrappingAdd, word,
+    Add, AddAssign, Checked, CheckedAdd, CtOption, Limb, Uint, Wrapping, WrappingAdd, word,
 };
 
 impl<const LIMBS: usize> Uint<LIMBS> {
@@ -106,9 +106,9 @@ impl<const LIMBS: usize> AddAssign<&Checked<Uint<LIMBS>>> for Checked<Uint<LIMBS
 }
 
 impl<const LIMBS: usize> CheckedAdd for Uint<LIMBS> {
-    fn checked_add(&self, rhs: &Self) -> ConstCtOption<Self> {
+    fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
         let (result, carry) = self.carrying_add(rhs, Limb::ZERO);
-        ConstCtOption::new(result, carry.is_zero())
+        CtOption::new(result, carry.is_zero())
     }
 }
 

--- a/src/uint/bit_and.rs
+++ b/src/uint/bit_and.rs
@@ -1,7 +1,7 @@
 //! [`Uint`] bitwise AND operations.
 
 use super::Uint;
-use crate::{BitAnd, BitAndAssign, ConstCtOption, Limb, Wrapping};
+use crate::{BitAnd, BitAndAssign, CtOption, Limb, Wrapping};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `a & b`.
@@ -40,9 +40,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         self.bitand(rhs)
     }
 
-    /// Perform checked bitwise `AND`, returning a [`ConstCtOption`] which `is_some` always
-    pub const fn checked_and(&self, rhs: &Self) -> ConstCtOption<Self> {
-        ConstCtOption::some(self.bitand(rhs))
+    /// Perform checked bitwise `AND`, returning a [`CtOption`] which `is_some` always
+    pub const fn checked_and(&self, rhs: &Self) -> CtOption<Self> {
+        CtOption::some(self.bitand(rhs))
     }
 }
 

--- a/src/uint/bit_or.rs
+++ b/src/uint/bit_or.rs
@@ -1,7 +1,7 @@
 //! [`Uint`] bitwise OR operations.
 
 use super::Uint;
-use crate::{BitOr, BitOrAssign, ConstCtOption, Limb, Wrapping};
+use crate::{BitOr, BitOrAssign, CtOption, Limb, Wrapping};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `a & b`.
@@ -26,9 +26,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         self.bitor(rhs)
     }
 
-    /// Perform checked bitwise `OR`, returning a [`ConstCtOption`] which `is_some` always
-    pub const fn checked_or(&self, rhs: &Self) -> ConstCtOption<Self> {
-        ConstCtOption::some(self.bitor(rhs))
+    /// Perform checked bitwise `OR`, returning a [`CtOption`] which `is_some` always
+    pub const fn checked_or(&self, rhs: &Self) -> CtOption<Self> {
+        CtOption::some(self.bitor(rhs))
     }
 }
 

--- a/src/uint/bit_xor.rs
+++ b/src/uint/bit_xor.rs
@@ -1,7 +1,7 @@
 //! [`Uint`] bitwise XOR operations.
 
 use super::Uint;
-use crate::{BitXor, BitXorAssign, ConstCtOption, Limb, Wrapping};
+use crate::{BitXor, BitXorAssign, CtOption, Limb, Wrapping};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `a ^ b`.
@@ -26,9 +26,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         self.bitxor(rhs)
     }
 
-    /// Perform checked bitwise `XOR`, returning a [`ConstCtOption`] which `is_some` always
-    pub const fn checked_xor(&self, rhs: &Self) -> ConstCtOption<Self> {
-        ConstCtOption::some(self.bitxor(rhs))
+    /// Perform checked bitwise `XOR`, returning a [`CtOption`] which `is_some` always
+    pub const fn checked_xor(&self, rhs: &Self) -> CtOption<Self> {
+        CtOption::some(self.bitxor(rhs))
     }
 }
 

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -1,9 +1,9 @@
-use crate::{BitOps, ConstChoice, Uint};
+use crate::{BitOps, Choice, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
-    /// Get the value of the bit at position `index`, as a truthy or falsy `ConstChoice`.
+    /// Get the value of the bit at position `index`, as a truthy or falsy `Choice`.
     /// Returns the falsy value for indices out of range.
-    pub const fn bit(&self, index: u32) -> ConstChoice {
+    pub const fn bit(&self, index: u32) -> Choice {
         self.as_uint_ref().bit(index)
     }
 
@@ -62,7 +62,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Sets the bit at `index` to 0 or 1 depending on the value of `bit_value`.
-    pub(crate) const fn set_bit(self, index: u32, bit_value: ConstChoice) -> Self {
+    pub(crate) const fn set_bit(self, index: u32, bit_value: Choice) -> Self {
         let mut result = self;
         result.as_mut_uint_ref().set_bit(index, bit_value);
         result
@@ -96,11 +96,11 @@ impl<const LIMBS: usize> BitOps for Uint<LIMBS> {
         self.leading_zeros()
     }
 
-    fn bit(&self, index: u32) -> ConstChoice {
+    fn bit(&self, index: u32) -> Choice {
         self.bit(index)
     }
 
-    fn set_bit(&mut self, index: u32, bit_value: ConstChoice) {
+    fn set_bit(&mut self, index: u32, bit_value: Choice) {
         *self = Self::set_bit(*self, index, bit_value);
     }
 
@@ -135,7 +135,7 @@ impl<const LIMBS: usize> BitOps for Uint<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, U256};
+    use crate::{Choice, U256};
 
     fn uint_with_bits_at(positions: &[u32]) -> U256 {
         let mut result = U256::ZERO;
@@ -281,26 +281,23 @@ mod tests {
     fn set_bit() {
         let u = uint_with_bits_at(&[16, 79, 150]);
         assert_eq!(
-            u.set_bit(127, ConstChoice::TRUE),
+            u.set_bit(127, Choice::TRUE),
             uint_with_bits_at(&[16, 79, 127, 150])
         );
 
         let u = uint_with_bits_at(&[16, 79, 150]);
         assert_eq!(
-            u.set_bit(150, ConstChoice::TRUE),
+            u.set_bit(150, Choice::TRUE),
             uint_with_bits_at(&[16, 79, 150])
         );
 
         let u = uint_with_bits_at(&[16, 79, 150]);
         assert_eq!(
-            u.set_bit(127, ConstChoice::FALSE),
+            u.set_bit(127, Choice::FALSE),
             uint_with_bits_at(&[16, 79, 150])
         );
 
         let u = uint_with_bits_at(&[16, 79, 150]);
-        assert_eq!(
-            u.set_bit(150, ConstChoice::FALSE),
-            uint_with_bits_at(&[16, 79])
-        );
+        assert_eq!(u.set_bit(150, Choice::FALSE), uint_with_bits_at(&[16, 79]));
     }
 }

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -28,8 +28,8 @@ mod sub_mod;
 mod rand;
 
 use crate::{
-    ConstChoice, ConstCtOption, CtEq, CtSelect, Integer, Limb, NonZero, Odd, One, Resize, UintRef,
-    Unsigned, Word, Zero, modular::BoxedMontyForm,
+    Choice, CtEq, CtOption, CtSelect, Integer, Limb, NonZero, Odd, One, Resize, UintRef, Unsigned,
+    Word, Zero, modular::BoxedMontyForm,
 };
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::{fmt, iter::repeat, ops::IndexMut};
@@ -90,20 +90,20 @@ impl BoxedUint {
     }
 
     /// Is this [`BoxedUint`] equal to zero?
-    pub fn is_zero(&self) -> ConstChoice {
+    pub fn is_zero(&self) -> Choice {
         self.limbs
             .iter()
-            .fold(ConstChoice::TRUE, |acc, limb| acc & limb.is_zero())
+            .fold(Choice::TRUE, |acc, limb| acc & limb.is_zero())
     }
 
     /// Is this [`BoxedUint`] *NOT* equal to zero?
     #[inline]
-    pub fn is_nonzero(&self) -> ConstChoice {
+    pub fn is_nonzero(&self) -> Choice {
         !self.is_zero()
     }
 
     /// Is this [`BoxedUint`] equal to one?
-    pub fn is_one(&self) -> ConstChoice {
+    pub fn is_one(&self) -> Choice {
         let mut iter = self.limbs.iter();
         let choice = iter.next().copied().unwrap_or(Limb::ZERO).ct_eq(&Limb::ONE);
         iter.fold(choice, |acc, limb| acc & limb.is_zero())
@@ -223,37 +223,37 @@ impl BoxedUint {
     /// Convert to a [`NonZero<BoxedUint>`].
     ///
     /// Returns some if the original value is non-zero, and false otherwise.
-    pub fn to_nz(&self) -> ConstCtOption<NonZero<Self>> {
+    pub fn to_nz(&self) -> CtOption<NonZero<Self>> {
         self.clone().into_nz()
     }
 
     /// Convert to an [`Odd<BoxedUint>`].
     ///
     /// Returns some if the original value is odd, and false otherwise.
-    pub fn to_odd(&self) -> ConstCtOption<Odd<Self>> {
+    pub fn to_odd(&self) -> CtOption<Odd<Self>> {
         self.clone().into_odd()
     }
 
     /// Convert to a [`NonZero<BoxedUint>`].
     ///
     /// Returns some if the original value is non-zero, and false otherwise.
-    pub fn into_nz(mut self) -> ConstCtOption<NonZero<Self>> {
+    pub fn into_nz(mut self) -> CtOption<NonZero<Self>> {
         let is_nz = self.is_nonzero();
 
         // Ensure the `NonZero` we construct is actually non-zero, even if the `CtOption` is none
         self.limbs[0].ct_assign(&Limb::ONE, !is_nz);
-        ConstCtOption::new(NonZero(self), is_nz)
+        CtOption::new(NonZero(self), is_nz)
     }
 
     /// Convert to an [`Odd<BoxedUint>`].
     ///
     /// Returns some if the original value is odd, and false otherwise.
-    pub fn into_odd(mut self) -> ConstCtOption<Odd<Self>> {
+    pub fn into_odd(mut self) -> CtOption<Odd<Self>> {
         let is_odd = self.is_odd();
 
         // Ensure the `Odd` we construct is actually odd, even if the `CtOption` is none
         self.limbs[0].ct_assign(&Limb::ONE, !is_odd);
-        ConstCtOption::new(Odd(self.clone()), is_odd)
+        CtOption::new(Odd(self.clone()), is_odd)
     }
 
     /// Widen this type's precision to the given number of bits.
@@ -469,7 +469,7 @@ impl Zero for BoxedUint {
         Self::zero()
     }
 
-    fn is_zero(&self) -> ConstChoice {
+    fn is_zero(&self) -> Choice {
         self.is_zero()
     }
 
@@ -489,7 +489,7 @@ impl One for BoxedUint {
         ret
     }
 
-    fn is_one(&self) -> ConstChoice {
+    fn is_one(&self) -> Choice {
         self.is_one()
     }
 

--- a/src/uint/boxed/add.rs
+++ b/src/uint/boxed/add.rs
@@ -1,8 +1,8 @@
 //! [`BoxedUint`] addition operations.
 
 use crate::{
-    Add, AddAssign, BoxedUint, CheckedAdd, ConstChoice, ConstCtOption, CtSelect, Limb, U64, U128,
-    Uint, Wrapping, WrappingAdd,
+    Add, AddAssign, BoxedUint, CheckedAdd, Choice, CtOption, CtSelect, Limb, U64, U128, Uint,
+    Wrapping, WrappingAdd,
 };
 
 impl BoxedUint {
@@ -50,11 +50,7 @@ impl BoxedUint {
 
     /// Perform in-place wrapping addition, returning the truthy value as the second element of the
     /// tuple if an overflow has occurred.
-    pub(crate) fn conditional_carrying_add_assign(
-        &mut self,
-        rhs: &Self,
-        choice: ConstChoice,
-    ) -> ConstChoice {
+    pub(crate) fn conditional_carrying_add_assign(&mut self, rhs: &Self, choice: Choice) -> Choice {
         debug_assert!(self.bits_precision() <= rhs.bits_precision());
         let mask = Limb::ZERO.ct_select(&Limb::MAX, choice);
         let mut carry = Limb::ZERO;
@@ -66,7 +62,7 @@ impl BoxedUint {
             carry = c;
         }
 
-        ConstChoice::new((carry.0 & 1) as u8)
+        Choice::new((carry.0 & 1) as u8)
     }
 }
 
@@ -175,9 +171,9 @@ impl AddAssign<&Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
 }
 
 impl CheckedAdd for BoxedUint {
-    fn checked_add(&self, rhs: &Self) -> ConstCtOption<Self> {
+    fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
         let (result, carry) = self.carrying_add(rhs, Limb::ZERO);
-        ConstCtOption::new(result, carry.is_zero())
+        CtOption::new(result, carry.is_zero())
     }
 }
 

--- a/src/uint/boxed/bit_and.rs
+++ b/src/uint/boxed/bit_and.rs
@@ -1,7 +1,7 @@
 //! [`BoxedUint`] bitwise AND operations.
 
 use super::BoxedUint;
-use crate::{BitAnd, BitAndAssign, ConstCtOption, Limb, Wrapping};
+use crate::{BitAnd, BitAndAssign, CtOption, Limb, Wrapping};
 
 impl BoxedUint {
     /// Computes bitwise `a & b`.
@@ -26,9 +26,9 @@ impl BoxedUint {
         self.bitand(rhs)
     }
 
-    /// Perform checked bitwise `AND`, returning a [`ConstCtOption`] which `is_some` always
-    pub fn checked_and(&self, rhs: &Self) -> ConstCtOption<Self> {
-        ConstCtOption::some(self.bitand(rhs))
+    /// Perform checked bitwise `AND`, returning a [`CtOption`] which `is_some` always
+    pub fn checked_and(&self, rhs: &Self) -> CtOption<Self> {
+        CtOption::some(self.bitand(rhs))
     }
 }
 

--- a/src/uint/boxed/bit_or.rs
+++ b/src/uint/boxed/bit_or.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] bitwise OR operations.
 
-use crate::{BitOr, BitOrAssign, BoxedUint, ConstCtOption, Wrapping};
+use crate::{BitOr, BitOrAssign, BoxedUint, CtOption, Wrapping};
 
 impl BoxedUint {
     /// Computes bitwise `a & b`.
@@ -17,9 +17,9 @@ impl BoxedUint {
         self.bitor(rhs)
     }
 
-    /// Perform checked bitwise `OR`, returning a [`ConstCtOption`] which `is_some` always
-    pub fn checked_or(&self, rhs: &Self) -> ConstCtOption<Self> {
-        ConstCtOption::some(self.bitor(rhs))
+    /// Perform checked bitwise `OR`, returning a [`CtOption`] which `is_some` always
+    pub fn checked_or(&self, rhs: &Self) -> CtOption<Self> {
+        CtOption::some(self.bitor(rhs))
     }
 }
 

--- a/src/uint/boxed/bit_xor.rs
+++ b/src/uint/boxed/bit_xor.rs
@@ -1,7 +1,7 @@
 //! [`BoxedUint`] bitwise XOR operations.
 
 use super::BoxedUint;
-use crate::{BitXor, BitXorAssign, ConstCtOption, Wrapping};
+use crate::{BitXor, BitXorAssign, CtOption, Wrapping};
 
 impl BoxedUint {
     /// Computes bitwise `a ^ b`.
@@ -18,9 +18,9 @@ impl BoxedUint {
         self.bitxor(rhs)
     }
 
-    /// Perform checked bitwise `XOR`, returning a [`ConstCtOption`] which `is_some` always
-    pub fn checked_xor(&self, rhs: &Self) -> ConstCtOption<Self> {
-        ConstCtOption::some(self.bitxor(rhs))
+    /// Perform checked bitwise `XOR`, returning a [`CtOption`] which `is_some` always
+    pub fn checked_xor(&self, rhs: &Self) -> CtOption<Self> {
+        CtOption::some(self.bitxor(rhs))
     }
 }
 

--- a/src/uint/boxed/bits.rs
+++ b/src/uint/boxed/bits.rs
@@ -1,11 +1,11 @@
 //! Bit manipulation functions.
 
-use crate::{BitOps, BoxedUint, ConstChoice, Limb};
+use crate::{BitOps, BoxedUint, Choice, Limb};
 
 impl BoxedUint {
     /// Get the value of the bit at position `index`, as a truthy or falsy `Choice`.
     /// Returns the falsy value for indices out of range.
-    pub fn bit(&self, index: u32) -> ConstChoice {
+    pub fn bit(&self, index: u32) -> Choice {
         self.as_uint_ref().bit(index)
     }
 
@@ -66,7 +66,7 @@ impl BoxedUint {
     }
 
     /// Sets the bit at `index` to 0 or 1 depending on the value of `bit_value`.
-    pub(crate) fn set_bit(&mut self, index: u32, bit_value: ConstChoice) {
+    pub(crate) fn set_bit(&mut self, index: u32, bit_value: Choice) {
         self.as_mut_uint_ref().set_bit(index, bit_value)
     }
 
@@ -97,11 +97,11 @@ impl BitOps for BoxedUint {
         self.bits()
     }
 
-    fn bit(&self, index: u32) -> ConstChoice {
+    fn bit(&self, index: u32) -> Choice {
         self.bit(index)
     }
 
-    fn set_bit(&mut self, index: u32, bit_value: ConstChoice) {
+    fn set_bit(&mut self, index: u32, bit_value: Choice) {
         self.set_bit(index, bit_value)
     }
 
@@ -137,7 +137,7 @@ impl BitOps for BoxedUint {
 #[cfg(test)]
 mod tests {
     use super::BoxedUint;
-    use crate::ConstChoice;
+    use crate::Choice;
     use hex_literal::hex;
 
     fn uint_with_bits_at(positions: &[u32]) -> BoxedUint {
@@ -175,19 +175,19 @@ mod tests {
     #[test]
     fn set_bit() {
         let mut u = uint_with_bits_at(&[16, 79, 150]);
-        u.set_bit(127, ConstChoice::TRUE);
+        u.set_bit(127, Choice::TRUE);
         assert_eq!(u, uint_with_bits_at(&[16, 79, 127, 150]));
 
         let mut u = uint_with_bits_at(&[16, 79, 150]);
-        u.set_bit(150, ConstChoice::TRUE);
+        u.set_bit(150, Choice::TRUE);
         assert_eq!(u, uint_with_bits_at(&[16, 79, 150]));
 
         let mut u = uint_with_bits_at(&[16, 79, 150]);
-        u.set_bit(127, ConstChoice::FALSE);
+        u.set_bit(127, Choice::FALSE);
         assert_eq!(u, uint_with_bits_at(&[16, 79, 150]));
 
         let mut u = uint_with_bits_at(&[16, 79, 150]);
-        u.set_bit(150, ConstChoice::FALSE);
+        u.set_bit(150, Choice::FALSE);
         assert_eq!(u, uint_with_bits_at(&[16, 79]));
     }
 

--- a/src/uint/boxed/cmp.rs
+++ b/src/uint/boxed/cmp.rs
@@ -5,7 +5,7 @@
 pub(super) use core::cmp::{Ordering, max};
 
 use super::BoxedUint;
-use crate::{ConstChoice, CtEq, CtGt, CtLt, CtSelect, Limb, Uint, word};
+use crate::{Choice, CtEq, CtGt, CtLt, CtSelect, Limb, Uint, word};
 
 impl BoxedUint {
     /// Returns the Ordering between `self` and `rhs` in variable time.
@@ -38,9 +38,9 @@ impl BoxedUint {
 
 impl CtEq for BoxedUint {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> ConstChoice {
+    fn ct_eq(&self, other: &Self) -> Choice {
         let limbs = max(self.nlimbs(), other.nlimbs());
-        let mut ret = ConstChoice::TRUE;
+        let mut ret = Choice::TRUE;
 
         for i in 0..limbs {
             let a = self.limbs.get(i).unwrap_or(&Limb::ZERO);
@@ -54,7 +54,7 @@ impl CtEq for BoxedUint {
 
 impl CtGt for BoxedUint {
     #[inline]
-    fn ct_gt(&self, other: &Self) -> ConstChoice {
+    fn ct_gt(&self, other: &Self) -> Choice {
         let (_, borrow) = other.borrowing_sub(self, Limb::ZERO);
         word::choice_from_mask(borrow.0)
     }
@@ -62,7 +62,7 @@ impl CtGt for BoxedUint {
 
 impl CtLt for BoxedUint {
     #[inline]
-    fn ct_lt(&self, other: &Self) -> ConstChoice {
+    fn ct_lt(&self, other: &Self) -> Choice {
         let (_, borrow) = self.borrowing_sub(other, Limb::ZERO);
         word::choice_from_mask(borrow.0)
     }

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -1,7 +1,7 @@
 //! [`BoxedUint`] division operations.
 
 use crate::{
-    BoxedUint, CheckedDiv, ConstCtOption, CtSelect, Div, DivAssign, DivRemLimb, DivVartime, Limb,
+    BoxedUint, CheckedDiv, CtOption, CtSelect, Div, DivAssign, DivRemLimb, DivVartime, Limb,
     NonZero, Reciprocal, Rem, RemAssign, RemLimb, RemMixed, UintRef, Wrapping,
 };
 
@@ -113,20 +113,20 @@ impl BoxedUint {
         self.div_rem_vartime(rhs).0
     }
 
-    /// Perform checked division, returning a [`ConstCtOption`] which `is_some`
+    /// Perform checked division, returning a [`CtOption`] which `is_some`
     /// only if the rhs != 0
-    pub fn checked_div(&self, rhs: &Self) -> ConstCtOption<Self> {
+    pub fn checked_div(&self, rhs: &Self) -> CtOption<Self> {
         let mut quo = self.clone();
         let is_nz = rhs.is_nonzero();
         let mut rem = Self::one_with_precision(self.bits_precision());
         rem.ct_assign(rhs, is_nz);
         quo.as_mut_uint_ref().div_rem(rem.as_mut_uint_ref());
-        ConstCtOption::new(quo, is_nz)
+        CtOption::new(quo, is_nz)
     }
 }
 
 impl CheckedDiv for BoxedUint {
-    fn checked_div(&self, rhs: &BoxedUint) -> ConstCtOption<Self> {
+    fn checked_div(&self, rhs: &BoxedUint) -> CtOption<Self> {
         self.checked_div(rhs)
     }
 }

--- a/src/uint/boxed/encoding.rs
+++ b/src/uint/boxed/encoding.rs
@@ -1,7 +1,7 @@
 //! Const-friendly decoding operations for [`BoxedUint`].
 
 use super::BoxedUint;
-use crate::{ConstCtOption, CtEq, DecodeError, Encoding, Limb, Word, uint::encoding};
+use crate::{CtEq, CtOption, DecodeError, Encoding, Limb, Word, uint::encoding};
 use alloc::{boxed::Box, string::String, vec::Vec};
 
 #[cfg(feature = "serde")]
@@ -156,7 +156,7 @@ impl BoxedUint {
     }
 
     /// Create a new [`BoxedUint`] from the provided big endian hex string.
-    pub fn from_be_hex(hex: &str, bits_precision: u32) -> ConstCtOption<Self> {
+    pub fn from_be_hex(hex: &str, bits_precision: u32) -> CtOption<Self> {
         let nlimbs = (bits_precision / Limb::BITS) as usize;
         let bytes = hex.as_bytes();
 
@@ -183,7 +183,7 @@ impl BoxedUint {
             i += 1;
         }
 
-        ConstCtOption::new(Self { limbs: res.into() }, err.ct_eq(&0))
+        CtOption::new(Self { limbs: res.into() }, err.ct_eq(&0))
     }
 
     /// Create a new [`BoxedUint`] from a big-endian string in a given base.

--- a/src/uint/boxed/invert_mod.rs
+++ b/src/uint/boxed/invert_mod.rs
@@ -1,24 +1,24 @@
 //! [`BoxedUint`] modular inverse (i.e. reciprocal) operations.
 
 use crate::{
-    BoxedUint, ConstChoice, ConstCtOption, CtEq, CtLt, CtSelect, Integer, InvertMod, Limb, NonZero,
-    Odd, U64, modular::safegcd, uint::invert_mod::expand_invert_mod2k,
+    BoxedUint, Choice, CtEq, CtLt, CtOption, CtSelect, Integer, InvertMod, Limb, NonZero, Odd, U64,
+    modular::safegcd, uint::invert_mod::expand_invert_mod2k,
 };
 
 impl BoxedUint {
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
     #[deprecated(since = "0.7.0", note = "please use `invert_odd_mod` instead")]
-    pub fn inv_odd_mod(&self, modulus: &Odd<Self>) -> ConstCtOption<Self> {
+    pub fn inv_odd_mod(&self, modulus: &Odd<Self>) -> CtOption<Self> {
         self.invert_odd_mod(modulus)
     }
 
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
-    pub fn invert_odd_mod(&self, modulus: &Odd<Self>) -> ConstCtOption<Self> {
+    pub fn invert_odd_mod(&self, modulus: &Odd<Self>) -> CtOption<Self> {
         safegcd::boxed::invert_odd_mod::<false>(self, modulus)
     }
 
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
-    pub fn invert_odd_mod_vartime(&self, modulus: &Odd<Self>) -> ConstCtOption<Self> {
+    pub fn invert_odd_mod_vartime(&self, modulus: &Odd<Self>) -> CtOption<Self> {
         safegcd::boxed::invert_odd_mod::<true>(self, modulus)
     }
 
@@ -28,7 +28,7 @@ impl BoxedUint {
     /// If the inverse does not exist (`k > 0` and `self` is even, or `k > bits_precision()`),
     /// returns `Choice::FALSE` as the second element of the tuple, otherwise returns `Choice::TRUE`.
     #[deprecated(since = "0.7.0", note = "please use `invert_mod2k_vartime` instead")]
-    pub fn inv_mod2k_vartime(&self, k: u32) -> (Self, ConstChoice) {
+    pub fn inv_mod2k_vartime(&self, k: u32) -> (Self, Choice) {
         self.invert_mod2k_vartime(k)
     }
 
@@ -37,13 +37,13 @@ impl BoxedUint {
     ///
     /// If the inverse does not exist (`k > 0` and `self` is even, or `k > bits_precision()`),
     /// returns `Choice::FALSE` as the second element of the tuple, otherwise returns `Choice::TRUE`.
-    pub fn invert_mod2k_vartime(&self, k: u32) -> (Self, ConstChoice) {
+    pub fn invert_mod2k_vartime(&self, k: u32) -> (Self, Choice) {
         let bits = self.bits_precision();
 
         if k == 0 {
-            (Self::zero_with_precision(bits), ConstChoice::TRUE)
+            (Self::zero_with_precision(bits), Choice::TRUE)
         } else if k > bits {
-            (Self::zero_with_precision(bits), ConstChoice::FALSE)
+            (Self::zero_with_precision(bits), Choice::FALSE)
         } else {
             let is_some = self.is_odd();
             let inv = Odd(Self::ct_select(
@@ -61,7 +61,7 @@ impl BoxedUint {
     /// If the inverse does not exist (`k > 0` and `self` is even, or `k > bits_precision()`),
     /// returns `Choice::FALSE` as the second element of the tuple, otherwise returns `Choice::TRUE`.
     #[deprecated(since = "0.7.0", note = "please use `invert_mod2k` instead")]
-    pub fn inv_mod2k(&self, k: u32) -> (Self, ConstChoice) {
+    pub fn inv_mod2k(&self, k: u32) -> (Self, Choice) {
         self.invert_mod2k(k)
     }
 
@@ -69,7 +69,7 @@ impl BoxedUint {
     ///
     /// If the inverse does not exist (`k > 0` and `self` is even, or `k > bits_precision()`),
     /// returns `Choice::FALSE` as the second element of the tuple, otherwise returns `Choice::TRUE`.
-    pub fn invert_mod2k(&self, k: u32) -> (Self, ConstChoice) {
+    pub fn invert_mod2k(&self, k: u32) -> (Self, Choice) {
         let bits = self.bits_precision();
         let is_some = k.ct_lt(&(bits + 1)) & (k.ct_eq(&0) | self.is_odd());
         let mut inv = Odd(Self::ct_select(
@@ -88,7 +88,7 @@ impl BoxedUint {
     ///
     /// TODO: maybe some better documentation is needed
     #[deprecated(since = "0.7.0", note = "please use `invert_mod` instead")]
-    pub fn inv_mod(&self, modulus: &Self) -> ConstCtOption<Self> {
+    pub fn inv_mod(&self, modulus: &Self) -> CtOption<Self> {
         let is_nz = modulus.is_nonzero();
         let m = NonZero(Self::ct_select(
             &Self::one_with_precision(self.bits_precision()),
@@ -99,7 +99,7 @@ impl BoxedUint {
         let is_some = inv_mod_s.is_some();
         let result =
             Option::from(inv_mod_s).unwrap_or(Self::zero_with_precision(self.bits_precision()));
-        ConstCtOption::new(result, is_some & is_nz)
+        CtOption::new(result, is_some & is_nz)
     }
 
     /// Computes the multiplicative inverse of `self` mod `modulus`
@@ -107,7 +107,7 @@ impl BoxedUint {
     /// `self` and `modulus` must have the same number of limbs, or the function will panic
     ///
     /// TODO: maybe some better documentation is needed
-    pub fn invert_mod(&self, modulus: &NonZero<Self>) -> ConstCtOption<Self> {
+    pub fn invert_mod(&self, modulus: &NonZero<Self>) -> CtOption<Self> {
         debug_assert_eq!(self.bits_precision(), modulus.bits_precision());
         let k = modulus.trailing_zeros();
         let s = Odd(modulus.shr(k));
@@ -126,7 +126,7 @@ impl BoxedUint {
         t.restrict_bits(k);
         let result = inv_mod_s.wrapping_add(&s.wrapping_mul(&t));
 
-        ConstCtOption::new(result, is_some)
+        CtOption::new(result, is_some)
     }
 }
 
@@ -174,7 +174,7 @@ impl Odd<BoxedUint> {
 impl InvertMod for BoxedUint {
     type Output = Self;
 
-    fn invert_mod(&self, modulus: &NonZero<Self>) -> ConstCtOption<Self> {
+    fn invert_mod(&self, modulus: &NonZero<Self>) -> CtOption<Self> {
         self.invert_mod(modulus)
     }
 }

--- a/src/uint/boxed/mul.rs
+++ b/src/uint/boxed/mul.rs
@@ -1,7 +1,7 @@
 //! [`BoxedUint`] multiplication operations.
 
 use crate::{
-    BoxedUint, CheckedMul, ConcatenatingMul, ConstCtOption, Limb, Mul, MulAssign, Uint, UintRef,
+    BoxedUint, CheckedMul, ConcatenatingMul, CtOption, Limb, Mul, MulAssign, Uint, UintRef,
     Wrapping, WrappingMul,
     uint::mul::{karatsuba, wrapping_mul_overflow},
 };
@@ -30,11 +30,11 @@ impl BoxedUint {
 
     /// Multiply `self` by `rhs`, wrapping to the width of `self`.
     /// Returns `CtOption::None` if the result overflowed the precision of `self`.
-    pub fn checked_mul(&self, rhs: &Self) -> ConstCtOption<Self> {
+    pub fn checked_mul(&self, rhs: &Self) -> CtOption<Self> {
         let (res, carry) = self.wrapping_mul_carry(rhs.as_limbs(), self.nlimbs());
         let overflow =
             wrapping_mul_overflow(self.as_uint_ref(), self.as_uint_ref(), carry.is_nonzero());
-        ConstCtOption::new(res, overflow.not())
+        CtOption::new(res, overflow.not())
     }
 
     /// Perform saturating multiplication, returning `MAX` on overflow.
@@ -70,11 +70,11 @@ impl BoxedUint {
 
     /// Multiply `self` by itself, wrapping to the width of `self`.
     /// Returns `CtOption::None` if the result overflowed the precision of `self`.
-    pub fn checked_square(&self) -> ConstCtOption<Self> {
+    pub fn checked_square(&self) -> CtOption<Self> {
         let (res, carry) = self.wrapping_square_carry(self.nlimbs());
         let overflow =
             wrapping_mul_overflow(self.as_uint_ref(), self.as_uint_ref(), carry.is_nonzero());
-        ConstCtOption::new(res, overflow.not())
+        CtOption::new(res, overflow.not())
     }
 
     /// Perform saturating squaring, returning `MAX` on overflow.
@@ -98,7 +98,7 @@ impl BoxedUint {
 }
 
 impl CheckedMul for BoxedUint {
-    fn checked_mul(&self, rhs: &BoxedUint) -> ConstCtOption<Self> {
+    fn checked_mul(&self, rhs: &BoxedUint) -> CtOption<Self> {
         self.checked_mul(rhs)
     }
 }

--- a/src/uint/boxed/neg.rs
+++ b/src/uint/boxed/neg.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] negation operations.
 
-use crate::{BoxedUint, ConstChoice, CtNeg, CtSelect, Limb, WideWord, Word, WrappingNeg};
+use crate::{BoxedUint, Choice, CtNeg, CtSelect, Limb, WideWord, Word, WrappingNeg};
 
 impl BoxedUint {
     /// Perform wrapping negation.
@@ -19,7 +19,7 @@ impl BoxedUint {
 
     /// Perform in-place wrapping subtraction, returning the truthy value as the second element of
     /// the tuple if an underflow has occurred.
-    pub(crate) fn conditional_wrapping_neg_assign(&mut self, choice: ConstChoice) {
+    pub(crate) fn conditional_wrapping_neg_assign(&mut self, choice: Choice) {
         let mut carry = 1;
 
         for i in 0..self.nlimbs() {
@@ -31,12 +31,12 @@ impl BoxedUint {
 }
 
 impl CtNeg for BoxedUint {
-    fn ct_neg(&self, choice: ConstChoice) -> Self {
+    fn ct_neg(&self, choice: Choice) -> Self {
         let self_neg = self.wrapping_neg();
         self.ct_select(&self_neg, choice)
     }
 
-    fn ct_neg_assign(&mut self, choice: ConstChoice) {
+    fn ct_neg_assign(&mut self, choice: Choice) {
         let self_neg = self.wrapping_neg();
         self.ct_assign(&self_neg, choice)
     }
@@ -58,13 +58,13 @@ impl subtle::ConditionallyNegatable for BoxedUint {
 
 #[cfg(test)]
 mod tests {
-    use crate::{BoxedUint, ConstChoice, CtNeg};
+    use crate::{BoxedUint, Choice, CtNeg};
 
     #[test]
     fn ct_neg() {
         let a = BoxedUint::from(123u64);
-        assert_eq!(a.ct_neg(ConstChoice::FALSE), a);
-        assert_eq!(a.ct_neg(ConstChoice::TRUE), a.wrapping_neg());
+        assert_eq!(a.ct_neg(Choice::FALSE), a);
+        assert_eq!(a.ct_neg(Choice::TRUE), a.wrapping_neg());
     }
 
     #[test]
@@ -72,10 +72,10 @@ mod tests {
         let mut a = BoxedUint::from(123u64);
         let control = a.clone();
 
-        a.ct_neg_assign(ConstChoice::FALSE);
+        a.ct_neg_assign(Choice::FALSE);
         assert_eq!(a, control);
 
-        a.ct_neg_assign(ConstChoice::TRUE);
+        a.ct_neg_assign(Choice::TRUE);
         assert_ne!(a, control);
         assert_eq!(a, control.wrapping_neg());
     }
@@ -87,10 +87,10 @@ mod tests {
         let mut a = BoxedUint::from(123u64);
         let control = a.clone();
 
-        a.conditional_negate(ConstChoice::FALSE.into());
+        a.conditional_negate(Choice::FALSE.into());
         assert_eq!(a, control);
 
-        a.conditional_negate(ConstChoice::TRUE.into());
+        a.conditional_negate(Choice::TRUE.into());
         assert_ne!(a, control);
         assert_eq!(a, control.wrapping_neg());
     }

--- a/src/uint/boxed/select.rs
+++ b/src/uint/boxed/select.rs
@@ -1,11 +1,11 @@
 //! Constant-time selection support.
 
 use super::BoxedUint;
-use crate::{ConstChoice, CtSelect, Limb};
+use crate::{Choice, CtSelect, Limb};
 
 impl CtSelect for BoxedUint {
     #[inline]
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         debug_assert_eq!(self.bits_precision(), other.bits_precision());
         let mut limbs = vec![Limb::ZERO; self.nlimbs()].into_boxed_slice();
 
@@ -17,7 +17,7 @@ impl CtSelect for BoxedUint {
     }
 
     #[inline]
-    fn ct_assign(&mut self, other: &Self, choice: ConstChoice) {
+    fn ct_assign(&mut self, other: &Self, choice: Choice) {
         debug_assert_eq!(self.bits_precision(), other.bits_precision());
 
         for i in 0..self.nlimbs() {
@@ -26,7 +26,7 @@ impl CtSelect for BoxedUint {
     }
 
     #[inline]
-    fn ct_swap(&mut self, other: &mut Self, choice: ConstChoice) {
+    fn ct_swap(&mut self, other: &mut Self, choice: Choice) {
         debug_assert_eq!(self.bits_precision(), other.bits_precision());
 
         for i in 0..self.nlimbs() {
@@ -37,14 +37,14 @@ impl CtSelect for BoxedUint {
 
 #[cfg(test)]
 mod tests {
-    use crate::{BoxedUint, ConstChoice, CtSelect};
+    use crate::{BoxedUint, Choice, CtSelect};
 
     #[test]
     fn ct_select() {
         let a = BoxedUint::zero_with_precision(128);
         let b = BoxedUint::max(128);
 
-        assert_eq!(a, BoxedUint::ct_select(&a, &b, ConstChoice::FALSE));
-        assert_eq!(b, BoxedUint::ct_select(&a, &b, ConstChoice::TRUE));
+        assert_eq!(a, BoxedUint::ct_select(&a, &b, Choice::FALSE));
+        assert_eq!(b, BoxedUint::ct_select(&a, &b, Choice::TRUE));
     }
 }

--- a/src/uint/boxed/shl.rs
+++ b/src/uint/boxed/shl.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] bitwise left shift operations.
 
-use crate::{BoxedUint, ConstChoice, ConstCtOption, Limb, Shl, ShlAssign, ShlVartime, WrappingShl};
+use crate::{BoxedUint, Choice, CtOption, Limb, Shl, ShlAssign, ShlVartime, WrappingShl};
 
 impl BoxedUint {
     /// Computes `self << shift`.
@@ -24,7 +24,7 @@ impl BoxedUint {
     ///
     /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
     /// or the result and a falsy `Choice` otherwise.
-    pub fn overflowing_shl(&self, shift: u32) -> (Self, ConstChoice) {
+    pub fn overflowing_shl(&self, shift: u32) -> (Self, Choice) {
         let mut result = self.clone();
         let overflow = result.as_mut_uint_ref().overflowing_shl_assign(shift);
         (result, overflow)
@@ -34,7 +34,7 @@ impl BoxedUint {
     ///
     /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
     /// or the result and a falsy `Choice` otherwise.
-    pub fn overflowing_shl_vartime(&self, shift: u32) -> (Self, ConstChoice) {
+    pub fn overflowing_shl_vartime(&self, shift: u32) -> (Self, Choice) {
         let mut result = self.clone();
         let overflow = result
             .as_mut_uint_ref()
@@ -45,14 +45,14 @@ impl BoxedUint {
     /// Computes `self <<= shift`.
     ///
     /// Returns a truthy `Choice` if `shift >= self.bits_precision()` or a falsy `Choice` otherwise.
-    pub fn overflowing_shl_assign(&mut self, shift: u32) -> ConstChoice {
+    pub fn overflowing_shl_assign(&mut self, shift: u32) -> Choice {
         self.as_mut_uint_ref().overflowing_shl_assign(shift)
     }
 
     /// Computes `self <<= shift` in variable-time.
     ///
     /// Returns a truthy `Choice` if `shift >= self.bits_precision()` or a falsy `Choice` otherwise.
-    pub fn overflowing_shl_assign_vartime(&mut self, shift: u32) -> ConstChoice {
+    pub fn overflowing_shl_assign_vartime(&mut self, shift: u32) -> Choice {
         self.as_mut_uint_ref().overflowing_shl_assign_vartime(shift)
     }
 
@@ -123,7 +123,7 @@ impl BoxedUint {
     }
 
     /// Computes `self <<= 1` in constant-time.
-    pub(crate) fn shl1_assign(&mut self) -> ConstChoice {
+    pub(crate) fn shl1_assign(&mut self) -> Choice {
         self.as_mut_uint_ref().shl1_assign()
     }
 }
@@ -167,9 +167,9 @@ impl WrappingShl for BoxedUint {
 }
 
 impl ShlVartime for BoxedUint {
-    fn overflowing_shl_vartime(&self, shift: u32) -> ConstCtOption<Self> {
+    fn overflowing_shl_vartime(&self, shift: u32) -> CtOption<Self> {
         let (result, overflow) = self.overflowing_shl(shift);
-        ConstCtOption::new(result, !overflow)
+        CtOption::new(result, !overflow)
     }
     fn wrapping_shl_vartime(&self, shift: u32) -> Self {
         self.wrapping_shl(shift)

--- a/src/uint/boxed/shr.rs
+++ b/src/uint/boxed/shr.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] bitwise right shift operations.
 
-use crate::{BoxedUint, ConstChoice, ConstCtOption, Limb, Shr, ShrAssign, ShrVartime, WrappingShr};
+use crate::{BoxedUint, Choice, CtOption, Limb, Shr, ShrAssign, ShrVartime, WrappingShr};
 
 impl BoxedUint {
     /// Computes `self >> shift`.
@@ -30,7 +30,7 @@ impl BoxedUint {
     ///
     /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
     /// or the result and a falsy `Choice` otherwise.
-    pub fn overflowing_shr(&self, shift: u32) -> (Self, ConstChoice) {
+    pub fn overflowing_shr(&self, shift: u32) -> (Self, Choice) {
         let mut result = self.clone();
         let overflow = result.overflowing_shr_assign(shift);
         (result, overflow)
@@ -40,7 +40,7 @@ impl BoxedUint {
     ///
     /// Returns a zero and a truthy `Choice` if `shift >= self.bits_precision()`,
     /// or the result and a falsy `Choice` otherwise.
-    pub fn overflowing_shr_vartime(&self, shift: u32) -> (Self, ConstChoice) {
+    pub fn overflowing_shr_vartime(&self, shift: u32) -> (Self, Choice) {
         let mut result = self.clone();
         let overflow = result.overflowing_shr_assign_vartime(shift);
         (result, overflow)
@@ -49,14 +49,14 @@ impl BoxedUint {
     /// Computes `self >>= shift`.
     ///
     /// Returns a truthy `Choice` if `shift >= self.bits_precision()` or a falsy `Choice` otherwise.
-    pub fn overflowing_shr_assign(&mut self, shift: u32) -> ConstChoice {
+    pub fn overflowing_shr_assign(&mut self, shift: u32) -> Choice {
         self.as_mut_uint_ref().overflowing_shr_assign(shift)
     }
 
     /// Computes `self >>= shift` in variable-time.
     ///
     /// Returns a truthy `Choice` if `shift >= self.bits_precision()` or a falsy `Choice` otherwise.
-    pub fn overflowing_shr_assign_vartime(&mut self, shift: u32) -> ConstChoice {
+    pub fn overflowing_shr_assign_vartime(&mut self, shift: u32) -> Choice {
         self.as_mut_uint_ref().overflowing_shr_assign_vartime(shift)
     }
 
@@ -120,7 +120,7 @@ impl BoxedUint {
     }
 
     /// Computes `self >>= 1` in-place in constant-time.
-    pub(crate) fn shr1_assign(&mut self) -> ConstChoice {
+    pub(crate) fn shr1_assign(&mut self) -> Choice {
         self.as_mut_uint_ref().shr1_assign()
     }
 }
@@ -164,9 +164,9 @@ impl WrappingShr for BoxedUint {
 }
 
 impl ShrVartime for BoxedUint {
-    fn overflowing_shr_vartime(&self, shift: u32) -> ConstCtOption<Self> {
+    fn overflowing_shr_vartime(&self, shift: u32) -> CtOption<Self> {
         let (result, overflow) = self.overflowing_shr(shift);
-        ConstCtOption::new(result, !overflow)
+        CtOption::new(result, !overflow)
     }
     fn wrapping_shr_vartime(&self, shift: u32) -> Self {
         self.wrapping_shr(shift)

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] square root operations.
 
-use crate::{BitOps, BoxedUint, ConstCtOption, CtEq, CtGt, CtSelect, Limb, SquareRoot};
+use crate::{BitOps, BoxedUint, CtEq, CtGt, CtOption, CtSelect, Limb, SquareRoot};
 
 impl BoxedUint {
     /// Computes √(`self`) in constant time.
@@ -102,20 +102,20 @@ impl BoxedUint {
         self.sqrt_vartime()
     }
 
-    /// Perform checked sqrt, returning a [`ConstCtOption`] which `is_some`
+    /// Perform checked sqrt, returning a [`CtOption`] which `is_some`
     /// only if the √(`self`)² == self
-    pub fn checked_sqrt(&self) -> ConstCtOption<Self> {
+    pub fn checked_sqrt(&self) -> CtOption<Self> {
         let r = self.sqrt();
         let s = r.wrapping_mul(&r);
-        ConstCtOption::new(r, self.ct_eq(&s))
+        CtOption::new(r, self.ct_eq(&s))
     }
 
-    /// Perform checked sqrt, returning a [`ConstCtOption`] which `is_some`
+    /// Perform checked sqrt, returning a [`CtOption`] which `is_some`
     /// only if the √(`self`)² == self
-    pub fn checked_sqrt_vartime(&self) -> ConstCtOption<Self> {
+    pub fn checked_sqrt_vartime(&self) -> CtOption<Self> {
         let r = self.sqrt_vartime();
         let s = r.wrapping_mul(&r);
-        ConstCtOption::new(r, self.ct_eq(&s))
+        CtOption::new(r, self.ct_eq(&s))
     }
 }
 

--- a/src/uint/boxed/sub.rs
+++ b/src/uint/boxed/sub.rs
@@ -1,8 +1,8 @@
 //! [`BoxedUint`] subtraction operations.
 
 use crate::{
-    BoxedUint, CheckedSub, ConstChoice, ConstCtOption, CtSelect, Limb, Sub, SubAssign, U64, U128,
-    Uint, Wrapping, WrappingSub,
+    BoxedUint, CheckedSub, Choice, CtOption, CtSelect, Limb, Sub, SubAssign, U64, U128, Uint,
+    Wrapping, WrappingSub,
 };
 
 impl BoxedUint {
@@ -53,8 +53,8 @@ impl BoxedUint {
     pub(crate) fn conditional_borrowing_sub_assign(
         &mut self,
         rhs: &Self,
-        choice: ConstChoice,
-    ) -> ConstChoice {
+        choice: Choice,
+    ) -> Choice {
         debug_assert!(self.bits_precision() <= rhs.bits_precision());
         let mask = Limb::ct_select(&Limb::ZERO, &Limb::MAX, choice);
         let mut borrow = Limb::ZERO;
@@ -66,14 +66,14 @@ impl BoxedUint {
             borrow = b;
         }
 
-        ConstChoice::new((borrow.0 & 1) as u8)
+        Choice::new((borrow.0 & 1) as u8)
     }
 }
 
 impl CheckedSub for BoxedUint {
-    fn checked_sub(&self, rhs: &Self) -> ConstCtOption<Self> {
+    fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
         let (result, carry) = self.borrowing_sub(rhs, Limb::ZERO);
-        ConstCtOption::new(result, carry.is_zero())
+        CtOption::new(result, carry.is_zero())
     }
 }
 

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -3,13 +3,13 @@
 //! By default, these are all constant-time.
 
 use super::Uint;
-use crate::{ConstChoice, CtEq, CtGt, CtLt, Limb, word};
+use crate::{Choice, CtEq, CtGt, CtLt, Limb, word};
 use core::cmp::Ordering;
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Returns the truthy value if `self`!=0 or the falsy value otherwise.
     #[inline]
-    pub(crate) const fn is_nonzero(&self) -> ConstChoice {
+    pub(crate) const fn is_nonzero(&self) -> Choice {
         let mut b = 0;
         let mut i = 0;
         while i < LIMBS {
@@ -33,13 +33,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Returns the truthy value if `self` is odd or the falsy value otherwise.
-    pub(crate) const fn is_odd(&self) -> ConstChoice {
+    pub(crate) const fn is_odd(&self) -> Choice {
         word::choice_from_lsb(self.limbs[0].0 & 1)
     }
 
     /// Returns the truthy value if `self == rhs` or the falsy value otherwise.
     #[inline]
-    pub(crate) const fn eq(lhs: &Self, rhs: &Self) -> ConstChoice {
+    pub(crate) const fn eq(lhs: &Self, rhs: &Self) -> Choice {
         let mut acc = 0;
         let mut i = 0;
 
@@ -54,7 +54,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Returns the truthy value if `self < rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn lt(lhs: &Self, rhs: &Self) -> ConstChoice {
+    pub(crate) const fn lt(lhs: &Self, rhs: &Self) -> Choice {
         // We could use the same approach as in Limb::ct_lt(),
         // but since we have to use Uint::wrapping_sub(), which calls `borrowing_sub()`,
         // there are no savings compared to just calling `borrowing_sub()` directly.
@@ -64,13 +64,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Returns the truthy value if `self <= rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn lte(lhs: &Self, rhs: &Self) -> ConstChoice {
+    pub(crate) const fn lte(lhs: &Self, rhs: &Self) -> Choice {
         Self::gt(lhs, rhs).not()
     }
 
     /// Returns the truthy value if `self > rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn gt(lhs: &Self, rhs: &Self) -> ConstChoice {
+    pub(crate) const fn gt(lhs: &Self, rhs: &Self) -> Choice {
         let (_res, borrow) = rhs.borrowing_sub(lhs, Limb::ZERO);
         word::choice_from_mask(borrow.0)
     }
@@ -118,21 +118,21 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
 impl<const LIMBS: usize> CtEq for Uint<LIMBS> {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> ConstChoice {
+    fn ct_eq(&self, other: &Self) -> Choice {
         self.limbs.ct_eq(&other.limbs)
     }
 }
 
 impl<const LIMBS: usize> CtGt for Uint<LIMBS> {
     #[inline]
-    fn ct_gt(&self, other: &Self) -> ConstChoice {
+    fn ct_gt(&self, other: &Self) -> Choice {
         Self::gt(self, other)
     }
 }
 
 impl<const LIMBS: usize> CtLt for Uint<LIMBS> {
     #[inline]
-    fn ct_lt(&self, other: &Self) -> ConstChoice {
+    fn ct_lt(&self, other: &Self) -> Choice {
         Self::lt(self, other)
     }
 }
@@ -193,7 +193,7 @@ impl<const LIMBS: usize> subtle::ConstantTimeLess for Uint<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, CtEq, CtGt, CtLt, Integer, U128, Uint};
+    use crate::{Choice, CtEq, CtGt, CtLt, Integer, U128, Uint};
     use core::cmp::Ordering;
 
     #[test]
@@ -327,11 +327,11 @@ mod tests {
         let mut a = U128::ZERO;
         let mut b = U128::MAX;
 
-        Uint::conditional_swap(&mut a, &mut b, ConstChoice::FALSE);
+        Uint::conditional_swap(&mut a, &mut b, Choice::FALSE);
         assert_eq!(a, Uint::ZERO);
         assert_eq!(b, Uint::MAX);
 
-        Uint::conditional_swap(&mut a, &mut b, ConstChoice::TRUE);
+        Uint::conditional_swap(&mut a, &mut b, Choice::TRUE);
         assert_eq!(a, Uint::MAX);
         assert_eq!(b, Uint::ZERO);
     }

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -2,8 +2,8 @@
 
 use super::div_limb::Reciprocal;
 use crate::{
-    CheckedDiv, ConstCtOption, Div, DivAssign, DivRemLimb, DivVartime, Limb, NonZero, Rem,
-    RemAssign, RemLimb, Uint, UintRef, Wrapping,
+    CheckedDiv, CtOption, Div, DivAssign, DivRemLimb, DivVartime, Limb, NonZero, Rem, RemAssign,
+    RemLimb, Uint, UintRef, Wrapping,
 };
 
 impl<const LIMBS: usize> Uint<LIMBS> {
@@ -154,7 +154,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         self.div_rem_vartime(rhs).0
     }
 
-    /// Perform checked division, returning a [`ConstCtOption`] which `is_some`
+    /// Perform checked division, returning a [`CtOption`] which `is_some`
     /// only if the rhs != 0.
     ///
     /// ### Usage:
@@ -172,10 +172,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// let zero = U448::from(0_u64);
     /// assert!(a.checked_div(&zero).is_none().to_bool(), "should be None for division by zero");
     /// ```
-    pub fn checked_div<const RHS_LIMBS: usize>(
-        &self,
-        rhs: &Uint<RHS_LIMBS>,
-    ) -> ConstCtOption<Self> {
+    pub fn checked_div<const RHS_LIMBS: usize>(&self, rhs: &Uint<RHS_LIMBS>) -> CtOption<Self> {
         NonZero::new(*rhs).map(|rhs| {
             let (q, _r) = self.div_rem(&rhs);
             q
@@ -200,7 +197,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         self.rem_vartime(&nz_rhs)
     }
 
-    /// Perform checked reduction, returning a [`ConstCtOption`] which `is_some`
+    /// Perform checked reduction, returning a [`CtOption`] which `is_some`
     /// only if the rhs != 0
     ///
     /// ### Usage:
@@ -221,10 +218,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     pub fn checked_rem<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
-    ) -> ConstCtOption<Uint<RHS_LIMBS>> {
+    ) -> CtOption<Uint<RHS_LIMBS>> {
         // TODO(tarcieri): proper constant-time operation
         if rhs.is_zero().to_bool() {
-            return ConstCtOption::none();
+            return CtOption::none();
         }
 
         NonZero::new(*rhs).map(|rhs| self.rem(&rhs))
@@ -418,7 +415,7 @@ impl<const LIMBS: usize> RemAssign<&NonZero<Limb>> for Wrapping<Uint<LIMBS>> {
 //
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> CheckedDiv<Uint<RHS_LIMBS>> for Uint<LIMBS> {
-    fn checked_div(&self, rhs: &Uint<RHS_LIMBS>) -> ConstCtOption<Self> {
+    fn checked_div(&self, rhs: &Uint<RHS_LIMBS>) -> CtOption<Self> {
         self.checked_div(rhs)
     }
 }

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -3,7 +3,7 @@
 //! (DOI: 10.1109/TC.2010.143, <https://gmplib.org/~tege/division-paper.pdf>).
 
 use crate::{
-    ConstChoice, CtSelect, Limb, NonZero, Uint, WideWord, Word,
+    Choice, CtSelect, Limb, NonZero, Uint, WideWord, Word,
     primitives::{addhilo, widening_mul},
     word,
 };
@@ -36,7 +36,7 @@ pub const fn reciprocal(d: Word) -> Word {
     // Hence the `ct_select()`.
     let x = v2.wrapping_add(1);
     let (_lo, hi) = widening_mul(x, d);
-    let hi = word::select(d, hi, ConstChoice::from_u32_nz(x));
+    let hi = word::select(d, hi, Choice::from_u32_nz(x));
 
     v2.wrapping_sub(hi).wrapping_sub(d)
 }
@@ -90,7 +90,7 @@ const fn short_div(mut dividend: u32, dividend_bits: u32, divisor: u32, divisor_
 
     while i > 0 {
         i -= 1;
-        let bit = ConstChoice::from_u32_lt(dividend, divisor);
+        let bit = Choice::from_u32_lt(dividend, divisor);
         dividend = bit.select_u32(dividend.wrapping_sub(divisor), dividend);
         divisor >>= 1;
         quotient |= bit.not().select_u32(0, 1 << i);
@@ -226,7 +226,7 @@ impl Reciprocal {
 }
 
 impl CtSelect for Reciprocal {
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         Self {
             divisor_normalized: Word::ct_select(
                 &self.divisor_normalized,

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -15,7 +15,7 @@ use super::Uint;
 use crate::{DecodeError, Encoding, Limb, Word};
 
 #[cfg(feature = "alloc")]
-use crate::{ConstChoice, NonZero, Reciprocal, UintRef, WideWord};
+use crate::{Choice, NonZero, Reciprocal, UintRef, WideWord};
 
 #[cfg(feature = "alloc")]
 const RADIX_ENCODING_LIMBS_LARGE: usize = 16;
@@ -785,7 +785,7 @@ impl RadixDivisionParams {
                     div_large,
                     RADIX_ENCODING_LIMBS_LARGE as u32,
                     self.recip_large,
-                    ConstChoice::TRUE,
+                    Choice::TRUE,
                 );
                 let limbs_rem;
                 // At this point, the limbs at and above RADIX_ENCODING_LIMBS_LARGE represent

--- a/src/uint/gcd.rs
+++ b/src/uint/gcd.rs
@@ -3,7 +3,7 @@
 use crate::modular::bingcd::xgcd::PatternXgcdOutput;
 use crate::modular::safegcd;
 use crate::primitives::u32_min;
-use crate::{ConstChoice, Gcd, Int, NonZero, NonZeroUint, Odd, OddUint, Uint, Xgcd};
+use crate::{Choice, Gcd, Int, NonZero, NonZeroUint, Odd, OddUint, Uint, Xgcd};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Compute the greatest common divisor of `self` and `rhs`.
@@ -122,7 +122,7 @@ impl<const LIMBS: usize> NonZeroUint<LIMBS> {
         rhs = rhs.shr(k);
 
         // At this point, either lhs or rhs is odd (or both); swap to make sure lhs is odd.
-        let swap = ConstChoice::from_u32_lt(j, i);
+        let swap = Choice::from_u32_lt(j, i);
         Uint::conditional_swap(&mut lhs, &mut rhs, swap);
         let lhs = lhs.to_odd().expect_copied("odd by construction");
         let rhs = rhs.to_nz().expect_copied("non-zero by construction");
@@ -262,11 +262,7 @@ impl<const LIMBS: usize> OddUintXgcdOutput<LIMBS> {
         }
     }
 
-    pub(crate) const fn to_nz_output(
-        self,
-        k: u32,
-        swap: ConstChoice,
-    ) -> NonZeroUintXgcdOutput<LIMBS> {
+    pub(crate) const fn to_nz_output(self, k: u32, swap: Choice) -> NonZeroUintXgcdOutput<LIMBS> {
         let Self {
             ref gcd,
             mut x,

--- a/src/uint/mul_int.rs
+++ b/src/uint/mul_int.rs
@@ -1,4 +1,4 @@
-use crate::{ConcatMixed, ConstChoice, ConstCtOption, Int, Uint};
+use crate::{Choice, ConcatMixed, CtOption, Int, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Compute "wide" multiplication between an [`Uint`] and [`Int`] as 3-tuple `(lo, hi, negate)`.
@@ -10,7 +10,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     pub const fn widening_mul_int<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
-    ) -> (Uint<LIMBS>, Uint<RHS_LIMBS>, ConstChoice) {
+    ) -> (Uint<LIMBS>, Uint<RHS_LIMBS>, Choice) {
         let (rhs_abs, rhs_sgn) = rhs.abs_sign();
         let (lo, hi) = self.widening_mul(&rhs_abs);
         (lo, hi, rhs_sgn)
@@ -35,7 +35,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     pub fn checked_mul_int<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
-    ) -> ConstCtOption<Int<LIMBS>> {
+    ) -> CtOption<Int<LIMBS>> {
         let (abs_rhs, rhs_sgn) = rhs.abs_sign();
         let maybe_res = self.checked_mul(&abs_rhs);
         Int::new_from_abs_opt_sign(maybe_res, rhs_sgn)
@@ -44,7 +44,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, I64, I128, I256, U64, U128};
+    use crate::{Choice, I64, I128, I256, U64, U128};
 
     #[test]
     fn widening_mul_int() {
@@ -53,7 +53,7 @@ mod tests {
             (
                 U128::from_be_hex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC9"),
                 U64::from_u64(54),
-                ConstChoice::TRUE
+                Choice::TRUE
             )
         )
     }

--- a/src/uint/neg.rs
+++ b/src/uint/neg.rs
@@ -1,4 +1,4 @@
-use crate::{ConstChoice, Limb, Uint, WideWord, Word, WrappingNeg, word};
+use crate::{Choice, Limb, Uint, WideWord, Word, WrappingNeg, word};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Perform wrapping negation.
@@ -10,7 +10,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Additionally return whether the carry flag is set on the addition.
     ///
     /// Note: the carry is set if and only if `self == Self::ZERO`.
-    pub const fn carrying_neg(&self) -> (Self, ConstChoice) {
+    pub const fn carrying_neg(&self) -> (Self, Choice) {
         let mut ret = [Limb::ZERO; LIMBS];
         let mut carry = 1;
         let mut i = 0;
@@ -24,7 +24,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Perform wrapping negation, if `negate` is truthy. Otherwise, return `self`.
-    pub const fn wrapping_neg_if(&self, negate: ConstChoice) -> Self {
+    pub const fn wrapping_neg_if(&self, negate: Choice) -> Self {
         Uint::select(self, &self.wrapping_neg(), negate)
     }
 }
@@ -38,7 +38,7 @@ impl<const LIMBS: usize> WrappingNeg for Uint<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, U256};
+    use crate::{Choice, U256};
 
     #[test]
     fn wrapping_neg() {
@@ -56,19 +56,19 @@ mod tests {
 
     #[test]
     fn carrying_neg() {
-        assert_eq!(U256::ZERO.carrying_neg(), (U256::ZERO, ConstChoice::TRUE));
-        assert_eq!(U256::ONE.carrying_neg(), (U256::MAX, ConstChoice::FALSE));
-        assert_eq!(U256::MAX.carrying_neg(), (U256::ONE, ConstChoice::FALSE));
+        assert_eq!(U256::ZERO.carrying_neg(), (U256::ZERO, Choice::TRUE));
+        assert_eq!(U256::ONE.carrying_neg(), (U256::MAX, Choice::FALSE));
+        assert_eq!(U256::MAX.carrying_neg(), (U256::ONE, Choice::FALSE));
     }
 
     #[test]
     fn wrapping_neg_if() {
-        let negate = ConstChoice::TRUE;
+        let negate = Choice::TRUE;
         assert_eq!(U256::ZERO.wrapping_neg_if(negate), U256::ZERO);
         assert_eq!(U256::ONE.wrapping_neg_if(negate), U256::MAX);
         assert_eq!(U256::MAX.wrapping_neg_if(negate), U256::ONE);
 
-        let do_not_negate = ConstChoice::FALSE;
+        let do_not_negate = Choice::FALSE;
         assert_eq!(U256::ZERO.wrapping_neg_if(do_not_negate), U256::ZERO);
         assert_eq!(U256::ONE.wrapping_neg_if(do_not_negate), U256::ONE);
         assert_eq!(U256::MAX.wrapping_neg_if(do_not_negate), U256::MAX);

--- a/src/uint/ref_type.rs
+++ b/src/uint/ref_type.rs
@@ -1,6 +1,6 @@
 //! Unsigned integer reference type.
 
-use crate::{ConstChoice, Limb, Uint};
+use crate::{Choice, Limb, Uint};
 use core::{
     fmt,
     ops::{Index, IndexMut},
@@ -110,7 +110,7 @@ impl UintRef {
 
     /// Conditionally assign all of the limbs to zero.
     #[inline(always)]
-    pub const fn conditional_set_zero(&mut self, choice: ConstChoice) {
+    pub const fn conditional_set_zero(&mut self, choice: Choice) {
         let mut i = 0;
         while i < self.nlimbs() {
             self.0[i] = Limb::select(self.0[i], Limb::ZERO, choice);
@@ -121,7 +121,7 @@ impl UintRef {
     /// Conditionally assign all of the limbs to the maximum.
     #[cfg(feature = "alloc")]
     #[inline]
-    pub const fn conditional_set_max(&mut self, choice: ConstChoice) {
+    pub const fn conditional_set_max(&mut self, choice: Choice) {
         let mut i = 0;
         while i < self.nlimbs() {
             self.0[i] = Limb::select(self.0[i], Limb::MAX, choice);

--- a/src/uint/ref_type/add.rs
+++ b/src/uint/ref_type/add.rs
@@ -1,5 +1,5 @@
 use super::UintRef;
-use crate::{ConstChoice, Limb};
+use crate::{Choice, Limb};
 
 impl UintRef {
     /// Perform an in-place carrying add of a limb, returning the carried limb value.
@@ -44,7 +44,7 @@ impl UintRef {
         &mut self,
         rhs: &Self,
         carry: Limb,
-        choice: ConstChoice,
+        choice: Choice,
     ) -> Limb {
         self.conditional_add_assign_slice(rhs.as_slice(), carry, choice)
     }
@@ -56,7 +56,7 @@ impl UintRef {
         &mut self,
         rhs: &[Limb],
         mut carry: Limb,
-        choice: ConstChoice,
+        choice: Choice,
     ) -> Limb {
         assert!(
             self.0.len() == rhs.len(),

--- a/src/uint/ref_type/bits.rs
+++ b/src/uint/ref_type/bits.rs
@@ -1,5 +1,5 @@
 use super::UintRef;
-use crate::{ConstChoice, Limb, traits::BitOps, word};
+use crate::{Choice, Limb, traits::BitOps, word};
 
 impl UintRef {
     /// Get the precision of this number in bits.
@@ -7,10 +7,10 @@ impl UintRef {
         self.0.len() as u32 * Limb::BITS
     }
 
-    /// Get the value of the bit at position `index`, as a truthy or falsy [`ConstChoice`].
+    /// Get the value of the bit at position `index`, as a truthy or falsy [`Choice`].
     /// Returns the falsy value for indices out of range.
     #[inline(always)]
-    pub const fn bit(&self, index: u32) -> ConstChoice {
+    pub const fn bit(&self, index: u32) -> Choice {
         let limb_num = index / Limb::BITS;
         let index_in_limb = index % Limb::BITS;
         let index_mask = 1 << index_in_limb;
@@ -19,7 +19,7 @@ impl UintRef {
         let mut i = 0;
         while i < self.0.len() {
             let bit = self.0[i].0 & index_mask;
-            let is_right_limb = ConstChoice::from_u32_eq(i as u32, limb_num);
+            let is_right_limb = Choice::from_u32_eq(i as u32, limb_num);
             result |= word::select(0, bit, is_right_limb);
             i += 1;
         }
@@ -67,14 +67,14 @@ impl UintRef {
 
     /// Sets the bit at `index` to 0 or 1 depending on the value of `bit_value`.
     #[inline(always)]
-    pub const fn set_bit(&mut self, index: u32, bit_value: ConstChoice) {
+    pub const fn set_bit(&mut self, index: u32, bit_value: Choice) {
         let limb_num = index / Limb::BITS;
         let index_in_limb = index % Limb::BITS;
         let index_mask = 1 << index_in_limb;
 
         let mut i = 0;
         while i < self.0.len() {
-            let is_right_limb = ConstChoice::from_u32_eq(i as u32, limb_num);
+            let is_right_limb = Choice::from_u32_eq(i as u32, limb_num);
             let old_limb = self.0[i].0;
             let new_limb = word::select(old_limb & !index_mask, old_limb | index_mask, bit_value);
             self.0[i] = Limb(word::select(old_limb, new_limb, is_right_limb));
@@ -99,7 +99,7 @@ impl UintRef {
     pub const fn leading_zeros(&self) -> u32 {
         let mut count = 0;
         let mut i = self.0.len();
-        let mut nonzero_limb_not_encountered = ConstChoice::TRUE;
+        let mut nonzero_limb_not_encountered = Choice::TRUE;
         while i > 0 {
             i -= 1;
             let l = self.0[i];
@@ -117,7 +117,7 @@ impl UintRef {
     pub const fn trailing_zeros(&self) -> u32 {
         let mut count = 0;
         let mut i = 0;
-        let mut nonzero_limb_not_encountered = ConstChoice::TRUE;
+        let mut nonzero_limb_not_encountered = Choice::TRUE;
         while i < self.0.len() {
             let l = self.0[i];
             let z = l.trailing_zeros();
@@ -154,7 +154,7 @@ impl UintRef {
     pub const fn trailing_ones(&self) -> u32 {
         let mut count = 0;
         let mut i = 0;
-        let mut nonmax_limb_not_encountered = ConstChoice::TRUE;
+        let mut nonmax_limb_not_encountered = Choice::TRUE;
         while i < self.0.len() {
             let l = self.0[i];
             let z = l.trailing_ones();
@@ -191,9 +191,9 @@ impl UintRef {
         let limb = len / Limb::BITS;
         let limb_mask = Limb((1 << (len % Limb::BITS)) - 1);
         let mut i = 0;
-        let mut clear = ConstChoice::FALSE;
+        let mut clear = Choice::FALSE;
         while i < self.nlimbs() {
-            let apply = ConstChoice::from_u32_eq(i as u32, limb);
+            let apply = Choice::from_u32_eq(i as u32, limb);
             self.0[i] = self.0[i].bitand(Limb::select(
                 Limb(word::choice_to_mask(clear.not())),
                 limb_mask,
@@ -220,11 +220,11 @@ impl BitOps for UintRef {
         self.leading_zeros()
     }
 
-    fn bit(&self, index: u32) -> ConstChoice {
+    fn bit(&self, index: u32) -> Choice {
         self.bit(index)
     }
 
-    fn set_bit(&mut self, index: u32, bit_value: ConstChoice) {
+    fn set_bit(&mut self, index: u32, bit_value: Choice) {
         self.set_bit(index, bit_value);
     }
 

--- a/src/uint/select.rs
+++ b/src/uint/select.rs
@@ -1,11 +1,11 @@
 //! Constant-time selection support.
 
-use crate::{ConstChoice, CtSelect, Limb, Uint};
+use crate::{Choice, CtSelect, Limb, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
-    pub(crate) const fn select(a: &Self, b: &Self, c: ConstChoice) -> Self {
+    pub(crate) const fn select(a: &Self, b: &Self, c: Choice) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
 
         let mut i = 0;
@@ -19,7 +19,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Swap `a` and `b` if `c` is truthy, otherwise, do nothing.
     #[inline]
-    pub(crate) const fn conditional_swap(a: &mut Self, b: &mut Self, c: ConstChoice) {
+    pub(crate) const fn conditional_swap(a: &mut Self, b: &mut Self, c: Choice) {
         let mut i = 0;
         let a = a.as_mut_limbs();
         let b = b.as_mut_limbs();
@@ -32,13 +32,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Swap `a` and `b`
     #[inline]
     pub(crate) const fn swap(a: &mut Self, b: &mut Self) {
-        Self::conditional_swap(a, b, ConstChoice::TRUE)
+        Self::conditional_swap(a, b, Choice::TRUE)
     }
 }
 
 impl<const LIMBS: usize> CtSelect for Uint<LIMBS> {
     #[inline]
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         Self {
             limbs: self.limbs.ct_select(&other.limbs, choice),
         }
@@ -55,17 +55,17 @@ impl<const LIMBS: usize> subtle::ConditionallySelectable for Uint<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ConstChoice, CtSelect, U128};
+    use crate::{Choice, CtSelect, U128};
 
     #[test]
     fn ct_select() {
         let a = U128::from_be_hex("00002222444466668888AAAACCCCEEEE");
         let b = U128::from_be_hex("11113333555577779999BBBBDDDDFFFF");
 
-        let select_0 = U128::ct_select(&a, &b, ConstChoice::FALSE);
+        let select_0 = U128::ct_select(&a, &b, Choice::FALSE);
         assert_eq!(a, select_0);
 
-        let select_1 = U128::ct_select(&a, &b, ConstChoice::TRUE);
+        let select_1 = U128::ct_select(&a, &b, Choice::TRUE);
         assert_eq!(b, select_1);
     }
 }

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -1,6 +1,6 @@
 //! [`Uint`] square root operations.
 
-use crate::{ConstCtOption, CtEq, NonZero, SquareRoot, Uint};
+use crate::{CtEq, CtOption, NonZero, SquareRoot, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes √(`self`) in constant time.
@@ -90,20 +90,20 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         self.sqrt_vartime()
     }
 
-    /// Perform checked sqrt, returning a [`ConstCtOption`] which `is_some`
+    /// Perform checked sqrt, returning a [`CtOption`] which `is_some`
     /// only if the √(`self`)² == self
-    pub fn checked_sqrt(&self) -> ConstCtOption<Self> {
+    pub fn checked_sqrt(&self) -> CtOption<Self> {
         let r = self.sqrt();
         let s = r.wrapping_mul(&r);
-        ConstCtOption::new(r, self.ct_eq(&s))
+        CtOption::new(r, self.ct_eq(&s))
     }
 
-    /// Perform checked sqrt, returning a [`ConstCtOption`] which `is_some`
+    /// Perform checked sqrt, returning a [`CtOption`] which `is_some`
     /// only if the √(`self`)² == self
-    pub fn checked_sqrt_vartime(&self) -> ConstCtOption<Self> {
+    pub fn checked_sqrt_vartime(&self) -> CtOption<Self> {
         let r = self.sqrt_vartime();
         let s = r.wrapping_mul(&r);
-        ConstCtOption::new(r, self.ct_eq(&s))
+        CtOption::new(r, self.ct_eq(&s))
     }
 }
 

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -1,9 +1,7 @@
 //! [`Uint`] subtraction operations.
 
 use super::Uint;
-use crate::{
-    Checked, CheckedSub, ConstCtOption, Limb, Sub, SubAssign, Wrapping, WrappingSub, word,
-};
+use crate::{Checked, CheckedSub, CtOption, Limb, Sub, SubAssign, Wrapping, WrappingSub, word};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self - (rhs + borrow)`, returning the result along with the new borrow.
@@ -42,9 +40,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 }
 
 impl<const LIMBS: usize> CheckedSub for Uint<LIMBS> {
-    fn checked_sub(&self, rhs: &Self) -> ConstCtOption<Self> {
+    fn checked_sub(&self, rhs: &Self) -> CtOption<Self> {
         let (result, underflow) = self.borrowing_sub(rhs, Limb::ZERO);
-        ConstCtOption::new(result, underflow.is_zero())
+        CtOption::new(result, underflow.is_zero())
     }
 }
 

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -1,8 +1,8 @@
 //! Wrapping arithmetic.
 
 use crate::{
-    ConstChoice, CtEq, CtSelect, One, WrappingAdd, WrappingMul, WrappingNeg, WrappingShl,
-    WrappingShr, WrappingSub, Zero,
+    Choice, CtEq, CtSelect, One, WrappingAdd, WrappingMul, WrappingNeg, WrappingShl, WrappingShr,
+    WrappingSub, Zero,
 };
 use core::{
     fmt,
@@ -189,7 +189,7 @@ where
     T: CtEq,
 {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> ConstChoice {
+    fn ct_eq(&self, other: &Self) -> Choice {
         CtEq::ct_eq(&self.0, &other.0)
     }
 }
@@ -199,7 +199,7 @@ where
     T: CtSelect,
 {
     #[inline]
-    fn ct_select(&self, other: &Self, choice: ConstChoice) -> Self {
+    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         Self(self.0.ct_select(&other.0, choice))
     }
 }

--- a/tests/boxed_uint.rs
+++ b/tests/boxed_uint.rs
@@ -6,7 +6,7 @@ mod common;
 
 use common::to_biguint;
 use crypto_bigint::{
-    BitOps, BoxedUint, CheckedAdd, ConstChoice, Gcd, Integer, Limb, NonZero, Odd, Resize,
+    BitOps, BoxedUint, CheckedAdd, Choice, Gcd, Integer, Limb, NonZero, Odd, Resize,
 };
 use num_bigint::BigUint;
 use num_integer::Integer as _;
@@ -139,7 +139,7 @@ proptest! {
 
     #[test]
     fn invert_mod2k(mut a in uint(), k in any::<u32>()) {
-        a.set_bit(0, ConstChoice::TRUE); // make odd
+        a.set_bit(0, Choice::TRUE); // make odd
         let k = k % (a.bits() + 1);
         let a_bi = to_biguint(&a);
         let m_bi = BigUint::one() << k as usize;

--- a/tests/monty_form.rs
+++ b/tests/monty_form.rs
@@ -4,7 +4,7 @@ mod common;
 
 use common::to_biguint;
 use crypto_bigint::{
-    Bounded, ConstCtOption, Constants, EncodedUint, Encoding, Integer, Invert, Monty, NonZero, Odd,
+    Bounded, Constants, CtOption, EncodedUint, Encoding, Integer, Invert, Monty, NonZero, Odd,
     U128, U256, U512, U1024, U2048, U4096, Unsigned,
     modular::{MontyForm, MontyParams},
 };
@@ -50,7 +50,7 @@ fn random_invertible_uint<T>(
 ) -> Result<(T, <T as Unsigned>::Monty, <T as Unsigned>::Monty, BigUint), TestCaseError>
 where
     T: Unsigned + Bounded + Encoding,
-    <T as Unsigned>::Monty: Invert<Output = ConstCtOption<T::Monty>>,
+    <T as Unsigned>::Monty: Invert<Output = CtOption<T::Monty>>,
 {
     let r = T::from_be_bytes(bytes.clone());
     let rm = <T as Unsigned>::Monty::new(r.clone(), monty_params);


### PR DESCRIPTION
At long last, the split is healed and we have one `Choice` and one `CtOption` type that can both do it all.

The implementation of both actually contains large parts of the old `ConstChoice` and `ConstCtOption` types extracted into the `ctutils` crate, along with more `subtle`-like functionality.

This commit renames all of the following usages:
- `ConstChoice` => `Choice`
- `ConstCtOption` => `CtOption`

For legacy compatibility, deprecated type aliases are made available for the old names, pointing to the new ones.