### PR TITLE
Add `getrandom` feature and `Random` trait support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "criterion",
  "ctutils",
  "der",
+ "getrandom 0.4.0-rc.0",
  "hex-literal",
  "hybrid-array",
  "num-bigint",
@@ -298,6 +299,19 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b99f0d993a2b9b97b9a201193aa8ad21305cde06a3be9a7e1f8f4201e5cc27e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.0-rc-3",
+ "wasip2",
 ]
 
 [[package]]
@@ -538,7 +552,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -733,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -792,7 +806,16 @@ version = "0.14.3+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.45.0",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen 0.46.0",
 ]
 
 [[package]]
@@ -957,6 +980,12 @@ name = "wit-bindgen"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ num-traits = { version = "0.2.19", default-features = false }
 # optional dependencies
 der = { version = "0.8.0-rc.10", optional = true, default-features = false }
 hybrid-array = { version = "0.4.5", optional = true }
+getrandom = { version = "0.4.0-rc.0", optional = true, features = ["sys_rng"] }
 rand_core = { version = "0.10.0-rc-3", optional = true, default-features = false }
 rlp = { version = "0.6", optional = true, default-features = false }
 serdect = { version = "0.4", optional = true, default-features = false }
@@ -44,6 +45,7 @@ default = ["rand"]
 alloc = ["serdect?/alloc"]
 
 extra-sizes = []
+getrandom = ["dep:getrandom", "rand"]
 rand = ["rand_core"]
 serde = ["dep:serdect"]
 subtle = ["dep:subtle", "ctutils/subtle", "hybrid-array?/subtle"]

--- a/benches/const_monty.rs
+++ b/benches/const_monty.rs
@@ -29,7 +29,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
 
     group.bench_function("ConstMontyForm retrieve", |b| {
         b.iter_batched(
-            || ConstMontyForm::random(&mut rng),
+            || ConstMontyForm::random_from_rng(&mut rng),
             |x| black_box(x.retrieve()),
             BatchSize::SmallInput,
         )
@@ -42,8 +42,8 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("add, U256", |b| {
         b.iter_batched(
             || {
-                let a = ConstMontyForm::random(&mut rng);
-                let b = ConstMontyForm::random(&mut rng);
+                let a = ConstMontyForm::random_from_rng(&mut rng);
+                let b = ConstMontyForm::random_from_rng(&mut rng);
                 (a, b)
             },
             |(a, b)| black_box(a).add(&black_box(b)),
@@ -53,7 +53,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 
     group.bench_function("double, U256", |b| {
         b.iter_batched(
-            || ConstMontyForm::random(&mut rng),
+            || ConstMontyForm::random_from_rng(&mut rng),
             |a| black_box(a).double(),
             BatchSize::SmallInput,
         )
@@ -62,8 +62,8 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("sub, U256", |b| {
         b.iter_batched(
             || {
-                let a = ConstMontyForm::random(&mut rng);
-                let b = ConstMontyForm::random(&mut rng);
+                let a = ConstMontyForm::random_from_rng(&mut rng);
+                let b = ConstMontyForm::random_from_rng(&mut rng);
                 (a, b)
             },
             |(a, b)| black_box(a).sub(&black_box(b)),
@@ -73,7 +73,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 
     group.bench_function("neg, U256", |b| {
         b.iter_batched(
-            || ConstMontyForm::random(&mut rng),
+            || ConstMontyForm::random_from_rng(&mut rng),
             |a| black_box(a).neg(),
             BatchSize::SmallInput,
         )
@@ -81,7 +81,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 
     group.bench_function("invert, U256", |b| {
         b.iter_batched(
-            || ConstMontyForm::random(&mut rng),
+            || ConstMontyForm::random_from_rng(&mut rng),
             |x| black_box(x).invert(),
             BatchSize::SmallInput,
         )
@@ -90,8 +90,8 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("multiplication, U256*U256", |b| {
         b.iter_batched(
             || {
-                let x = ConstMontyForm::random(&mut rng);
-                let y = ConstMontyForm::random(&mut rng);
+                let x = ConstMontyForm::random_from_rng(&mut rng);
+                let y = ConstMontyForm::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x).mul(&black_box(y)),
@@ -101,7 +101,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 
     group.bench_function("squaring, U256*U256", |b| {
         b.iter_batched(
-            || ConstMontyForm::random(&mut rng),
+            || ConstMontyForm::random_from_rng(&mut rng),
             |x| black_box(x).square(),
             BatchSize::SmallInput,
         )
@@ -110,8 +110,8 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("modpow, U256^U256", |b| {
         b.iter_batched(
             || {
-                let x_m = ConstMontyForm::random(&mut rng);
-                let p = U256::random(&mut rng) | (U256::ONE << (U256::BITS - 1));
+                let x_m = ConstMontyForm::random_from_rng(&mut rng);
+                let p = U256::random_from_rng(&mut rng) | (U256::ONE << (U256::BITS - 1));
                 (x_m, p)
             },
             |(x, p)| black_box(x.pow(&p)),
@@ -121,7 +121,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 
     group.bench_function("jacobi_symbol", |b| {
         b.iter_batched(
-            || ConstMontyForm::random(&mut rng),
+            || ConstMontyForm::random_from_rng(&mut rng),
             |a| a.jacobi_symbol(),
             BatchSize::SmallInput,
         )
@@ -129,7 +129,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 
     group.bench_function("jacobi_symbol_vartime", |b| {
         b.iter_batched(
-            || ConstMontyForm::random(&mut rng),
+            || ConstMontyForm::random_from_rng(&mut rng),
             |a| a.jacobi_symbol_vartime(),
             BatchSize::SmallInput,
         )
@@ -137,7 +137,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 
     group.bench_function("lincomb, U256*U256+U256*U256", |b| {
         b.iter_batched(
-            || ConstMontyForm::random(&mut rng),
+            || ConstMontyForm::random_from_rng(&mut rng),
             |a| {
                 ConstMontyForm::lincomb(&[
                     (black_box(a), black_box(a)),
@@ -157,8 +157,9 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                     || {
                         let bases_and_exponents: Vec<(ConstMontyForm, U256)> = (1..=i)
                             .map(|_| {
-                                let x_m = ConstMontyForm::random(&mut rng);
-                                let p = U256::random(&mut rng) | (U256::ONE << (U256::BITS - 1));
+                                let x_m = ConstMontyForm::random_from_rng(&mut rng);
+                                let p = U256::random_from_rng(&mut rng)
+                                    | (U256::ONE << (U256::BITS - 1));
                                 (x_m, p)
                             })
                             .collect();
@@ -185,5 +186,4 @@ fn bench_montgomery(c: &mut Criterion) {
 }
 
 criterion_group!(benches, bench_montgomery);
-
 criterion_main!(benches);

--- a/benches/int.rs
+++ b/benches/int.rs
@@ -12,7 +12,12 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("widening_mul, I128xI128", |b| {
         b.iter_batched(
-            || (I256::random(&mut rng), I256::random(&mut rng)),
+            || {
+                (
+                    I256::random_from_rng(&mut rng),
+                    I256::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -20,7 +25,12 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("widening_mul, I256xI256", |b| {
         b.iter_batched(
-            || (I256::random(&mut rng), I256::random(&mut rng)),
+            || {
+                (
+                    I256::random_from_rng(&mut rng),
+                    I256::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -28,7 +38,12 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("widening_mul, I512xI512", |b| {
         b.iter_batched(
-            || (I512::random(&mut rng), I512::random(&mut rng)),
+            || {
+                (
+                    I512::random_from_rng(&mut rng),
+                    I512::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -36,7 +51,12 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("widening_mul, I1024xI1024", |b| {
         b.iter_batched(
-            || (I1024::random(&mut rng), I1024::random(&mut rng)),
+            || {
+                (
+                    I1024::random_from_rng(&mut rng),
+                    I1024::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -44,7 +64,12 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("widening_mul, I2048xI2048", |b| {
         b.iter_batched(
-            || (I2048::random(&mut rng), I2048::random(&mut rng)),
+            || {
+                (
+                    I2048::random_from_rng(&mut rng),
+                    I2048::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -52,7 +77,12 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("widening_mul, I4096xI4096", |b| {
         b.iter_batched(
-            || (I4096::random(&mut rng), I4096::random(&mut rng)),
+            || {
+                (
+                    I4096::random_from_rng(&mut rng),
+                    I4096::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -65,7 +95,12 @@ fn bench_concatenating_mul(c: &mut Criterion) {
 
     group.bench_function("concatenating_mul, I128xI128", |b| {
         b.iter_batched(
-            || (I128::random(&mut rng), I128::random(&mut rng)),
+            || {
+                (
+                    I128::random_from_rng(&mut rng),
+                    I128::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -73,7 +108,12 @@ fn bench_concatenating_mul(c: &mut Criterion) {
 
     group.bench_function("concatenating_mul, I256xI256", |b| {
         b.iter_batched(
-            || (I256::random(&mut rng), I256::random(&mut rng)),
+            || {
+                (
+                    I256::random_from_rng(&mut rng),
+                    I256::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -81,7 +121,12 @@ fn bench_concatenating_mul(c: &mut Criterion) {
 
     group.bench_function("concatenating_mul, I512xI512", |b| {
         b.iter_batched(
-            || (I512::random(&mut rng), I512::random(&mut rng)),
+            || {
+                (
+                    I512::random_from_rng(&mut rng),
+                    I512::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -89,7 +134,12 @@ fn bench_concatenating_mul(c: &mut Criterion) {
 
     group.bench_function("concatenating_mul, I1024xI1024", |b| {
         b.iter_batched(
-            || (I1024::random(&mut rng), I1024::random(&mut rng)),
+            || {
+                (
+                    I1024::random_from_rng(&mut rng),
+                    I1024::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -97,7 +147,12 @@ fn bench_concatenating_mul(c: &mut Criterion) {
 
     group.bench_function("concatenating_mul, I2048xI2048", |b| {
         b.iter_batched(
-            || (I2048::random(&mut rng), I2048::random(&mut rng)),
+            || {
+                (
+                    I2048::random_from_rng(&mut rng),
+                    I2048::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -105,7 +160,12 @@ fn bench_concatenating_mul(c: &mut Criterion) {
 
     group.bench_function("concatenating_mul, I4096xI4096", |b| {
         b.iter_batched(
-            || (I4096::random(&mut rng), I4096::random(&mut rng)),
+            || {
+                (
+                    I4096::random_from_rng(&mut rng),
+                    I4096::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -118,7 +178,12 @@ fn bench_wrapping_mul(c: &mut Criterion) {
 
     group.bench_function("wrapping_mul, I128xI128", |b| {
         b.iter_batched(
-            || (I256::random(&mut rng), I256::random(&mut rng)),
+            || {
+                (
+                    I256::random_from_rng(&mut rng),
+                    I256::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -126,7 +191,12 @@ fn bench_wrapping_mul(c: &mut Criterion) {
 
     group.bench_function("wrapping_mul, I256xI256", |b| {
         b.iter_batched(
-            || (I256::random(&mut rng), I256::random(&mut rng)),
+            || {
+                (
+                    I256::random_from_rng(&mut rng),
+                    I256::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -134,7 +204,12 @@ fn bench_wrapping_mul(c: &mut Criterion) {
 
     group.bench_function("wrapping_mul, I512xI512", |b| {
         b.iter_batched(
-            || (I512::random(&mut rng), I512::random(&mut rng)),
+            || {
+                (
+                    I512::random_from_rng(&mut rng),
+                    I512::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -142,7 +217,12 @@ fn bench_wrapping_mul(c: &mut Criterion) {
 
     group.bench_function("wrapping_mul, I1024xI1024", |b| {
         b.iter_batched(
-            || (I1024::random(&mut rng), I1024::random(&mut rng)),
+            || {
+                (
+                    I1024::random_from_rng(&mut rng),
+                    I1024::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -150,7 +230,12 @@ fn bench_wrapping_mul(c: &mut Criterion) {
 
     group.bench_function("wrapping_mul, I2048xI2048", |b| {
         b.iter_batched(
-            || (I2048::random(&mut rng), I2048::random(&mut rng)),
+            || {
+                (
+                    I2048::random_from_rng(&mut rng),
+                    I2048::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -158,7 +243,12 @@ fn bench_wrapping_mul(c: &mut Criterion) {
 
     group.bench_function("wrapping_mul, I4096xI4096", |b| {
         b.iter_batched(
-            || (I4096::random(&mut rng), I4096::random(&mut rng)),
+            || {
+                (
+                    I4096::random_from_rng(&mut rng),
+                    I4096::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -172,8 +262,8 @@ fn bench_div(c: &mut Criterion) {
     group.bench_function("div, I256/I128, full size", |b| {
         b.iter_batched(
             || {
-                let x = I256::random(&mut rng);
-                let y = I128::random(&mut rng).resize::<{ I256::LIMBS }>();
+                let x = I256::random_from_rng(&mut rng);
+                let y = I128::random_from_rng(&mut rng).resize::<{ I256::LIMBS }>();
                 (x, NonZero::new(y).unwrap())
             },
             |(x, y)| black_box(x.div(&y)),
@@ -184,8 +274,8 @@ fn bench_div(c: &mut Criterion) {
     group.bench_function("div, I512/I256, full size", |b| {
         b.iter_batched(
             || {
-                let x = I512::random(&mut rng);
-                let y = I256::random(&mut rng).resize::<{ I512::LIMBS }>();
+                let x = I512::random_from_rng(&mut rng);
+                let y = I256::random_from_rng(&mut rng).resize::<{ I512::LIMBS }>();
                 (x, NonZero::new(y).unwrap())
             },
             |(x, y)| black_box(x.div(&y)),
@@ -196,8 +286,8 @@ fn bench_div(c: &mut Criterion) {
     group.bench_function("div, I1024/I512, full size", |b| {
         b.iter_batched(
             || {
-                let x = I1024::random(&mut rng);
-                let y = I512::random(&mut rng).resize::<{ I1024::LIMBS }>();
+                let x = I1024::random_from_rng(&mut rng);
+                let y = I512::random_from_rng(&mut rng).resize::<{ I1024::LIMBS }>();
                 (x, NonZero::new(y).unwrap())
             },
             |(x, y)| black_box(x.div(&y)),
@@ -208,8 +298,8 @@ fn bench_div(c: &mut Criterion) {
     group.bench_function("div, I2048/I1024, full size", |b| {
         b.iter_batched(
             || {
-                let x = I2048::random(&mut rng);
-                let y = I1024::random(&mut rng).resize::<{ I2048::LIMBS }>();
+                let x = I2048::random_from_rng(&mut rng);
+                let y = I1024::random_from_rng(&mut rng).resize::<{ I2048::LIMBS }>();
                 (x, NonZero::new(y).unwrap())
             },
             |(x, y)| black_box(x.div(&y)),
@@ -220,8 +310,8 @@ fn bench_div(c: &mut Criterion) {
     group.bench_function("div, I4096/I2048, full size", |b| {
         b.iter_batched(
             || {
-                let x = I4096::random(&mut rng);
-                let y = I2048::random(&mut rng).resize::<{ I4096::LIMBS }>();
+                let x = I4096::random_from_rng(&mut rng);
+                let y = I2048::random_from_rng(&mut rng).resize::<{ I4096::LIMBS }>();
                 (x, NonZero::new(y).unwrap())
             },
             |(x, y)| black_box(x.div(&y)),
@@ -239,8 +329,8 @@ fn bench_add(c: &mut Criterion) {
     group.bench_function("add, I128+I128", |b| {
         b.iter_batched(
             || {
-                let x = I128::random(&mut rng);
-                let y = I128::random(&mut rng);
+                let x = I128::random_from_rng(&mut rng);
+                let y = I128::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x.wrapping_add(&y)),
@@ -251,8 +341,8 @@ fn bench_add(c: &mut Criterion) {
     group.bench_function("add, I256+I256", |b| {
         b.iter_batched(
             || {
-                let x = I256::random(&mut rng);
-                let y = I256::random(&mut rng);
+                let x = I256::random_from_rng(&mut rng);
+                let y = I256::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x.wrapping_add(&y)),
@@ -263,8 +353,8 @@ fn bench_add(c: &mut Criterion) {
     group.bench_function("add, I512+I512", |b| {
         b.iter_batched(
             || {
-                let x = I512::random(&mut rng);
-                let y = I512::random(&mut rng);
+                let x = I512::random_from_rng(&mut rng);
+                let y = I512::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x.wrapping_add(&y)),
@@ -275,8 +365,8 @@ fn bench_add(c: &mut Criterion) {
     group.bench_function("add, I1024+I1024", |b| {
         b.iter_batched(
             || {
-                let x = I1024::random(&mut rng);
-                let y = I1024::random(&mut rng);
+                let x = I1024::random_from_rng(&mut rng);
+                let y = I1024::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x.wrapping_add(&y)),
@@ -287,8 +377,8 @@ fn bench_add(c: &mut Criterion) {
     group.bench_function("add, I2048+I2048", |b| {
         b.iter_batched(
             || {
-                let x = I2048::random(&mut rng);
-                let y = I2048::random(&mut rng);
+                let x = I2048::random_from_rng(&mut rng);
+                let y = I2048::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x.wrapping_add(&y)),
@@ -299,8 +389,8 @@ fn bench_add(c: &mut Criterion) {
     group.bench_function("add, I4096+I4096", |b| {
         b.iter_batched(
             || {
-                let x = I4096::random(&mut rng);
-                let y = I4096::random(&mut rng);
+                let x = I4096::random_from_rng(&mut rng);
+                let y = I4096::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x.wrapping_add(&y)),
@@ -318,8 +408,8 @@ fn bench_sub(c: &mut Criterion) {
     group.bench_function("sub, I128-I128", |b| {
         b.iter_batched(
             || {
-                let x = I128::random(&mut rng);
-                let y = I128::random(&mut rng);
+                let x = I128::random_from_rng(&mut rng);
+                let y = I128::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x.wrapping_sub(&y)),
@@ -330,8 +420,8 @@ fn bench_sub(c: &mut Criterion) {
     group.bench_function("sub, I256-I256", |b| {
         b.iter_batched(
             || {
-                let x = I256::random(&mut rng);
-                let y = I256::random(&mut rng);
+                let x = I256::random_from_rng(&mut rng);
+                let y = I256::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x.wrapping_sub(&y)),
@@ -342,8 +432,8 @@ fn bench_sub(c: &mut Criterion) {
     group.bench_function("sub, I512-I512", |b| {
         b.iter_batched(
             || {
-                let x = I512::random(&mut rng);
-                let y = I512::random(&mut rng);
+                let x = I512::random_from_rng(&mut rng);
+                let y = I512::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x.wrapping_sub(&y)),
@@ -354,8 +444,8 @@ fn bench_sub(c: &mut Criterion) {
     group.bench_function("sub, I1024-I1024", |b| {
         b.iter_batched(
             || {
-                let x = I1024::random(&mut rng);
-                let y = I1024::random(&mut rng);
+                let x = I1024::random_from_rng(&mut rng);
+                let y = I1024::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x.wrapping_sub(&y)),
@@ -366,8 +456,8 @@ fn bench_sub(c: &mut Criterion) {
     group.bench_function("sub, I2048-I2048", |b| {
         b.iter_batched(
             || {
-                let x = I2048::random(&mut rng);
-                let y = I2048::random(&mut rng);
+                let x = I2048::random_from_rng(&mut rng);
+                let y = I2048::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x.wrapping_sub(&y)),
@@ -378,8 +468,8 @@ fn bench_sub(c: &mut Criterion) {
     group.bench_function("sub, I4096-I4096", |b| {
         b.iter_batched(
             || {
-                let x = I4096::random(&mut rng);
-                let y = I4096::random(&mut rng);
+                let x = I4096::random_from_rng(&mut rng);
+                let y = I4096::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x.wrapping_sub(&y)),

--- a/benches/limb.rs
+++ b/benches/limb.rs
@@ -11,8 +11,8 @@ fn bench_cmp<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("ct_lt", |b| {
         b.iter_batched(
             || {
-                let x = Limb::random(&mut rng);
-                let y = Limb::random(&mut rng);
+                let x = Limb::random_from_rng(&mut rng);
+                let y = Limb::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x.ct_lt(&y)),
@@ -23,8 +23,8 @@ fn bench_cmp<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("ct_eq", |b| {
         b.iter_batched(
             || {
-                let x = Limb::random(&mut rng);
-                let y = Limb::random(&mut rng);
+                let x = Limb::random_from_rng(&mut rng);
+                let y = Limb::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x.ct_eq(&y)),
@@ -35,8 +35,8 @@ fn bench_cmp<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     group.bench_function("ct_gt", |b| {
         b.iter_batched(
             || {
-                let x = Limb::random(&mut rng);
-                let y = Limb::random(&mut rng);
+                let x = Limb::random_from_rng(&mut rng);
+                let y = Limb::random_from_rng(&mut rng);
                 (x, y)
             },
             |(x, y)| black_box(x.ct_gt(&y)),

--- a/benches/monty.rs
+++ b/benches/monty.rs
@@ -16,7 +16,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
     let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
     group.bench_function("MontyParams::new", |b| {
         b.iter_batched(
-            || Odd::<U256>::random(&mut rng),
+            || Odd::<U256>::random_from_rng(&mut rng),
             |modulus| black_box(MontyParams::new(modulus)),
             BatchSize::SmallInput,
         )
@@ -24,13 +24,13 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
 
     group.bench_function("MontyParams::new_vartime", |b| {
         b.iter_batched(
-            || Odd::<U256>::random(&mut rng),
+            || Odd::<U256>::random_from_rng(&mut rng),
             |modulus| black_box(MontyParams::new_vartime(modulus)),
             BatchSize::SmallInput,
         )
     });
 
-    let params = MontyParams::new_vartime(Odd::<U256>::random(&mut rng));
+    let params = MontyParams::new_vartime(Odd::<U256>::random_from_rng(&mut rng));
     group.bench_function("MontyForm::new", |b| {
         b.iter_batched(
             || U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
@@ -39,7 +39,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
         )
     });
 
-    let params = MontyParams::new_vartime(Odd::<U256>::random(&mut rng));
+    let params = MontyParams::new_vartime(Odd::<U256>::random_from_rng(&mut rng));
     group.bench_function("MontyForm retrieve", |b| {
         b.iter_batched(
             || {
@@ -56,7 +56,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
 
 fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
     let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
-    let params = MontyParams::new_vartime(Odd::<U256>::random(&mut rng));
+    let params = MontyParams::new_vartime(Odd::<U256>::random_from_rng(&mut rng));
 
     group.bench_function("add, U256", |b| {
         b.iter_batched(

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -19,14 +19,14 @@ fn bench_random(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("random_mod_vartime, U1024", |b| {
-        let bound = U1024::random(&mut rng);
+        let bound = U1024::random_from_rng(&mut rng);
         let bound_nz = NonZero::new(bound).unwrap();
         b.iter(|| black_box(U1024::random_mod_vartime(&mut rng, &bound_nz)));
     });
 
     let mut rng = make_rng();
     group.bench_function("random_bits, U1024", |b| {
-        let bound = U1024::random(&mut rng);
+        let bound = U1024::random_from_rng(&mut rng);
         let bound_bits = bound.bits_vartime();
         b.iter(|| {
             let mut r = U1024::random_bits(&mut rng, bound_bits);
@@ -59,7 +59,7 @@ fn bench_random(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("random_mod_vartime, U1024, 512 bit bound low", |b| {
-        let bound = U512::random(&mut rng);
+        let bound = U512::random_from_rng(&mut rng);
         let bound = U1024::from((bound, U512::ZERO));
         let bound_nz = NonZero::new(bound).unwrap();
         b.iter(|| black_box(U1024::random_mod_vartime(&mut rng, &bound_nz)));
@@ -67,7 +67,7 @@ fn bench_random(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("random_bits, U1024, 512 bit bound low", |b| {
-        let bound = U512::random(&mut rng);
+        let bound = U512::random_from_rng(&mut rng);
         let bound = U1024::from((bound, U512::ZERO));
         let bound_bits = bound.bits_vartime();
         b.iter(|| {
@@ -81,7 +81,7 @@ fn bench_random(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("random_mod_vartime, U1024, 512 bit bound hi", |b| {
-        let bound = U512::random(&mut rng);
+        let bound = U512::random_from_rng(&mut rng);
         let bound = U1024::from((U512::ZERO, bound));
         let bound_nz = NonZero::new(bound).unwrap();
         b.iter(|| black_box(U1024::random_mod_vartime(&mut rng, &bound_nz)));
@@ -89,7 +89,7 @@ fn bench_random(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("random_bits, U1024, 512 bit bound hi", |b| {
-        let bound = U512::random(&mut rng);
+        let bound = U512::random_from_rng(&mut rng);
         let bound = U1024::from((U512::ZERO, bound));
         let bound_bits = bound.bits_vartime();
         b.iter(|| {
@@ -152,7 +152,12 @@ fn bench_mul(c: &mut Criterion) {
     let mut rng = make_rng();
     group.bench_function("widening_mul, U256xU256", |b| {
         b.iter_batched(
-            || (U256::random(&mut rng), U256::random(&mut rng)),
+            || {
+                (
+                    U256::random_from_rng(&mut rng),
+                    U256::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -160,7 +165,12 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("widening_mul, U4096xU4096", |b| {
         b.iter_batched(
-            || (U4096::random(&mut rng), U4096::random(&mut rng)),
+            || {
+                (
+                    U4096::random_from_rng(&mut rng),
+                    U4096::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -168,7 +178,12 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("widening_mul, U8192xU4096", |b| {
         b.iter_batched(
-            || (U8192::random(&mut rng), U4096::random(&mut rng)),
+            || {
+                (
+                    U8192::random_from_rng(&mut rng),
+                    U4096::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -176,7 +191,12 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("wrapping_mul, U256xU256", |b| {
         b.iter_batched(
-            || (U256::random(&mut rng), U256::random(&mut rng)),
+            || {
+                (
+                    U256::random_from_rng(&mut rng),
+                    U256::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -184,7 +204,12 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("wrapping_mul, U4096xU4096", |b| {
         b.iter_batched(
-            || (U4096::random(&mut rng), U4096::random(&mut rng)),
+            || {
+                (
+                    U4096::random_from_rng(&mut rng),
+                    U4096::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -192,7 +217,12 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("wrapping_mul, U8192xU4096", |b| {
         b.iter_batched(
-            || (U8192::random(&mut rng), U4096::random(&mut rng)),
+            || {
+                (
+                    U8192::random_from_rng(&mut rng),
+                    U4096::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -200,7 +230,12 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("checked_mul, U256xU256", |b| {
         b.iter_batched(
-            || (U256::random(&mut rng), U256::random(&mut rng)),
+            || {
+                (
+                    U256::random_from_rng(&mut rng),
+                    U256::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.checked_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -208,7 +243,12 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("checked_mul, U4096xU4096", |b| {
         b.iter_batched(
-            || (U4096::random(&mut rng), U4096::random(&mut rng)),
+            || {
+                (
+                    U4096::random_from_rng(&mut rng),
+                    U4096::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x.checked_mul(&y)),
             BatchSize::SmallInput,
         )
@@ -216,7 +256,7 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("square_wide, U256", |b| {
         b.iter_batched(
-            || U256::random(&mut rng),
+            || U256::random_from_rng(&mut rng),
             |x| black_box(x.square_wide()),
             BatchSize::SmallInput,
         )
@@ -224,7 +264,7 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("square_wide, U4096", |b| {
         b.iter_batched(
-            || U4096::random(&mut rng),
+            || U4096::random_from_rng(&mut rng),
             |x| black_box(x.square_wide()),
             BatchSize::SmallInput,
         )
@@ -232,7 +272,7 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("wrapping_square, U256xU256", |b| {
         b.iter_batched(
-            || U256::random(&mut rng),
+            || U256::random_from_rng(&mut rng),
             |x| x.wrapping_square(),
             BatchSize::SmallInput,
         )
@@ -240,7 +280,7 @@ fn bench_mul(c: &mut Criterion) {
 
     group.bench_function("wrapping_square, U4096xU4096", |b| {
         b.iter_batched(
-            || U4096::random(&mut rng),
+            || U4096::random_from_rng(&mut rng),
             |x| x.wrapping_square(),
             BatchSize::SmallInput,
         )
@@ -249,7 +289,7 @@ fn bench_mul(c: &mut Criterion) {
     group.bench_function("mul_mod, U256", |b| {
         b.iter_batched(
             || {
-                let m = Odd::<U256>::random(&mut rng);
+                let m = Odd::<U256>::random_from_rng(&mut rng);
                 let x = U256::random_mod_vartime(&mut rng, m.as_nz_ref());
                 (m.to_nz().unwrap(), x)
             },
@@ -261,7 +301,7 @@ fn bench_mul(c: &mut Criterion) {
     group.bench_function("mul_mod_vartime, U256", |b| {
         b.iter_batched(
             || {
-                let m = Odd::<U256>::random(&mut rng);
+                let m = Odd::<U256>::random_from_rng(&mut rng);
                 let x = U256::random_mod_vartime(&mut rng, m.as_nz_ref());
                 (m.to_nz().unwrap(), x)
             },
@@ -273,8 +313,8 @@ fn bench_mul(c: &mut Criterion) {
     group.bench_function("mul_mod_special, U256", |b| {
         b.iter_batched(
             || {
-                let m = Limb::random(&mut rng);
-                let x = U256::random(&mut rng);
+                let m = Limb::random_from_rng(&mut rng);
+                let x = U256::random_from_rng(&mut rng);
                 (m, x)
             },
             |(m, x)| black_box(x).mul_mod_special(black_box(&x), m),
@@ -289,7 +329,12 @@ fn bench_division(c: &mut Criterion) {
 
     group.bench_function("div/rem, U256/U128", |b| {
         b.iter_batched(
-            || (U256::random(&mut rng), NonZero::<U128>::random(&mut rng)),
+            || {
+                (
+                    U256::random_from_rng(&mut rng),
+                    NonZero::<U128>::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| x.div_rem(&y),
             BatchSize::SmallInput,
         )
@@ -298,8 +343,8 @@ fn bench_division(c: &mut Criterion) {
     group.bench_function("div/rem, U256/U128 (in U256)", |b| {
         b.iter_batched(
             || {
-                let x = U256::random(&mut rng);
-                let y_half = U128::random(&mut rng);
+                let x = U256::random_from_rng(&mut rng);
+                let y_half = U128::random_from_rng(&mut rng);
                 let y: U256 = (y_half, U128::ZERO).into();
                 (x, NonZero::new(y).unwrap())
             },
@@ -311,8 +356,8 @@ fn bench_division(c: &mut Criterion) {
     group.bench_function("div/rem, U256/U128 (in U512)", |b| {
         b.iter_batched(
             || {
-                let x = U256::random(&mut rng);
-                let y: U512 = U128::random(&mut rng).resize();
+                let x = U256::random_from_rng(&mut rng);
+                let y: U512 = U128::random_from_rng(&mut rng).resize();
                 (x, NonZero::new(y).unwrap())
             },
             |(x, y)| x.div_rem(&y),
@@ -323,7 +368,7 @@ fn bench_division(c: &mut Criterion) {
     group.bench_function("div/rem_vartime, U256/U128, full size", |b| {
         b.iter_batched(
             || {
-                let x = U256::random(&mut rng);
+                let x = U256::random_from_rng(&mut rng);
                 let y: U256 = (U128::MAX, U128::ZERO).into();
                 (x, NonZero::new(y).unwrap())
             },
@@ -334,7 +379,12 @@ fn bench_division(c: &mut Criterion) {
 
     group.bench_function("rem, U256/U128", |b| {
         b.iter_batched(
-            || (U256::random(&mut rng), NonZero::<U128>::random(&mut rng)),
+            || {
+                (
+                    U256::random_from_rng(&mut rng),
+                    NonZero::<U128>::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| x.rem(&y),
             BatchSize::SmallInput,
         )
@@ -343,8 +393,8 @@ fn bench_division(c: &mut Criterion) {
     group.bench_function("rem, U256/U128 (in U256)", |b| {
         b.iter_batched(
             || {
-                let x = U256::random(&mut rng);
-                let y: U256 = U128::random(&mut rng).resize();
+                let x = U256::random_from_rng(&mut rng);
+                let y: U256 = U128::random_from_rng(&mut rng).resize();
                 (x, NonZero::new(y).unwrap())
             },
             |(x, y)| x.rem(&y),
@@ -355,8 +405,8 @@ fn bench_division(c: &mut Criterion) {
     group.bench_function("rem, U256/U128 (in U512)", |b| {
         b.iter_batched(
             || {
-                let x = U256::random(&mut rng);
-                let y: U512 = U128::random(&mut rng).resize();
+                let x = U256::random_from_rng(&mut rng);
+                let y: U512 = U128::random_from_rng(&mut rng).resize();
                 (x, NonZero::new(y).unwrap())
             },
             |(x, y)| x.rem(&y),
@@ -367,7 +417,7 @@ fn bench_division(c: &mut Criterion) {
     group.bench_function("rem_vartime, U256/U128, full size", |b| {
         b.iter_batched(
             || {
-                let x = U256::random(&mut rng);
+                let x = U256::random_from_rng(&mut rng);
                 let y: U256 = (U128::MAX, U128::ZERO).into();
                 (x, NonZero::new(y).unwrap())
             },
@@ -379,8 +429,11 @@ fn bench_division(c: &mut Criterion) {
     group.bench_function("rem_wide, U256", |b| {
         b.iter_batched(
             || {
-                let (x_lo, x_hi) = (U256::random(&mut rng), U256::random(&mut rng));
-                let y = U256::random(&mut rng);
+                let (x_lo, x_hi) = (
+                    U256::random_from_rng(&mut rng),
+                    U256::random_from_rng(&mut rng),
+                );
+                let y = U256::random_from_rng(&mut rng);
                 (x_lo, x_hi, NonZero::new(y).unwrap())
             },
             |(x_lo, x_hi, y)| Uint::rem_wide((x_lo, x_hi), &y),
@@ -391,7 +444,10 @@ fn bench_division(c: &mut Criterion) {
     group.bench_function("rem_wide_vartime, U256", |b| {
         b.iter_batched(
             || {
-                let (x_lo, x_hi) = (U256::random(&mut rng), U256::random(&mut rng));
+                let (x_lo, x_hi) = (
+                    U256::random_from_rng(&mut rng),
+                    U256::random_from_rng(&mut rng),
+                );
                 let y: U256 = (U128::MAX, U128::ZERO).into();
                 (x_lo, x_hi, NonZero::new(y).unwrap())
             },
@@ -403,8 +459,8 @@ fn bench_division(c: &mut Criterion) {
     group.bench_function("div/rem, U256/Limb, full size", |b| {
         b.iter_batched(
             || {
-                let x = U256::random(&mut rng);
-                let y_small = Limb::random(&mut rng);
+                let x = U256::random_from_rng(&mut rng);
+                let y_small = Limb::random_from_rng(&mut rng);
                 let y = U256::from_word(y_small.0);
                 (x, NonZero::new(y).unwrap())
             },
@@ -416,8 +472,8 @@ fn bench_division(c: &mut Criterion) {
     group.bench_function("div/rem_vartime, U256/Limb, full size", |b| {
         b.iter_batched(
             || {
-                let x = U256::random(&mut rng);
-                let y_small = Limb::random(&mut rng);
+                let x = U256::random_from_rng(&mut rng);
+                let y_small = Limb::random_from_rng(&mut rng);
                 let y = U256::from_word(y_small.0);
                 (x, NonZero::new(y).unwrap())
             },
@@ -428,7 +484,12 @@ fn bench_division(c: &mut Criterion) {
 
     group.bench_function("div/rem, U256/Limb, single limb", |b| {
         b.iter_batched(
-            || (U256::random(&mut rng), NonZero::<Limb>::random(&mut rng)),
+            || {
+                (
+                    U256::random_from_rng(&mut rng),
+                    NonZero::<Limb>::random_from_rng(&mut rng),
+                )
+            },
             |(x, y)| black_box(x).div_rem_limb(black_box(y)),
             BatchSize::SmallInput,
         )
@@ -438,8 +499,8 @@ fn bench_division(c: &mut Criterion) {
         b.iter_batched(
             || {
                 (
-                    U256::random(&mut rng),
-                    Reciprocal::new(NonZero::<Limb>::random(&mut rng)),
+                    U256::random_from_rng(&mut rng),
+                    Reciprocal::new(NonZero::<Limb>::random_from_rng(&mut rng)),
                 )
             },
             |(x, r)| black_box(x).div_rem_limb_with_reciprocal(black_box(&r)),
@@ -449,7 +510,12 @@ fn bench_division(c: &mut Criterion) {
 
     group.bench_function("rem, U256/Limb, single limb", |b| {
         b.iter_batched(
-            || (U256::random(&mut rng), NonZero::<Limb>::random(&mut rng)),
+            || {
+                (
+                    U256::random_from_rng(&mut rng),
+                    NonZero::<Limb>::random_from_rng(&mut rng),
+                )
+            },
             |(x, r)| black_box(x).rem_limb(black_box(r)),
             BatchSize::SmallInput,
         )
@@ -459,8 +525,8 @@ fn bench_division(c: &mut Criterion) {
         b.iter_batched(
             || {
                 (
-                    U256::random(&mut rng),
-                    Reciprocal::new(NonZero::<Limb>::random(&mut rng)),
+                    U256::random_from_rng(&mut rng),
+                    Reciprocal::new(NonZero::<Limb>::random_from_rng(&mut rng)),
                 )
             },
             |(x, r)| black_box(x).rem_limb_with_reciprocal(black_box(&r)),
@@ -478,8 +544,8 @@ fn gcd_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: Uint<LIMB
         b.iter_batched(
             || {
                 (
-                    Uint::<LIMBS>::random(&mut rng),
-                    Uint::<LIMBS>::random(&mut rng),
+                    Uint::<LIMBS>::random_from_rng(&mut rng),
+                    Uint::<LIMBS>::random_from_rng(&mut rng),
                 )
             },
             |(f, g)| black_box(Uint::gcd(&f, &g)),
@@ -491,8 +557,8 @@ fn gcd_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: Uint<LIMB
         b.iter_batched(
             || {
                 (
-                    Uint::<LIMBS>::random(&mut rng),
-                    Uint::<LIMBS>::random(&mut rng),
+                    Uint::<LIMBS>::random_from_rng(&mut rng),
+                    Uint::<LIMBS>::random_from_rng(&mut rng),
                 )
             },
             |(f, g)| black_box(Uint::gcd_vartime(&f, &g)),
@@ -504,8 +570,8 @@ fn gcd_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: Uint<LIMB
         b.iter_batched(
             || {
                 (
-                    OddUint::<LIMBS>::random(&mut rng),
-                    Uint::<LIMBS>::random(&mut rng),
+                    OddUint::<LIMBS>::random_from_rng(&mut rng),
+                    Uint::<LIMBS>::random_from_rng(&mut rng),
                 )
             },
             |(f, g)| black_box(f.bingcd(&g)),
@@ -517,8 +583,8 @@ fn gcd_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: Uint<LIMB
         b.iter_batched(
             || {
                 (
-                    OddUint::<LIMBS>::random(&mut rng),
-                    Uint::<LIMBS>::random(&mut rng),
+                    OddUint::<LIMBS>::random_from_rng(&mut rng),
+                    Uint::<LIMBS>::random_from_rng(&mut rng),
                 )
             },
             |(f, g)| black_box(f.bingcd_vartime(&g)),
@@ -530,8 +596,8 @@ fn gcd_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: Uint<LIMB
         b.iter_batched(
             || {
                 (
-                    OddUint::<LIMBS>::random(&mut rng),
-                    Uint::<LIMBS>::random(&mut rng),
+                    OddUint::<LIMBS>::random_from_rng(&mut rng),
+                    Uint::<LIMBS>::random_from_rng(&mut rng),
                 )
             },
             |(f, g)| black_box(f.safegcd(&g)),
@@ -543,8 +609,8 @@ fn gcd_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: Uint<LIMB
         b.iter_batched(
             || {
                 (
-                    OddUint::<LIMBS>::random(&mut rng),
-                    Uint::<LIMBS>::random(&mut rng),
+                    OddUint::<LIMBS>::random_from_rng(&mut rng),
+                    Uint::<LIMBS>::random_from_rng(&mut rng),
                 )
             },
             |(f, g)| black_box(f.safegcd_vartime(&g)),
@@ -573,8 +639,8 @@ fn xgcd_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: Uint<LIM
         b.iter_batched(
             || {
                 (
-                    Uint::<LIMBS>::random(&mut rng),
-                    Uint::<LIMBS>::random(&mut rng),
+                    Uint::<LIMBS>::random_from_rng(&mut rng),
+                    Uint::<LIMBS>::random_from_rng(&mut rng),
                 )
             },
             |(f, g)| black_box(Uint::xgcd(&f, &g)),
@@ -610,8 +676,8 @@ fn mod_symbols_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: U
         b.iter_batched(
             || {
                 (
-                    OddUint::<LIMBS>::random(&mut rng),
-                    Uint::<LIMBS>::random(&mut rng),
+                    OddUint::<LIMBS>::random_from_rng(&mut rng),
+                    Uint::<LIMBS>::random_from_rng(&mut rng),
                 )
             },
             |(f, g)| black_box(g.jacobi_symbol(&f)),
@@ -623,8 +689,8 @@ fn mod_symbols_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: U
         b.iter_batched(
             || {
                 (
-                    OddUint::<LIMBS>::random(&mut rng),
-                    Uint::<LIMBS>::random(&mut rng),
+                    OddUint::<LIMBS>::random_from_rng(&mut rng),
+                    Uint::<LIMBS>::random_from_rng(&mut rng),
                 )
             },
             |(f, g)| black_box(g.jacobi_symbol_vartime(&f)),
@@ -710,9 +776,9 @@ fn bench_invert_mod(c: &mut Criterion) {
     group.bench_function("invert_odd_mod, U256", |b| {
         b.iter_batched(
             || {
-                let m = Odd::<U256>::random(&mut rng);
+                let m = Odd::<U256>::random_from_rng(&mut rng);
                 loop {
-                    let x = U256::random(&mut rng);
+                    let x = U256::random_from_rng(&mut rng);
                     let inv_x = x.invert_odd_mod(&m);
                     if inv_x.is_some().into() {
                         break (x, m);
@@ -727,9 +793,9 @@ fn bench_invert_mod(c: &mut Criterion) {
     group.bench_function("invert_odd_mod_vartime, U256", |b| {
         b.iter_batched(
             || {
-                let m = Odd::<U256>::random(&mut rng);
+                let m = Odd::<U256>::random_from_rng(&mut rng);
                 loop {
-                    let x = U256::random(&mut rng);
+                    let x = U256::random_from_rng(&mut rng);
                     let inv_x = x.invert_odd_mod_vartime(&m);
                     if inv_x.is_some().into() {
                         break (x, m);
@@ -744,9 +810,9 @@ fn bench_invert_mod(c: &mut Criterion) {
     group.bench_function("invert_mod, U256, odd modulus", |b| {
         b.iter_batched(
             || {
-                let m = Odd::<U256>::random(&mut rng);
+                let m = Odd::<U256>::random_from_rng(&mut rng);
                 loop {
-                    let x = U256::random(&mut rng);
+                    let x = U256::random_from_rng(&mut rng);
                     let inv_x = x.invert_odd_mod(&m);
                     if inv_x.is_some().into() {
                         break (x, m);
@@ -761,9 +827,9 @@ fn bench_invert_mod(c: &mut Criterion) {
     group.bench_function("invert_mod, U256", |b| {
         b.iter_batched(
             || {
-                let m = NonZero::<U256>::random(&mut rng);
+                let m = NonZero::<U256>::random_from_rng(&mut rng);
                 loop {
-                    let x = U256::random(&mut rng);
+                    let x = U256::random_from_rng(&mut rng);
                     let inv_x = x.invert_mod(&m);
                     if inv_x.is_some().into() {
                         break (x, m);
@@ -777,7 +843,7 @@ fn bench_invert_mod(c: &mut Criterion) {
 
     group.bench_function("invert_mod2k, U256", |b| {
         b.iter_batched(
-            || U256::random(&mut rng),
+            || U256::random_from_rng(&mut rng),
             |x| x.invert_mod2k(black_box(1)),
             BatchSize::SmallInput,
         )
@@ -785,7 +851,7 @@ fn bench_invert_mod(c: &mut Criterion) {
 
     group.bench_function("invert_mod2k_vartime, U256", |b| {
         b.iter_batched(
-            || U256::random(&mut rng),
+            || U256::random_from_rng(&mut rng),
             |x| x.invert_mod2k_vartime(black_box(1)),
             BatchSize::SmallInput,
         )
@@ -800,7 +866,7 @@ fn bench_sqrt(c: &mut Criterion) {
 
     group.bench_function("sqrt, U256", |b| {
         b.iter_batched(
-            || U256::random(&mut rng),
+            || U256::random_from_rng(&mut rng),
             |x| x.sqrt(),
             BatchSize::SmallInput,
         )
@@ -808,7 +874,7 @@ fn bench_sqrt(c: &mut Criterion) {
 
     group.bench_function("sqrt_vartime, U256", |b| {
         b.iter_batched(
-            || U256::random(&mut rng),
+            || U256::random_from_rng(&mut rng),
             |x| x.sqrt_vartime(),
             BatchSize::SmallInput,
         )

--- a/src/int/div_uint.rs
+++ b/src/int/div_uint.rs
@@ -494,8 +494,10 @@ mod tests {
     fn test_div_ct_vs_vt() {
         let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
         for _ in 0..50 {
-            let num = I1024::random(&mut rng);
-            let denom = U1024::from(&U512::random(&mut rng)).to_nz().unwrap();
+            let num = I1024::random_from_rng(&mut rng);
+            let denom = U1024::from(&U512::random_from_rng(&mut rng))
+                .to_nz()
+                .unwrap();
 
             assert_eq!(num.div_uint(&denom), num.div_uint_vartime(&denom))
         }
@@ -563,8 +565,10 @@ mod tests {
     fn test_div_floor_ct_vs_vt() {
         let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
         for _ in 0..50 {
-            let num = I1024::random(&mut rng);
-            let denom = U1024::from(&U512::random(&mut rng)).to_nz().unwrap();
+            let num = I1024::random_from_rng(&mut rng);
+            let denom = U1024::from(&U512::random_from_rng(&mut rng))
+                .to_nz()
+                .unwrap();
 
             assert_eq!(
                 num.div_floor_uint(&denom),

--- a/src/int/rand.rs
+++ b/src/int/rand.rs
@@ -8,8 +8,8 @@ use super::Uint;
 
 impl<const LIMBS: usize> Random for Int<LIMBS> {
     /// Generate a cryptographically secure random [`Int`].
-    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        Ok(Self(Uint::try_random(rng)?))
+    fn try_random_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        Ok(Self(Uint::try_random_from_rng(rng)?))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@
 //! # }
 //! use crypto_bigint::{Random, U256};
 //!
-//! let n = U256::random(&mut rng());
+//! let n = U256::random_from_rng(&mut rng());
 //! # }
 //! ```
 //!

--- a/src/limb/rand.rs
+++ b/src/limb/rand.rs
@@ -5,7 +5,7 @@ use crate::{CtLt, Encoding, NonZero, Random, RandomMod};
 use rand_core::TryRngCore;
 
 impl Random for Limb {
-    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_random_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         #[cfg(target_pointer_width = "32")]
         let val = rng.try_next_u32()?;
         #[cfg(target_pointer_width = "64")]

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -194,7 +194,7 @@ where
     MOD: ConstMontyParams<LIMBS>,
 {
     #[inline]
-    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_random_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         Ok(Self::new(&Uint::try_random_mod_vartime(
             rng,
             MOD::PARAMS.modulus.as_nz_ref(),

--- a/src/modular/monty_form/lincomb.rs
+++ b/src/modular/monty_form/lincomb.rs
@@ -40,7 +40,7 @@ mod tests {
 
         let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
         for n in 0..1500 {
-            let modulus = Odd::<U256>::random(&mut rng);
+            let modulus = Odd::<U256>::random_from_rng(&mut rng);
             let params = MontyParams::new_vartime(modulus);
             let m = modulus.as_nz_ref();
             let a = U256::random_mod_vartime(&mut rng, m);

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -348,9 +348,9 @@ where
     /// As a result, it runs in variable time. If the generator `rng` is
     /// cryptographically secure (for example, it implements `CryptoRng`),
     /// then this is guaranteed not to leak anything about the output value.
-    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_random_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         loop {
-            if let Some(result) = Self::new(T::try_random(rng)?).into() {
+            if let Some(result) = Self::new(T::try_random_from_rng(rng)?).into() {
                 break Ok(result);
             }
         }

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -307,8 +307,8 @@ impl Resize for &Odd<BoxedUint> {
 #[cfg(feature = "rand_core")]
 impl<const LIMBS: usize> Random for Odd<Uint<LIMBS>> {
     /// Generate a random `Odd<Uint<T>>`.
-    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        let mut ret = Uint::try_random(rng)?;
+    fn try_random_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        let mut ret = Uint::try_random_from_rng(rng)?;
         ret.limbs[0] |= Limb::ONE;
         Ok(Odd(ret))
     }

--- a/src/uint/add_mod.rs
+++ b/src/uint/add_mod.rs
@@ -86,8 +86,8 @@ mod tests {
             fn $test_name() {
                 let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
                 let moduli = [
-                    NonZero::<Limb>::random(&mut rng),
-                    NonZero::<Limb>::random(&mut rng),
+                    NonZero::<Limb>::random_from_rng(&mut rng),
+                    NonZero::<Limb>::random_from_rng(&mut rng),
                 ];
 
                 for special in &moduli {

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -101,8 +101,8 @@ mod tests {
             fn $test_name() {
                 let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
                 let moduli = [
-                    NonZero::<Limb>::random(&mut rng),
-                    NonZero::<Limb>::random(&mut rng),
+                    NonZero::<Limb>::random_from_rng(&mut rng),
+                    NonZero::<Limb>::random_from_rng(&mut rng),
                 ];
 
                 for special in &moduli {

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -711,9 +711,15 @@ mod tests {
     fn div() {
         let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
         for _ in 0..25 {
-            let num = U256::random(&mut rng).overflowing_shr_vartime(128).unwrap();
-            let den =
-                NonZero::new(U256::random(&mut rng).overflowing_shr_vartime(128).unwrap()).unwrap();
+            let num = U256::random_from_rng(&mut rng)
+                .overflowing_shr_vartime(128)
+                .unwrap();
+            let den = NonZero::new(
+                U256::random_from_rng(&mut rng)
+                    .overflowing_shr_vartime(128)
+                    .unwrap(),
+            )
+            .unwrap();
             let n = num.checked_mul(den.as_ref());
             if n.is_some().into() {
                 let n = n.unwrap();
@@ -913,7 +919,7 @@ mod tests {
     fn rem2krand() {
         let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
         for _ in 0..25 {
-            let num = U256::random(&mut rng);
+            let num = U256::random_from_rng(&mut rng);
             let k = rng.next_u32() % 256;
             let den = U256::ONE.overflowing_shl_vartime(k).unwrap();
 

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -1138,7 +1138,7 @@ mod tests {
         let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
 
         for _ in 0..100 {
-            let uint = U256::random(&mut rng);
+            let uint = U256::random_from_rng(&mut rng);
             for radix in 2..=36 {
                 let enc = uint.to_string_radix_vartime(radix);
                 let res = U256::from_str_radix_vartime(&enc, radix).expect("decoding error");

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -397,7 +397,7 @@ mod tests {
         let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
 
         for _ in 0..50 {
-            let a = U4096::random(&mut rng);
+            let a = U4096::random_from_rng(&mut rng);
             assert_eq!(a.widening_mul(&a), a.square_wide(), "a = {a}");
             assert_eq!(a.wrapping_mul(&a), a.wrapping_square(), "a = {a}");
             assert_eq!(a.saturating_mul(&a), a.saturating_square(), "a = {a}");

--- a/src/uint/mul/karatsuba.rs
+++ b/src/uint/mul/karatsuba.rs
@@ -561,8 +561,8 @@ mod tests {
         const SIZE: usize = 200;
         let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
         for n in 0..100 {
-            let a = Uint::<SIZE>::random(&mut rng);
-            let b = Uint::<SIZE>::random(&mut rng);
+            let a = Uint::<SIZE>::random_from_rng(&mut rng);
+            let b = Uint::<SIZE>::random_from_rng(&mut rng);
             let size_a = rng.next_u32() as usize % SIZE;
             let size_b = rng.next_u32() as usize % SIZE;
             let a = a.as_uint_ref().leading(size_a);
@@ -587,7 +587,7 @@ mod tests {
         const SIZE: usize = 200;
         let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
         for n in 0..100 {
-            let a = Uint::<SIZE>::random(&mut rng);
+            let a = Uint::<SIZE>::random_from_rng(&mut rng);
             let size_a = rng.next_u32() as usize % SIZE;
             let a = a.as_uint_ref().leading(size_a);
             let mut wide = [Limb::ZERO; SIZE * 2];

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -110,8 +110,8 @@ mod tests {
             fn $test_name() {
                 let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
                 let moduli = [
-                    NonZero::<Limb>::random(&mut rng),
-                    NonZero::<Limb>::random(&mut rng),
+                    NonZero::<Limb>::random_from_rng(&mut rng),
+                    NonZero::<Limb>::random_from_rng(&mut rng),
                 ];
 
                 for special in &moduli {

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -5,11 +5,11 @@ use crate::{CtLt, Encoding, Limb, NonZero, Random, RandomBits, RandomBitsError, 
 use rand_core::{RngCore, TryRngCore};
 
 impl<const LIMBS: usize> Random for Uint<LIMBS> {
-    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_random_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut limbs = [Limb::ZERO; LIMBS];
 
         for limb in &mut limbs {
-            *limb = Limb::try_random(rng)?
+            *limb = Limb::try_random_from_rng(rng)?
         }
 
         Ok(limbs.into())
@@ -141,7 +141,7 @@ mod tests {
     #[test]
     fn random_platform_independence() {
         let mut rng = get_four_sequential_rng();
-        assert_eq!(U1024::random(&mut rng), RANDOM_OUTPUT);
+        assert_eq!(U1024::random_from_rng(&mut rng), RANDOM_OUTPUT);
     }
 
     #[test]

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -241,7 +241,7 @@ mod tests {
         }
 
         for _ in 0..50 {
-            let s = U256::random(&mut rng);
+            let s = U256::random_from_rng(&mut rng);
             let mut s2 = U512::ZERO;
             s2.limbs[..s.limbs.len()].copy_from_slice(&s.limbs);
             assert_eq!(s.square().sqrt(), s2);

--- a/src/uint/sub_mod.rs
+++ b/src/uint/sub_mod.rs
@@ -82,8 +82,8 @@ mod tests {
             fn $test_name() {
                 let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
                 let moduli = [
-                    NonZero::<Uint<$size>>::random(&mut rng),
-                    NonZero::<Uint<$size>>::random(&mut rng),
+                    NonZero::<Uint<$size>>::random_from_rng(&mut rng),
+                    NonZero::<Uint<$size>>::random_from_rng(&mut rng),
                 ];
 
                 for p in &moduli {
@@ -102,8 +102,8 @@ mod tests {
 
                     if $size > 1 {
                         for _i in 0..100 {
-                            let a: Uint<$size> = Limb::random(&mut rng).into();
-                            let b: Uint<$size> = Limb::random(&mut rng).into();
+                            let a: Uint<$size> = Limb::random_from_rng(&mut rng).into();
+                            let b: Uint<$size> = Limb::random_from_rng(&mut rng).into();
                             let (a, b) = if a < b { (b, a) } else { (a, b) };
 
                             let c = a.sub_mod(&b, p);
@@ -135,8 +135,8 @@ mod tests {
             fn $test_name() {
                 let mut rng = chacha20::ChaCha8Rng::seed_from_u64(1);
                 let moduli = [
-                    NonZero::<Limb>::random(&mut rng),
-                    NonZero::<Limb>::random(&mut rng),
+                    NonZero::<Limb>::random_from_rng(&mut rng),
+                    NonZero::<Limb>::random_from_rng(&mut rng),
                 ];
 
                 for special in &moduli {

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -274,8 +274,8 @@ impl<T: fmt::UpperHex> fmt::UpperHex for Wrapping<T> {
 
 #[cfg(feature = "rand_core")]
 impl<T: Random> Random for Wrapping<T> {
-    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
-        Ok(Wrapping(Random::try_random(rng)?))
+    fn try_random_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        Ok(Wrapping(Random::try_random_from_rng(rng)?))
     }
 }
 


### PR DESCRIPTION
Renames the following methods of the `Random` trait:

- `Random::random` => `Random::random_from_rng`
- `Random::try_random` => `Random::try_random_from_rng`

And adds new `Random::random` and `Random::try_random` gated on `getrandom` that use the new `getrandom::SysRng` to call the old `rand_core`-based methods.