### PR TITLE
Rename `rand` feature to `rand_core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,12 +41,12 @@ proptest = "1.9"
 rand_core = "0.10.0-rc-3"
 
 [features]
-default = ["rand"]
+default = ["rand_core"]
 alloc = ["serdect?/alloc"]
 
 extra-sizes = []
-getrandom = ["dep:getrandom", "rand"]
-rand = ["rand_core"]
+getrandom = ["dep:getrandom", "rand_core"]
+rand_core = ["dep:rand_core"]
 serde = ["dep:serdect"]
 subtle = ["dep:subtle", "ctutils/subtle", "hybrid-array?/subtle"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@
 //! using any RNG by using the [`Random`] trait:
 //!
 //! ```
-//! # #[cfg(feature = "rand")]
+//! # #[cfg(feature = "rand_core")]
 //! # {
 //! # use chacha20::ChaCha8Rng;
 //! # use rand_core::SeedableRng;
@@ -136,7 +136,7 @@
 //! distribution around a given [`NonZero`] modulus.
 //!
 //! ```
-//! # #[cfg(feature = "rand")]
+//! # #[cfg(feature = "rand_core")]
 //! # {
 //! # use chacha20::ChaCha8Rng;
 //! # use rand_core::SeedableRng;

--- a/src/modular/boxed_monty_form/lincomb.rs
+++ b/src/modular/boxed_monty_form/lincomb.rs
@@ -29,7 +29,7 @@ impl BoxedMontyForm {
 #[cfg(test)]
 mod tests {
 
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "rand_core")]
     #[test]
     fn lincomb_expected() {
         use crate::modular::{BoxedMontyForm, BoxedMontyParams};

--- a/src/modular/const_monty_form/lincomb.rs
+++ b/src/modular/const_monty_form/lincomb.rs
@@ -22,7 +22,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
 #[cfg(test)]
 mod tests {
 
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "rand_core")]
     #[test]
     fn lincomb_expected() {
         use super::{ConstMontyForm, ConstMontyParams};

--- a/src/modular/monty_form/lincomb.rs
+++ b/src/modular/monty_form/lincomb.rs
@@ -28,7 +28,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "rand_core")]
     #[test]
     fn lincomb_expected() {
         use crate::U256;

--- a/src/uint/add_mod.rs
+++ b/src/uint/add_mod.rs
@@ -45,7 +45,7 @@ impl<const LIMBS: usize> AddMod for Uint<LIMBS> {
     }
 }
 
-#[cfg(all(test, feature = "rand"))]
+#[cfg(all(test, feature = "rand_core"))]
 mod tests {
     use crate::{Limb, NonZero, Random, RandomMod, U256, Uint};
     use rand_core::SeedableRng;

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -90,7 +90,7 @@ fn mac_by_limb(a: &BoxedUint, b: &BoxedUint, c: Limb, carry: Limb) -> (BoxedUint
     (a, carry)
 }
 
-#[cfg(all(test, feature = "rand"))]
+#[cfg(all(test, feature = "rand_core"))]
 mod tests {
     use crate::{Limb, NonZero, Random, RandomMod, Uint};
     use rand_core::SeedableRng;

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -133,7 +133,7 @@ impl SquareRoot for BoxedUint {
 mod tests {
     use crate::{BoxedUint, Limb};
 
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "rand_core")]
     use {
         crate::RandomBits,
         chacha20::ChaCha8Rng,
@@ -284,7 +284,7 @@ mod tests {
         assert_eq!(BoxedUint::from(10u8).sqrt_vartime(), BoxedUint::from(3u8));
     }
 
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "rand_core")]
     #[test]
     fn fuzz() {
         let mut rng = ChaCha8Rng::from_seed([7u8; 32]);

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -678,7 +678,7 @@ mod tests {
         Uint, Word, Zero,
     };
 
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "rand_core")]
     use {crate::Random, chacha20::ChaCha8Rng, rand_core::RngCore, rand_core::SeedableRng};
 
     #[test]
@@ -706,7 +706,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "rand_core")]
     #[test]
     fn div() {
         let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
@@ -914,7 +914,7 @@ mod tests {
         assert_eq!(r, a);
     }
 
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "rand_core")]
     #[test]
     fn rem2krand() {
         let mut rng = ChaCha8Rng::from_seed([7u8; 32]);

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -1130,7 +1130,7 @@ mod tests {
         assert_eq!(&out, hex);
     }
 
-    #[cfg(all(feature = "rand", feature = "alloc"))]
+    #[cfg(all(feature = "rand_core", feature = "alloc"))]
     #[test]
     fn encode_radix_round_trip() {
         use crate::{Random, U256};

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -99,7 +99,7 @@ const fn mac_by_limb<const LIMBS: usize>(
     (a, carry)
 }
 
-#[cfg(all(test, feature = "rand"))]
+#[cfg(all(test, feature = "rand_core"))]
 mod tests {
     use crate::{Limb, NonZero, Random, RandomMod, Uint};
     use rand_core::SeedableRng;

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -121,7 +121,7 @@ impl<const LIMBS: usize> SquareRoot for Uint<LIMBS> {
 mod tests {
     use crate::{Limb, U192, U256};
 
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "rand_core")]
     use {
         crate::{Random, U512},
         chacha20::ChaCha8Rng,
@@ -226,7 +226,7 @@ mod tests {
         assert_eq!(U256::from(10u8).sqrt_vartime(), U256::from(3u8));
     }
 
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "rand_core")]
     #[test]
     fn fuzz() {
         let mut rng = ChaCha8Rng::from_seed([7u8; 32]);

--- a/src/uint/sub_mod.rs
+++ b/src/uint/sub_mod.rs
@@ -53,7 +53,7 @@ impl<const LIMBS: usize> SubMod for Uint<LIMBS> {
     }
 }
 
-#[cfg(all(test, feature = "rand"))]
+#[cfg(all(test, feature = "rand_core"))]
 mod tests {
     use crate::{Limb, NonZero, Random, RandomMod, U256, Uint};
     use rand_core::SeedableRng;


### PR DESCRIPTION
This crate previously had *both* a `rand` and `rand_core` feature, where `rand_core` enabled most functionality, but a small amount was gated under `rand` for no particular reason.

This renames those usages to `rand_core`, and the feature overall, which follows the general pattern we use elsewhere.