### PR TITLE
v0.7.0-rc.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.10"
+version = "0.7.0-rc.11"
 dependencies = [
  "chacha20",
  "criterion",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef9cc07c2130072ca4cf0b22b52c4b455e11ff769a870934f3d27db52fd4ee13"
+checksum = "925ebe186f09a7894817213f89eae07c39374f5c934613605af7accc8aea6414"
 dependencies = [
  "cmov",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-bigint"
-version = "0.7.0-rc.10"
+version = "0.7.0-rc.11"
 description = """
 Pure Rust implementation of a big integer library which has been designed from
 the ground-up for use in cryptographic applications. Provides constant-time,
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-ctutils = "0.2.1"
+ctutils = "0.2.2"
 num-traits = { version = "0.2.19", default-features = false }
 
 # optional dependencies


### PR DESCRIPTION
This release notably includes a migration from `subtle` to `ctutils`, with feature-gated backwards compatibility for `subtle`.