### PR TITLE
Remove `derive(Hash)` on `BoxedUint`

### DIFF
--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -45,8 +45,7 @@ use zeroize::Zeroize;
 /// Unlike many other heap-allocated big integer libraries, this type is not
 /// arbitrary precision and will wrap at its fixed-precision rather than
 /// automatically growing.
-#[allow(clippy::derived_hash_with_manual_eq)]
-#[derive(Clone, Hash)]
+#[derive(Clone)]
 pub struct BoxedUint {
     /// Boxed slice containing limbs.
     ///


### PR DESCRIPTION
As noted in #1031 and as identifiable via clippy, the `Hash` impl does not align with the (Partial)`Eq` impl.

Rather than actually fixing the problem, this PR opts to remove the `Hash` impl until it can be added back correctly.