### PR TITLE
Bump `ctutils` to v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925ebe186f09a7894817213f89eae07c39374f5c934613605af7accc8aea6414"
+checksum = "3d0d4ebbcf0ee8b260dd060b79b7449973fffccdbaa5c871c9867c7b44445e75"
 dependencies = [
  "cmov",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-ctutils = "0.2.2"
+ctutils = "0.2.3"
 num-traits = { version = "0.2.19", default-features = false }
 
 # optional dependencies

--- a/src/checked.rs
+++ b/src/checked.rs
@@ -330,7 +330,7 @@ impl<'de, T: Default + Deserialize<'de>> Deserialize<'de> for Checked<T> {
         D: Deserializer<'de>,
     {
         let value = Option::<T>::deserialize(deserializer)?;
-        let choice = Choice::new(value.is_some() as u8);
+        let choice = Choice::from_u8_lsb(value.is_some() as u8);
         Ok(Self(CtOption::new(value.unwrap_or_default(), choice)))
     }
 }

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -89,6 +89,11 @@ impl Limb {
         let nz_word = word::select(1, self.0, is_nz);
         CtOption::new(NonZero(Self(nz_word)), is_nz)
     }
+
+    /// Convert the least significant bit of this [`Limb`] to a [`Choice`].
+    pub const fn lsb_to_choice(self) -> Choice {
+        word::choice_from_lsb(self.0)
+    }
 }
 
 impl Bounded for Limb {

--- a/src/uint/boxed/add.rs
+++ b/src/uint/boxed/add.rs
@@ -62,7 +62,7 @@ impl BoxedUint {
             carry = c;
         }
 
-        Choice::new((carry.0 & 1) as u8)
+        carry.lsb_to_choice()
     }
 }
 

--- a/src/uint/boxed/sub.rs
+++ b/src/uint/boxed/sub.rs
@@ -66,7 +66,7 @@ impl BoxedUint {
             borrow = b;
         }
 
-        Choice::new((borrow.0 & 1) as u8)
+        borrow.lsb_to_choice()
     }
 }
 

--- a/src/word.rs
+++ b/src/word.rs
@@ -86,7 +86,7 @@ pub(crate) const fn choice_from_gt(x: Word, y: Word) -> Choice {
 /// Returns the truthy value if `value == 1`, and the falsy value if `value == 0`.
 #[inline]
 pub(crate) const fn choice_from_lsb(value: Word) -> Choice {
-    Choice::new((value & 1) as u8)
+    Choice::from_u8_lsb((value & 1) as u8)
 }
 
 /// Returns the truthy value if `value == Word::MAX`, and the falsy value if `value == 0`.


### PR DESCRIPTION
Handles the deprecation of `Choice::new`

Also adds a `Limb::lsb_to_choice` convenience method, uses it in the implementation, and makes it public because it might be handy elsewhere.