### PR TITLE
Bump `ctutils` v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0d4ebbcf0ee8b260dd060b79b7449973fffccdbaa5c871c9867c7b44445e75"
+checksum = "130ffe18bdf7a4926e57ed19d404995244e6c8d6a97abf4eddde1f892bf1ce0c"
 dependencies = [
  "cmov",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-ctutils = "0.2.3"
+ctutils = "0.3"
 num-traits = { version = "0.2.19", default-features = false }
 
 # optional dependencies

--- a/src/int.rs
+++ b/src/int.rs
@@ -371,7 +371,7 @@ where
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use crate::{Choice, I128, U128};
+    use crate::{I128, U128};
 
     #[cfg(target_pointer_width = "64")]
     #[test]
@@ -450,19 +450,19 @@ mod tests {
     #[test]
     fn is_minimal() {
         let min = I128::from_be_hex("80000000000000000000000000000000");
-        assert_eq!(min.is_min(), Choice::TRUE);
+        assert!(min.is_min().to_bool());
 
         let random = I128::from_be_hex("11113333555577779999BBBBDDDDFFFF");
-        assert_eq!(random.is_min(), Choice::FALSE);
+        assert!(!random.is_min().to_bool());
     }
 
     #[test]
     fn is_maximal() {
         let max = I128::from_be_hex("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
-        assert_eq!(max.is_max(), Choice::TRUE);
+        assert!(max.is_max().to_bool());
 
         let random = I128::from_be_hex("11113333555577779999BBBBDDDDFFFF");
-        assert_eq!(random.is_max(), Choice::FALSE);
+        assert!(!random.is_max().to_bool());
     }
 
     #[test]

--- a/src/int/add.rs
+++ b/src/int/add.rs
@@ -102,7 +102,7 @@ impl<const LIMBS: usize> WrappingAdd for Int<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Choice, I128, U128};
+    use crate::{I128, U128};
 
     #[test]
     fn checked_add() {
@@ -217,105 +217,105 @@ mod tests {
         // lhs = MIN
 
         let (_val, overflow) = I128::MIN.overflowing_add(&I128::MIN);
-        assert_eq!(overflow, Choice::TRUE);
+        assert!(overflow.to_bool());
 
         let (_val, overflow) = I128::MIN.overflowing_add(&I128::MINUS_ONE);
-        assert_eq!(overflow, Choice::TRUE);
+        assert!(overflow.to_bool());
 
         let (val, overflow) = I128::MIN.overflowing_add(&I128::ZERO);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, I128::MIN);
 
         let (val, overflow) = I128::MIN.overflowing_add(&I128::ONE);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, min_plus_one);
 
         let (val, overflow) = I128::MIN.overflowing_add(&I128::MAX);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, I128::MINUS_ONE);
 
         // lhs = -1
 
         let (_val, overflow) = I128::MINUS_ONE.overflowing_add(&I128::MIN);
-        assert_eq!(overflow, Choice::TRUE);
+        assert!(overflow.to_bool());
 
         let (val, overflow) = I128::MINUS_ONE.overflowing_add(&I128::MINUS_ONE);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, two.wrapping_neg());
 
         let (val, overflow) = I128::MINUS_ONE.overflowing_add(&I128::ZERO);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, I128::MINUS_ONE);
 
         let (val, overflow) = I128::MINUS_ONE.overflowing_add(&I128::ONE);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, I128::ZERO);
 
         let (val, overflow) = I128::MINUS_ONE.overflowing_add(&I128::MAX);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, max_minus_one);
 
         // lhs = 0
 
         let (val, overflow) = I128::ZERO.overflowing_add(&I128::MIN);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, I128::MIN);
 
         let (val, overflow) = I128::ZERO.overflowing_add(&I128::MINUS_ONE);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, I128::MINUS_ONE);
 
         let (val, overflow) = I128::ZERO.overflowing_add(&I128::ZERO);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, I128::ZERO);
 
         let (val, overflow) = I128::ZERO.overflowing_add(&I128::ONE);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, I128::ONE);
 
         let (val, overflow) = I128::ZERO.overflowing_add(&I128::MAX);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, I128::MAX);
 
         // lhs = 1
 
         let (val, overflow) = I128::ONE.overflowing_add(&I128::MIN);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, min_plus_one);
 
         let (val, overflow) = I128::ONE.overflowing_add(&I128::MINUS_ONE);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, I128::ZERO);
 
         let (val, overflow) = I128::ONE.overflowing_add(&I128::ZERO);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, I128::ONE);
 
         let (val, overflow) = I128::ONE.overflowing_add(&I128::ONE);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, two);
 
         let (_val, overflow) = I128::ONE.overflowing_add(&I128::MAX);
-        assert_eq!(overflow, Choice::TRUE);
+        assert!(overflow.to_bool());
 
         // lhs = MAX
 
         let (val, overflow) = I128::MAX.overflowing_add(&I128::MIN);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, I128::MINUS_ONE);
 
         let (val, overflow) = I128::MAX.overflowing_add(&I128::MINUS_ONE);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, max_minus_one);
 
         let (val, overflow) = I128::MAX.overflowing_add(&I128::ZERO);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
         assert_eq!(val, I128::MAX);
 
         let (_val, overflow) = I128::MAX.overflowing_add(&I128::ONE);
-        assert_eq!(overflow, Choice::TRUE);
+        assert!(overflow.to_bool());
 
         let (_val, overflow) = I128::MAX.overflowing_add(&I128::MAX);
-        assert_eq!(overflow, Choice::TRUE);
+        assert!(overflow.to_bool());
     }
 }

--- a/src/int/div.rs
+++ b/src/int/div.rs
@@ -503,7 +503,7 @@ impl<const LIMBS: usize> RemAssign<&NonZero<Int<LIMBS>>> for Wrapping<Int<LIMBS>
 
 #[cfg(test)]
 mod tests {
-    use crate::{Choice, CtSelect, DivVartime, I128, Int, NonZero, One, Zero};
+    use crate::{CtSelect, DivVartime, I128, Int, NonZero, One, Zero};
 
     #[test]
     #[allow(clippy::init_numbered_fields)]
@@ -622,7 +622,7 @@ mod tests {
     fn test_checked_div_mod_floor() {
         let (quotient, remainder) =
             I128::MIN.checked_div_rem_floor(&I128::MINUS_ONE.to_nz().unwrap());
-        assert_eq!(quotient.is_some(), Choice::FALSE);
+        assert!(!quotient.is_some().to_bool());
         assert_eq!(remainder, I128::ZERO);
     }
 

--- a/src/int/mul.rs
+++ b/src/int/mul.rs
@@ -198,7 +198,7 @@ impl<const LIMBS: usize> MulAssign<&Checked<Int<LIMBS>>> for Checked<Int<LIMBS>>
 
 #[cfg(test)]
 mod tests {
-    use crate::{Choice, I64, I128, I256, Int, U64, U128, U256};
+    use crate::{I64, I128, I256, Int, U64, U128, U256};
 
     #[test]
     #[allow(clippy::init_numbered_fields)]
@@ -522,7 +522,7 @@ mod tests {
     #[test]
     fn test_checked_square() {
         let res = I128::from_i64(i64::MIN).checked_square();
-        assert_eq!(res.is_some(), Choice::TRUE);
+        assert!(res.is_some().to_bool());
         assert_eq!(
             res.unwrap(),
             U128::from_be_hex("40000000000000000000000000000000")
@@ -530,7 +530,7 @@ mod tests {
 
         let x: I128 = I128::MINUS_ONE << 64;
         let res = x.checked_square();
-        assert_eq!(res.is_none(), Choice::TRUE)
+        assert!(res.is_none().to_bool());
     }
 
     #[test]

--- a/src/int/neg.rs
+++ b/src/int/neg.rs
@@ -58,23 +58,23 @@ mod tests {
 
         let (res, overflow) = I128::MIN.overflowing_neg();
         assert_eq!(res, I128::MIN);
-        assert_eq!(overflow, Choice::TRUE);
+        assert!(overflow.to_bool());
 
         let (res, overflow) = I128::MINUS_ONE.overflowing_neg();
         assert_eq!(res, I128::ONE);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
 
         let (res, overflow) = I128::ZERO.overflowing_neg();
         assert_eq!(res, I128::ZERO);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
 
         let (res, overflow) = I128::ONE.overflowing_neg();
         assert_eq!(res, I128::MINUS_ONE);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
 
         let (res, overflow) = I128::MAX.overflowing_neg();
         assert_eq!(res, min_plus_one);
-        assert_eq!(overflow, Choice::FALSE);
+        assert!(!overflow.to_bool());
     }
 
     #[test]
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn checked_neg() {
-        assert_eq!(I128::MIN.checked_neg().is_none(), Choice::TRUE);
+        assert!(I128::MIN.checked_neg().is_none().to_bool());
         assert_eq!(I128::MINUS_ONE.checked_neg().unwrap(), I128::ONE);
         assert_eq!(I128::ZERO.checked_neg().unwrap(), I128::ZERO);
         assert_eq!(I128::ONE.checked_neg().unwrap(), I128::MINUS_ONE);

--- a/src/int/sign.rs
+++ b/src/int/sign.rs
@@ -75,63 +75,70 @@ mod tests {
 
     #[test]
     fn new_from_abs_sign() {
-        assert_eq!(
-            I128::new_from_abs_sign(U128::ZERO, Choice::FALSE).is_some(),
-            Choice::TRUE
+        assert!(
+            I128::new_from_abs_sign(U128::ZERO, Choice::FALSE)
+                .is_some()
+                .to_bool()
         );
-        assert_eq!(
-            I128::new_from_abs_sign(U128::ZERO, Choice::TRUE).is_some(),
-            Choice::TRUE
+        assert!(
+            I128::new_from_abs_sign(U128::ZERO, Choice::TRUE)
+                .is_some()
+                .to_bool()
         );
-        assert_eq!(
-            I128::new_from_abs_sign(I128::MIN.abs(), Choice::FALSE).is_some(),
-            Choice::FALSE
+        assert!(
+            I128::new_from_abs_sign(I128::MIN.abs(), Choice::FALSE)
+                .is_none()
+                .to_bool()
         );
-        assert_eq!(
-            I128::new_from_abs_sign(I128::MIN.abs(), Choice::TRUE).is_some(),
-            Choice::TRUE
+        assert!(
+            I128::new_from_abs_sign(I128::MIN.abs(), Choice::TRUE)
+                .is_some()
+                .to_bool()
         );
-        assert_eq!(
-            I128::new_from_abs_sign(I128::MAX.abs(), Choice::FALSE).is_some(),
-            Choice::TRUE
+        assert!(
+            I128::new_from_abs_sign(I128::MAX.abs(), Choice::FALSE)
+                .is_some()
+                .to_bool()
         );
-        assert_eq!(
-            I128::new_from_abs_sign(I128::MAX.abs(), Choice::TRUE).is_some(),
-            Choice::TRUE
+        assert!(
+            I128::new_from_abs_sign(I128::MAX.abs(), Choice::TRUE)
+                .is_some()
+                .to_bool()
         );
-        assert_eq!(
-            I128::new_from_abs_sign(U128::MAX, Choice::TRUE).is_some(),
-            Choice::FALSE
+        assert!(
+            I128::new_from_abs_sign(U128::MAX, Choice::TRUE)
+                .is_none()
+                .to_bool()
         );
     }
 
     #[test]
     fn is_negative() {
-        assert_eq!(I128::MIN.is_negative(), Choice::TRUE);
-        assert_eq!(I128::MINUS_ONE.is_negative(), Choice::TRUE);
-        assert_eq!(I128::ZERO.is_negative(), Choice::FALSE);
-        assert_eq!(I128::ONE.is_negative(), Choice::FALSE);
-        assert_eq!(I128::MAX.is_negative(), Choice::FALSE);
+        assert!(I128::MIN.is_negative().to_bool());
+        assert!(I128::MINUS_ONE.is_negative().to_bool());
+        assert!(!I128::ZERO.is_negative().to_bool());
+        assert!(!I128::ONE.is_negative().to_bool());
+        assert!(!I128::MAX.is_negative().to_bool());
 
         let random_negative = I128::from_be_hex("91113333555577779999BBBBDDDDFFFF");
-        assert_eq!(random_negative.is_negative(), Choice::TRUE);
+        assert!(random_negative.is_negative().to_bool());
 
         let random_positive = I128::from_be_hex("71113333555577779999BBBBDDDDFFFF");
-        assert_eq!(random_positive.is_negative(), Choice::FALSE);
+        assert!(!random_positive.is_negative().to_bool());
     }
 
     #[test]
     fn is_positive() {
-        assert_eq!(I128::MIN.is_positive(), Choice::FALSE);
-        assert_eq!(I128::MINUS_ONE.is_positive(), Choice::FALSE);
-        assert_eq!(I128::ZERO.is_positive(), Choice::FALSE);
-        assert_eq!(I128::ONE.is_positive(), Choice::TRUE);
-        assert_eq!(I128::MAX.is_positive(), Choice::TRUE);
+        assert!(!I128::MIN.is_positive().to_bool());
+        assert!(!I128::MINUS_ONE.is_positive().to_bool());
+        assert!(!I128::ZERO.is_positive().to_bool());
+        assert!(I128::ONE.is_positive().to_bool());
+        assert!(I128::MAX.is_positive().to_bool());
 
         let random_negative = I128::from_be_hex("deadbeefcafebabedeadbeefcafebabe");
-        assert_eq!(random_negative.is_positive(), Choice::FALSE);
+        assert!(!random_negative.is_positive().to_bool());
 
         let random_positive = I128::from_be_hex("0badc0dedeadc0decafebabedeadcafe");
-        assert_eq!(random_positive.is_positive(), Choice::TRUE);
+        assert!(random_positive.is_positive().to_bool());
     }
 }

--- a/src/modular/bingcd/matrix.rs
+++ b/src/modular/bingcd/matrix.rs
@@ -1,5 +1,6 @@
 use crate::modular::bingcd::extension::ExtendedInt;
 use crate::{Choice, Uint};
+use ctutils::CtEq;
 
 pub trait Unit: Sized {
     /// The unit matrix.
@@ -90,7 +91,7 @@ impl<const LIMBS: usize> IntMatrix<LIMBS> {
 /// [ -m10  m11 ]   or    [  m10 -m11 ]
 /// ```
 /// depending on whether `pattern` is respectively truthy or not.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct PatternMatrix<const LIMBS: usize> {
     pub m00: Uint<LIMBS>,
     pub m01: Uint<LIMBS>,
@@ -197,6 +198,17 @@ impl<const LIMBS: usize> PatternMatrix<LIMBS> {
     #[inline]
     pub(crate) const fn conditional_negate(&mut self, negate: Choice) {
         self.pattern = self.pattern.xor(negate);
+    }
+}
+
+impl<const LIMBS: usize> PartialEq for PatternMatrix<LIMBS> {
+    fn eq(&self, other: &Self) -> bool {
+        (self.m00.ct_eq(&other.m00)
+            & self.m01.ct_eq(&other.m01)
+            & self.m10.ct_eq(&other.m10)
+            & self.m11.ct_eq(&other.m11)
+            & self.pattern.ct_eq(&other.pattern))
+        .into()
     }
 }
 

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -524,13 +524,13 @@ impl<T: zeroize::Zeroize + Zero> zeroize::Zeroize for NonZero<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Choice, I128, U128};
+    use crate::{I128, U128};
 
     #[test]
     fn int_abs_sign() {
         let x = I128::from(-55).to_nz().unwrap();
         let (abs, sgn) = x.abs_sign();
         assert_eq!(abs, U128::from(55u32).to_nz().unwrap());
-        assert_eq!(sgn, Choice::TRUE);
+        assert!(sgn.to_bool());
     }
 }

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -220,7 +220,7 @@ impl<const LIMBS: usize> WrappingMul for Uint<LIMBS> {
 /// We determine whether an overflow would occur by comparing limbs in
 /// `lhs[i=0..n]` and `rhs[j=0..m]`. Any combination where the sum of indexes
 /// `i + j >= n`, `lhs[i] != 0`, and `rhs[j] != 0` would cause an overflow.
-/// For efficiency we OR all limbs in `rhs` that would apply to each limb in
+/// For efficiency, we OR all limbs in `rhs` that would apply to each limb in
 /// `lhs` in turn.
 pub(crate) const fn wrapping_mul_overflow(
     lhs: &UintRef,
@@ -248,7 +248,7 @@ pub(crate) const fn wrapping_mul_overflow(
 
 #[cfg(test)]
 mod tests {
-    use crate::{Choice, U64, U128, U192, U256, Uint};
+    use crate::{U64, U128, U192, U256, Uint};
 
     #[test]
     fn widening_mul_zero_and_one() {
@@ -362,13 +362,13 @@ mod tests {
     fn checked_square() {
         let n = U256::from_u64(u64::MAX).wrapping_add(&U256::ONE);
         let n2 = n.checked_square();
-        assert_eq!(n2.is_some(), Choice::TRUE);
+        assert!(n2.is_some().to_bool());
         let n4 = n2.unwrap().checked_square();
-        assert_eq!(n4.is_none(), Choice::TRUE);
+        assert!(n4.is_none().to_bool());
         let z = U256::ZERO.checked_square();
-        assert_eq!(z.is_some(), Choice::TRUE);
+        assert!(z.is_some().to_bool());
         let m = U256::MAX.checked_square();
-        assert_eq!(m.is_none(), Choice::TRUE);
+        assert!(m.is_none().to_bool());
     }
 
     #[test]
@@ -419,7 +419,7 @@ mod tests {
                 let res = a.widening_mul(&b);
                 let res_overflow = res.1.is_nonzero();
                 let checked = a.checked_mul(&b);
-                assert_eq!(checked.is_some(), res_overflow.not());
+                assert_eq!(checked.is_some().to_bool(), res_overflow.not().to_bool());
                 assert_eq!(
                     checked.as_inner_unchecked(),
                     &res.0,
@@ -440,7 +440,7 @@ mod tests {
             let res = a.square_wide();
             let res_overflow = res.1.is_nonzero();
             let checked = a.checked_square();
-            assert_eq!(checked.is_some(), res_overflow.not());
+            assert_eq!(checked.is_some().to_bool(), res_overflow.not().to_bool());
             assert_eq!(checked.as_inner_unchecked(), &res.0, "a = 2**{n}");
         }
     }

--- a/src/uint/mul_int.rs
+++ b/src/uint/mul_int.rs
@@ -44,18 +44,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Choice, I64, I128, I256, U64, U128};
+    use crate::{I64, I128, I256, U64, U128};
 
     #[test]
     fn widening_mul_int() {
-        assert_eq!(
-            U128::MAX.widening_mul_int(&I64::from_i64(-55)),
-            (
-                U128::from_be_hex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC9"),
-                U64::from_u64(54),
-                Choice::TRUE
-            )
-        )
+        let (lo, hi, rhs_sgn) = U128::MAX.widening_mul_int(&I64::from_i64(-55));
+        assert_eq!(lo, U128::from_be_hex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC9"));
+        assert_eq!(hi, U64::from_u64(54));
+        assert!(rhs_sgn.to_bool());
     }
 
     #[test]

--- a/src/uint/neg.rs
+++ b/src/uint/neg.rs
@@ -56,9 +56,17 @@ mod tests {
 
     #[test]
     fn carrying_neg() {
-        assert_eq!(U256::ZERO.carrying_neg(), (U256::ZERO, Choice::TRUE));
-        assert_eq!(U256::ONE.carrying_neg(), (U256::MAX, Choice::FALSE));
-        assert_eq!(U256::MAX.carrying_neg(), (U256::ONE, Choice::FALSE));
+        let (ret, carry) = U256::ZERO.carrying_neg();
+        assert_eq!(ret, U256::ZERO);
+        assert!(carry.to_bool());
+
+        let (ret, carry) = U256::ONE.carrying_neg();
+        assert_eq!(ret, U256::MAX);
+        assert!(!carry.to_bool());
+
+        let (ret, carry) = U256::MAX.carrying_neg();
+        assert_eq!(ret, U256::ONE);
+        assert!(!carry.to_bool());
     }
 
     #[test]

--- a/src/uint/ref_type/shl.rs
+++ b/src/uint/ref_type/shl.rs
@@ -217,7 +217,7 @@ impl UintRef {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Choice, U256};
+    use crate::U256;
     #[cfg(feature = "alloc")]
     use crate::{Limb, Uint};
 
@@ -232,17 +232,17 @@ mod tests {
         let mut n = N;
         let carry = n.as_mut_uint_ref().shl1_assign();
         assert_eq!(n, TWO_N);
-        assert_eq!(carry, Choice::TRUE);
+        assert!(carry.to_bool());
 
         let mut m = U256::MAX;
         let carry = m.as_mut_uint_ref().shl1_assign();
         assert_eq!(m, U256::MAX.shl_vartime(1));
-        assert_eq!(carry, Choice::TRUE);
+        assert!(carry.to_bool());
 
         let mut z = U256::ZERO;
         let carry = z.as_mut_uint_ref().shl1_assign();
         assert_eq!(z, U256::ZERO);
-        assert_eq!(carry, Choice::FALSE);
+        assert!(!carry.to_bool());
     }
 
     #[cfg(feature = "alloc")]

--- a/src/uint/ref_type/shr.rs
+++ b/src/uint/ref_type/shr.rs
@@ -234,7 +234,7 @@ impl UintRef {
 mod tests {
     use crate::Uint;
     #[cfg(feature = "alloc")]
-    use crate::{Choice, Limb, U256};
+    use crate::{Limb, U256};
 
     #[cfg(feature = "alloc")]
     const N: U256 =
@@ -250,17 +250,17 @@ mod tests {
         let mut n = N;
         let carry = n.as_mut_uint_ref().shr1_assign();
         assert_eq!(n, N_2);
-        assert_eq!(carry, Choice::TRUE);
+        assert!(carry.to_bool());
 
         let mut m = U256::MAX;
         let carry = m.as_mut_uint_ref().shr1_assign();
         assert_eq!(m, U256::MAX.shr_vartime(1));
-        assert_eq!(carry, Choice::TRUE);
+        assert!(carry.to_bool());
 
         let mut z = U256::ZERO;
         let carry = z.as_mut_uint_ref().shr1_assign();
         assert_eq!(z, U256::ZERO);
-        assert_eq!(carry, Choice::FALSE);
+        assert!(!carry.to_bool());
     }
 
     #[cfg(feature = "alloc")]

--- a/src/word.rs
+++ b/src/word.rs
@@ -146,23 +146,23 @@ mod tests {
 
     #[test]
     fn choice_from_lt() {
-        assert_eq!(super::choice_from_lt(4, 5), Choice::TRUE);
-        assert_eq!(super::choice_from_lt(5, 5), Choice::FALSE);
-        assert_eq!(super::choice_from_lt(6, 5), Choice::FALSE);
+        assert!(super::choice_from_lt(4, 5).to_bool());
+        assert!(!super::choice_from_lt(5, 5).to_bool());
+        assert!(!super::choice_from_lt(6, 5).to_bool());
     }
 
     #[test]
     fn choice_from_gt() {
-        assert_eq!(super::choice_from_gt(4, 5), Choice::FALSE);
-        assert_eq!(super::choice_from_gt(5, 5), Choice::FALSE);
-        assert_eq!(super::choice_from_gt(6, 5), Choice::TRUE);
+        assert!(!super::choice_from_gt(4, 5).to_bool());
+        assert!(!super::choice_from_gt(5, 5).to_bool());
+        assert!(super::choice_from_gt(6, 5).to_bool());
     }
 
     #[test]
     fn choice_from_wide_le() {
-        assert_eq!(super::choice_from_wide_le(4, 5), Choice::TRUE);
-        assert_eq!(super::choice_from_wide_le(5, 5), Choice::TRUE);
-        assert_eq!(super::choice_from_wide_le(6, 5), Choice::FALSE);
+        assert!(super::choice_from_wide_le(4, 5).to_bool());
+        assert!(super::choice_from_wide_le(5, 5).to_bool());
+        assert!(!super::choice_from_wide_le(6, 5).to_bool());
     }
 
     #[test]


### PR DESCRIPTION
This notably removes the `(Partial)Eq` impl(s) from `Choice`, so anywhere affected has been updated to use e.g. `to_bool` instead.