### PR TITLE
Fix `Default` impl for `Odd`

### DIFF
--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -322,11 +322,11 @@ where
 
 impl<T> Default for NonZero<T>
 where
-    T: Constants,
+    T: One,
 {
     #[inline]
     fn default() -> Self {
-        Self(T::ONE)
+        Self(T::one())
     }
 }
 
@@ -524,7 +524,13 @@ impl<T: zeroize::Zeroize + Zero> zeroize::Zeroize for NonZero<T> {
 
 #[cfg(test)]
 mod tests {
+    use super::NonZero;
     use crate::{I128, U128};
+
+    #[test]
+    fn default() {
+        assert!(!NonZero::<U128>::default().is_zero().to_bool());
+    }
 
     #[test]
     fn int_abs_sign() {

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -36,7 +36,7 @@ pub type OddBoxedUint = Odd<BoxedUint>;
 /// Wrapper type for odd integers.
 ///
 /// These are frequently used in cryptography, e.g. as a modulus.
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Odd<T: ?Sized>(pub(crate) T);
 
@@ -177,6 +177,16 @@ where
     #[inline]
     fn ct_select(&self, other: &Self, choice: Choice) -> Self {
         Self(self.0.ct_select(&other.0, choice))
+    }
+}
+
+impl<T> Default for Odd<T>
+where
+    T: One,
+{
+    #[inline]
+    fn default() -> Self {
+        Odd(T::one())
     }
 }
 
@@ -427,6 +437,12 @@ mod tests {
     #[cfg(feature = "alloc")]
     use super::BoxedUint;
     use super::{Odd, Uint};
+    use crate::U128;
+
+    #[test]
+    fn default() {
+        assert!(Odd::<U128>::default().is_odd().to_bool());
+    }
 
     #[test]
     fn not_odd_numbers() {


### PR DESCRIPTION
It was previously derived, which would use the `Default` impl of the underlying `T` which, in almost every case, will return zero, violating the invariant of the type.

This adds a custom `Default` impl similar to the one on `NonZero` which is bounded on `One` trait, and returns `Odd(T::one())`.

Fixes #1070