### PR TITLE
Add `get_copy` method to `NonZero`/`Odd`

### DIFF
--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -61,6 +61,18 @@ impl<T> NonZero<T> {
     pub fn get(self) -> T {
         self.0
     }
+
+    /// Returns a copy of the inner value for `Copy` types.
+    ///
+    /// This allows the function to be `const fn`, since `Copy` is implicitly `!Drop`, which avoids
+    /// problems around `const fn` destructors.
+    #[inline]
+    pub const fn get_copy(self) -> T
+    where
+        T: Copy,
+    {
+        self.0
+    }
 }
 
 impl<T: ?Sized> NonZero<T> {

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -61,6 +61,18 @@ impl<T> Odd<T> {
     pub fn get(self) -> T {
         self.0
     }
+
+    /// Returns a copy of the inner value for `Copy` types.
+    ///
+    /// This allows the function to be `const fn`, since `Copy` is implicitly `!Drop`, which avoids
+    /// problems around `const fn` destructors.
+    #[inline]
+    pub const fn get_copy(self) -> T
+    where
+        T: Copy,
+    {
+        self.0
+    }
 }
 
 impl<T: ?Sized> Odd<T> {


### PR DESCRIPTION
By adding a `T: Copy` bound, we can have a function equivalent to `get` which is `const fn`, since `Copy` types are `!Drop` and otherwise `get` needs to worry about destructors