### PR TITLE
Rename `Uint::gcd_uint(_vartime)` => `::gcd(_vartime)`

### DIFF
--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -4,7 +4,7 @@ use criterion::{
     BatchSize, BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main,
 };
 use crypto_bigint::{
-    Gcd, Limb, NonZero, Odd, OddUint, Random, RandomBits, RandomMod, Reciprocal, U128, U256, U512,
+    Limb, NonZero, Odd, OddUint, Random, RandomBits, RandomMod, Reciprocal, U128, U256, U512,
     U1024, U2048, U4096, U8192, Uint,
 };
 use rand_core::{RngCore, SeedableRng};

--- a/src/int/gcd.rs
+++ b/src/int/gcd.rs
@@ -9,14 +9,14 @@ use crate::{Choice, Gcd, Int, NonZero, NonZeroInt, NonZeroUint, Odd, OddInt, Odd
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Compute the greatest common divisor of `self` and `rhs`.
     pub const fn gcd_uint(&self, rhs: &Uint<LIMBS>) -> Uint<LIMBS> {
-        self.abs().gcd_uint(rhs)
+        self.abs().gcd(rhs)
     }
 
     /// Compute the greatest common divisor of `self` and `rhs`.
     ///
     /// Executes in variable time w.r.t. all input parameters.
     pub const fn gcd_uint_vartime(&self, rhs: &Uint<LIMBS>) -> Uint<LIMBS> {
-        self.abs().gcd_uint_vartime(rhs)
+        self.abs().gcd_vartime(rhs)
     }
 
     /// Executes the Extended GCD algorithm.

--- a/src/modular/bingcd/xgcd.rs
+++ b/src/modular/bingcd/xgcd.rs
@@ -366,7 +366,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 #[cfg(all(test, not(miri)))]
 mod tests {
     use crate::modular::bingcd::xgcd::PatternXgcdOutput;
-    use crate::{ConcatMixed, Gcd, Uint};
+    use crate::{ConcatMixed, Uint};
     use core::ops::Div;
 
     mod test_extract_quotients {

--- a/src/uint/lcm.rs
+++ b/src/uint/lcm.rs
@@ -11,7 +11,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let self_is_nz = self.is_nonzero();
         let rhs_is_nz = rhs.is_nonzero();
 
-        let gcd_nz = NonZero(self.gcd_uint(&Uint::select(&Uint::ONE, rhs, rhs_is_nz)));
+        let gcd_nz = NonZero(self.gcd(&Uint::select(&Uint::ONE, rhs, rhs_is_nz)));
 
         let lcm = self.wrapping_div(&gcd_nz).concatenating_mul(rhs);
 

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -4,7 +4,7 @@ mod common;
 
 use common::to_biguint;
 use crypto_bigint::{
-    Encoding, Gcd, Limb, NonZero, Odd, U256, U512, U4096, U8192, Uint, Word,
+    Encoding, Limb, NonZero, Odd, U256, U512, U4096, U8192, Uint, Word,
     modular::{MontyForm, MontyParams},
 };
 use num_bigint::BigUint;


### PR DESCRIPTION
In this case `self` and `rhs` are both `Uint`, so there's no need for a `*_uint` to disambiguate the argument type.

This overlaps with the trait impl but has the same signature aside from being a `const fn`, which is a pattern we use throughout the library.

Using UFCS-ish syntax it's possible to disambiguate, e.g. `Uint::gcd(a, b)` will prefer the inherent impl, whereas `Gcd::gcd(a, b)` will use the trait.