### PR TITLE
Reapply "Write `random_mod` in terms of new `random_bits`"

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -639,7 +639,6 @@ pub trait Encoding: Sized {
     /// Byte array representation.
     type Repr: AsRef<[u8]>
         + AsMut<[u8]>
-        + Copy
         + Clone
         + Sized
         + for<'a> TryFrom<&'a [u8], Error: core::error::Error>;

--- a/src/uint/boxed/encoding.rs
+++ b/src/uint/boxed/encoding.rs
@@ -1,7 +1,7 @@
 //! Const-friendly decoding operations for [`BoxedUint`].
 
 use super::BoxedUint;
-use crate::{CtEq, CtOption, DecodeError, Limb, Word, uint::encoding};
+use crate::{CtEq, CtOption, DecodeError, Encoding, Limb, Word, uint::encoding};
 use alloc::{boxed::Box, string::String, vec::Vec};
 
 #[cfg(feature = "serde")]
@@ -242,6 +242,28 @@ impl BoxedUint {
     /// Panics if `radix` is not in the range from 2 to 36.
     pub fn to_string_radix_vartime(&self, radix: u32) -> String {
         encoding::radix_encode_limbs_to_string(radix, &self.limbs)
+    }
+}
+
+impl Encoding for BoxedUint {
+    type Repr = Box<[u8]>;
+
+    fn to_be_bytes(&self) -> Self::Repr {
+        BoxedUint::to_be_bytes(self)
+    }
+
+    fn to_le_bytes(&self) -> Self::Repr {
+        BoxedUint::to_le_bytes(self)
+    }
+
+    fn from_be_bytes(bytes: Self::Repr) -> Self {
+        BoxedUint::from_be_slice(&bytes, (bytes.len() * 8).try_into().expect("overflow"))
+            .expect("decode error")
+    }
+
+    fn from_le_bytes(bytes: Self::Repr) -> Self {
+        BoxedUint::from_le_slice(&bytes, (bytes.len() * 8).try_into().expect("overflow"))
+            .expect("decode error")
     }
 }
 

--- a/src/uint/boxed/rand.rs
+++ b/src/uint/boxed/rand.rs
@@ -3,7 +3,7 @@
 use super::BoxedUint;
 use crate::{
     NonZero, RandomBits, RandomBitsError, RandomMod,
-    uint::rand::{random_bits_core, random_mod_core},
+    uint::rand::{random_bits_core, random_mod_vartime_core},
 };
 use rand_core::{RngCore, TryRngCore};
 
@@ -28,7 +28,7 @@ impl RandomBits for BoxedUint {
         }
 
         let mut ret = BoxedUint::zero_with_precision(bits_precision);
-        random_bits_core(rng, &mut ret.limbs, bit_length)?;
+        random_bits_core(rng, &mut ret, bit_length).map_err(RandomBitsError::RandCore)?;
         Ok(ret)
     }
 }
@@ -36,7 +36,7 @@ impl RandomBits for BoxedUint {
 impl RandomMod for BoxedUint {
     fn random_mod_vartime<R: RngCore + ?Sized>(rng: &mut R, modulus: &NonZero<Self>) -> Self {
         let mut n = BoxedUint::zero_with_precision(modulus.bits_precision());
-        let Ok(()) = random_mod_core(rng, &mut n, modulus, modulus.bits());
+        let Ok(()) = random_mod_vartime_core(rng, &mut n, modulus, modulus.bits());
         n
     }
 
@@ -45,7 +45,7 @@ impl RandomMod for BoxedUint {
         modulus: &NonZero<Self>,
     ) -> Result<Self, R::Error> {
         let mut n = BoxedUint::zero_with_precision(modulus.bits_precision());
-        random_mod_core(rng, &mut n, modulus, modulus.bits())?;
+        random_mod_vartime_core(rng, &mut n, modulus, modulus.bits())?;
         Ok(n)
     }
 }

--- a/tests/monty_form.rs
+++ b/tests/monty_form.rs
@@ -52,7 +52,7 @@ where
     T: Unsigned + Bounded + Encoding,
     <T as Unsigned>::Monty: Invert<Output = CtOption<T::Monty>>,
 {
-    let r = T::from_be_bytes(bytes);
+    let r = T::from_be_bytes(bytes.clone());
     let rm = <T as Unsigned>::Monty::new(r.clone(), monty_params);
     let rm_inv = rm.invert();
     prop_assume!(bool::from(rm_inv.is_some()), "r={:?} is not invertible", r);


### PR DESCRIPTION
Depends on RustCrypto/signatures#1139 as well as potentially changes to other dependent crates.

Reverts RustCrypto/crypto-bigint#1060