### PR TITLE
Add `BoxedUint::pow_mod`

### DIFF
--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -17,6 +17,7 @@ mod mul;
 mod mul_mod;
 mod neg;
 mod neg_mod;
+mod pow_mod;
 mod select;
 mod shl;
 mod shr;

--- a/src/uint/boxed/pow_mod.rs
+++ b/src/uint/boxed/pow_mod.rs
@@ -1,0 +1,17 @@
+//! [`BoxedUint`] modular exponentiation operations.
+
+use crate::{
+    BoxedUint, Odd,
+    modular::{BoxedMontyForm, BoxedMontyParams},
+};
+
+impl BoxedUint {
+    /// Computes `self ^ rhs mod p` for odd `p`.
+    pub fn pow_mod(&self, rhs: &BoxedUint, p: &Odd<BoxedUint>) -> BoxedUint {
+        BoxedMontyForm::new(self.clone(), BoxedMontyParams::new(p.clone()))
+            .pow(rhs)
+            .retrieve()
+    }
+}
+
+// NOTE: tested via proptests in `tests/boxed_uint.rs`

--- a/tests/boxed_uint.rs
+++ b/tests/boxed_uint.rs
@@ -198,6 +198,19 @@ proptest! {
     }
 
     #[test]
+    fn pow_mod(a in uint(), b in uint(), n in modulus()) {
+        let a = reduce(&a, n.as_nz_ref());
+
+        let a_bi = to_biguint(&a);
+        let b_bi = to_biguint(&b);
+        let n_bi = to_biguint(&n);
+
+        let expected = to_uint(a_bi.modpow(&b_bi, &n_bi));
+        let actual = a.pow_mod(&b, &n);
+        prop_assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn widening_mul(a in uint(), b in uint()) {
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);


### PR DESCRIPTION
Simplified modular exponentiation interface for cases where it doesn't make sense to create persistent Montgomery form values (i.e.  `BoxedMontyForm`)