### PR TITLE
Have `BoxedMontyForm::new` auto-`Clone` its params

### DIFF
--- a/benches/boxed_monty.rs
+++ b/benches/boxed_monty.rs
@@ -26,11 +26,11 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || {
                 let a = BoxedMontyForm::new(
                     BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params.clone(),
+                    &params,
                 );
                 let b = BoxedMontyForm::new(
                     BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params.clone(),
+                    &params,
                 );
                 (a, b)
             },
@@ -44,7 +44,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || {
                 BoxedMontyForm::new(
                     BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params.clone(),
+                    &params,
                 )
             },
             |a| black_box(a).double(),
@@ -57,11 +57,11 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || {
                 let a = BoxedMontyForm::new(
                     BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params.clone(),
+                    &params,
                 );
                 let b = BoxedMontyForm::new(
                     BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params.clone(),
+                    &params,
                 );
                 (a, b)
             },
@@ -75,7 +75,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || {
                 BoxedMontyForm::new(
                     BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params.clone(),
+                    &params,
                 )
             },
             |a| black_box(a).neg(),
@@ -88,7 +88,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || {
                 BoxedMontyForm::new(
                     BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params.clone(),
+                    &params,
                 )
             },
             |x| black_box(x).invert(),
@@ -101,11 +101,11 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || {
                 let x = BoxedMontyForm::new(
                     BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params.clone(),
+                    &params,
                 );
                 let y = BoxedMontyForm::new(
                     BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params.clone(),
+                    &params,
                 );
                 (x, y)
             },
@@ -133,7 +133,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 let x = BoxedUint::random_bits(&mut rng, UINT_BITS);
-                let x_m = BoxedMontyForm::new(x, params.clone());
+                let x_m = BoxedMontyForm::new(x, &params);
                 let p = BoxedUint::random_bits(&mut rng, UINT_BITS)
                     | (BoxedUint::one_with_precision(UINT_BITS) << (UINT_BITS - 1));
                 (x_m, p)
@@ -166,7 +166,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                 || {
                     BoxedMontyForm::new(
                         BoxedUint::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                        params.clone(),
+                        &params,
                     )
                 },
                 |a| {
@@ -203,7 +203,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
     group.bench_function("BoxedMontyForm::new", |b| {
         b.iter_batched(
             || BoxedUint::random_bits(&mut rng, UINT_BITS),
-            |x| black_box(BoxedMontyForm::new(x, params.clone())),
+            |x| black_box(BoxedMontyForm::new(x, &params)),
             BatchSize::SmallInput,
         )
     });
@@ -211,7 +211,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
     let params = BoxedMontyParams::new(Odd::<BoxedUint>::random(&mut rng, UINT_BITS));
     group.bench_function("BoxedMontyForm::retrieve", |b| {
         b.iter_batched(
-            || BoxedMontyForm::new(BoxedUint::random_bits(&mut rng, UINT_BITS), params.clone()),
+            || BoxedMontyForm::new(BoxedUint::random_bits(&mut rng, UINT_BITS), &params),
             |x| black_box(x.retrieve()),
             BatchSize::SmallInput,
         )

--- a/benches/monty.rs
+++ b/benches/monty.rs
@@ -34,7 +34,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
     group.bench_function("MontyForm::new", |b| {
         b.iter_batched(
             || U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-            |x| black_box(MontyForm::new(&x, params)),
+            |x| black_box(MontyForm::new(&x, &params)),
             BatchSize::SmallInput,
         )
     });
@@ -45,7 +45,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
             || {
                 MontyForm::new(
                     &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params,
+                    &params,
                 )
             },
             |x| black_box(x.retrieve()),
@@ -63,11 +63,11 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || {
                 let a = MontyForm::new(
                     &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params,
+                    &params,
                 );
                 let b = MontyForm::new(
                     &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params,
+                    &params,
                 );
                 (a, b)
             },
@@ -81,7 +81,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || {
                 MontyForm::new(
                     &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params,
+                    &params,
                 )
             },
             |a| black_box(a).double(),
@@ -94,11 +94,11 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || {
                 let a = MontyForm::new(
                     &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params,
+                    &params,
                 );
                 let b = MontyForm::new(
                     &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params,
+                    &params,
                 );
                 (a, b)
             },
@@ -112,7 +112,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || {
                 MontyForm::new(
                     &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params,
+                    &params,
                 )
             },
             |a| black_box(a).neg(),
@@ -125,7 +125,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || {
                 MontyForm::new(
                     &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params,
+                    &params,
                 )
             },
             |x| black_box(x).invert(),
@@ -138,11 +138,11 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || {
                 let x = MontyForm::new(
                     &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params,
+                    &params,
                 );
                 let y = MontyForm::new(
                     &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params,
+                    &params,
                 );
                 (x, y)
             },
@@ -156,7 +156,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || {
                 MontyForm::new(
                     &U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
-                    params,
+                    &params,
                 )
             },
             |x| x.square(),
@@ -168,7 +168,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 let x = U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref());
-                let x_m = MontyForm::new(&x, params);
+                let x_m = MontyForm::new(&x, &params);
                 let p = U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref())
                     | (U256::ONE << (U256::BITS - 1));
                 (x_m, p)
@@ -182,7 +182,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         b.iter_batched(
             || {
                 let x = U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref());
-                MontyForm::new(&x, params)
+                MontyForm::new(&x, &params)
             },
             |x| black_box(x.div_by_2()),
             BatchSize::SmallInput,
@@ -202,7 +202,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                                     &mut rng,
                                     params.modulus().as_nz_ref(),
                                 );
-                                let x_m = MontyForm::new(&x, params);
+                                let x_m = MontyForm::new(&x, &params);
                                 let p = U256::random_mod_vartime(
                                     &mut rng,
                                     params.modulus().as_nz_ref(),

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -168,14 +168,14 @@ pub struct BoxedMontyForm {
 
 impl BoxedMontyForm {
     /// Instantiates a new [`BoxedMontyForm`] that represents an integer modulo the provided params.
-    pub fn new(mut integer: BoxedUint, params: BoxedMontyParams) -> Self {
+    pub fn new(mut integer: BoxedUint, params: &BoxedMontyParams) -> Self {
         debug_assert_eq!(integer.bits_precision(), params.bits_precision());
-        convert_to_montgomery(&mut integer, &params);
+        convert_to_montgomery(&mut integer, params);
 
         #[allow(clippy::useless_conversion)]
         Self {
             montgomery_form: integer,
-            params,
+            params: params.clone(),
         }
     }
 
@@ -293,7 +293,7 @@ impl Monty for BoxedMontyForm {
         BoxedMontyParams::new_vartime(modulus)
     }
 
-    fn new(value: Self::Integer, params: Self::Params) -> Self {
+    fn new(value: Self::Integer, params: &Self::Params) -> Self {
         BoxedMontyForm::new(value, params)
     }
 

--- a/src/modular/boxed_monty_form/add.rs
+++ b/src/modular/boxed_monty_form/add.rs
@@ -93,14 +93,14 @@ mod tests {
             256,
         )
         .unwrap();
-        let mut x_mod = BoxedMontyForm::new(x, params.clone());
+        let mut x_mod = BoxedMontyForm::new(x, &params);
 
         let y = BoxedUint::from_be_slice(
             &hex!("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251"),
             256,
         )
         .unwrap();
-        let y_mod = BoxedMontyForm::new(y, params.clone());
+        let y_mod = BoxedMontyForm::new(y, &params);
 
         x_mod += &y_mod;
 

--- a/src/modular/boxed_monty_form/invert.rs
+++ b/src/modular/boxed_monty_form/invert.rs
@@ -87,7 +87,7 @@ mod tests {
             256,
         )
         .unwrap();
-        let x_mod = BoxedMontyForm::new(x, params);
+        let x_mod = BoxedMontyForm::new(x, &params);
 
         let inv = x_mod.invert().unwrap();
         let res = x_mod * inv;

--- a/src/modular/boxed_monty_form/lincomb.rs
+++ b/src/modular/boxed_monty_form/lincomb.rs
@@ -56,16 +56,16 @@ mod tests {
 
             let lincomb = BoxedMontyForm::lincomb_vartime(&[
                 (
-                    &BoxedMontyForm::new(a, params.clone()),
-                    &BoxedMontyForm::new(b, params.clone()),
+                    &BoxedMontyForm::new(a, &params),
+                    &BoxedMontyForm::new(b, &params),
                 ),
                 (
-                    &BoxedMontyForm::new(c, params.clone()),
-                    &BoxedMontyForm::new(d, params.clone()),
+                    &BoxedMontyForm::new(c, &params),
+                    &BoxedMontyForm::new(d, &params),
                 ),
                 (
-                    &BoxedMontyForm::new(e, params.clone()),
-                    &BoxedMontyForm::new(f, params.clone()),
+                    &BoxedMontyForm::new(e, &params),
+                    &BoxedMontyForm::new(f, &params),
                 ),
             ]);
 

--- a/src/modular/boxed_monty_form/mul.rs
+++ b/src/modular/boxed_monty_form/mul.rs
@@ -329,7 +329,7 @@ mod tests {
 
         let boxed_modulus = BoxedUint::from(modulus);
         let boxed_params = BoxedMontyParams::new(boxed_modulus.to_odd().unwrap());
-        let boxed_monty = BoxedMontyForm::new(BoxedUint::from(x), boxed_params);
+        let boxed_monty = BoxedMontyForm::new(BoxedUint::from(x), &boxed_params);
         let boxed_square = boxed_monty.square();
 
         // TODO(tarcieri): test for correct output

--- a/src/modular/boxed_monty_form/neg.rs
+++ b/src/modular/boxed_monty_form/neg.rs
@@ -51,8 +51,8 @@ mod tests {
             256,
         )
         .expect("error creating boxeduint");
-        let x_mod = BoxedMontyForm::new(x, params.clone());
 
+        let x_mod = BoxedMontyForm::new(x, &params);
         assert!(bool::from((x_mod.neg() + x_mod).is_zero()));
     }
 }

--- a/src/modular/boxed_monty_form/sub.rs
+++ b/src/modular/boxed_monty_form/sub.rs
@@ -88,14 +88,14 @@ mod tests {
             256,
         )
         .unwrap();
-        let mut x_mod = BoxedMontyForm::new(x, params.clone());
+        let mut x_mod = BoxedMontyForm::new(x, &params);
 
         let y = BoxedUint::from_be_slice(
             &hex!("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251"),
             256,
         )
         .unwrap();
-        let y_mod = BoxedMontyForm::new(y, params);
+        let y_mod = BoxedMontyForm::new(y, &params);
 
         x_mod -= &y_mod;
 

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -140,12 +140,12 @@ pub struct MontyForm<const LIMBS: usize> {
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Instantiates a new `MontyForm` that represents this `integer` mod `MOD`.
-    pub const fn new(integer: &Uint<LIMBS>, params: MontyParams<LIMBS>) -> Self {
+    pub const fn new(integer: &Uint<LIMBS>, params: &MontyParams<LIMBS>) -> Self {
         let montgomery_form =
             mul_montgomery_form(integer, &params.r2, &params.modulus, params.mod_neg_inv());
         Self {
             montgomery_form,
-            params,
+            params: *params,
         }
     }
 
@@ -227,7 +227,7 @@ impl<const LIMBS: usize> Monty for MontyForm<LIMBS> {
         MontyParams::new_vartime(modulus)
     }
 
-    fn new(value: Self::Integer, params: Self::Params) -> Self {
+    fn new(value: Self::Integer, params: &Self::Params) -> Self {
         MontyForm::new(&value, params)
     }
 

--- a/src/modular/monty_form/add.rs
+++ b/src/modular/monty_form/add.rs
@@ -84,11 +84,11 @@ mod tests {
 
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
-        let mut x_mod = MontyForm::new(&x, params);
+        let mut x_mod = MontyForm::new(&x, &params);
 
         let y =
             U256::from_be_hex("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251");
-        let y_mod = MontyForm::new(&y, params);
+        let y_mod = MontyForm::new(&y, &params);
 
         x_mod += &y_mod;
 

--- a/src/modular/monty_form/invert.rs
+++ b/src/modular/monty_form/invert.rs
@@ -100,7 +100,7 @@ mod tests {
         let params = params();
         let x =
             U256::from_be_hex("77117F1273373C26C700D076B3F780074D03339F56DD0EFB60E7F58441FD3685");
-        let x_monty = MontyForm::new(&x, params);
+        let x_monty = MontyForm::new(&x, &params);
 
         let inv = x_monty.invert().unwrap();
         let res = x_monty * inv;

--- a/src/modular/monty_form/lincomb.rs
+++ b/src/modular/monty_form/lincomb.rs
@@ -51,8 +51,8 @@ mod tests {
             assert_eq!(
                 a.mul_mod(&b, m).add_mod(&c.mul_mod(&d, m), m),
                 MontyForm::lincomb_vartime(&[
-                    (&MontyForm::new(&a, params), &MontyForm::new(&b, params)),
-                    (&MontyForm::new(&c, params), &MontyForm::new(&d, params)),
+                    (&MontyForm::new(&a, &params), &MontyForm::new(&b, &params)),
+                    (&MontyForm::new(&c, &params), &MontyForm::new(&d, &params)),
                 ])
                 .retrieve(),
                 "n={n}, a={a}, b={b}, c={c}, d={d}"

--- a/src/modular/monty_form/mod_symbol.rs
+++ b/src/modular/monty_form/mod_symbol.rs
@@ -41,7 +41,7 @@ mod tests {
     fn jacobi_quad_residue() {
         let x =
             U256::from_be_hex("14BFAE46F4026E97C7A3FCD889B379A5F025719911C994A594FC6C5092AC58B1");
-        let x_mod = MontyForm::new(&x, PARAMS);
+        let x_mod = MontyForm::new(&x, &PARAMS);
 
         let jac = x_mod.jacobi_symbol();
         let jac_vartime = x_mod.jacobi_symbol_vartime();
@@ -53,7 +53,7 @@ mod tests {
     fn jacobi_quad_nonresidue() {
         let x =
             U256::from_be_hex("1D2EFB21D283A2DDE77004B9DE9A9624F7B15CEEF055CD02E9EF1A9F1B76F253");
-        let x_mod = MontyForm::new(&x, PARAMS);
+        let x_mod = MontyForm::new(&x, &PARAMS);
 
         let jac = x_mod.jacobi_symbol();
         let jac_vartime = x_mod.jacobi_symbol_vartime();

--- a/src/modular/monty_form/sub.rs
+++ b/src/modular/monty_form/sub.rs
@@ -76,11 +76,11 @@ mod tests {
 
         let x =
             U256::from_be_hex("44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
-        let mut x_mod = MontyForm::new(&x, params);
+        let mut x_mod = MontyForm::new(&x, &params);
 
         let y =
             U256::from_be_hex("d5777c45019673125ad240f83094d4252d829516fac8601ed01979ec1ec1a251");
-        let y_mod = MontyForm::new(&y, params);
+        let y_mod = MontyForm::new(&y, &params);
 
         x_mod -= &y_mod;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1021,7 +1021,7 @@ pub trait Monty:
     fn new_params_vartime(modulus: Odd<Self::Integer>) -> Self::Params;
 
     /// Convert the value into the representation using precomputed data.
-    fn new(value: Self::Integer, params: Self::Params) -> Self;
+    fn new(value: Self::Integer, params: &Self::Params) -> Self;
 
     /// Returns zero in this representation.
     fn zero(params: Self::Params) -> Self;

--- a/src/uint/boxed/pow_mod.rs
+++ b/src/uint/boxed/pow_mod.rs
@@ -8,7 +8,7 @@ use crate::{
 impl BoxedUint {
     /// Computes `self ^ rhs mod p` for odd `p`.
     pub fn pow_mod(&self, rhs: &BoxedUint, p: &Odd<BoxedUint>) -> BoxedUint {
-        BoxedMontyForm::new(self.clone(), BoxedMontyParams::new(p.clone()))
+        BoxedMontyForm::new(self.clone(), &BoxedMontyParams::new(p.clone()))
             .pow(rhs)
             .retrieve()
     }

--- a/tests/boxed_monty_form.rs
+++ b/tests/boxed_monty_form.rs
@@ -20,8 +20,7 @@ fn retrieve_biguint(monty_form: &BoxedMontyForm) -> BigUint {
 
 fn reduce(n: &BoxedUint, p: BoxedMontyParams) -> BoxedMontyForm {
     let n_reduced = n.rem_vartime(p.modulus().as_nz_ref());
-
-    BoxedMontyForm::new(n_reduced, p)
+    BoxedMontyForm::new(n_reduced, &p)
 }
 
 prop_compose! {

--- a/tests/monty_form.rs
+++ b/tests/monty_form.rs
@@ -23,7 +23,7 @@ fn retrieve_biguint(monty_form: &MontyForm256) -> BigUint {
 
 fn reduce(n: &U256, p: MontyParams256) -> MontyForm256 {
     let n_reduced = n.rem_vartime(p.modulus().as_nz_ref());
-    MontyForm256::new(&n_reduced, p)
+    MontyForm256::new(&n_reduced, &p)
 }
 
 prop_compose! {
@@ -53,7 +53,7 @@ where
     <T as Unsigned>::Monty: Invert<Output = CtOption<T::Monty>>,
 {
     let r = T::from_be_bytes(bytes.clone());
-    let rm = <T as Unsigned>::Monty::new(r.clone(), monty_params);
+    let rm = <T as Unsigned>::Monty::new(r.clone(), &monty_params);
     let rm_inv = rm.invert();
     prop_assume!(bool::from(rm_inv.is_some()), "r={:?} is not invertible", r);
     let num_modular_modulus = BigUint::from_be_bytes(modulus.to_be_bytes().as_ref());

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -566,7 +566,7 @@ proptest! {
 
         let expected = to_uint(a_bi.modpow(&b_bi, &p_bi));
         let params = MontyParams::new_vartime(P);
-        let a_m = MontyForm::new(&a, params);
+        let a_m = MontyForm::new(&a, &params);
         let actual = a_m.pow(&b).retrieve();
 
         prop_assert_eq!(expected, actual);
@@ -583,7 +583,7 @@ proptest! {
         let expected = to_uint(a_bi.modpow(&b_bi, &p_bi));
 
         let params = MontyParams::new_vartime(P);
-        let a_m = MontyForm::new(&a, params);
+        let a_m = MontyForm::new(&a, &params);
         let actual = a_m.pow_bounded_exp(&b, exponent_bits.into()).retrieve();
 
         prop_assert_eq!(expected, actual);
@@ -604,7 +604,7 @@ proptest! {
         let expected = to_uint(expected);
 
         let params = MontyParams::new_vartime(P);
-        let a_m = MontyForm::new(&a, params);
+        let a_m = MontyForm::new(&a, &params);
         let actual = a_m.div_by_2().retrieve();
 
         prop_assert_eq!(expected, actual);


### PR DESCRIPTION
Changes the `params` argument to `&BoxedMontyParams` and automatically invokes `Clone` on it, since cloning the inner `Arc` is cheap.

We were otherwise leaving this to the caller to do which is annoying, especially since it can be automatic.

However, changing this to a reference effectively means we also need to change the `Monty::new` trait method to take a reference, which means we also need to change `MontyForm::new` to keep everything consistent. That's not really a problem as `MontyParams` are `Copy`.

This does wind up being quite a bit of a breaking change, but should be worth it to get rid of the need for callers to clone params.