### PR TITLE
BoxedMontyForm: `From` conversions for `(Const)MontyForm`

### DIFF
--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -2,6 +2,7 @@
 
 mod add;
 mod cmp;
+mod from;
 mod invert;
 mod lincomb;
 mod mul;
@@ -10,7 +11,7 @@ mod pow;
 mod select;
 mod sub;
 
-use super::{MontyParams, Retrieve, div_by_2, reduction::montgomery_retrieve_inner};
+use super::{Retrieve, div_by_2, reduction::montgomery_retrieve_inner};
 use crate::{BoxedUint, Choice, Limb, Monty, Odd, U64, Word};
 use alloc::sync::Arc;
 use mul::BoxedMontyMultiplier;
@@ -132,27 +133,6 @@ impl BoxedMontyParams {
 
     pub(crate) fn mod_leading_zeros(&self) -> u32 {
         self.0.mod_leading_zeros
-    }
-}
-
-impl<const LIMBS: usize> From<&MontyParams<LIMBS>> for BoxedMontyParams {
-    fn from(params: &MontyParams<LIMBS>) -> Self {
-        Self(
-            BoxedMontyParamsInner {
-                modulus: params.modulus.into(),
-                one: params.one.into(),
-                r2: params.r2.into(),
-                mod_inv: params.mod_inv,
-                mod_leading_zeros: params.mod_leading_zeros,
-            }
-            .into(),
-        )
-    }
-}
-
-impl<const LIMBS: usize> From<MontyParams<LIMBS>> for BoxedMontyParams {
-    fn from(params: MontyParams<LIMBS>) -> Self {
-        BoxedMontyParams::from(&params)
     }
 }
 

--- a/src/modular/boxed_monty_form/from.rs
+++ b/src/modular/boxed_monty_form/from.rs
@@ -1,0 +1,61 @@
+//! `From`-like conversions for [`BoxedMontyForm`] and [`BoxedMontyParams`].
+
+use super::{BoxedMontyForm, BoxedMontyParams, BoxedMontyParamsInner};
+use crate::modular::{ConstMontyForm, ConstMontyParams, MontyForm, MontyParams};
+
+impl<const LIMBS: usize, Params> From<ConstMontyForm<Params, LIMBS>> for BoxedMontyForm
+where
+    Params: ConstMontyParams<LIMBS>,
+{
+    fn from(input: ConstMontyForm<Params, LIMBS>) -> Self {
+        Self::from(&input)
+    }
+}
+
+impl<const LIMBS: usize, Params> From<&ConstMontyForm<Params, LIMBS>> for BoxedMontyForm
+where
+    Params: ConstMontyParams<LIMBS>,
+{
+    fn from(input: &ConstMontyForm<Params, LIMBS>) -> Self {
+        BoxedMontyForm {
+            montgomery_form: input.as_montgomery().into(),
+            params: Params::PARAMS.into(),
+        }
+    }
+}
+
+impl<const LIMBS: usize> From<MontyForm<LIMBS>> for BoxedMontyForm {
+    fn from(input: MontyForm<LIMBS>) -> Self {
+        Self::from(&input)
+    }
+}
+
+impl<const LIMBS: usize> From<&MontyForm<LIMBS>> for BoxedMontyForm {
+    fn from(input: &MontyForm<LIMBS>) -> Self {
+        BoxedMontyForm {
+            montgomery_form: input.as_montgomery().into(),
+            params: input.params().into(),
+        }
+    }
+}
+
+impl<const LIMBS: usize> From<&MontyParams<LIMBS>> for BoxedMontyParams {
+    fn from(params: &MontyParams<LIMBS>) -> Self {
+        Self(
+            BoxedMontyParamsInner {
+                modulus: params.modulus.into(),
+                one: params.one.into(),
+                r2: params.r2.into(),
+                mod_inv: params.mod_inv,
+                mod_leading_zeros: params.mod_leading_zeros,
+            }
+            .into(),
+        )
+    }
+}
+
+impl<const LIMBS: usize> From<MontyParams<LIMBS>> for BoxedMontyParams {
+    fn from(params: MontyParams<LIMBS>) -> Self {
+        BoxedMontyParams::from(&params)
+    }
+}


### PR DESCRIPTION
Support for converting from `ConstMontyForm` and `MontyForm` into `BoxedMontyForm`.

This is useful for SRP where I'm trying to use `ConstMontyForm` and `ConstMontyParams` to represent groups as precomputed constants which can be converted to the heap allocated types to perform `modpow`, which currently isn't impl'd for the stack allocated types.

Sidebar: it would be nice to fix that too.