### PR TITLE
Add array/slice `Limb` => `Word` cast helpers

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -94,6 +94,50 @@ impl Limb {
     pub const fn lsb_to_choice(self) -> Choice {
         word::choice_from_lsb(self.0)
     }
+
+    /// Convert a shared reference to an array of [`Limb`]s into a shared reference to their inner
+    /// [`Word`]s for each limb.
+    #[inline]
+    pub const fn array_as_words<const N: usize>(array: &[Self; N]) -> &[Word; N] {
+        // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
+        #[allow(unsafe_code)]
+        unsafe {
+            &*array.as_ptr().cast()
+        }
+    }
+
+    /// Convert a mutable reference to an array of [`Limb`]s into a mutable reference to their inner
+    /// [`Word`]s for each limb.
+    #[inline]
+    pub const fn array_as_mut_words<const N: usize>(array: &mut [Self; N]) -> &mut [Word; N] {
+        // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
+        #[allow(unsafe_code)]
+        unsafe {
+            &mut *array.as_mut_ptr().cast()
+        }
+    }
+
+    /// Convert a shared reference to an array of [`Limb`]s into a shared reference to their inner
+    /// [`Word`]s for each limb.
+    #[inline]
+    pub const fn slice_as_words(slice: &[Self]) -> &[Word] {
+        // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
+        #[allow(trivial_casts, unsafe_code)]
+        unsafe {
+            &*((slice as *const [Limb]) as *const [Word])
+        }
+    }
+
+    /// Convert a mutable reference to an array of [`Limb`]s into a mutable reference to their inner
+    /// [`Word`]s for each limb.
+    #[inline]
+    pub const fn slice_as_mut_words(slice: &mut [Self]) -> &mut [Word] {
+        // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
+        #[allow(trivial_casts, unsafe_code)]
+        unsafe {
+            &mut *((slice as *mut [Limb]) as *mut [Word])
+        }
+    }
 }
 
 impl Bounded for Limb {

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -152,20 +152,12 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Borrow the inner limbs as an array of [`Word`]s.
     pub const fn as_words(&self) -> &[Word; LIMBS] {
-        // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
-        #[allow(unsafe_code)]
-        unsafe {
-            &*self.limbs.as_ptr().cast()
-        }
+        Limb::array_as_words(&self.limbs)
     }
 
     /// Borrow the inner limbs as a mutable array of [`Word`]s.
     pub const fn as_mut_words(&mut self) -> &mut [Word; LIMBS] {
-        // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
-        #[allow(unsafe_code)]
-        unsafe {
-            &mut *self.limbs.as_mut_ptr().cast()
-        }
+        Limb::array_as_mut_words(&mut self.limbs)
     }
 
     /// Borrow the inner limbs as a mutable slice of [`Word`]s.
@@ -233,6 +225,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Note: this is a casting operation. See [`Self::try_into_int`] for the checked equivalent.
     pub const fn as_int(&self) -> &Int<LIMBS> {
+        // SAFETY: `Int` is a `repr(transparent)` newtype for `Uint`, and this operation is intended
+        // to be a reinterpreting cast between the two types.
         #[allow(trivial_casts, unsafe_code)]
         unsafe {
             &*(self as *const Uint<LIMBS> as *const Int<LIMBS>)

--- a/src/uint/ref_type.rs
+++ b/src/uint/ref_type.rs
@@ -71,22 +71,14 @@ impl UintRef {
     #[cfg(feature = "alloc")]
     #[inline]
     pub const fn as_words(&self) -> &[Word] {
-        // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
-        #[allow(trivial_casts, unsafe_code)]
-        unsafe {
-            &*((&self.0 as *const [Limb]) as *const [Word])
-        }
+        Limb::slice_as_words(&self.0)
     }
 
     /// Borrow the inner limbs as a mutable slice of [`Word`]s.
     #[cfg(feature = "alloc")]
     #[inline]
     pub const fn as_mut_words(&mut self) -> &mut [Word] {
-        // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
-        #[allow(trivial_casts, unsafe_code)]
-        unsafe {
-            &mut *((&mut self.0 as *mut [Limb]) as *mut [Word])
-        }
+        Limb::slice_as_mut_words(&mut self.0)
     }
 
     /// Get an iterator over the inner limbs.


### PR DESCRIPTION
Adds the following functions which can cast from arrays or slices of `Limb` to `Word`:

- `Limb::array_as_words`
- `Limb::array_as_mut_words`
- `Limb::slice_as_words`
- `Limb::slice_as_mut_words`