### PR TITLE
Bump `ctutils` to v0.4.0-pre.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cmov"
-version = "0.5.0-pre.0"
+version = "0.5.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96"
+checksum = "008db54a740b5bc7242282d859316f5d56119d3ff8a80fc0f39e8a0f99039780"
 
 [[package]]
 name = "cpufeatures"
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.3.2"
+version = "0.4.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758e5ed90be3c8abff7f9a6f37ab7f6d8c59c2210d448b81f3f508134aec84e4"
+checksum = "e111d31fd98cc9d8f15996e5e2890291d8a7b887478a28c96b99e0d13702e748"
 dependencies = [
  "cmov",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 exclude = [".codecov.yml", ".github", ".gitignore"]
 
 [dependencies]
-ctutils = "0.3"
+ctutils = "0.4.0-pre.2"
 num-traits = { version = "0.2.19", default-features = false }
 
 # optional dependencies

--- a/src/int/ct.rs
+++ b/src/int/ct.rs
@@ -1,12 +1,19 @@
 //! Constant-time support: impls of `Ct*` traits and constant-time `const fn` operations.
 
-use crate::{Choice, CtEq, CtGt, CtLt, CtSelect, Int, Uint};
+use crate::{Choice, CtAssign, CtEq, CtGt, CtLt, CtSelect, Int, Uint};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
     pub(crate) const fn select(a: &Self, b: &Self, c: Choice) -> Self {
         Self(Uint::select(&a.0, &b.0, c))
+    }
+}
+
+impl<const LIMBS: usize> CtAssign for Int<LIMBS> {
+    #[inline]
+    fn ct_assign(&mut self, other: &Self, choice: Choice) {
+        self.0.ct_assign(&other.0, choice);
     }
 }
 

--- a/src/int/div.rs
+++ b/src/int/div.rs
@@ -503,7 +503,7 @@ impl<const LIMBS: usize> RemAssign<&NonZero<Int<LIMBS>>> for Wrapping<Int<LIMBS>
 
 #[cfg(test)]
 mod tests {
-    use crate::{CtSelect, DivVartime, I128, Int, NonZero, One, Zero};
+    use crate::{CtAssign, DivVartime, I128, Int, NonZero, One, Zero};
 
     #[test]
     #[allow(clippy::init_numbered_fields)]
@@ -628,7 +628,7 @@ mod tests {
 
     #[test]
     fn div_vartime_through_trait() {
-        fn myfn<T: DivVartime + Zero + One + CtSelect>(x: T, y: T) -> T {
+        fn myfn<T: DivVartime + Zero + One + CtAssign>(x: T, y: T) -> T {
             x.div_vartime(&NonZero::new(y).unwrap())
         }
         assert_eq!(myfn(I128::from(8), I128::from(3)), I128::from(2));

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -1,6 +1,6 @@
 //! Limb comparisons
 
-use crate::{Choice, CtEq, CtGt, CtLt, CtSelect, Limb, word};
+use crate::{Choice, CtAssign, CtEq, CtGt, CtLt, Limb, word};
 use core::cmp::Ordering;
 
 impl Limb {

--- a/src/limb/ct.rs
+++ b/src/limb/ct.rs
@@ -1,6 +1,6 @@
 //! Constant-time support: impls of `Ct*` traits and constant-time `const fn` operations.
 
-use crate::{Choice, CtEq, CtGt, CtLt, CtSelect, Limb, word};
+use crate::{Choice, CtAssign, CtEq, CtGt, CtLt, CtSelect, Limb, word};
 
 impl Limb {
     /// Return `b` if `c` is truthy, otherwise return `a`.
@@ -16,6 +16,12 @@ impl Limb {
             Self(word::select(a.0, b.0, c)),
             Self(word::select(b.0, a.0, c)),
         )
+    }
+}
+
+impl CtAssign for Limb {
+    fn ct_assign(&mut self, other: &Self, choice: Choice) {
+        self.0.ct_assign(&other.0, choice);
     }
 }
 

--- a/src/modular/safegcd/boxed.rs
+++ b/src/modular/safegcd/boxed.rs
@@ -5,7 +5,8 @@
 
 use super::{GCD_BATCH_SIZE, Matrix, iterations, jump};
 use crate::{
-    BoxedUint, Choice, CtOption, CtSelect, I64, Int, Limb, NonZero, Odd, Resize, U64, Uint,
+    BoxedUint, Choice, CtAssign, CtOption, CtSelect, I64, Int, Limb, NonZero, Odd, Resize, U64,
+    Uint,
     primitives::{u32_max, u32_min},
 };
 use core::fmt;

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -1,8 +1,8 @@
 //! Wrapper type for non-zero integers.
 
 use crate::{
-    Bounded, Choice, ConstOne, Constants, CtEq, CtOption, CtSelect, Encoding, Int, Limb, Mul, Odd,
-    One, Uint, Zero,
+    Bounded, Choice, ConstOne, Constants, CtAssign, CtEq, CtOption, CtSelect, Encoding, Int, Limb,
+    Mul, Odd, One, Uint, Zero,
 };
 use core::{
     fmt,
@@ -45,7 +45,7 @@ impl<T> NonZero<T> {
     #[inline]
     pub fn new(mut n: T) -> CtOption<Self>
     where
-        T: Zero + One + CtSelect,
+        T: Zero + One + CtAssign,
     {
         let is_zero = n.is_zero();
 
@@ -106,7 +106,7 @@ where
 
 impl<T> NonZero<T>
 where
-    T: Zero + One + CtSelect + Encoding,
+    T: Zero + One + CtAssign + Encoding,
 {
     /// Decode from big endian bytes.
     pub fn from_be_bytes(bytes: T::Repr) -> CtOption<Self> {
@@ -298,7 +298,7 @@ impl<const LIMBS: usize> NonZeroInt<LIMBS> {
 #[cfg(feature = "hybrid-array")]
 impl<T> NonZero<T>
 where
-    T: ArrayEncoding + Zero + One + CtSelect,
+    T: ArrayEncoding + Zero + One + CtAssign,
 {
     /// Decode a non-zero integer from big endian bytes.
     pub fn from_be_byte_array(bytes: ByteArray<T>) -> CtOption<Self> {
@@ -358,7 +358,7 @@ impl<T: ?Sized> Deref for NonZero<T> {
 #[cfg(feature = "rand_core")]
 impl<T> Random for NonZero<T>
 where
-    T: Random + Zero + One + CtSelect,
+    T: Random + Zero + One + CtAssign,
 {
     /// This uses rejection sampling to avoid zero.
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -4,7 +4,7 @@ pub use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
     Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
 };
-pub use ctutils::{CtEq, CtGt, CtLt, CtNeg, CtSelect};
+pub use ctutils::{CtAssign, CtEq, CtGt, CtLt, CtNeg, CtSelect};
 pub use num_traits::{
     ConstOne, ConstZero, WrappingAdd, WrappingMul, WrappingNeg, WrappingShl, WrappingShr,
     WrappingSub,
@@ -51,6 +51,7 @@ pub trait Integer:
     + CheckedDiv
     + CheckedSquareRoot<Output = Self>
     + Clone
+    + CtAssign
     + CtEq
     + CtGt
     + CtLt

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -29,7 +29,7 @@ mod sub_mod;
 mod rand;
 
 use crate::{
-    Choice, CtEq, CtOption, CtSelect, Integer, Limb, NonZero, Odd, One, Resize, UintRef, Unsigned,
+    Choice, CtAssign, CtEq, CtOption, Integer, Limb, NonZero, Odd, One, Resize, UintRef, Unsigned,
     Word, Zero, modular::BoxedMontyForm,
 };
 use alloc::{boxed::Box, vec, vec::Vec};

--- a/src/uint/boxed/cmp.rs
+++ b/src/uint/boxed/cmp.rs
@@ -5,7 +5,7 @@
 pub(super) use core::cmp::{Ordering, max};
 
 use super::BoxedUint;
-use crate::{CtEq, CtGt, CtLt, CtSelect, Limb, Uint};
+use crate::{CtAssign, CtEq, CtGt, CtLt, Limb, Uint};
 
 impl BoxedUint {
     /// Returns the Ordering between `self` and `rhs` in variable time.

--- a/src/uint/boxed/ct.rs
+++ b/src/uint/boxed/ct.rs
@@ -1,8 +1,16 @@
 //! Constant-time support: impls of `Ct*` traits.
 
 use super::BoxedUint;
-use crate::{Choice, CtEq, CtGt, CtLt, CtNeg, CtSelect, Limb, word};
+use crate::{Choice, CtAssign, CtEq, CtGt, CtLt, CtNeg, CtSelect, Limb, word};
 use core::cmp::max;
+
+impl CtAssign for BoxedUint {
+    #[inline]
+    fn ct_assign(&mut self, other: &Self, choice: Choice) {
+        debug_assert_eq!(self.bits_precision(), other.bits_precision());
+        self.as_mut_words().ct_assign(other.as_words(), choice);
+    }
+}
 
 impl CtEq for BoxedUint {
     #[inline]
@@ -59,15 +67,6 @@ impl CtSelect for BoxedUint {
         }
 
         Self { limbs }
-    }
-
-    #[inline]
-    fn ct_assign(&mut self, other: &Self, choice: Choice) {
-        debug_assert_eq!(self.bits_precision(), other.bits_precision());
-
-        for i in 0..self.nlimbs() {
-            self.limbs[i].ct_assign(&other.limbs[i], choice);
-        }
     }
 
     #[inline]

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -1,7 +1,7 @@
 //! [`BoxedUint`] division operations.
 
 use crate::{
-    BoxedUint, CheckedDiv, CtOption, CtSelect, Div, DivAssign, DivRemLimb, DivVartime, Limb,
+    BoxedUint, CheckedDiv, CtAssign, CtOption, Div, DivAssign, DivRemLimb, DivVartime, Limb,
     NonZero, Reciprocal, Rem, RemAssign, RemLimb, RemMixed, UintRef, Wrapping,
 };
 
@@ -294,7 +294,7 @@ impl RemMixed<BoxedUint> for BoxedUint {
 #[cfg(test)]
 mod tests {
     use super::{BoxedUint, Limb, NonZero};
-    use crate::{CtSelect, DivVartime, One, Resize, Zero};
+    use crate::{CtAssign, DivVartime, One, Resize, Zero};
 
     #[test]
     fn rem() {
@@ -383,7 +383,7 @@ mod tests {
             x: T,
             y: T,
         }
-        impl<T: DivVartime + Clone + Zero + One + CtSelect> A<T> {
+        impl<T: DivVartime + Clone + Zero + One + CtAssign> A<T> {
             fn divide_x_by_y(&self) -> T {
                 let rhs = &NonZero::new(self.y.clone()).unwrap();
                 self.x.div_vartime(rhs)

--- a/src/uint/boxed/neg.rs
+++ b/src/uint/boxed/neg.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] negation operations.
 
-use crate::{BoxedUint, Choice, CtSelect, Limb, WideWord, Word, WrappingNeg};
+use crate::{BoxedUint, Choice, CtAssign, Limb, WideWord, Word, WrappingNeg};
 
 impl BoxedUint {
     /// Perform wrapping negation.

--- a/src/uint/boxed/neg_mod.rs
+++ b/src/uint/boxed/neg_mod.rs
@@ -1,6 +1,6 @@
 //! [`BoxedUint`] modular negation operations.
 
-use crate::{BoxedUint, CtSelect, Limb, NegMod, NonZero};
+use crate::{BoxedUint, CtAssign, Limb, NegMod, NonZero};
 
 impl BoxedUint {
     /// Computes `-a mod p`.

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -1,7 +1,7 @@
 //! [`BoxedUint`] square root operations.
 
 use crate::{
-    BitOps, BoxedUint, CheckedSquareRoot, CtEq, CtGt, CtOption, CtSelect, FloorSquareRoot, Limb,
+    BitOps, BoxedUint, CheckedSquareRoot, CtAssign, CtEq, CtGt, CtOption, FloorSquareRoot, Limb,
 };
 
 impl BoxedUint {

--- a/src/uint/ct.rs
+++ b/src/uint/ct.rs
@@ -1,6 +1,6 @@
 //! Constant-time support: impls of `Ct*` traits and constant-time `const fn` operations.
 
-use crate::{Choice, CtEq, CtGt, CtLt, CtSelect, Limb, Uint};
+use crate::{Choice, CtAssign, CtEq, CtGt, CtLt, CtSelect, Limb, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Return `b` if `c` is truthy, otherwise return `a`.
@@ -36,10 +36,17 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 }
 
+impl<const LIMBS: usize> CtAssign for Uint<LIMBS> {
+    #[inline]
+    fn ct_assign(&mut self, other: &Self, choice: Choice) {
+        self.as_mut_words().ct_assign(other.as_words(), choice);
+    }
+}
+
 impl<const LIMBS: usize> CtEq for Uint<LIMBS> {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
-        self.limbs.ct_eq(&other.limbs)
+        self.as_words().ct_eq(other.as_words())
     }
 }
 
@@ -60,9 +67,7 @@ impl<const LIMBS: usize> CtLt for Uint<LIMBS> {
 impl<const LIMBS: usize> CtSelect for Uint<LIMBS> {
     #[inline]
     fn ct_select(&self, other: &Self, choice: Choice) -> Self {
-        Self {
-            limbs: self.limbs.ct_select(&other.limbs, choice),
-        }
+        Self::from_words(self.as_words().ct_select(other.as_words(), choice))
     }
 }
 

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -674,7 +674,7 @@ impl<const LIMBS: usize> RemLimb for Uint<LIMBS> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        CtSelect, DivVartime, Limb, NonZero, One, RemMixed, U64, U128, U256, U512, U896, U1024,
+        CtAssign, DivVartime, Limb, NonZero, One, RemMixed, U64, U128, U256, U512, U896, U1024,
         Uint, Word, Zero,
     };
 
@@ -997,7 +997,7 @@ mod tests {
         impl<T, U> A<T, U>
         where
             T: RemMixed<U>,
-            U: Clone + Zero + One + CtSelect,
+            U: Clone + Zero + One + CtAssign,
         {
             fn reduce_t_by_u(&self) -> U {
                 let rhs = &NonZero::new(self.u.clone()).unwrap();
@@ -1020,7 +1020,7 @@ mod tests {
         }
         impl<T> A<T>
         where
-            T: DivVartime + Clone + Zero + One + CtSelect,
+            T: DivVartime + Clone + Zero + One + CtAssign,
         {
             fn divide_x_by_y(&self) -> T {
                 let rhs = &NonZero::new(self.y.clone()).unwrap();

--- a/src/uint/ref_type.rs
+++ b/src/uint/ref_type.rs
@@ -72,7 +72,6 @@ impl UintRef {
     }
 
     /// Borrow the inner limbs as a mutable slice of [`Word`]s.
-    #[cfg(feature = "alloc")]
     #[inline]
     pub const fn as_mut_words(&mut self) -> &mut [Word] {
         Limb::slice_as_mut_words(&mut self.0)

--- a/src/uint/ref_type/ct.rs
+++ b/src/uint/ref_type/ct.rs
@@ -1,7 +1,15 @@
 //! Constant-time support: impls of `Ct*` traits and constant-time `const fn` operations.
 
 use super::UintRef;
-use crate::{Choice, CtEq};
+use crate::{Choice, CtAssign, CtEq};
+
+impl CtAssign for UintRef {
+    #[inline]
+    fn ct_assign(&mut self, other: &Self, choice: Choice) {
+        debug_assert_eq!(self.bits_precision(), other.bits_precision());
+        self.as_mut_words().ct_assign(other.as_words(), choice);
+    }
+}
 
 impl CtEq for UintRef {
     #[inline]


### PR DESCRIPTION
Notable changes include splitting out a `CtAssign` trait from `CtSelect`, which is now possible to impl for `UintRef`.

It also includes performance improvements through better code generation.