### PR TITLE
Add `ctutils` trait impls: `CtAssignSlice`/`CtEqSlice`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cmov"
-version = "0.5.0-pre.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008db54a740b5bc7242282d859316f5d56119d3ff8a80fc0f39e8a0f99039780"
+checksum = "03968eed9162993de84b238cfc28851352572714ecadb2599638636bab90aa49"
 
 [[package]]
 name = "cpufeatures"
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.4.0-pre.2"
+version = "0.4.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e111d31fd98cc9d8f15996e5e2890291d8a7b887478a28c96b99e0d13702e748"
+checksum = "fbb255642521ef4deccf330e4681da91dbe3e563a05539eeaa9623809e26ce45"
 dependencies = [
  "cmov",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 exclude = [".codecov.yml", ".github", ".gitignore"]
 
 [dependencies]
-ctutils = "0.4.0-pre.2"
+ctutils = "0.4.0-pre.4"
 num-traits = { version = "0.2.19", default-features = false }
 
 # optional dependencies

--- a/src/int/ct.rs
+++ b/src/int/ct.rs
@@ -1,6 +1,7 @@
 //! Constant-time support: impls of `Ct*` traits and constant-time `const fn` operations.
 
 use crate::{Choice, CtAssign, CtEq, CtGt, CtLt, CtSelect, Int, Uint};
+use ctutils::{CtAssignSlice, CtEqSlice};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Return `b` if `c` is truthy, otherwise return `a`.
@@ -16,6 +17,7 @@ impl<const LIMBS: usize> CtAssign for Int<LIMBS> {
         self.0.ct_assign(&other.0, choice);
     }
 }
+impl<const LIMBS: usize> CtAssignSlice for Int<LIMBS> {}
 
 impl<const LIMBS: usize> CtEq for Int<LIMBS> {
     #[inline]
@@ -23,6 +25,7 @@ impl<const LIMBS: usize> CtEq for Int<LIMBS> {
         CtEq::ct_eq(&self.0, &other.0)
     }
 }
+impl<const LIMBS: usize> CtEqSlice for Int<LIMBS> {}
 
 impl<const LIMBS: usize> CtGt for Int<LIMBS> {
     #[inline]

--- a/src/limb/ct.rs
+++ b/src/limb/ct.rs
@@ -1,6 +1,7 @@
 //! Constant-time support: impls of `Ct*` traits and constant-time `const fn` operations.
 
 use crate::{Choice, CtAssign, CtEq, CtGt, CtLt, CtSelect, Limb, word};
+use ctutils::{CtAssignSlice, CtEqSlice};
 
 impl Limb {
     /// Return `b` if `c` is truthy, otherwise return `a`.
@@ -25,6 +26,12 @@ impl CtAssign for Limb {
     }
 }
 
+impl CtAssignSlice for Limb {
+    fn ct_assign_slice(dst: &mut [Self], src: &[Self], choice: Choice) {
+        Self::slice_as_mut_words(dst).ct_assign(Self::slice_as_words(src), choice);
+    }
+}
+
 impl CtEq for Limb {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
@@ -34,6 +41,12 @@ impl CtEq for Limb {
     #[inline]
     fn ct_ne(&self, other: &Self) -> Choice {
         CtEq::ct_ne(&self.0, &other.0)
+    }
+}
+
+impl CtEqSlice for Limb {
+    fn ct_eq_slice(a: &[Self], b: &[Self]) -> Choice {
+        Self::slice_as_words(a).ct_eq(Self::slice_as_words(b))
     }
 }
 

--- a/src/modular/const_monty_form/ct.rs
+++ b/src/modular/const_monty_form/ct.rs
@@ -1,8 +1,25 @@
 //! Constant-time support: impls of `Ct*` traits and constant-time `const fn` operations.
 
 use super::{ConstMontyForm, ConstMontyParams};
-use crate::{Choice, CtEq, CtSelect, Uint};
-use core::marker::PhantomData;
+use crate::{Choice, CtAssign, CtEq};
+use ctutils::{CtAssignSlice, CtEqSlice, CtSelectUsingCtAssign};
+
+#[cfg(feature = "subtle")]
+use crate::CtSelect;
+
+impl<MOD, const LIMBS: usize> CtAssign for ConstMontyForm<MOD, LIMBS>
+where
+    MOD: ConstMontyParams<LIMBS>,
+{
+    fn ct_assign(&mut self, other: &Self, choice: Choice) {
+        self.montgomery_form
+            .ct_assign(&other.montgomery_form, choice);
+    }
+}
+impl<MOD, const LIMBS: usize> CtAssignSlice for ConstMontyForm<MOD, LIMBS> where
+    MOD: ConstMontyParams<LIMBS>
+{
+}
 
 impl<MOD, const LIMBS: usize> CtEq for ConstMontyForm<MOD, LIMBS>
 where
@@ -12,6 +29,15 @@ where
         CtEq::ct_eq(&self.montgomery_form, &other.montgomery_form)
     }
 }
+impl<MOD, const LIMBS: usize> CtEqSlice for ConstMontyForm<MOD, LIMBS> where
+    MOD: ConstMontyParams<LIMBS>
+{
+}
+
+impl<MOD, const LIMBS: usize> CtSelectUsingCtAssign for ConstMontyForm<MOD, LIMBS> where
+    MOD: ConstMontyParams<LIMBS>
+{
+}
 
 #[cfg(feature = "subtle")]
 impl<MOD, const LIMBS: usize> subtle::ConstantTimeEq for ConstMontyForm<MOD, LIMBS>
@@ -20,18 +46,6 @@ where
 {
     fn ct_eq(&self, other: &Self) -> subtle::Choice {
         CtEq::ct_eq(&self.montgomery_form, &other.montgomery_form).into()
-    }
-}
-
-impl<MOD, const LIMBS: usize> CtSelect for ConstMontyForm<MOD, LIMBS>
-where
-    MOD: ConstMontyParams<LIMBS>,
-{
-    fn ct_select(&self, other: &Self, choice: Choice) -> Self {
-        ConstMontyForm {
-            montgomery_form: Uint::ct_select(&self.montgomery_form, &other.montgomery_form, choice),
-            phantom: PhantomData,
-        }
     }
 }
 

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -9,6 +9,7 @@ use core::{
     num::{NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128},
     ops::Deref,
 };
+use ctutils::{CtAssignSlice, CtEqSlice};
 
 #[cfg(feature = "alloc")]
 use crate::BoxedUint;
@@ -317,6 +318,17 @@ impl<T: ?Sized> AsRef<T> for NonZero<T> {
     }
 }
 
+impl<T> CtAssign for NonZero<T>
+where
+    T: CtAssign,
+{
+    #[inline]
+    fn ct_assign(&mut self, other: &Self, choice: Choice) {
+        self.0.ct_assign(&other.0, choice);
+    }
+}
+impl<T> CtAssignSlice for NonZero<T> where T: CtAssign {}
+
 impl<T> CtEq for NonZero<T>
 where
     T: CtEq + ?Sized,
@@ -326,6 +338,7 @@ where
         CtEq::ct_eq(&self.0, &other.0)
     }
 }
+impl<T> CtEqSlice for NonZero<T> where T: CtEq {}
 
 impl<T> CtSelect for NonZero<T>
 where

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -1,10 +1,11 @@
 //! Wrapper type for non-zero integers.
 
 use crate::{
-    Bounded, Choice, ConstOne, CtEq, CtOption, CtSelect, Int, Integer, Limb, Mul, NonZero, One,
-    Uint, UintRef,
+    Bounded, Choice, ConstOne, CtAssign, CtEq, CtOption, CtSelect, Int, Integer, Limb, Mul,
+    NonZero, One, Uint, UintRef,
 };
 use core::{cmp::Ordering, fmt, ops::Deref};
+use ctutils::{CtAssignSlice, CtEqSlice};
 
 #[cfg(feature = "alloc")]
 use crate::{BoxedUint, Resize};
@@ -174,6 +175,17 @@ impl<T: ?Sized> AsRef<NonZero<T>> for Odd<T> {
     }
 }
 
+impl<T> CtAssign for Odd<T>
+where
+    T: CtAssign,
+{
+    #[inline]
+    fn ct_assign(&mut self, other: &Self, choice: Choice) {
+        self.0.ct_assign(&other.0, choice);
+    }
+}
+impl<T> CtAssignSlice for Odd<T> where T: CtAssignSlice {}
+
 impl<T> CtEq for Odd<T>
 where
     T: CtEq + ?Sized,
@@ -183,6 +195,7 @@ where
         CtEq::ct_eq(&self.0, &other.0)
     }
 }
+impl<T> CtEqSlice for Odd<T> where T: CtEq {}
 
 impl<T> CtSelect for Odd<T>
 where

--- a/src/uint/boxed/ct.rs
+++ b/src/uint/boxed/ct.rs
@@ -3,15 +3,18 @@
 use super::BoxedUint;
 use crate::{Choice, CtAssign, CtEq, CtGt, CtLt, CtNeg, CtSelect, Limb, word};
 use core::cmp::max;
+use ctutils::{CtAssignSlice, CtEqSlice};
 
 impl CtAssign for BoxedUint {
     #[inline]
     fn ct_assign(&mut self, other: &Self, choice: Choice) {
         debug_assert_eq!(self.bits_precision(), other.bits_precision());
-        self.as_mut_words().ct_assign(other.as_words(), choice);
+        self.limbs.ct_assign(&other.limbs, choice);
     }
 }
+impl CtAssignSlice for BoxedUint {}
 
+// Note: special impl with implicit widening
 impl CtEq for BoxedUint {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
@@ -27,6 +30,7 @@ impl CtEq for BoxedUint {
         ret
     }
 }
+impl CtEqSlice for BoxedUint {}
 
 impl CtGt for BoxedUint {
     #[inline]

--- a/src/uint/ct.rs
+++ b/src/uint/ct.rs
@@ -1,6 +1,7 @@
 //! Constant-time support: impls of `Ct*` traits and constant-time `const fn` operations.
 
 use crate::{Choice, CtAssign, CtEq, CtGt, CtLt, CtSelect, Limb, Uint};
+use ctutils::{CtAssignSlice, CtEqSlice};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Return `b` if `c` is truthy, otherwise return `a`.
@@ -39,16 +40,18 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 impl<const LIMBS: usize> CtAssign for Uint<LIMBS> {
     #[inline]
     fn ct_assign(&mut self, other: &Self, choice: Choice) {
-        self.as_mut_words().ct_assign(other.as_words(), choice);
+        self.limbs.ct_assign(&other.limbs, choice);
     }
 }
+impl<const LIMBS: usize> CtAssignSlice for Uint<LIMBS> {}
 
 impl<const LIMBS: usize> CtEq for Uint<LIMBS> {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
-        self.as_words().ct_eq(other.as_words())
+        self.limbs.ct_eq(&other.limbs)
     }
 }
+impl<const LIMBS: usize> CtEqSlice for Uint<LIMBS> {}
 
 impl<const LIMBS: usize> CtGt for Uint<LIMBS> {
     #[inline]

--- a/src/uint/ref_type.rs
+++ b/src/uint/ref_type.rs
@@ -1,11 +1,5 @@
 //! Unsigned integer reference type.
 
-use crate::{Choice, Limb, Uint, Word};
-use core::{
-    fmt,
-    ops::{Index, IndexMut},
-};
-
 mod add;
 mod bits;
 mod ct;
@@ -15,6 +9,15 @@ mod shl;
 mod shr;
 mod slice;
 mod sub;
+
+use crate::{Choice, Limb, Uint};
+use core::{
+    fmt,
+    ops::{Index, IndexMut},
+};
+
+#[cfg(feature = "alloc")]
+use crate::Word;
 
 /// Unsigned integer reference type.
 ///
@@ -67,12 +70,14 @@ impl UintRef {
 
     /// Borrow the inner limbs as a slice of [`Word`]s.
     #[inline]
+    #[cfg(feature = "alloc")]
     pub const fn as_words(&self) -> &[Word] {
         Limb::slice_as_words(&self.0)
     }
 
     /// Borrow the inner limbs as a mutable slice of [`Word`]s.
     #[inline]
+    #[cfg(feature = "alloc")]
     pub const fn as_mut_words(&mut self) -> &mut [Word] {
         Limb::slice_as_mut_words(&mut self.0)
     }

--- a/src/uint/ref_type/ct.rs
+++ b/src/uint/ref_type/ct.rs
@@ -7,13 +7,13 @@ impl CtAssign for UintRef {
     #[inline]
     fn ct_assign(&mut self, other: &Self, choice: Choice) {
         debug_assert_eq!(self.bits_precision(), other.bits_precision());
-        self.as_mut_words().ct_assign(other.as_words(), choice);
+        self.0.ct_assign(&other.0, choice);
     }
 }
 
 impl CtEq for UintRef {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
-        self.as_words().ct_eq(other.as_words())
+        self.0.ct_eq(&other.0)
     }
 }


### PR DESCRIPTION
Also fills in some missing `CtAssign` impls and leverages the new `CtSelectUsingCtAssign` marker trait.

The `*Slice` impls make it possible to use `CtAssign` and `CtEq` on `[T]` for the types which impl it in this crate. `Limb` uses an optimized implementation which does what the impls on `Uint`/`UintRef` were previously doing: leveraging `as_(mut_)words` and then using the impls on that.

Now everything should just work!