### PR TITLE
Unified `GenericMontyParams`

### DIFF
--- a/src/modular.rs
+++ b/src/modular.rs
@@ -25,6 +25,7 @@ mod reduction;
 mod add;
 pub(crate) mod bingcd;
 mod div_by_2;
+mod monty_params;
 mod mul;
 mod pow;
 pub(crate) mod safegcd;
@@ -35,7 +36,8 @@ pub(crate) mod boxed_monty_form;
 
 pub use self::{
     const_monty_form::{ConstMontyForm, ConstMontyParams},
-    monty_form::{MontyForm, MontyParams},
+    monty_form::MontyForm,
+    monty_params::{GenericMontyParams, MontyParams},
 };
 
 pub(crate) use self::safegcd::SafeGcdInverter;

--- a/src/modular/boxed_monty_form/ct.rs
+++ b/src/modular/boxed_monty_form/ct.rs
@@ -1,6 +1,6 @@
 //! Constant-time support: impls of `Ct*` traits.
 
-use super::{BoxedMontyForm, BoxedMontyParams, BoxedMontyParamsInner};
+use super::{BoxedMontyForm, BoxedMontyParams};
 use crate::{Choice, CtAssign, CtEq, CtSelect};
 use alloc::sync::Arc;
 use ctutils::{CtAssignSlice, CtEqSlice, CtSelectUsingCtAssign};
@@ -45,15 +45,3 @@ impl CtSelect for BoxedMontyParams {
         Self(Arc::new(self.0.ct_select(&other.0, choice)))
     }
 }
-
-impl CtAssign for BoxedMontyParamsInner {
-    fn ct_assign(&mut self, other: &Self, choice: Choice) {
-        self.modulus.ct_assign(&other.modulus, choice);
-        self.one.ct_assign(&other.one, choice);
-        self.r2.ct_assign(&other.r2, choice);
-        self.mod_inv.ct_assign(&other.mod_inv, choice);
-        self.mod_leading_zeros
-            .ct_assign(&other.mod_leading_zeros, choice);
-    }
-}
-impl CtSelectUsingCtAssign for BoxedMontyParamsInner {}

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -11,30 +11,14 @@ mod pow;
 mod sub;
 
 use super::{
-    Retrieve,
+    MontyParams, Retrieve,
     const_monty_form::{ConstMontyForm, ConstMontyParams},
     div_by_2::div_by_2,
     mul::mul_montgomery_form,
     reduction::montgomery_retrieve,
 };
-use crate::{Choice, Limb, Monty, Odd, U64, Uint, Word};
+use crate::{Choice, Monty, Odd, U64, Uint, Word};
 use mul::DynMontyMultiplier;
-
-/// Parameters to efficiently go to/from the Montgomery form for an odd modulus provided at runtime.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct MontyParams<const LIMBS: usize> {
-    /// The constant modulus
-    pub(super) modulus: Odd<Uint<LIMBS>>,
-    /// 1 in Montgomery form (a.k.a. `R`)
-    pub(super) one: Uint<LIMBS>,
-    /// `R^2 mod modulus`, used to move into Montgomery form
-    pub(super) r2: Uint<LIMBS>,
-    /// The lowest limbs of MODULUS^-1 mod 2**64
-    /// This value is used in Montgomery reduction and modular inversion
-    pub(super) mod_inv: U64,
-    /// Leading zeros in the modulus, used to choose optimized algorithms
-    pub(super) mod_leading_zeros: u32,
-}
 
 impl<const LIMBS: usize> MontyParams<LIMBS> {
     /// Instantiates a new set of `MontyParams` representing the given odd `modulus`.
@@ -94,38 +78,6 @@ impl<const LIMBS: usize> MontyParams<LIMBS> {
             mod_inv,
             mod_leading_zeros,
         }
-    }
-
-    /// Returns the modulus which was used to initialize these parameters.
-    pub const fn modulus(&self) -> &Odd<Uint<LIMBS>> {
-        &self.modulus
-    }
-
-    /// 1 in Montgomery form (a.k.a. `R`).
-    pub const fn one(&self) -> &Uint<LIMBS> {
-        &self.one
-    }
-
-    /// `R^2 mod modulus`, used to move into Montgomery form.
-    pub const fn r2(&self) -> &Uint<LIMBS> {
-        &self.r2
-    }
-
-    /// Returns the modulus which was used to initialize these parameters.
-    #[inline(always)]
-    pub(crate) const fn mod_neg_inv(&self) -> Limb {
-        self.mod_inv.limbs[0].wrapping_neg()
-    }
-}
-
-#[cfg(feature = "zeroize")]
-impl<const LIMBS: usize> zeroize::Zeroize for MontyParams<LIMBS> {
-    fn zeroize(&mut self) {
-        self.modulus.zeroize();
-        self.one.zeroize();
-        self.r2.zeroize();
-        self.mod_inv.zeroize();
-        self.mod_leading_zeros.zeroize();
     }
 }
 

--- a/src/modular/monty_form/ct.rs
+++ b/src/modular/monty_form/ct.rs
@@ -1,6 +1,5 @@
 //! Constant-time support: impls of `Ct*` traits and constant-time `const fn` operations.
 
-use super::MontyParams;
 use crate::{Choice, CtAssign, CtEq, modular::MontyForm};
 use ctutils::{CtAssignSlice, CtEqSlice, CtSelectUsingCtAssign};
 
@@ -24,28 +23,6 @@ impl<const LIMBS: usize> CtEq for MontyForm<LIMBS> {
 }
 impl<const LIMBS: usize> CtEqSlice for MontyForm<LIMBS> {}
 
-impl<const LIMBS: usize> CtAssign for MontyParams<LIMBS> {
-    fn ct_assign(&mut self, other: &Self, choice: Choice) {
-        self.modulus.ct_assign(&other.modulus, choice);
-        self.one.ct_assign(&other.one, choice);
-        self.r2.ct_assign(&other.r2, choice);
-        self.mod_inv.ct_assign(&other.mod_inv, choice);
-        self.mod_leading_zeros
-            .ct_assign(&other.mod_leading_zeros, choice);
-    }
-}
-
-impl<const LIMBS: usize> CtEq for MontyParams<LIMBS> {
-    fn ct_eq(&self, other: &Self) -> Choice {
-        self.modulus.ct_eq(&other.modulus)
-            & self.one.ct_eq(&other.one)
-            & self.r2.ct_eq(&other.r2)
-            & self.mod_inv.ct_eq(&other.mod_inv)
-    }
-}
-
-impl<const LIMBS: usize> CtSelectUsingCtAssign for MontyParams<LIMBS> {}
-
 #[cfg(feature = "subtle")]
 impl<const LIMBS: usize> subtle::ConstantTimeEq for MontyForm<LIMBS> {
     fn ct_eq(&self, other: &Self) -> subtle::Choice {
@@ -54,21 +31,7 @@ impl<const LIMBS: usize> subtle::ConstantTimeEq for MontyForm<LIMBS> {
 }
 
 #[cfg(feature = "subtle")]
-impl<const LIMBS: usize> subtle::ConstantTimeEq for MontyParams<LIMBS> {
-    fn ct_eq(&self, other: &Self) -> subtle::Choice {
-        CtEq::ct_eq(self, other).into()
-    }
-}
-
-#[cfg(feature = "subtle")]
 impl<const LIMBS: usize> subtle::ConditionallySelectable for MontyForm<LIMBS> {
-    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
-        a.ct_select(b, choice.into())
-    }
-}
-
-#[cfg(feature = "subtle")]
-impl<const LIMBS: usize> subtle::ConditionallySelectable for MontyParams<LIMBS> {
     fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
         a.ct_select(b, choice.into())
     }

--- a/src/modular/monty_params.rs
+++ b/src/modular/monty_params.rs
@@ -1,0 +1,129 @@
+//! Modulus-specific Montgomery form parameters.
+
+use crate::{Choice, CtAssign, CtEq, Limb, Odd, U64, Uint, Unsigned};
+use core::fmt::{self, Debug};
+use ctutils::{CtAssignSlice, CtEqSlice, CtSelectUsingCtAssign};
+
+#[cfg(feature = "subtle")]
+use crate::CtSelect;
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
+/// Parameters to efficiently go to/from the Montgomery form for an odd modulus provided at runtime.
+///
+/// This version is generic over the underlying unsigned integer type.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct GenericMontyParams<U: Unsigned> {
+    /// The constant modulus.
+    pub(super) modulus: Odd<U>,
+
+    /// 1 in Montgomery form (a.k.a. `R`).
+    pub(super) one: U,
+
+    /// `R^2 mod modulus`, used to move into Montgomery form.
+    pub(super) r2: U,
+
+    /// The lowest limbs of `MODULUS^-1 mod 2**64`.
+    ///
+    /// This value is used in Montgomery reduction and modular inversion.
+    pub(super) mod_inv: U64,
+
+    /// Leading zeros in the modulus, used to choose optimized algorithms
+    pub(super) mod_leading_zeros: u32,
+}
+
+/// Parameters to efficiently go to/from the Montgomery form for an odd modulus provided at runtime.
+pub type MontyParams<const LIMBS: usize> = GenericMontyParams<Uint<LIMBS>>;
+
+impl<U: Unsigned> GenericMontyParams<U> {
+    /// Returns the modulus which was used to initialize these parameters.
+    pub const fn modulus(&self) -> &Odd<U> {
+        &self.modulus
+    }
+
+    /// 1 in Montgomery form (a.k.a. `R`).
+    pub const fn one(&self) -> &U {
+        &self.one
+    }
+
+    /// `R^2 mod modulus`, used to move into Montgomery form.
+    pub const fn r2(&self) -> &U {
+        &self.r2
+    }
+
+    /// Returns the modulus which was used to initialize these parameters.
+    #[inline(always)]
+    pub(crate) const fn mod_neg_inv(&self) -> Limb {
+        self.mod_inv.limbs[0].wrapping_neg()
+    }
+
+    /// Core implementation of the debug impl which lets us customize it for various types/type
+    /// aliases.
+    pub(crate) fn debug_struct(&self, mut debug: fmt::DebugStruct<'_, '_>) -> fmt::Result {
+        debug
+            .field("modulus", &self.modulus)
+            .field("one", &self.one)
+            .field("r2", &self.r2)
+            .field("mod_inv", &self.mod_inv)
+            .field("mod_leading_zeros", &self.mod_leading_zeros)
+            .finish()
+    }
+}
+
+impl<U: Unsigned> CtAssign for GenericMontyParams<U> {
+    fn ct_assign(&mut self, other: &Self, choice: Choice) {
+        self.modulus.ct_assign(&other.modulus, choice);
+        self.one.ct_assign(&other.one, choice);
+        self.r2.ct_assign(&other.r2, choice);
+        self.mod_inv.ct_assign(&other.mod_inv, choice);
+        self.mod_leading_zeros
+            .ct_assign(&other.mod_leading_zeros, choice);
+    }
+}
+impl<U: Unsigned> CtAssignSlice for GenericMontyParams<U> {}
+impl<U: Unsigned> CtSelectUsingCtAssign for GenericMontyParams<U> {}
+
+impl<U: Unsigned> CtEq for GenericMontyParams<U> {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.modulus.ct_eq(&other.modulus)
+            & self.one.ct_eq(&other.one)
+            & self.r2.ct_eq(&other.r2)
+            & self.mod_inv.ct_eq(&other.mod_inv)
+    }
+}
+impl<U: Unsigned> CtEqSlice for GenericMontyParams<U> {}
+
+impl<const LIMBS: usize> Debug for MontyParams<LIMBS> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.debug_struct(f.debug_struct("MontyParams"))
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<U: Unsigned> subtle::ConstantTimeEq for GenericMontyParams<U> {
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        CtEq::ct_eq(self, other).into()
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<U: Unsigned + Copy> subtle::ConditionallySelectable for GenericMontyParams<U> {
+    fn conditional_assign(&mut self, src: &Self, choice: subtle::Choice) {
+        self.ct_assign(src, choice.into());
+    }
+
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        a.ct_select(b, choice.into())
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl<U: Unsigned + Zeroize> Zeroize for GenericMontyParams<U> {
+    fn zeroize(&mut self) {
+        self.modulus.zeroize();
+        self.one.zeroize();
+        self.r2.zeroize();
+        self.mod_inv.zeroize();
+        self.mod_leading_zeros.zeroize();
+    }
+}


### PR DESCRIPTION
Replaces `struct MontyParams` and `struct BoxedMontyParamsInner` with type aliases for a single struct which is generic around `U: Unsigned`, as these two types previously had identical structure and only differed in the unsigned integer type they used.

This makes it possible to consolidate some impls generically.