### PR TITLE
Remove `BoxedMontyParamsInner` type alias

### DIFF
--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -24,9 +24,7 @@ use zeroize::Zeroize;
 /// Parameters to efficiently go to/from the Montgomery form for an odd modulus whose size and value
 /// are both chosen at runtime.
 #[derive(Clone, Eq, PartialEq)]
-pub struct BoxedMontyParams(Arc<BoxedMontyParamsInner>);
-
-type BoxedMontyParamsInner = GenericMontyParams<BoxedUint>;
+pub struct BoxedMontyParams(Arc<GenericMontyParams<BoxedUint>>);
 
 impl BoxedMontyParams {
     /// Instantiates a new set of [`BoxedMontyParams`] representing the given `modulus`.
@@ -50,7 +48,7 @@ impl BoxedMontyParams {
         let mod_leading_zeros = modulus.as_ref().leading_zeros().min(Word::BITS - 1);
 
         Self(
-            BoxedMontyParamsInner {
+            GenericMontyParams {
                 modulus,
                 one,
                 r2,
@@ -83,7 +81,7 @@ impl BoxedMontyParams {
         let mod_leading_zeros = modulus.as_ref().leading_zeros().min(Word::BITS - 1);
 
         Self(
-            BoxedMontyParamsInner {
+            GenericMontyParams {
                 modulus,
                 one,
                 r2,

--- a/src/modular/boxed_monty_form/from.rs
+++ b/src/modular/boxed_monty_form/from.rs
@@ -1,6 +1,6 @@
 //! `From`-like conversions for [`BoxedMontyForm`] and [`BoxedMontyParams`].
 
-use super::{BoxedMontyForm, BoxedMontyParams, BoxedMontyParamsInner};
+use super::{BoxedMontyForm, BoxedMontyParams, GenericMontyParams};
 use crate::modular::{ConstMontyForm, ConstMontyParams, MontyForm, MontyParams};
 
 impl<const LIMBS: usize, Params> From<ConstMontyForm<Params, LIMBS>> for BoxedMontyForm
@@ -42,7 +42,7 @@ impl<const LIMBS: usize> From<&MontyForm<LIMBS>> for BoxedMontyForm {
 impl<const LIMBS: usize> From<&MontyParams<LIMBS>> for BoxedMontyParams {
     fn from(params: &MontyParams<LIMBS>) -> Self {
         Self(
-            BoxedMontyParamsInner {
+            GenericMontyParams {
                 modulus: params.modulus.into(),
                 one: params.one.into(),
                 r2: params.r2.into(),


### PR DESCRIPTION
We don't need it and can just use `GenericMontyParams` instead, which is shorter and one less type name to worry about.