### PR TITLE
clippy improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,12 +51,35 @@ rand_core = ["dep:rand_core"]
 serde = ["dep:serdect"]
 subtle = ["dep:subtle", "ctutils/subtle", "hybrid-array?/subtle"]
 
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+[lints.clippy]
+borrow_as_ptr = "warn"
+checked_conversions = "warn"
+doc_markdown = "warn"
+from_iter_instead_of_collect = "warn"
+manual_assert = "warn"
+map_unwrap_or = "warn"
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"
+mod_module_files = "warn"
+must_use_candidate = "warn"
+implicit_saturating_sub = "warn"
+panic_in_result_fn = "warn"
+ptr_as_ptr = "warn"
+redundant_closure_for_method-calls = "warn"
+ref_as_ptr = "warn"
+return_self_not_must_use = "warn"
+semicolon_if_nothing_returned = "warn"
+trivially_copy_pass_by_ref = "warn"
 
-[package.metadata.typos.default]
-extend-ignore-re = ["([0-9A-Fa-f]{16,})"]
+[lints.rust]
+missing_docs = "warn"
+missing_debug_implementations = "warn"
+missing_copy_implementations = "warn"
+trivial_casts = "warn"
+trivial_numeric_casts = "warn"
+unsafe_code = "deny"
+unused_lifetimes = "warn"
+unused_qualifications = "warn"
 
 [[bench]]
 name = "boxed_monty"
@@ -90,3 +113,10 @@ harness = false
 
 [profile.dev]
 opt-level = 2
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.typos.default]
+extend-ignore-re = ["([0-9A-Fa-f]{16,})"]

--- a/benches/boxed_monty.rs
+++ b/benches/boxed_monty.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use chacha20::ChaCha8Rng;
 use criterion::{
     BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
@@ -36,7 +38,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(a, b)| black_box(a).add(&black_box(b)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function(format!("double, {UINT_BITS}-bit"), |b| {
@@ -49,7 +51,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |a| black_box(a).double(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function(format!("sub, {UINT_BITS}-bit"), |b| {
@@ -67,7 +69,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(a, b)| black_box(a).sub(&black_box(b)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function(format!("neg, {UINT_BITS}-bit"), |b| {
@@ -80,7 +82,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |a| black_box(a).neg(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function(format!("invert, {UINT_BITS}-bit"), |b| {
@@ -93,7 +95,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |x| black_box(x).invert(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function(format!("invert_vartime, {UINT_BITS}-bit"), |b| {
@@ -106,7 +108,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |x| black_box(x).invert_vartime(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("multiplication, BoxedUint*BoxedUint", |b| {
@@ -124,7 +126,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(x, y)| black_box(x * y),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     let modulus = to_biguint(params.modulus());
@@ -137,7 +139,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(x, y)| x * y % &modulus,
             BatchSize::SmallInput,
-        )
+        );
     });
 
     let m = Odd::<BoxedUint>::random(&mut rng, UINT_BITS);
@@ -153,7 +155,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(x, p)| black_box(x.pow(&p)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("modpow, BigUint^BigUint (num-bigint-dig)", |b| {
@@ -169,7 +171,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(x, p)| black_box(x.modpow(&p, &modulus)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function(
@@ -189,7 +191,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                     ])
                 },
                 BatchSize::SmallInput,
-            )
+            );
         },
     );
 }
@@ -201,7 +203,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
             || Odd::<BoxedUint>::random(&mut rng, UINT_BITS),
             |modulus| black_box(BoxedMontyParams::new(modulus)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("BoxedMontyParams::new_vartime", |b| {
@@ -209,7 +211,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
             || Odd::<BoxedUint>::random(&mut rng, UINT_BITS),
             |modulus| black_box(BoxedMontyParams::new_vartime(modulus)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     let params = BoxedMontyParams::new(Odd::<BoxedUint>::random(&mut rng, UINT_BITS));
@@ -218,7 +220,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
             || BoxedUint::random_bits(&mut rng, UINT_BITS),
             |x| black_box(BoxedMontyForm::new(x, &params)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     let params = BoxedMontyParams::new(Odd::<BoxedUint>::random(&mut rng, UINT_BITS));
@@ -227,7 +229,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
             || BoxedMontyForm::new(BoxedUint::random_bits(&mut rng, UINT_BITS), &params),
             |x| black_box(x.retrieve()),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 

--- a/benches/boxed_uint.rs
+++ b/benches/boxed_uint.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use chacha20::ChaCha8Rng;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use crypto_bigint::{BoxedUint, Gcd, Integer, Limb, NonZero, RandomBits};
@@ -17,7 +19,7 @@ fn bench_shifts(c: &mut Criterion) {
             || BoxedUint::random_bits(&mut rng, UINT_BITS),
             |x| black_box(x.shl_vartime(UINT_BITS / 2 + 10)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("shl", |b| {
@@ -25,7 +27,7 @@ fn bench_shifts(c: &mut Criterion) {
             || BoxedUint::random_bits(&mut rng, UINT_BITS),
             |x| black_box(x.overflowing_shl(UINT_BITS / 2 + 10)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("shr_vartime", |b| {
@@ -33,7 +35,7 @@ fn bench_shifts(c: &mut Criterion) {
             || BoxedUint::random_bits(&mut rng, UINT_BITS),
             |x| black_box(x.shr_vartime(UINT_BITS / 2 + 10)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("shr", |b| {
@@ -41,7 +43,7 @@ fn bench_shifts(c: &mut Criterion) {
             || BoxedUint::random_bits(&mut rng, UINT_BITS),
             |x| black_box(x.overflowing_shr(UINT_BITS / 2 + 10)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.finish();
@@ -61,7 +63,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("boxed_wrapping_mul", |b| {
@@ -74,7 +76,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("boxed_checked_mul", |b| {
@@ -87,7 +89,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.checked_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("boxed_square", |b| {
@@ -95,7 +97,7 @@ fn bench_mul(c: &mut Criterion) {
             || BoxedUint::random_bits(&mut rng, UINT_BITS),
             |x| black_box(x.square()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("boxed_wrapping_square", |b| {
@@ -103,7 +105,7 @@ fn bench_mul(c: &mut Criterion) {
             || BoxedUint::random_bits(&mut rng, UINT_BITS),
             |x| black_box(x.wrapping_square()),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 
@@ -126,7 +128,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.div_rem(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("boxed_div_rem_vartime", |b| {
@@ -144,7 +146,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.div_rem_vartime(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("boxed_div_rem_limb", |b| {
@@ -152,7 +154,7 @@ fn bench_division(c: &mut Criterion) {
             || (BoxedUint::max(UINT_BITS), NonZero::new(Limb::ONE).unwrap()),
             |(x, y)| black_box(x.div_rem_limb(y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("boxed_rem", |b| {
@@ -170,7 +172,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.rem(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("boxed_rem_vartime", |b| {
@@ -188,7 +190,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.rem_vartime(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("boxed_rem_limb", |b| {
@@ -196,7 +198,7 @@ fn bench_division(c: &mut Criterion) {
             || (BoxedUint::max(UINT_BITS), NonZero::new(Limb::ONE).unwrap()),
             |(x, y)| black_box(x.rem_limb(y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.finish();
@@ -211,7 +213,7 @@ fn bench_boxed_sqrt(c: &mut Criterion) {
             || BoxedUint::random_bits(&mut rng, UINT_BITS),
             |x| black_box(x.floor_sqrt()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("floor_sqrt_vartime, 4096", |b| {
@@ -219,7 +221,7 @@ fn bench_boxed_sqrt(c: &mut Criterion) {
             || BoxedUint::random_bits(&mut rng, UINT_BITS),
             |x| black_box(x.floor_sqrt_vartime()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("checked_sqrt, 4096", |b| {
@@ -227,7 +229,7 @@ fn bench_boxed_sqrt(c: &mut Criterion) {
             || BoxedUint::random_bits(&mut rng, UINT_BITS),
             |x| black_box(x.checked_sqrt()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("checked_sqrt_vartime, 4096", |b| {
@@ -235,7 +237,7 @@ fn bench_boxed_sqrt(c: &mut Criterion) {
             || BoxedUint::random_bits(&mut rng, UINT_BITS),
             |x| black_box(x.checked_sqrt_vartime()),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 
@@ -253,7 +255,7 @@ fn bench_radix_encoding(c: &mut Criterion) {
                     ))
                 },
                 BatchSize::SmallInput,
-            )
+            );
         });
 
         group.bench_function(format!("parse_bytes, {radix} (num-bigint-dig)"), |b| {
@@ -261,7 +263,7 @@ fn bench_radix_encoding(c: &mut Criterion) {
                 || BoxedUint::random_bits(&mut rng, UINT_BITS).to_string_radix_vartime(10),
                 |x| black_box(BigUint::parse_bytes(x.as_bytes(), radix)),
                 BatchSize::SmallInput,
-            )
+            );
         });
 
         group.bench_function(format!("to_str_radix_vartime, {radix}"), |b| {
@@ -269,7 +271,7 @@ fn bench_radix_encoding(c: &mut Criterion) {
                 || BoxedUint::random_bits(&mut rng, UINT_BITS),
                 |x| black_box(x.to_string_radix_vartime(radix)),
                 BatchSize::SmallInput,
-            )
+            );
         });
 
         group.bench_function(format!("to_str_radix, {radix} (num-bigint-dig)"), |b| {
@@ -280,7 +282,7 @@ fn bench_radix_encoding(c: &mut Criterion) {
                 },
                 |x| black_box(x.to_str_radix(radix)),
                 BatchSize::SmallInput,
-            )
+            );
         });
     }
 }
@@ -299,7 +301,7 @@ fn bench_gcd(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.gcd(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("gcd_vartime", |b| {
@@ -312,7 +314,7 @@ fn bench_gcd(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.gcd_vartime(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 
@@ -334,7 +336,7 @@ fn bench_invert(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.invert_odd_mod(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("invert_mod", |b| {
@@ -351,7 +353,7 @@ fn bench_invert(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.invert_mod(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("invert_mod2k", |b| {
@@ -359,7 +361,7 @@ fn bench_invert(c: &mut Criterion) {
             || BoxedUint::random_bits(&mut rng, UINT_BITS),
             |x| x.invert_mod2k(black_box(1)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("invert_mod2k_vartime", |b| {
@@ -367,7 +369,7 @@ fn bench_invert(c: &mut Criterion) {
             || BoxedUint::random_bits(&mut rng, UINT_BITS),
             |x| x.invert_mod2k_vartime(black_box(1)),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 

--- a/benches/const_monty.rs
+++ b/benches/const_monty.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use chacha20::ChaCha8Rng;
 use criterion::{
     BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
@@ -24,7 +26,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
             || U256::random_mod_vartime(&mut rng, Modulus::PARAMS.modulus().as_nz_ref()),
             |x| black_box(ConstMontyForm::new(&x)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("ConstMontyForm retrieve", |b| {
@@ -32,7 +34,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
             || ConstMontyForm::random_from_rng(&mut rng),
             |x| black_box(x.retrieve()),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 
@@ -48,7 +50,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(a, b)| black_box(a).add(&black_box(b)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("double, U256", |b| {
@@ -56,7 +58,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || ConstMontyForm::random_from_rng(&mut rng),
             |a| black_box(a).double(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("sub, U256", |b| {
@@ -68,7 +70,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(a, b)| black_box(a).sub(&black_box(b)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("neg, U256", |b| {
@@ -76,7 +78,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || ConstMontyForm::random_from_rng(&mut rng),
             |a| black_box(a).neg(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("invert, U256", |b| {
@@ -84,7 +86,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || ConstMontyForm::random_from_rng(&mut rng),
             |x| black_box(x).invert(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("multiplication, U256*U256", |b| {
@@ -96,7 +98,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(x, y)| black_box(x).mul(&black_box(y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("squaring, U256*U256", |b| {
@@ -104,7 +106,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || ConstMontyForm::random_from_rng(&mut rng),
             |x| black_box(x).square(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("modpow, U256^U256", |b| {
@@ -116,7 +118,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(x, p)| black_box(x.pow(&p)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("jacobi_symbol", |b| {
@@ -124,7 +126,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || ConstMontyForm::random_from_rng(&mut rng),
             |a| a.jacobi_symbol(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("jacobi_symbol_vartime", |b| {
@@ -132,7 +134,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             || ConstMontyForm::random_from_rng(&mut rng),
             |a| a.jacobi_symbol_vartime(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("lincomb, U256*U256+U256*U256", |b| {
@@ -145,7 +147,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                 ])
             },
             BatchSize::SmallInput,
-        )
+        );
     });
 
     #[cfg(feature = "alloc")]
@@ -172,7 +174,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                         ))
                     },
                     BatchSize::SmallInput,
-                )
+                );
             },
         );
     }

--- a/benches/int.rs
+++ b/benches/int.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use chacha20::ChaCha8Rng;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use rand_core::SeedableRng;
@@ -20,7 +22,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("widening_mul, I256xI256", |b| {
@@ -33,7 +35,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("widening_mul, I512xI512", |b| {
@@ -46,7 +48,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("widening_mul, I1024xI1024", |b| {
@@ -59,7 +61,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("widening_mul, I2048xI2048", |b| {
@@ -72,7 +74,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("widening_mul, I4096xI4096", |b| {
@@ -85,7 +87,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 
@@ -103,7 +105,7 @@ fn bench_concatenating_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("concatenating_mul, I256xI256", |b| {
@@ -116,7 +118,7 @@ fn bench_concatenating_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("concatenating_mul, I512xI512", |b| {
@@ -129,7 +131,7 @@ fn bench_concatenating_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("concatenating_mul, I1024xI1024", |b| {
@@ -142,7 +144,7 @@ fn bench_concatenating_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("concatenating_mul, I2048xI2048", |b| {
@@ -155,7 +157,7 @@ fn bench_concatenating_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("concatenating_mul, I4096xI4096", |b| {
@@ -168,7 +170,7 @@ fn bench_concatenating_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.concatenating_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 
@@ -186,7 +188,7 @@ fn bench_wrapping_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("wrapping_mul, I256xI256", |b| {
@@ -199,7 +201,7 @@ fn bench_wrapping_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("wrapping_mul, I512xI512", |b| {
@@ -212,7 +214,7 @@ fn bench_wrapping_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("wrapping_mul, I1024xI1024", |b| {
@@ -225,7 +227,7 @@ fn bench_wrapping_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("wrapping_mul, I2048xI2048", |b| {
@@ -238,7 +240,7 @@ fn bench_wrapping_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("wrapping_mul, I4096xI4096", |b| {
@@ -251,7 +253,7 @@ fn bench_wrapping_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 
@@ -268,7 +270,7 @@ fn bench_div(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.div(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("div, I512/I256, full size", |b| {
@@ -280,7 +282,7 @@ fn bench_div(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.div(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("div, I1024/I512, full size", |b| {
@@ -292,7 +294,7 @@ fn bench_div(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.div(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("div, I2048/I1024, full size", |b| {
@@ -304,7 +306,7 @@ fn bench_div(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.div(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("div, I4096/I2048, full size", |b| {
@@ -316,7 +318,7 @@ fn bench_div(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.div(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.finish();
@@ -335,7 +337,7 @@ fn bench_add(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_add(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("add, I256+I256", |b| {
@@ -347,7 +349,7 @@ fn bench_add(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_add(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("add, I512+I512", |b| {
@@ -359,7 +361,7 @@ fn bench_add(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_add(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("add, I1024+I1024", |b| {
@@ -371,7 +373,7 @@ fn bench_add(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_add(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("add, I2048+I2048", |b| {
@@ -383,7 +385,7 @@ fn bench_add(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_add(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("add, I4096+I4096", |b| {
@@ -395,7 +397,7 @@ fn bench_add(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_add(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.finish();
@@ -414,7 +416,7 @@ fn bench_sub(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_sub(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("sub, I256-I256", |b| {
@@ -426,7 +428,7 @@ fn bench_sub(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_sub(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("sub, I512-I512", |b| {
@@ -438,7 +440,7 @@ fn bench_sub(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_sub(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("sub, I1024-I1024", |b| {
@@ -450,7 +452,7 @@ fn bench_sub(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_sub(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("sub, I2048-I2048", |b| {
@@ -462,7 +464,7 @@ fn bench_sub(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_sub(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("sub, I4096-I4096", |b| {
@@ -474,7 +476,7 @@ fn bench_sub(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_sub(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.finish();

--- a/benches/limb.rs
+++ b/benches/limb.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use chacha20::ChaCha8Rng;
 use criterion::{
     BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
@@ -17,7 +19,7 @@ fn bench_cmp<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(x, y)| black_box(x.ct_lt(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("ct_eq", |b| {
@@ -29,7 +31,7 @@ fn bench_cmp<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(x, y)| black_box(x.ct_eq(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("ct_gt", |b| {
@@ -41,7 +43,7 @@ fn bench_cmp<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(x, y)| black_box(x.ct_gt(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 

--- a/benches/monty.rs
+++ b/benches/monty.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use chacha20::ChaCha8Rng;
 use criterion::{
     BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
@@ -19,7 +21,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
             || Odd::<U256>::random_from_rng(&mut rng),
             |modulus| black_box(MontyParams::new(modulus)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("MontyParams::new_vartime", |b| {
@@ -27,7 +29,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
             || Odd::<U256>::random_from_rng(&mut rng),
             |modulus| black_box(MontyParams::new_vartime(modulus)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     let params = MontyParams::new_vartime(Odd::<U256>::random_from_rng(&mut rng));
@@ -36,7 +38,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
             || U256::random_mod_vartime(&mut rng, params.modulus().as_nz_ref()),
             |x| black_box(MontyForm::new(&x, &params)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     let params = MontyParams::new_vartime(Odd::<U256>::random_from_rng(&mut rng));
@@ -50,7 +52,7 @@ fn bench_montgomery_conversion<M: Measurement>(group: &mut BenchmarkGroup<'_, M>
             },
             |x| black_box(x.retrieve()),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 
@@ -73,7 +75,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(a, b)| black_box(a).add(&black_box(b)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("double, U256", |b| {
@@ -86,7 +88,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |a| black_box(a).double(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("sub, U256", |b| {
@@ -104,7 +106,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(a, b)| black_box(a).sub(&black_box(b)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("neg, U256", |b| {
@@ -117,7 +119,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |a| black_box(a).neg(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("invert, U256", |b| {
@@ -130,7 +132,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |x| black_box(x).invert(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("multiplication, U256*U256", |b| {
@@ -148,7 +150,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(x, y)| black_box(x * y),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("square, U256", |b| {
@@ -161,7 +163,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |x| x.square(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("modpow, U256^U256", |b| {
@@ -175,7 +177,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |(x, p)| black_box(x.pow(&p)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("div_by_2, U256", |b| {
@@ -186,7 +188,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
             },
             |x| black_box(x.div_by_2()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     #[cfg(feature = "alloc")]
@@ -219,7 +221,7 @@ fn bench_montgomery_ops<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                         ))
                     },
                     BatchSize::SmallInput,
-                )
+                );
             },
         );
     }

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use chacha20::ChaCha8Rng;
 use criterion::measurement::WallTime;
 use criterion::{
@@ -161,7 +163,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("widening_mul, U4096xU4096", |b| {
@@ -174,7 +176,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("widening_mul, U8192xU4096", |b| {
@@ -187,7 +189,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.widening_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("wrapping_mul, U256xU256", |b| {
@@ -200,7 +202,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("wrapping_mul, U4096xU4096", |b| {
@@ -213,7 +215,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("wrapping_mul, U8192xU4096", |b| {
@@ -226,7 +228,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.wrapping_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("checked_mul, U256xU256", |b| {
@@ -239,7 +241,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.checked_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("checked_mul, U4096xU4096", |b| {
@@ -252,7 +254,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(x, y)| black_box(x.checked_mul(&y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("square_wide, U256", |b| {
@@ -260,7 +262,7 @@ fn bench_mul(c: &mut Criterion) {
             || U256::random_from_rng(&mut rng),
             |x| black_box(x.square_wide()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("square_wide, U4096", |b| {
@@ -268,7 +270,7 @@ fn bench_mul(c: &mut Criterion) {
             || U4096::random_from_rng(&mut rng),
             |x| black_box(x.square_wide()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("wrapping_square, U256xU256", |b| {
@@ -276,7 +278,7 @@ fn bench_mul(c: &mut Criterion) {
             || U256::random_from_rng(&mut rng),
             |x| x.wrapping_square(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("wrapping_square, U4096xU4096", |b| {
@@ -284,7 +286,7 @@ fn bench_mul(c: &mut Criterion) {
             || U4096::random_from_rng(&mut rng),
             |x| x.wrapping_square(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("mul_mod, U256", |b| {
@@ -296,7 +298,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(m, x)| black_box(x).mul_mod(black_box(&x), &m),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("mul_mod_vartime, U256", |b| {
@@ -308,7 +310,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(m, x)| black_box(x).mul_mod_vartime(black_box(&x), &m),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("mul_mod_special, U256", |b| {
@@ -320,7 +322,7 @@ fn bench_mul(c: &mut Criterion) {
             },
             |(m, x)| black_box(x).mul_mod_special(black_box(&x), m),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 
@@ -338,7 +340,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, y)| x.div_rem(&y),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("div/rem, U256/U128 (in U256)", |b| {
@@ -351,7 +353,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, y)| x.div_rem(&y),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("div/rem, U256/U128 (in U512)", |b| {
@@ -363,7 +365,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, y)| x.div_rem(&y),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("div/rem_vartime, U256/U128, full size", |b| {
@@ -375,7 +377,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, y)| x.div_rem_vartime(&y),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("rem, U256/U128", |b| {
@@ -388,7 +390,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, y)| x.rem(&y),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("rem, U256/U128 (in U256)", |b| {
@@ -400,7 +402,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, y)| x.rem(&y),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("rem, U256/U128 (in U512)", |b| {
@@ -412,7 +414,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, y)| x.rem(&y),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("rem_vartime, U256/U128, full size", |b| {
@@ -424,7 +426,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, y)| x.rem_vartime(&y),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("rem_wide, U256", |b| {
@@ -439,7 +441,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x_lo, x_hi, y)| Uint::rem_wide((x_lo, x_hi), &y),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("rem_wide_vartime, U256", |b| {
@@ -454,7 +456,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x_lo, x_hi, y)| Uint::rem_wide_vartime((x_lo, x_hi), &y),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("div/rem, U256/Limb, full size", |b| {
@@ -467,7 +469,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, y)| x.div_rem(&y),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("div/rem_vartime, U256/Limb, full size", |b| {
@@ -480,7 +482,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, y)| x.div_rem_vartime(&y),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("div/rem, U256/Limb, single limb", |b| {
@@ -493,7 +495,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, y)| black_box(x).div_rem_limb(black_box(y)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("div/rem, U256/Limb, single limb with reciprocal", |b| {
@@ -506,7 +508,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, r)| black_box(x).div_rem_limb_with_reciprocal(black_box(&r)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("rem, U256/Limb, single limb", |b| {
@@ -519,7 +521,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, r)| black_box(x).rem_limb(black_box(r)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("rem, U256/Limb, single limb with reciprocal", |b| {
@@ -532,7 +534,7 @@ fn bench_division(c: &mut Criterion) {
             },
             |(x, r)| black_box(x).rem_limb_with_reciprocal(black_box(&r)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.finish();
@@ -551,7 +553,7 @@ fn gcd_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: Uint<LIMB
             },
             |(f, g)| black_box(Uint::gcd(&f, &g)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     g.bench_function(BenchmarkId::new("gcd_vartime", LIMBS), |b| {
@@ -564,7 +566,7 @@ fn gcd_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: Uint<LIMB
             },
             |(f, g)| black_box(Uint::gcd_vartime(&f, &g)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     g.bench_function(BenchmarkId::new("bingcd", LIMBS), |b| {
@@ -577,7 +579,7 @@ fn gcd_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: Uint<LIMB
             },
             |(f, g)| black_box(f.bingcd(&g)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     g.bench_function(BenchmarkId::new("bingcd_vartime", LIMBS), |b| {
@@ -590,7 +592,7 @@ fn gcd_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: Uint<LIMB
             },
             |(f, g)| black_box(f.bingcd_vartime(&g)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     g.bench_function(BenchmarkId::new("safegcd", LIMBS), |b| {
@@ -603,7 +605,7 @@ fn gcd_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: Uint<LIMB
             },
             |(f, g)| black_box(f.safegcd(&g)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     g.bench_function(BenchmarkId::new("safegcd_vartime", LIMBS), |b| {
@@ -616,7 +618,7 @@ fn gcd_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: Uint<LIMB
             },
             |(f, g)| black_box(f.safegcd_vartime(&g)),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 
@@ -646,7 +648,7 @@ fn xgcd_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: Uint<LIM
             },
             |(f, g)| black_box(Uint::xgcd(&f, &g)),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 
@@ -683,7 +685,7 @@ fn mod_symbols_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: U
             },
             |(f, g)| black_box(g.jacobi_symbol(&f)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     g.bench_function(BenchmarkId::new("jacobi_symbol_vartime", LIMBS), |b| {
@@ -696,7 +698,7 @@ fn mod_symbols_bench<const LIMBS: usize>(g: &mut BenchmarkGroup<WallTime>, _x: U
             },
             |(f, g)| black_box(g.jacobi_symbol_vartime(&f)),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 
@@ -714,7 +716,7 @@ fn bench_shl(c: &mut Criterion) {
     let mut group = c.benchmark_group("left shift");
 
     group.bench_function("shl_vartime, small, U2048", |b| {
-        b.iter_batched(|| U2048::ONE, |x| x.shl_vartime(10), BatchSize::SmallInput)
+        b.iter_batched(|| U2048::ONE, |x| x.shl_vartime(10), BatchSize::SmallInput);
     });
 
     group.bench_function("shl_vartime, large, U2048", |b| {
@@ -722,7 +724,7 @@ fn bench_shl(c: &mut Criterion) {
             || U2048::ONE,
             |x| x.shl_vartime(1024 + 10),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("shl_vartime_wide, large, U2048", |b| {
@@ -730,11 +732,11 @@ fn bench_shl(c: &mut Criterion) {
             || (U2048::ONE, U2048::ONE),
             |x| Uint::overflowing_shl_vartime_wide(x, 1024 + 10),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("shl, U2048", |b| {
-        b.iter_batched(|| U2048::ONE, |x| x.shl(1024 + 10), BatchSize::SmallInput)
+        b.iter_batched(|| U2048::ONE, |x| x.shl(1024 + 10), BatchSize::SmallInput);
     });
 
     group.finish();
@@ -744,7 +746,7 @@ fn bench_shr(c: &mut Criterion) {
     let mut group = c.benchmark_group("right shift");
 
     group.bench_function("shr_vartime, small, U2048", |b| {
-        b.iter_batched(|| U2048::ONE, |x| x.shr_vartime(10), BatchSize::SmallInput)
+        b.iter_batched(|| U2048::ONE, |x| x.shr_vartime(10), BatchSize::SmallInput);
     });
 
     group.bench_function("shr_vartime, large, U2048", |b| {
@@ -752,7 +754,7 @@ fn bench_shr(c: &mut Criterion) {
             || U2048::ONE,
             |x| x.shr_vartime(1024 + 10),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("shr_vartime_wide, large, U2048", |b| {
@@ -760,11 +762,11 @@ fn bench_shr(c: &mut Criterion) {
             || (U2048::ONE, U2048::ONE),
             |x| Uint::overflowing_shr_vartime_wide(x, 1024 + 10),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("shr, U2048", |b| {
-        b.iter_batched(|| U2048::ONE, |x| x.shr(1024 + 10), BatchSize::SmallInput)
+        b.iter_batched(|| U2048::ONE, |x| x.shr(1024 + 10), BatchSize::SmallInput);
     });
 
     group.finish();
@@ -788,7 +790,7 @@ fn bench_invert_mod(c: &mut Criterion) {
             },
             |(x, m)| black_box(x.invert_odd_mod(&m)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("invert_odd_mod_vartime, U256", |b| {
@@ -805,7 +807,7 @@ fn bench_invert_mod(c: &mut Criterion) {
             },
             |(x, m)| black_box(x.invert_odd_mod_vartime(&m)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("invert_mod, U256, odd modulus", |b| {
@@ -822,7 +824,7 @@ fn bench_invert_mod(c: &mut Criterion) {
             },
             |(x, m)| black_box(x.invert_mod(m.as_nz_ref())),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("invert_mod, U256", |b| {
@@ -839,7 +841,7 @@ fn bench_invert_mod(c: &mut Criterion) {
             },
             |(x, m)| black_box(x.invert_mod(&m)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("invert_mod2k, U256", |b| {
@@ -847,7 +849,7 @@ fn bench_invert_mod(c: &mut Criterion) {
             || U256::random_from_rng(&mut rng),
             |x| x.invert_mod2k(black_box(1)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("invert_mod2k_vartime, U256", |b| {
@@ -855,7 +857,7 @@ fn bench_invert_mod(c: &mut Criterion) {
             || U256::random_from_rng(&mut rng),
             |x| x.invert_mod2k_vartime(black_box(1)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.finish();
@@ -870,7 +872,7 @@ fn bench_sqrt(c: &mut Criterion) {
             || U256::random_from_rng(&mut rng),
             |x| x.floor_sqrt(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("floor_sqrt, U512", |b| {
@@ -878,7 +880,7 @@ fn bench_sqrt(c: &mut Criterion) {
             || U512::random_from_rng(&mut rng),
             |x| x.floor_sqrt(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("floor_sqrt_vartime, U256", |b| {
@@ -886,7 +888,7 @@ fn bench_sqrt(c: &mut Criterion) {
             || U256::random_from_rng(&mut rng),
             |x| x.floor_sqrt_vartime(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("floor_sqrt_vartime, U256 one Limb", |b| {
@@ -894,7 +896,7 @@ fn bench_sqrt(c: &mut Criterion) {
             || U256::from_word(Limb::random_from_rng(&mut rng).0),
             |x| x.floor_sqrt_vartime(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("checked_sqrt, U256", |b| {
@@ -902,7 +904,7 @@ fn bench_sqrt(c: &mut Criterion) {
             || U256::random_from_rng(&mut rng),
             |x| x.checked_sqrt(),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("checked_sqrt_vartime, U256", |b| {
@@ -910,7 +912,7 @@ fn bench_sqrt(c: &mut Criterion) {
             || U256::random_from_rng(&mut rng),
             |x| x.checked_sqrt_vartime(),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 
@@ -924,7 +926,7 @@ fn bench_root(c: &mut Criterion) {
             || U256::random_from_rng(&mut rng),
             |x| x.floor_root_vartime(black_box(exp)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("floor_root_vartime(4), U256", |b| {
@@ -933,7 +935,7 @@ fn bench_root(c: &mut Criterion) {
             || U256::random_from_rng(&mut rng),
             |x| x.floor_root_vartime(black_box(exp)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("checked_root_vartime(3), U256", |b| {
@@ -942,7 +944,7 @@ fn bench_root(c: &mut Criterion) {
             || U256::random_from_rng(&mut rng),
             |x| x.checked_root_vartime(black_box(exp)),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("checked_root_vartime(4), U256", |b| {
@@ -951,7 +953,7 @@ fn bench_root(c: &mut Criterion) {
             || U256::random_from_rng(&mut rng),
             |x| x.checked_root_vartime(black_box(exp)),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -77,6 +77,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub const LIMBS: usize = LIMBS;
 
     /// Const-friendly [`Int`] constructor.
+    #[must_use]
     pub const fn new(limbs: [Limb; LIMBS]) -> Self {
         Self(Uint::new(limbs))
     }
@@ -93,6 +94,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Create an [`Int`] from an array of [`Word`]s (i.e. word-sized unsigned
     /// integers).
     #[inline]
+    #[must_use]
     pub const fn from_words(arr: [Word; LIMBS]) -> Self {
         Self(Uint::from_words(arr))
     }
@@ -100,11 +102,13 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Create an array of [`Word`]s (i.e. word-sized unsigned integers) from
     /// an [`Int`].
     #[inline]
+    #[must_use]
     pub const fn to_words(self) -> [Word; LIMBS] {
         self.0.to_words()
     }
 
     /// Borrow the inner limbs as an array of [`Word`]s.
+    #[must_use]
     pub const fn as_words(&self) -> &[Word; LIMBS] {
         self.0.as_words()
     }
@@ -121,6 +125,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 
     /// Borrow the limbs of this [`Int`].
+    #[must_use]
     pub const fn as_limbs(&self) -> &[Limb; LIMBS] {
         self.0.as_limbs()
     }
@@ -137,6 +142,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 
     /// Convert this [`Int`] into its inner limbs.
+    #[must_use]
     pub const fn to_limbs(self) -> [Limb; LIMBS] {
         self.0.to_limbs()
     }
@@ -144,6 +150,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Convert to a [`NonZero<Int<LIMBS>>`].
     ///
     /// Returns some if the original value is non-zero, and false otherwise.
+    #[must_use]
     pub const fn to_nz(self) -> CtOption<NonZero<Self>> {
         CtOption::new(NonZero(self), self.0.is_nonzero())
     }
@@ -151,6 +158,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Convert to a [`Odd<Int<LIMBS>>`].
     ///
     /// Returns some if the original value is odd, and false otherwise.
+    #[must_use]
     pub const fn to_odd(self) -> CtOption<Odd<Self>> {
         CtOption::new(Odd(self), self.0.is_odd())
     }
@@ -160,6 +168,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Note: this is a casting operation. See
     /// - [`Self::try_into_uint`] for the checked equivalent, and
     /// - [`Self::abs`] to obtain the absolute value of `self`.
+    #[must_use]
     pub const fn as_uint(&self) -> &Uint<LIMBS> {
         &self.0
     }
@@ -169,21 +178,25 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Note: this is a checked conversion operation. See
     /// - [`Self::as_uint`] for the unchecked equivalent, and
     /// - [`Self::abs`] to obtain the absolute value of `self`.
+    #[must_use]
     pub const fn try_into_uint(self) -> CtOption<Uint<LIMBS>> {
         CtOption::new(self.0, self.is_negative().not())
     }
 
     /// Whether this [`Int`] is equal to `Self::MIN`.
+    #[must_use]
     pub const fn is_min(&self) -> Choice {
         Self::eq(self, &Self::MIN)
     }
 
     /// Whether this [`Int`] is equal to `Self::MAX`.
+    #[must_use]
     pub const fn is_max(&self) -> Choice {
         Self::eq(self, &Self::MAX)
     }
 
     /// Is this [`Int`] equal to zero?
+    #[must_use]
     pub const fn is_zero(&self) -> Choice {
         self.0.is_zero()
     }

--- a/src/int/add.rs
+++ b/src/int/add.rs
@@ -4,12 +4,14 @@ use crate::{Add, AddAssign, Checked, CheckedAdd, Choice, CtOption, Int, Wrapping
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Perform checked addition. Returns `none` when the addition overflowed.
+    #[must_use]
     pub const fn checked_add(&self, rhs: &Self) -> CtOption<Self> {
         let (value, overflow) = self.overflowing_add(rhs);
         CtOption::new(value, overflow.not())
     }
 
     /// Perform addition, raising the `overflow` flag on overflow.
+    #[must_use]
     pub const fn overflowing_add(&self, rhs: &Self) -> (Self, Choice) {
         // Step 1. add operands
         let res = Self(self.0.wrapping_add(&rhs.0));
@@ -30,6 +32,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 
     /// Perform wrapping addition, discarding overflow.
+    #[must_use]
     pub const fn wrapping_add(&self, rhs: &Self) -> Self {
         Self(self.0.wrapping_add(&rhs.0))
     }

--- a/src/int/bit_and.rs
+++ b/src/int/bit_and.rs
@@ -7,12 +7,14 @@ use crate::{CtOption, Int, Limb, Uint, Wrapping};
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Computes bitwise `a & b`.
     #[inline(always)]
+    #[must_use]
     pub const fn bitand(&self, rhs: &Self) -> Self {
         Self(Uint::bitand(&self.0, &rhs.0))
     }
 
     /// Perform bitwise `AND` between `self` and the given [`Limb`], performing the `AND` operation
     /// on every limb of `self`.
+    #[must_use]
     pub const fn bitand_limb(&self, rhs: Limb) -> Self {
         Self(Uint::bitand_limb(&self.0, rhs))
     }
@@ -21,11 +23,13 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub const fn wrapping_and(&self, rhs: &Self) -> Self {
         self.bitand(rhs)
     }
 
     /// Perform checked bitwise `AND`, returning a [`CtOption`] which `is_some` always
+    #[must_use]
     pub const fn checked_and(&self, rhs: &Self) -> CtOption<Self> {
         CtOption::some(self.bitand(rhs))
     }

--- a/src/int/bit_not.rs
+++ b/src/int/bit_not.rs
@@ -9,6 +9,7 @@ use super::Int;
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Computes bitwise `!a`.
     #[inline(always)]
+    #[must_use]
     pub const fn not(&self) -> Self {
         Self(Uint::not(&self.0))
     }

--- a/src/int/bit_or.rs
+++ b/src/int/bit_or.rs
@@ -9,6 +9,7 @@ use super::Int;
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Computes bitwise `a & b`.
     #[inline(always)]
+    #[must_use]
     pub const fn bitor(&self, rhs: &Self) -> Self {
         Self(Uint::bitor(&self.0, &rhs.0))
     }
@@ -17,11 +18,13 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub const fn wrapping_or(&self, rhs: &Self) -> Self {
         self.bitor(rhs)
     }
 
     /// Perform checked bitwise `OR`, returning a [`CtOption`] which `is_some` always
+    #[must_use]
     pub const fn checked_or(&self, rhs: &Self) -> CtOption<Self> {
         CtOption::some(self.bitor(rhs))
     }

--- a/src/int/bit_xor.rs
+++ b/src/int/bit_xor.rs
@@ -9,6 +9,7 @@ use super::Int;
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Computes bitwise `a ^ b`.
     #[inline(always)]
+    #[must_use]
     pub const fn bitxor(&self, rhs: &Self) -> Self {
         Self(Uint::bitxor(&self.0, &rhs.0))
     }
@@ -17,11 +18,13 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub const fn wrapping_xor(&self, rhs: &Self) -> Self {
         self.bitxor(rhs)
     }
 
     /// Perform checked bitwise `XOR`, returning a [`CtOption`] which `is_some` always
+    #[must_use]
     pub fn checked_xor(&self, rhs: &Self) -> CtOption<Self> {
         CtOption::some(self.bitxor(rhs))
     }

--- a/src/int/cmp.rs
+++ b/src/int/cmp.rs
@@ -47,6 +47,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 
     /// Returns the Ordering between `self` and `rhs` in variable time.
+    #[must_use]
     pub const fn cmp_vartime(&self, rhs: &Self) -> Ordering {
         self.invert_msb().0.cmp_vartime(&rhs.invert_msb().0)
     }

--- a/src/int/div.rs
+++ b/src/int/div.rs
@@ -6,7 +6,7 @@ use core::ops::{Div, DivAssign, Rem, RemAssign};
 /// Checked division operations.
 impl<const LIMBS: usize> Int<LIMBS> {
     #[inline]
-    /// Base div_rem operation on dividing [`Int`]s.
+    /// Base `div_rem` operation on dividing [`Int`]s.
     ///
     /// Computes the quotient and remainder of `self / rhs`.
     /// Furthermore, returns the signs of `self` and `rhs`.
@@ -49,6 +49,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// assert_eq!(quotient.unwrap(), I128::from(2));
     /// assert_eq!(remainder, I128::from(-2));
     /// ```
+    #[must_use]
     pub const fn checked_div_rem<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Int<RHS_LIMBS>>,
@@ -66,11 +67,13 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// - `self != MIN` or `rhs != MINUS_ONE`.
     ///
     /// Note: this operation rounds towards zero, truncating any fractional part of the exact result.
+    #[must_use]
     pub fn checked_div<const RHS_LIMBS: usize>(&self, rhs: &Int<RHS_LIMBS>) -> CtOption<Self> {
         NonZero::new(*rhs).and_then(|rhs| self.checked_div_rem(&rhs).0)
     }
 
     /// Computes `self` % `rhs`, returns the remainder.
+    #[must_use]
     pub const fn rem<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Int<RHS_LIMBS>>,
@@ -109,6 +112,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
+    #[must_use]
     pub const fn checked_div_rem_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Int<RHS_LIMBS>>,
@@ -127,6 +131,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
+    #[must_use]
     pub fn checked_div_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
@@ -140,6 +145,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
+    #[must_use]
     pub const fn rem_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Int<RHS_LIMBS>>,
@@ -156,6 +162,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
+    #[must_use]
     pub const fn checked_div_rem_floor_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Int<RHS_LIMBS>>,
@@ -190,6 +197,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
+    #[must_use]
     pub fn checked_div_floor_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
@@ -226,6 +234,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///     I128::from(2)
     /// )
     /// ```
+    #[must_use]
     pub fn checked_div_floor<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
@@ -263,6 +272,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// assert_eq!(quotient.unwrap(), I128::from(2));
     /// assert_eq!(remainder, I128::from(2));
     /// ```
+    #[must_use]
     pub const fn checked_div_rem_floor<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Int<RHS_LIMBS>>,
@@ -332,7 +342,7 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<NonZero<Int<RHS_LIMBS>>> fo
 
 impl<const LIMBS: usize> DivAssign<&NonZero<Int<LIMBS>>> for Int<LIMBS> {
     fn div_assign(&mut self, rhs: &NonZero<Int<LIMBS>>) {
-        *self /= *rhs
+        *self /= *rhs;
     }
 }
 
@@ -439,7 +449,7 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Rem<NonZero<Int<RHS_LIMBS>>> fo
 
 impl<const LIMBS: usize> RemAssign<&NonZero<Int<LIMBS>>> for Int<LIMBS> {
     fn rem_assign(&mut self, rhs: &NonZero<Int<LIMBS>>) {
-        *self %= *rhs
+        *self %= *rhs;
     }
 }
 
@@ -497,7 +507,7 @@ impl<const LIMBS: usize> RemAssign<NonZero<Int<LIMBS>>> for Wrapping<Int<LIMBS>>
 
 impl<const LIMBS: usize> RemAssign<&NonZero<Int<LIMBS>>> for Wrapping<Int<LIMBS>> {
     fn rem_assign(&mut self, rhs: &NonZero<Int<LIMBS>>) {
-        *self = Wrapping(self.0 % rhs)
+        *self = Wrapping(self.0 % rhs);
     }
 }
 

--- a/src/int/div_unsigned.rs
+++ b/src/int/div_unsigned.rs
@@ -6,7 +6,7 @@ use crate::{Choice, Int, NonZero, Uint, Wrapping};
 /// Checked division operations.
 impl<const LIMBS: usize> Int<LIMBS> {
     #[inline]
-    /// Base div_rem operation on dividing an [`Int`] by a [`Uint`].
+    /// Base `div_rem` operation on dividing an [`Int`] by a [`Uint`].
     /// Computes the quotient and remainder of `self / rhs`.
     /// Furthermore, returns the sign of `self`.
     const fn div_rem_base_unsigned<const RHS_LIMBS: usize>(
@@ -32,6 +32,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// assert_eq!(quotient, I128::from(-2));
     /// assert_eq!(remainder, I128::from(-2));
     /// ```
+    #[must_use]
     pub const fn div_rem_unsigned<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
@@ -45,6 +46,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
 
     /// Perform division.
     /// Note: this operation rounds towards zero, truncating any fractional part of the exact result.
+    #[must_use]
     pub const fn div_unsigned<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
@@ -54,6 +56,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
 
     /// Compute the remainder.
     /// The remainder will have the same sign as `self` (or be zero).
+    #[must_use]
     pub const fn rem_unsigned<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
@@ -86,6 +89,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
+    #[must_use]
     pub const fn div_rem_unsigned_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
@@ -103,6 +107,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
+    #[must_use]
     pub const fn div_unsigned_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
@@ -116,6 +121,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
+    #[must_use]
     pub const fn rem_unsigned_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
@@ -144,6 +150,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///     (I128::from(-3), U128::ONE)
     /// );
     /// ```
+    #[must_use]
     pub fn div_rem_floor_unsigned<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
@@ -178,6 +185,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///     I128::from(-3)
     /// );
     /// ```
+    #[must_use]
     pub fn div_floor_unsigned<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
@@ -200,6 +208,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///     U128::ONE
     /// );
     /// ```
+    #[must_use]
     pub fn normalized_rem<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
@@ -217,6 +226,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
+    #[must_use]
     pub fn div_rem_floor_unsigned_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
@@ -242,6 +252,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
+    #[must_use]
     pub fn div_floor_unsigned_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
@@ -256,6 +267,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
+    #[must_use]
     pub fn normalized_rem_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
@@ -299,7 +311,7 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<NonZero<Uint<RHS_LIMBS>>> f
 
 impl<const LIMBS: usize> DivAssign<&NonZero<Uint<LIMBS>>> for Int<LIMBS> {
     fn div_assign(&mut self, rhs: &NonZero<Uint<LIMBS>>) {
-        *self /= *rhs
+        *self /= *rhs;
     }
 }
 
@@ -395,7 +407,7 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Rem<NonZero<Uint<RHS_LIMBS>>> f
 
 impl<const LIMBS: usize> RemAssign<&NonZero<Uint<LIMBS>>> for Int<LIMBS> {
     fn rem_assign(&mut self, rhs: &NonZero<Uint<LIMBS>>) {
-        *self %= *rhs
+        *self %= *rhs;
     }
 }
 
@@ -453,7 +465,7 @@ impl<const LIMBS: usize> RemAssign<NonZero<Uint<LIMBS>>> for Wrapping<Int<LIMBS>
 
 impl<const LIMBS: usize> RemAssign<&NonZero<Uint<LIMBS>>> for Wrapping<Int<LIMBS>> {
     fn rem_assign(&mut self, rhs: &NonZero<Uint<LIMBS>>) {
-        *self = Wrapping(self.0 % rhs)
+        *self = Wrapping(self.0 % rhs);
     }
 }
 
@@ -505,7 +517,7 @@ mod tests {
                 .to_nz()
                 .unwrap();
 
-            assert_eq!(num.div_unsigned(&denom), num.div_unsigned_vartime(&denom))
+            assert_eq!(num.div_unsigned(&denom), num.div_unsigned_vartime(&denom));
         }
     }
 
@@ -579,7 +591,7 @@ mod tests {
             assert_eq!(
                 num.div_floor_unsigned(&denom),
                 num.div_floor_unsigned_vartime(&denom)
-            )
+            );
         }
     }
 }

--- a/src/int/encoding.rs
+++ b/src/int/encoding.rs
@@ -5,9 +5,11 @@ use crate::{Int, Uint};
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Create a new [`Int`] from the provided big endian hex string.
     ///
-    /// Panics if the hex is malformed or not zero-padded accordingly for the size.
-    ///
     /// See [`Uint::from_be_hex`] for more details.
+    ///
+    /// # Panics
+    /// - if the hex is malformed or not zero-padded accordingly for the size.
+    #[must_use]
     pub const fn from_be_hex(hex: &str) -> Self {
         Self(Uint::from_be_hex(hex))
     }

--- a/src/int/from.rs
+++ b/src/int/from.rs
@@ -2,28 +2,39 @@
 
 use crate::{CtOption, I64, I128, Int, Limb, Uint, Word};
 
+macro_rules! check_limbs {
+    ($limbs:expr) => {
+        const {
+            assert!($limbs >= 1, "number of limbs must be greater than zero");
+        }
+    };
+}
+
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Create a [`Int`] from an `i8` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<i8>` when stable
     #[inline]
+    #[must_use]
     pub const fn from_i8(n: i8) -> Self {
-        assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        check_limbs!(LIMBS);
         Uint::new([Limb(n as Word)]).as_int().resize()
     }
 
     /// Create a [`Int`] from an `i16` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<i16>` when stable
     #[inline]
+    #[must_use]
     pub const fn from_i16(n: i16) -> Self {
-        assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        check_limbs!(LIMBS);
         Uint::new([Limb(n as Word)]).as_int().resize()
     }
 
     /// Create a [`Int`] from an `i32` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<i32>` when stable
     #[inline]
+    #[must_use]
     pub const fn from_i32(n: i32) -> Self {
-        assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        check_limbs!(LIMBS);
         Uint::new([Limb(n as Word)]).as_int().resize()
     }
 
@@ -32,6 +43,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     #[cfg(target_pointer_width = "32")]
     #[inline]
     pub const fn from_i64(n: i64) -> Self {
+        check_limbs!(LIMBS);
         Uint::<{ I64::LIMBS }>::from_u64(n as u64).as_int().resize()
     }
 
@@ -39,14 +51,16 @@ impl<const LIMBS: usize> Int<LIMBS> {
     // TODO(tarcieri): replace with `const impl From<i64>` when stable
     #[cfg(target_pointer_width = "64")]
     #[inline]
+    #[must_use]
     pub const fn from_i64(n: i64) -> Self {
-        assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        check_limbs!(LIMBS);
         Uint::new([Limb(n as Word)]).as_int().resize()
     }
 
     /// Create a [`Int`] from an `i128` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<i128>` when stable
     #[inline]
+    #[must_use]
     pub const fn from_i128(n: i128) -> Self {
         Uint::<{ I128::LIMBS }>::from_u128(n as u128)
             .as_int()

--- a/src/int/gcd.rs
+++ b/src/int/gcd.rs
@@ -8,6 +8,7 @@ use crate::{Choice, Gcd, Int, NonZero, NonZeroInt, NonZeroUint, Odd, OddInt, Odd
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Compute the greatest common divisor of `self` and `rhs`.
+    #[must_use]
     pub const fn gcd_unsigned(&self, rhs: &Uint<LIMBS>) -> Uint<LIMBS> {
         self.abs().gcd(rhs)
     }
@@ -15,6 +16,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Compute the greatest common divisor of `self` and `rhs`.
     ///
     /// Executes in variable time w.r.t. all input parameters.
+    #[must_use]
     pub const fn gcd_unsigned_vartime(&self, rhs: &Uint<LIMBS>) -> Uint<LIMBS> {
         self.abs().gcd_vartime(rhs)
     }
@@ -22,6 +24,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Executes the Extended GCD algorithm.
     ///
     /// Given `(self, rhs)`, computes `(g, x, y)`, s.t. `self * x + rhs * y = g = gcd(self, rhs)`.
+    #[must_use]
     pub const fn xgcd(&self, rhs: &Self) -> IntXgcdOutput<LIMBS> {
         // Make sure `self` and `rhs` are nonzero.
         let self_is_zero = self.is_nonzero().not();
@@ -74,6 +77,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
 
 impl<const LIMBS: usize> NonZero<Int<LIMBS>> {
     /// Compute the greatest common divisor of `self` and `rhs`.
+    #[must_use]
     pub const fn gcd_unsigned(&self, rhs: &Uint<LIMBS>) -> NonZero<Uint<LIMBS>> {
         self.abs().gcd_unsigned(rhs)
     }
@@ -81,6 +85,7 @@ impl<const LIMBS: usize> NonZero<Int<LIMBS>> {
     /// Compute the greatest common divisor of `self` and `rhs`.
     ///
     /// Executes in variable time w.r.t. all input parameters.
+    #[must_use]
     pub const fn gcd_unsigned_vartime(&self, rhs: &Uint<LIMBS>) -> NonZeroUint<LIMBS> {
         self.abs().gcd_unsigned_vartime(rhs)
     }
@@ -88,6 +93,7 @@ impl<const LIMBS: usize> NonZero<Int<LIMBS>> {
     /// Execute the Extended GCD algorithm.
     ///
     /// Given `(self, rhs)`, computes `(g, x, y)` s.t. `self * x + rhs * y = g = gcd(self, rhs)`.
+    #[must_use]
     pub const fn xgcd(&self, rhs: &Self) -> NonZeroIntXgcdOutput<LIMBS> {
         let (mut lhs, mut rhs) = (*self.as_ref(), *rhs.as_ref());
 
@@ -136,6 +142,7 @@ impl<const LIMBS: usize> NonZero<Int<LIMBS>> {
 
 impl<const LIMBS: usize> Odd<Int<LIMBS>> {
     /// Compute the greatest common divisor of `self` and `rhs`.
+    #[must_use]
     pub const fn gcd_unsigned(&self, rhs: &Uint<LIMBS>) -> Odd<Uint<LIMBS>> {
         self.abs().gcd_unsigned(rhs)
     }
@@ -143,6 +150,7 @@ impl<const LIMBS: usize> Odd<Int<LIMBS>> {
     /// Compute the greatest common divisor of `self` and `rhs`.
     ///
     /// Executes in variable time w.r.t. all input parameters.
+    #[must_use]
     pub const fn gcd_unsigned_vartime(&self, rhs: &Uint<LIMBS>) -> OddUint<LIMBS> {
         self.abs().gcd_unsigned_vartime(rhs)
     }
@@ -150,6 +158,7 @@ impl<const LIMBS: usize> Odd<Int<LIMBS>> {
     /// Execute the Extended GCD algorithm.
     ///
     /// Given `(self, rhs)`, computes `(g, x, y)` s.t. `self * x + rhs * y = g = gcd(self, rhs)`.
+    #[must_use]
     pub const fn xgcd(&self, rhs: &NonZero<Int<LIMBS>>) -> OddIntXgcdOutput<LIMBS> {
         let (abs_lhs, sgn_lhs) = self.abs_sign();
         let (abs_rhs, sgn_rhs) = rhs.abs_sign();
@@ -455,7 +464,7 @@ mod tests {
             Uint<LIMBS>: ConcatMixed<Uint<LIMBS>, MixedOutput = Uint<DOUBLE>>,
             Int<LIMBS>: Gcd<Output = Uint<LIMBS>>,
         {
-            xgcd_test(lhs, rhs, lhs.xgcd(&rhs))
+            xgcd_test(lhs, rhs, lhs.xgcd(&rhs));
         }
 
         fn run_tests<const LIMBS: usize, const DOUBLE: usize>()

--- a/src/int/invert_mod.rs
+++ b/src/int/invert_mod.rs
@@ -4,6 +4,7 @@ use crate::{CtOption, Int, InvertMod, NonZero, Odd, Uint};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
+    #[must_use]
     pub fn invert_odd_mod(&self, modulus: &Odd<Uint<LIMBS>>) -> CtOption<Uint<LIMBS>> {
         let (abs, sgn) = self.abs_sign();
         let maybe_inv = abs.invert_odd_mod(modulus);
@@ -20,6 +21,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Computes the multiplicative inverse of `self` mod `modulus`.
     ///
     /// Returns some if an inverse exists, otherwise none.
+    #[must_use]
     pub const fn invert_mod(&self, modulus: &NonZero<Uint<LIMBS>>) -> CtOption<Uint<LIMBS>> {
         let (abs, sgn) = self.abs_sign();
         let maybe_inv = abs.invert_mod(modulus);

--- a/src/int/mod_symbol.rs
+++ b/src/int/mod_symbol.rs
@@ -7,6 +7,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// For prime `rhs`, this corresponds to the Legendre symbol and
     /// indicates whether `self` is quadratic residue modulo `rhs`.
+    #[must_use]
     pub const fn jacobi_symbol(&self, rhs: &Odd<Uint<LIMBS>>) -> JacobiSymbol {
         let (abs, sign) = self.abs_sign();
         let jacobi = abs.jacobi_symbol(rhs) as i64;
@@ -21,6 +22,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// indicates whether `self` is quadratic residue modulo `rhs`.
     ///
     /// This method executes in variable-time for the value of `self`.
+    #[must_use]
     pub const fn jacobi_symbol_vartime(&self, rhs: &Odd<Uint<LIMBS>>) -> JacobiSymbol {
         let (abs, sign) = self.abs_sign();
         let jacobi = abs.jacobi_symbol_vartime(rhs);

--- a/src/int/mul.rs
+++ b/src/int/mul.rs
@@ -12,6 +12,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// Note: even if `negate` is truthy, the magnitude might be zero!
     #[deprecated(since = "0.7.0", note = "please use `widening_mul` instead")]
+    #[must_use]
     pub const fn split_mul<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
@@ -25,6 +26,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// negated when converted from [`Uint`] to [`Int`].
     ///
     /// Note: even if `negate` is truthy, the magnitude might be zero!
+    #[must_use]
     pub const fn widening_mul<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
@@ -46,6 +48,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 
     /// Multiply `self` by `rhs`, returning a concatenated "wide" result.
+    #[must_use]
     pub const fn concatenating_mul<const RHS_LIMBS: usize, const WIDE_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
@@ -64,6 +67,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
 
     /// Multiply `self` by `rhs`, returning a `CtOption` which is `is_some` only if
     /// overflow did not occur.
+    #[must_use]
     pub const fn checked_mul<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
@@ -75,6 +79,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 
     /// Multiply `self` by `rhs`, saturating at the numeric bounds instead of overflowing.
+    #[must_use]
     pub const fn saturating_mul<const RHS_LIMBS: usize>(&self, rhs: &Int<RHS_LIMBS>) -> Self {
         let (abs_lhs, lhs_sgn) = self.abs_sign();
         let (abs_rhs, rhs_sgn) = rhs.abs_sign();
@@ -90,6 +95,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
 
     /// Multiply `self` by `rhs`, wrapping the result in case of overflow.
     /// This is equivalent to `(self * rhs) % (Uint::<LIMBS>::MAX + 1)`.
+    #[must_use]
     pub const fn wrapping_mul<const RHS_LIMBS: usize>(&self, rhs: &Int<RHS_LIMBS>) -> Self {
         if RHS_LIMBS >= LIMBS {
             Self(self.0.wrapping_mul(&rhs.0))
@@ -103,6 +109,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
 /// Squaring operations.
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Square self, returning a concatenated "wide" result.
+    #[must_use]
     pub fn widening_square<const WIDE_LIMBS: usize>(&self) -> Uint<WIDE_LIMBS>
     where
         Uint<LIMBS>: ConcatMixed<Uint<LIMBS>, MixedOutput = Uint<WIDE_LIMBS>>,
@@ -111,16 +118,19 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 
     /// Square self, checking that the result fits in the original [`Uint`] size.
+    #[must_use]
     pub fn checked_square(&self) -> CtOption<Uint<LIMBS>> {
         self.abs().checked_square()
     }
 
     /// Perform wrapping square, discarding overflow.
+    #[must_use]
     pub const fn wrapping_square(&self) -> Uint<LIMBS> {
         self.abs().wrapping_square()
     }
 
     /// Perform saturating squaring, returning `MAX` on overflow.
+    #[must_use]
     pub const fn saturating_square(&self) -> Uint<LIMBS> {
         self.abs().saturating_square()
     }
@@ -174,13 +184,13 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Mul<&Int<RHS_LIMBS>> for &Int<L
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> MulAssign<Int<RHS_LIMBS>> for Int<LIMBS> {
     fn mul_assign(&mut self, rhs: Int<RHS_LIMBS>) {
-        *self = self.mul(&rhs)
+        *self = self.mul(&rhs);
     }
 }
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> MulAssign<&Int<RHS_LIMBS>> for Int<LIMBS> {
     fn mul_assign(&mut self, rhs: &Int<RHS_LIMBS>) {
-        *self = self.mul(rhs)
+        *self = self.mul(rhs);
     }
 }
 
@@ -516,7 +526,7 @@ mod tests {
         assert_eq!(
             res,
             U256::from_be_hex("0000000000000000000000000000000100000000000000000000000000000000")
-        )
+        );
     }
 
     #[test]
@@ -544,7 +554,7 @@ mod tests {
 
         let x: I128 = I128::from_i64(i64::MAX);
         let res = x.wrapping_square();
-        assert_eq!(res, U128::from_be_hex("3FFFFFFFFFFFFFFF0000000000000001"))
+        assert_eq!(res, U128::from_be_hex("3FFFFFFFFFFFFFFF0000000000000001"));
     }
 
     #[test]

--- a/src/int/mul_unsigned.rs
+++ b/src/int/mul_unsigned.rs
@@ -9,6 +9,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// Note: even if `negate` is truthy, the magnitude might be zero!
     #[deprecated(since = "0.7.0", note = "please use `widening_mul_unsigned` instead")]
+    #[must_use]
     pub const fn split_mul_unsigned<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
@@ -22,6 +23,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// negated when converted from [`Uint`] to [`Int`].
     ///
     /// Note: even if `negate` is truthy, the magnitude might be zero!
+    #[must_use]
     pub const fn widening_mul_unsigned<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
@@ -46,6 +48,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
         since = "0.7.0",
         note = "please use `Uint::widening_mul_signed` instead"
     )]
+    #[must_use]
     pub const fn split_mul_unsigned_right<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
@@ -63,6 +66,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
         since = "0.7.0",
         note = "please use `Uint::widening_mul_signed` instead"
     )]
+    #[must_use]
     pub const fn widening_mul_unsigned_right<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
@@ -71,6 +75,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 
     /// Multiply `self` by [`Uint`] `rhs`, returning a concatenated "wide" result.
+    #[must_use]
     pub const fn concatenating_mul_unsigned<const RHS_LIMBS: usize, const WIDE_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
@@ -88,6 +93,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Checked multiplication of self with an [`Uint<RHS_LIMBS>`], where the result is to be stored
     /// in an [`Int<RHS_LIMBS>`].
     #[deprecated(since = "0.7.0", note = "please use `Uint::checked_mul(_int)` instead")]
+    #[must_use]
     pub fn checked_mul_unsigned_right<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
@@ -96,6 +102,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 
     /// Checked multiplication with a [`Uint`].
+    #[must_use]
     pub fn checked_mul_unsigned<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,

--- a/src/int/neg.rs
+++ b/src/int/neg.rs
@@ -9,6 +9,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Returns the negation, as well as whether the operation overflowed.
     /// The operation overflows when attempting to negate [`Int::MIN`]; the positive counterpart
     /// of this value cannot be represented.
+    #[must_use]
     pub const fn overflowing_neg(&self) -> (Self, Choice) {
         Self(self.0.bitxor(&Uint::MAX)).overflowing_add(&Int::ONE)
     }
@@ -17,6 +18,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// Warning: this operation maps [`Int::MIN`] to itself, since the positive counterpart of this
     /// value cannot be represented.
+    #[must_use]
     pub const fn wrapping_neg(&self) -> Self {
         self.overflowing_neg().0
     }
@@ -25,6 +27,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// Warning: this operation maps [`Int::MIN`] to itself, since the positive counterpart of this
     /// value cannot be represented.
+    #[must_use]
     pub const fn wrapping_neg_if(&self, negate: Choice) -> Int<LIMBS> {
         Self(self.0.wrapping_neg_if(negate))
     }
@@ -33,6 +36,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// Yields `None` when `self == Self::MIN`, since the positive counterpart of this value cannot
     /// be represented.
+    #[must_use]
     pub const fn checked_neg(&self) -> CtOption<Self> {
         let (value, overflow) = self.overflowing_neg();
         CtOption::new(value, overflow.not())

--- a/src/int/resize.rs
+++ b/src/int/resize.rs
@@ -4,6 +4,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Resize the representation of `self` to an [`Int<T>`].
     /// Warning: this operation may lead to loss of information.
     #[inline(always)]
+    #[must_use]
     pub const fn resize<const T: usize>(&self) -> Int<T> {
         let mut limbs = [Limb::select(Limb::ZERO, Limb::MAX, self.is_negative()); T];
         let mut i = 0;

--- a/src/int/shl.rs
+++ b/src/int/shl.rs
@@ -6,14 +6,18 @@ use core::ops::{Shl, ShlAssign};
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Computes `self << shift`.
     ///
-    /// Panics if `shift >= Self::BITS`.
+    /// # Panics
+    /// - if `shift >= Self::BITS`.
+    #[must_use]
     pub const fn shl(&self, shift: u32) -> Self {
         Self(Uint::shl(&self.0, shift))
     }
 
     /// Computes `self << shift` in variable time.
     ///
-    /// Panics if `shift >= Self::BITS`.
+    /// # Panics
+    /// - if `shift >= Self::BITS`.
+    #[must_use]
     pub const fn shl_vartime(&self, shift: u32) -> Self {
         Self(Uint::shl_vartime(&self.0, shift))
     }
@@ -21,6 +25,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Computes `self << shift`.
     ///
     /// Returns `None` if `shift >= Self::BITS`.
+    #[must_use]
     pub const fn overflowing_shl(&self, shift: u32) -> CtOption<Self> {
         Self::from_uint_opt(self.0.overflowing_shl(shift))
     }
@@ -34,6 +39,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// When used with a fixed `shift`, this function is constant-time with respect
     /// to `self`.
     #[inline(always)]
+    #[must_use]
     pub const fn overflowing_shl_vartime(&self, shift: u32) -> Option<Self> {
         if let Some(uint) = self.0.overflowing_shl_vartime(shift) {
             Some(*uint.as_int())
@@ -44,12 +50,14 @@ impl<const LIMBS: usize> Int<LIMBS> {
 
     /// Computes `self << shift` in a panic-free manner, returning zero if the shift exceeds the
     /// precision.
+    #[must_use]
     pub const fn wrapping_shl(&self, shift: u32) -> Self {
         Self(self.0.wrapping_shl(shift))
     }
 
     /// Computes `self << shift` in variable-time in a panic-free manner, returning zero if the
     /// shift exceeds the precision.
+    #[must_use]
     pub const fn wrapping_shl_vartime(&self, shift: u32) -> Self {
         Self(self.0.wrapping_shl_vartime(shift))
     }

--- a/src/int/shr.rs
+++ b/src/int/shr.rs
@@ -9,7 +9,10 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Note, this is _signed_ shift right, i.e., the value shifted in on the left is equal to
     /// the most significant bit.
     ///
-    /// Panics if `shift >= Self::BITS`.
+    /// # Panics
+    /// - if `shift >= Self::BITS`.
+    #[must_use]
+    #[track_caller]
     pub const fn shr(&self, shift: u32) -> Self {
         self.overflowing_shr(shift)
             .expect_copied("`shift` within the bit size of the integer")
@@ -20,7 +23,10 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// Note, this is _signed_ shift right, i.e., the value shifted in on the left is equal to
     /// the most significant bit.
     ///
-    /// Panics if `shift >= Self::BITS`.
+    /// # Panics
+    /// - if `shift >= Self::BITS`.
+    #[must_use]
+    #[track_caller]
     pub const fn shr_vartime(&self, shift: u32) -> Self {
         self.overflowing_shr_vartime(shift)
             .expect("`shift` within the bit size of the integer")
@@ -32,6 +38,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// the most significant bit.
     ///
     /// Returns `None` if `shift >= Self::BITS`.
+    #[must_use]
     pub const fn overflowing_shr(&self, shift: u32) -> CtOption<Self> {
         // `floor(log2(BITS - 1))` is the number of bits in the representation of `shift`
         // (which lies in range `0 <= shift < BITS`).
@@ -61,6 +68,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// When used with a fixed `shift`, this function is constant-time with respect
     /// to `self`.
     #[inline(always)]
+    #[must_use]
     pub const fn overflowing_shr_vartime(&self, shift: u32) -> Option<Self> {
         if let Some(ret) = self.0.overflowing_shr_vartime(shift) {
             let neg_upper = Uint::select(
@@ -79,6 +87,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// If the shift exceeds the precision, returns
     /// - `0` when `self` is non-negative, and
     /// - `-1` when `self` is negative.
+    #[must_use]
     pub const fn wrapping_shr(&self, shift: u32) -> Self {
         let default = Self::select(&Self::ZERO, &Self::MINUS_ONE, self.is_negative());
         ctutils::unwrap_or!(self.overflowing_shr(shift), default, Self::select)
@@ -89,6 +98,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// If the shift exceeds the precision, returns
     /// - `0` when `self` is non-negative, and
     /// - `-1` when `self` is negative.
+    #[must_use]
     pub const fn wrapping_shr_vartime(&self, shift: u32) -> Self {
         if let Some(ret) = self.overflowing_shr_vartime(shift) {
             ret

--- a/src/int/sign.rs
+++ b/src/int/sign.rs
@@ -19,6 +19,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///
     /// Returns `None` when the result exceeds the bounds of an [`Int<LIMBS>`].
     #[inline]
+    #[must_use]
     pub const fn new_from_abs_sign(abs: Uint<LIMBS>, is_negative: Choice) -> CtOption<Self> {
         let abs_int = abs.as_int();
         let abs_msb = abs_int.is_negative();
@@ -45,16 +46,19 @@ impl<const LIMBS: usize> Int<LIMBS> {
 
     /// Whether this [`Int`] is negative, as a `Choice`.
     #[inline(always)]
+    #[must_use]
     pub const fn is_negative(&self) -> Choice {
         word::choice_from_msb(self.most_significant_word())
     }
 
     /// Whether this [`Int`] is positive, as a `Choice`.
+    #[must_use]
     pub const fn is_positive(&self) -> Choice {
         self.is_negative().not().and(self.is_nonzero())
     }
 
     /// The sign and magnitude of this [`Int`].
+    #[must_use]
     pub const fn abs_sign(&self) -> (Uint<LIMBS>, Choice) {
         let sign = self.is_negative();
         // Note: this negate_if is safe to use, since we are negating based on self.is_negative()
@@ -63,6 +67,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     }
 
     /// The magnitude of this [`Int`].
+    #[must_use]
     pub const fn abs(&self) -> Uint<LIMBS> {
         self.abs_sign().0
     }

--- a/src/int/sqrt.rs
+++ b/src/int/sqrt.rs
@@ -6,6 +6,7 @@ use crate::{CheckedSquareRoot, CtOption};
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Perform checked sqrt, returning a [`CtOption`] which `is_some`
     /// only if the integer is non-negative and the square root is exact.
+    #[must_use]
     pub fn checked_sqrt(&self) -> CtOption<Self> {
         self.as_uint()
             .checked_sqrt()
@@ -17,6 +18,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// only if the integer is non-negative and the square root is exact.
     ///
     /// Variable time with respect to `self`.
+    #[must_use]
     pub fn checked_sqrt_vartime(&self) -> Option<Self> {
         if self.is_negative().not().to_bool_vartime() {
             self.as_uint()

--- a/src/int/sub.rs
+++ b/src/int/sub.rs
@@ -5,6 +5,7 @@ use crate::{Checked, CheckedSub, Choice, CtOption, Int, Sub, SubAssign, Wrapping
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Perform subtraction, returning the result along with a [`Choice`] which `is_true`
     /// only if the operation underflowed.
+    #[must_use]
     pub const fn underflowing_sub(&self, rhs: &Self) -> (Self, Choice) {
         // Step 1. subtract operands
         let res = Self(self.0.wrapping_sub(&rhs.0));
@@ -26,6 +27,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
 
     /// Perform wrapping subtraction, discarding underflow and wrapping around the boundary of the
     /// type.
+    #[must_use]
     pub const fn wrapping_sub(&self, rhs: &Self) -> Self {
         self.underflowing_sub(rhs).0
     }
@@ -57,13 +59,13 @@ impl<const LIMBS: usize> Sub<&Int<LIMBS>> for Int<LIMBS> {
 
 impl<const LIMBS: usize> SubAssign<Int<LIMBS>> for Int<LIMBS> {
     fn sub_assign(&mut self, rhs: Int<LIMBS>) {
-        *self = self.sub(&rhs)
+        *self = self.sub(&rhs);
     }
 }
 
 impl<const LIMBS: usize> SubAssign<&Int<LIMBS>> for Int<LIMBS> {
     fn sub_assign(&mut self, rhs: &Int<LIMBS>) {
-        *self = self.sub(rhs)
+        *self = self.sub(rhs);
     }
 }
 

--- a/src/jacobi.rs
+++ b/src/jacobi.rs
@@ -20,21 +20,25 @@ pub enum JacobiSymbol {
 
 impl JacobiSymbol {
     /// Determine if the symbol is zero.
+    #[must_use]
     pub const fn is_zero(&self) -> Choice {
         Choice::from_i64_eq(*self as i8 as i64, 0)
     }
 
     /// Determine if the symbol is one.
+    #[must_use]
     pub const fn is_one(&self) -> Choice {
         Choice::from_i64_eq(*self as i8 as i64, 1)
     }
 
     /// Determine if the symbol is minus one.
+    #[must_use]
     pub const fn is_minus_one(&self) -> Choice {
         Choice::from_i64_eq(*self as i8 as i64, -1)
     }
 
     /// Negate the symbol.
+    #[must_use]
     pub const fn neg(self) -> Self {
         match self {
             Self::Zero => Self::Zero,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,17 +5,6 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![deny(unsafe_code)]
-#![warn(
-    clippy::mod_module_files,
-    missing_docs,
-    missing_debug_implementations,
-    missing_copy_implementations,
-    rust_2018_idioms,
-    trivial_casts,
-    trivial_numeric_casts,
-    unused_qualifications
-)]
 #![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
 //! ## Usage

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -24,7 +24,7 @@ use crate::{
     Bounded, Choice, ConstOne, ConstZero, Constants, CtEq, CtOption, NonZero, One, WideWord, Word,
     Zero, word,
 };
-use core::fmt;
+use core::{fmt, ptr};
 
 #[cfg(feature = "serde")]
 use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -75,6 +75,7 @@ impl Limb {
     pub const LOG2_BITS: u32 = u32::BITS - (Self::BITS - 1).leading_zeros();
 
     /// Is this limb equal to [`Limb::ZERO`]?
+    #[must_use]
     pub const fn is_zero(&self) -> Choice {
         word::choice_from_nz(self.0).not()
     }
@@ -82,6 +83,7 @@ impl Limb {
     /// Convert to a [`NonZero<Limb>`].
     ///
     /// Returns some if the original value is non-zero, and false otherwise.
+    #[must_use]
     pub const fn to_nz(self) -> CtOption<NonZero<Self>> {
         let is_nz = self.is_nonzero();
 
@@ -91,6 +93,7 @@ impl Limb {
     }
 
     /// Convert the least significant bit of this [`Limb`] to a [`Choice`].
+    #[must_use]
     pub const fn lsb_to_choice(self) -> Choice {
         word::choice_from_lsb(self.0)
     }
@@ -98,6 +101,7 @@ impl Limb {
     /// Convert a shared reference to an array of [`Limb`]s into a shared reference to their inner
     /// [`Word`]s for each limb.
     #[inline]
+    #[must_use]
     pub const fn array_as_words<const N: usize>(array: &[Self; N]) -> &[Word; N] {
         // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
         #[allow(unsafe_code)]
@@ -120,11 +124,12 @@ impl Limb {
     /// Convert a shared reference to an array of [`Limb`]s into a shared reference to their inner
     /// [`Word`]s for each limb.
     #[inline]
+    #[must_use]
     pub const fn slice_as_words(slice: &[Self]) -> &[Word] {
         // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
-        #[allow(trivial_casts, unsafe_code)]
+        #[allow(unsafe_code)]
         unsafe {
-            &*((slice as *const [Limb]) as *const [Word])
+            &*(ptr::from_ref(slice) as *const [Word])
         }
     }
 
@@ -133,9 +138,9 @@ impl Limb {
     #[inline]
     pub const fn slice_as_mut_words(slice: &mut [Self]) -> &mut [Word] {
         // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
-        #[allow(trivial_casts, unsafe_code)]
+        #[allow(unsafe_code)]
         unsafe {
-            &mut *((slice as *mut [Limb]) as *mut [Word])
+            &mut *(ptr::from_mut(slice) as *mut [Word])
         }
     }
 }

--- a/src/limb/add.rs
+++ b/src/limb/add.rs
@@ -8,12 +8,14 @@ use crate::{
 impl Limb {
     /// Computes `self + rhs + carry`, returning the result along with the new carry.
     #[deprecated(since = "0.7.0", note = "please use `carrying_add` instead")]
+    #[must_use]
     pub const fn adc(self, rhs: Limb, carry: Limb) -> (Limb, Limb) {
         self.carrying_add(rhs, carry)
     }
 
     /// Computes `self + rhs + carry`, returning the result along with the new carry.
     #[inline(always)]
+    #[must_use]
     pub const fn carrying_add(self, rhs: Limb, carry: Limb) -> (Limb, Limb) {
         let (res, carry) = carrying_add(self.0, rhs.0, carry.0);
         (Limb(res), Limb(carry))
@@ -21,6 +23,7 @@ impl Limb {
 
     /// Computes `self + rhs`, returning the result along with the carry.
     #[inline(always)]
+    #[must_use]
     pub const fn overflowing_add(self, rhs: Limb) -> (Limb, Limb) {
         let (res, carry) = overflowing_add(self.0, rhs.0);
         (Limb(res), Limb(carry))
@@ -28,12 +31,14 @@ impl Limb {
 
     /// Perform saturating addition.
     #[inline]
+    #[must_use]
     pub const fn saturating_add(&self, rhs: Self) -> Self {
         Limb(self.0.saturating_add(rhs.0))
     }
 
     /// Perform wrapping addition, discarding overflow.
     #[inline(always)]
+    #[must_use]
     pub const fn wrapping_add(&self, rhs: Self) -> Self {
         Limb(self.0.wrapping_add(rhs.0))
     }

--- a/src/limb/bit_and.rs
+++ b/src/limb/bit_and.rs
@@ -6,6 +6,7 @@ use core::ops::{BitAnd, BitAndAssign};
 impl Limb {
     /// Calculates `a & b`.
     #[inline(always)]
+    #[must_use]
     pub const fn bitand(self, rhs: Self) -> Self {
         Limb(self.0 & rhs.0)
     }

--- a/src/limb/bit_not.rs
+++ b/src/limb/bit_not.rs
@@ -6,6 +6,7 @@ use core::ops::Not;
 impl Limb {
     /// Calculates `!a`.
     #[inline(always)]
+    #[must_use]
     pub const fn not(self) -> Self {
         Limb(!self.0)
     }

--- a/src/limb/bit_or.rs
+++ b/src/limb/bit_or.rs
@@ -6,6 +6,7 @@ use core::ops::{BitOr, BitOrAssign};
 impl Limb {
     /// Calculates `a | b`.
     #[inline(always)]
+    #[must_use]
     pub const fn bitor(self, rhs: Self) -> Self {
         Limb(self.0 | rhs.0)
     }

--- a/src/limb/bit_xor.rs
+++ b/src/limb/bit_xor.rs
@@ -6,6 +6,7 @@ use core::ops::{BitXor, BitXorAssign};
 impl Limb {
     /// Calculates `a ^ b`.
     #[inline(always)]
+    #[must_use]
     pub const fn bitxor(self, rhs: Self) -> Self {
         Limb(self.0 ^ rhs.0)
     }

--- a/src/limb/bits.rs
+++ b/src/limb/bits.rs
@@ -5,29 +5,34 @@ use super::Limb;
 impl Limb {
     /// Calculate the number of bits needed to represent this number.
     #[inline(always)]
+    #[must_use]
     pub const fn bits(self) -> u32 {
         Limb::BITS - self.0.leading_zeros()
     }
 
     /// Calculate the number of leading zeros in the binary representation of this number.
     #[inline(always)]
+    #[must_use]
     pub const fn leading_zeros(self) -> u32 {
         self.0.leading_zeros()
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number.
     #[inline(always)]
+    #[must_use]
     pub const fn trailing_zeros(self) -> u32 {
         self.0.trailing_zeros()
     }
 
     /// Calculate the number of trailing ones the binary representation of this number.
     #[inline(always)]
+    #[must_use]
     pub const fn trailing_ones(self) -> u32 {
         self.0.trailing_ones()
     }
 
     /// Clear bits at or above the given bit position.
+    #[must_use]
     pub const fn restrict_bits(self, len: u32) -> Self {
         #[allow(trivial_numeric_casts)]
         self.bitand(Limb((1 as Word).overflowing_shl(len).0 - 1))

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -6,7 +6,8 @@ use core::cmp::Ordering;
 impl Limb {
     /// Is this limb an odd number?
     #[inline]
-    pub fn is_odd(&self) -> Choice {
+    #[must_use]
+    pub fn is_odd(self) -> Choice {
         word::choice_from_lsb(self.0 & 1)
     }
 
@@ -14,18 +15,20 @@ impl Limb {
     ///
     /// Note that the [`PartialOrd`] and [`Ord`] impls wrap constant-time
     /// comparisons using the `subtle` crate.
-    pub fn cmp_vartime(&self, other: &Self) -> Ordering {
+    #[must_use]
+    pub fn cmp_vartime(self, other: Self) -> Ordering {
         self.0.cmp(&other.0)
     }
 
     /// Performs an equality check in variable-time.
-    pub const fn eq_vartime(&self, other: &Self) -> bool {
+    #[must_use]
+    pub const fn eq_vartime(self, other: Self) -> bool {
         self.0 == other.0
     }
 
     /// Returns the truthy value if `self != 0` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn is_nonzero(&self) -> Choice {
+    pub(crate) const fn is_nonzero(self) -> Choice {
         word::choice_from_nz(self.0)
     }
 }

--- a/src/limb/ct.rs
+++ b/src/limb/ct.rs
@@ -16,7 +16,7 @@ impl Limb {
         (*a, *b) = (
             Self(word::select(a.0, b.0, c)),
             Self(word::select(b.0, a.0, c)),
-        )
+        );
     }
 }
 

--- a/src/limb/encoding.rs
+++ b/src/limb/encoding.rs
@@ -34,7 +34,8 @@ impl Encoding for Limb {
 impl Limb {
     /// Decode limb from a big endian byte slice.
     ///
-    /// Panics if the slice is larger than [`Limb::Repr`].
+    /// # Panics
+    /// - if the slice is larger than [`Limb::Repr`].
     pub(crate) fn from_be_slice(bytes: &[u8]) -> Self {
         let mut repr = Self::ZERO.to_be_bytes();
         let repr_len = repr.len();
@@ -48,7 +49,8 @@ impl Limb {
 
     /// Decode limb from a little endian byte slice.
     ///
-    /// Panics if the slice is not the same size as [`Limb::Repr`].
+    /// # Panics
+    /// - if the slice is not the same size as [`Limb::Repr`].
     pub(crate) fn from_le_slice(bytes: &[u8]) -> Self {
         let mut repr = Self::ZERO.to_le_bytes();
         let repr_len = repr.len();

--- a/src/limb/from.rs
+++ b/src/limb/from.rs
@@ -5,18 +5,21 @@ use super::{Limb, WideWord, Word};
 impl Limb {
     /// Create a [`Limb`] from a `u8` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u8>` when stable
+    #[must_use]
     pub const fn from_u8(n: u8) -> Self {
         Limb(n as Word)
     }
 
     /// Create a [`Limb`] from a `u16` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u16>` when stable
+    #[must_use]
     pub const fn from_u16(n: u16) -> Self {
         Limb(n as Word)
     }
 
     /// Create a [`Limb`] from a `u32` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u32>` when stable
+    #[must_use]
     pub const fn from_u32(n: u32) -> Self {
         #[allow(trivial_numeric_casts)]
         Limb(n as Word)
@@ -25,6 +28,7 @@ impl Limb {
     /// Create a [`Limb`] from a `u64` integer (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u64>` when stable
     #[cfg(target_pointer_width = "64")]
+    #[must_use]
     pub const fn from_u64(n: u64) -> Self {
         Limb(n)
     }

--- a/src/limb/mul.rs
+++ b/src/limb/mul.rs
@@ -11,12 +11,14 @@ impl Limb {
         since = "0.7.0",
         note = "please use `carrying_mul_add` instead (ordering of arguments changes)"
     )]
+    #[must_use]
     pub const fn mac(self, b: Limb, c: Limb, carry: Limb) -> (Limb, Limb) {
         b.carrying_mul_add(c, self, carry)
     }
 
     /// Computes `(self * rhs) + addend + carry`, returning the result along with the new carry.
     #[inline(always)]
+    #[must_use]
     pub const fn carrying_mul_add(self, rhs: Limb, addend: Limb, carry: Limb) -> (Limb, Limb) {
         let (res, carry) = carrying_mul_add(self.0, rhs.0, addend.0, carry.0);
         (Limb(res), Limb(carry))
@@ -24,18 +26,20 @@ impl Limb {
 
     /// Perform saturating multiplication.
     #[inline(always)]
-    pub const fn saturating_mul(&self, rhs: Self) -> Self {
+    #[must_use]
+    pub const fn saturating_mul(self, rhs: Self) -> Self {
         Limb(self.0.saturating_mul(rhs.0))
     }
 
     /// Perform wrapping multiplication, discarding overflow.
     #[inline(always)]
-    pub const fn wrapping_mul(&self, rhs: Self) -> Self {
+    #[must_use]
+    pub const fn wrapping_mul(self, rhs: Self) -> Self {
         Limb(self.0.wrapping_mul(rhs.0))
     }
 
     /// Compute "wide" multiplication, with a product twice the size of the input.
-    pub(crate) const fn widening_mul(&self, rhs: Self) -> (Self, Self) {
+    pub(crate) const fn widening_mul(self, rhs: Self) -> (Self, Self) {
         let (lo, hi) = widening_mul(self.0, rhs.0);
         (Limb(lo), Limb(hi))
     }
@@ -117,7 +121,7 @@ impl MulAssign<&Checked<Limb>> for Checked<Limb> {
 impl WrappingMul for Limb {
     #[inline]
     fn wrapping_mul(&self, v: &Self) -> Self {
-        self.wrapping_mul(*v)
+        Self::wrapping_mul(*self, *v)
     }
 }
 

--- a/src/limb/neg.rs
+++ b/src/limb/neg.rs
@@ -5,6 +5,7 @@ use crate::{Limb, WrappingNeg};
 impl Limb {
     /// Perform wrapping negation.
     #[inline(always)]
+    #[must_use]
     pub const fn wrapping_neg(self) -> Self {
         Limb(self.0.wrapping_neg())
     }

--- a/src/limb/shl.rs
+++ b/src/limb/shl.rs
@@ -4,8 +4,11 @@ use crate::{Limb, Shl, ShlAssign, WrappingShl};
 
 impl Limb {
     /// Computes `self << shift`.
-    /// Panics if `shift` overflows `Limb::BITS`.
+    ///
+    /// # Panics
+    /// - if `shift` overflows `Limb::BITS`.
     #[inline(always)]
+    #[must_use]
     pub const fn shl(self, shift: u32) -> Self {
         Limb(self.0 << shift)
     }

--- a/src/limb/shr.rs
+++ b/src/limb/shr.rs
@@ -5,8 +5,11 @@ use core::ops::{Shr, ShrAssign};
 
 impl Limb {
     /// Computes `self >> shift`.
-    /// Panics if `shift` overflows `Limb::BITS`.
+    ///
+    /// # Panics
+    /// - if `shift` overflows `Limb::BITS`.
     #[inline(always)]
+    #[must_use]
     pub const fn shr(self, shift: u32) -> Self {
         Limb(self.0 >> shift)
     }

--- a/src/limb/sub.rs
+++ b/src/limb/sub.rs
@@ -8,12 +8,14 @@ use crate::{
 impl Limb {
     /// Computes `self - (rhs + borrow)`, returning the result along with the new borrow.
     #[deprecated(since = "0.7.0", note = "please use `borrowing_sub` instead")]
+    #[must_use]
     pub const fn sbb(self, rhs: Limb, borrow: Limb) -> (Limb, Limb) {
         self.borrowing_sub(rhs, borrow)
     }
 
     /// Computes `self - (rhs + borrow)`, returning the result along with the new borrow.
     #[inline(always)]
+    #[must_use]
     pub const fn borrowing_sub(self, rhs: Limb, borrow: Limb) -> (Limb, Limb) {
         let (res, borrow) = borrowing_sub(self.0, rhs.0, borrow.0);
         (Limb(res), Limb(borrow))
@@ -21,6 +23,7 @@ impl Limb {
 
     /// Perform saturating subtraction.
     #[inline]
+    #[must_use]
     pub const fn saturating_sub(&self, rhs: Self) -> Self {
         Limb(self.0.saturating_sub(rhs.0))
     }
@@ -28,6 +31,7 @@ impl Limb {
     /// Perform wrapping subtraction, discarding underflow and wrapping around
     /// the boundary of the type.
     #[inline(always)]
+    #[must_use]
     pub const fn wrapping_sub(&self, rhs: Self) -> Self {
         Limb(self.0.wrapping_sub(rhs.0))
     }

--- a/src/modular/bingcd/div_mod_2k.rs
+++ b/src/modular/bingcd/div_mod_2k.rs
@@ -219,6 +219,6 @@ mod tests {
         let (hi, carry) = qf_hi.carrying_add(&Uint::ZERO, carry);
         assert_eq!(res, lo);
         assert_eq!(mac_carry, hi.limbs[0]);
-        assert_eq!(carry, Limb::ZERO)
+        assert_eq!(carry, Limb::ZERO);
     }
 }

--- a/src/modular/bingcd/extension.rs
+++ b/src/modular/bingcd/extension.rs
@@ -63,7 +63,8 @@ impl<const LIMBS: usize, const EXTRA: usize> ExtendedUint<LIMBS, EXTRA> {
 
     /// Shift `self` right by `shift` bits.
     ///
-    /// Panics if `shift ≥ UPPER_BOUND`.
+    /// # Panics
+    /// - if `shift ≥ UPPER_BOUND`.
     #[inline]
     pub const fn bounded_shr<const UPPER_BOUND: u32>(&self, shift: u32) -> Self {
         debug_assert!(shift <= UPPER_BOUND);
@@ -94,7 +95,8 @@ impl<const LIMBS: usize, const EXTRA: usize> ExtendedUint<LIMBS, EXTRA> {
 
     /// Shift `self` right by `shift` bits.
     ///
-    /// Panics if `shift ≥ Uint::<EXTRA>::BITS`.
+    /// # Panics
+    /// - if `shift ≥ Uint::<EXTRA>::BITS`.
     #[inline]
     pub const fn shr_vartime(&self, shift: u32) -> Self {
         debug_assert!(shift <= Uint::<EXTRA>::BITS);
@@ -200,7 +202,8 @@ impl<const LIMBS: usize, const EXTRA: usize> ExtendedInt<LIMBS, EXTRA> {
 
     /// Divide self by `2^k`, rounding towards zero.
     ///
-    /// Panics if `k ≥ UPPER_BOUND`.
+    /// # Panics
+    /// - if `k ≥ UPPER_BOUND`.
     #[inline]
     pub const fn bounded_div_2k<const UPPER_BOUND: u32>(&self, k: u32) -> Self {
         let (abs, sgn) = self.abs_sign();
@@ -221,11 +224,12 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self >> shift`.
     ///
     /// Returns `None` if `shift >= UPPER_BOUND`; panics if `UPPER_BOUND > Self::BITS`.
+    #[must_use]
     pub const fn bounded_overflowing_shr<const UPPER_BOUND: u32>(
         &self,
         shift: u32,
     ) -> CtOption<Self> {
-        assert!(UPPER_BOUND <= Self::BITS);
+        const { assert!(UPPER_BOUND <= Self::BITS) };
 
         // `floor(log2(BITS - 1))` is the number of bits in the representation of `shift`
         // (which lies in range `0 <= shift < BITS`).
@@ -300,7 +304,7 @@ mod tests {
                     .as_extended_uint()
                     .as_elements(),
                 (U64::from(12115270817252704455u64), U64::from(419837u64))
-            )
+            );
         }
     }
 

--- a/src/modular/bingcd/gcd.rs
+++ b/src/modular/bingcd/gcd.rs
@@ -113,11 +113,11 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
     /// Computes `gcd(self, rhs)`, leveraging the optimized Binary GCD algorithm.
     ///
     /// Note: this algorithm becomes more efficient than the classical algorithm for [Uint]s with
-    /// relatively many `LIMBS`. A best-effort threshold is presented in [Self::bingcd].
+    /// relatively many `LIMBS`. A best-effort threshold is presented in [`Self::bingcd`].
     ///
     /// Note: the full algorithm has an additional parameter; this function selects the best-effort
     /// value for this parameter. You might be able to further tune your performance by calling the
-    /// [Self::optimized_bingcd_] function directly.
+    /// [`Self::optimized_bingcd`_] function directly.
     ///
     /// Ref: Pornin, Optimized Binary GCD for Modular Inversion, Algorithm 2.
     /// <https://eprint.iacr.org/2020/972.pdf>

--- a/src/modular/bingcd/matrix.rs
+++ b/src/modular/bingcd/matrix.rs
@@ -110,7 +110,7 @@ impl<const LIMBS: usize> PatternMatrix<LIMBS> {
     };
 
     /// Apply this matrix to a vector of [Uint]s, returning the result as a vector of
-    /// [ExtendedInt]s.
+    /// [`ExtendedInt`]s.
     #[inline]
     pub(crate) const fn extended_apply_to<const VEC_LIMBS: usize>(
         &self,
@@ -259,7 +259,7 @@ impl<const LIMBS: usize> DividedPatternMatrix<LIMBS> {
     };
 
     /// Apply this matrix to a vector of [Uint]s, returning the result as a vector of
-    /// [ExtendedInt]s.
+    /// [`ExtendedInt`]s.
     #[inline]
     #[allow(unused)] // save for optimized xgcd
     pub const fn extended_apply_to<const VEC_LIMBS: usize, const UPPER_BOUND: u32>(
@@ -274,7 +274,7 @@ impl<const LIMBS: usize> DividedPatternMatrix<LIMBS> {
     }
 
     /// Apply this matrix to a vector of [Uint]s, returning the result as a vector of
-    /// [ExtendedInt]s.
+    /// [`ExtendedInt`]s.
     #[inline]
     pub const fn extended_apply_to_vartime<const VEC_LIMBS: usize>(
         &self,

--- a/src/modular/bingcd/xgcd.rs
+++ b/src/modular/bingcd/xgcd.rs
@@ -220,11 +220,11 @@ impl<const LIMBS: usize> OddUint<LIMBS> {
     /// **Warning**: `self` and `rhs` must be contained in an [U128] or larger.
     ///
     /// Note: this algorithm becomes more efficient than the classical algorithm for [Uint]s with
-    /// relatively many `LIMBS`. A best-effort threshold is presented in [Self::binxgcd_].
+    /// relatively many `LIMBS`. A best-effort threshold is presented in [`Self::binxgcd`_].
     ///
     /// Note: the full algorithm has an additional parameter; this function selects the best-effort
     /// value for this parameter. You might be able to further tune your performance by calling the
-    /// [Self::optimized_bingcd_] function directly.
+    /// [`Self::optimized_bingcd`_] function directly.
     ///
     /// Ref: Pornin, Optimized Binary GCD for Modular Inversion, Algorithm 2.
     /// <https://eprint.iacr.org/2020/972.pdf>.

--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -30,6 +30,7 @@ impl BoxedMontyParams {
     /// Instantiates a new set of [`BoxedMontyParams`] representing the given `modulus`.
     ///
     /// TODO(tarcieri): DRY out with `MontyParams::new`?
+    #[must_use]
     pub fn new(modulus: Odd<BoxedUint>) -> Self {
         let bits_precision = modulus.bits_precision();
 
@@ -63,6 +64,7 @@ impl BoxedMontyParams {
     /// This version operates in variable-time with respect to the modulus.
     ///
     /// TODO(tarcieri): DRY out with `MontyParams::new`?
+    #[must_use]
     pub fn new_vartime(modulus: Odd<BoxedUint>) -> Self {
         let bits_precision = modulus.bits_precision();
 
@@ -93,11 +95,13 @@ impl BoxedMontyParams {
     }
 
     /// Modulus value.
+    #[must_use]
     pub fn modulus(&self) -> &Odd<BoxedUint> {
         &self.0.modulus
     }
 
     /// Bits of precision in the modulus.
+    #[must_use]
     pub fn bits_precision(&self) -> u32 {
         self.0.modulus.bits_precision()
     }
@@ -141,6 +145,7 @@ pub struct BoxedMontyForm {
 
 impl BoxedMontyForm {
     /// Instantiates a new [`BoxedMontyForm`] that represents an integer modulo the provided params.
+    #[must_use]
     pub fn new(mut integer: BoxedUint, params: &BoxedMontyParams) -> Self {
         debug_assert_eq!(integer.bits_precision(), params.bits_precision());
         convert_to_montgomery(&mut integer, params);
@@ -153,11 +158,13 @@ impl BoxedMontyForm {
     }
 
     /// Bits of precision in the modulus.
+    #[must_use]
     pub fn bits_precision(&self) -> u32 {
         self.params.bits_precision()
     }
 
     /// Retrieves the integer currently encoded in this [`BoxedMontyForm`], guaranteed to be reduced.
+    #[must_use]
     pub fn retrieve(&self) -> BoxedUint {
         let mut out = BoxedUint::zero_with_precision(self.bits_precision());
         montgomery_retrieve_inner(
@@ -170,6 +177,7 @@ impl BoxedMontyForm {
     }
 
     /// Instantiates a new `ConstMontyForm` that represents zero.
+    #[must_use]
     pub fn zero(params: BoxedMontyParams) -> Self {
         Self {
             montgomery_form: BoxedUint::zero_with_precision(params.bits_precision()),
@@ -178,6 +186,7 @@ impl BoxedMontyForm {
     }
 
     /// Instantiates a new `ConstMontyForm` that represents 1.
+    #[must_use]
     pub fn one(params: BoxedMontyParams) -> Self {
         Self {
             montgomery_form: params.one().clone(),
@@ -190,6 +199,7 @@ impl BoxedMontyForm {
     /// # Returns
     ///
     /// If zero, returns `Choice(1)`. Otherwise, returns `Choice(0)`.
+    #[must_use]
     pub fn is_zero(&self) -> Choice {
         self.montgomery_form.is_zero()
     }
@@ -200,16 +210,19 @@ impl BoxedMontyForm {
     ///
     /// If zero, returns `Choice(0)`. Otherwise, returns `Choice(1)`.
     #[inline]
+    #[must_use]
     pub fn is_nonzero(&self) -> Choice {
         !self.is_zero()
     }
 
     /// Returns the parameter struct used to initialize this object.
+    #[must_use]
     pub fn params(&self) -> &BoxedMontyParams {
         &self.params
     }
 
     /// Access the [`BoxedMontyForm`] value in Montgomery form.
+    #[must_use]
     pub fn as_montgomery(&self) -> &BoxedUint {
         debug_assert!(&self.montgomery_form < self.params.modulus());
         &self.montgomery_form
@@ -221,6 +234,7 @@ impl BoxedMontyForm {
     }
 
     /// Create a [`BoxedMontyForm`] from a value in Montgomery form.
+    #[must_use]
     pub fn from_montgomery(integer: BoxedUint, params: BoxedMontyParams) -> Self {
         debug_assert_eq!(integer.bits_precision(), params.bits_precision());
         Self {
@@ -230,12 +244,14 @@ impl BoxedMontyForm {
     }
 
     /// Extract the value from the [`BoxedMontyForm`] in Montgomery form.
+    #[must_use]
     pub fn to_montgomery(&self) -> BoxedUint {
         debug_assert!(&self.montgomery_form < self.params.modulus());
         self.montgomery_form.clone()
     }
 
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
+    #[must_use]
     pub fn div_by_2(&self) -> Self {
         Self {
             montgomery_form: div_by_2::div_by_2_boxed(&self.montgomery_form, self.params.modulus()),
@@ -246,7 +262,7 @@ impl BoxedMontyForm {
     /// Performs division by 2 inplace, that is finds `x` such that `x + x = self`
     /// and writes it into `self`.
     pub fn div_by_2_assign(&mut self) {
-        div_by_2::div_by_2_boxed_assign(&mut self.montgomery_form, self.params.modulus())
+        div_by_2::div_by_2_boxed_assign(&mut self.montgomery_form, self.params.modulus());
     }
 }
 
@@ -306,7 +322,7 @@ impl Monty for BoxedMontyForm {
     }
 
     fn div_by_2_assign(&mut self) {
-        BoxedMontyForm::div_by_2_assign(self)
+        BoxedMontyForm::div_by_2_assign(self);
     }
 
     fn lincomb_vartime(products: &[(&Self, &Self)]) -> Self {

--- a/src/modular/boxed_monty_form/add.rs
+++ b/src/modular/boxed_monty_form/add.rs
@@ -5,6 +5,7 @@ use core::ops::{Add, AddAssign};
 
 impl BoxedMontyForm {
     /// Adds `rhs`.
+    #[must_use]
     pub fn add(&self, rhs: &Self) -> Self {
         debug_assert_eq!(self.params, rhs.params);
 
@@ -17,6 +18,7 @@ impl BoxedMontyForm {
     }
 
     /// Double `self`.
+    #[must_use]
     pub fn double(&self) -> Self {
         Self {
             montgomery_form: self

--- a/src/modular/boxed_monty_form/invert.rs
+++ b/src/modular/boxed_monty_form/invert.rs
@@ -6,6 +6,7 @@ use crate::{CtOption, Invert, modular::safegcd::boxed::BoxedSafeGcdInverter};
 impl BoxedMontyForm {
     /// Computes `self^-1` representing the multiplicative inverse of `self`,
     /// i.e. `self * self^-1 = 1`.
+    #[must_use]
     pub fn invert(&self) -> CtOption<Self> {
         let montgomery_form = self.params.inverter().invert(&self.montgomery_form);
         let is_some = montgomery_form.is_some();
@@ -23,6 +24,7 @@ impl BoxedMontyForm {
     ///
     /// This version is variable-time with respect to the self of `self`, but constant-time with
     /// respect to `self`'s `params`.
+    #[must_use]
     pub fn invert_vartime(&self) -> Option<Self> {
         self.params
             .inverter()

--- a/src/modular/boxed_monty_form/lincomb.rs
+++ b/src/modular/boxed_monty_form/lincomb.rs
@@ -7,10 +7,14 @@ impl BoxedMontyForm {
     /// Calculate the sum of products of pairs `(a, b)` in `products`.
     ///
     /// This method is variable time only with the value of the modulus.
+    ///
     /// For a modulus with leading zeros, this method is more efficient than a naive sum of products.
     ///
-    /// This method will panic if `products` is empty. All terms must be associated
-    /// with equivalent `MontyParams`.
+    /// All terms must be associated with equivalent `MontyParams`.
+    ///
+    /// # Panics
+    /// - if `products` is empty.
+    #[must_use]
     pub fn lincomb_vartime(products: &[(&Self, &Self)]) -> Self {
         assert!(!products.is_empty(), "empty products");
         let params = &products[0].0.params;

--- a/src/modular/boxed_monty_form/mul.rs
+++ b/src/modular/boxed_monty_form/mul.rs
@@ -16,6 +16,7 @@ use zeroize::Zeroize;
 
 impl BoxedMontyForm {
     /// Multiplies by `rhs`.
+    #[must_use]
     pub fn mul(&self, rhs: &Self) -> Self {
         debug_assert_eq!(&self.params, &rhs.params);
         let mut out = BoxedUint::zero_with_precision(self.bits_precision());
@@ -33,6 +34,7 @@ impl BoxedMontyForm {
     }
 
     /// Computes the (reduced) square.
+    #[must_use]
     pub fn square(&self) -> Self {
         let mut out = BoxedUint::zero_with_precision(self.bits_precision());
         montgomery_mul(
@@ -107,7 +109,7 @@ impl Mul<BoxedMontyForm> for BoxedMontyForm {
 
 impl MulAssign<BoxedMontyForm> for BoxedMontyForm {
     fn mul_assign(&mut self, rhs: BoxedMontyForm) {
-        Self::mul_assign(self, &rhs)
+        Self::mul_assign(self, &rhs);
     }
 }
 

--- a/src/modular/boxed_monty_form/neg.rs
+++ b/src/modular/boxed_monty_form/neg.rs
@@ -5,6 +5,7 @@ use core::ops::Neg;
 
 impl BoxedMontyForm {
     /// Negates the number.
+    #[must_use]
     pub fn neg(&self) -> Self {
         Self {
             montgomery_form: self

--- a/src/modular/boxed_monty_form/pow.rs
+++ b/src/modular/boxed_monty_form/pow.rs
@@ -5,6 +5,7 @@ use crate::{BoxedUint, PowBoundedExp, modular::pow::pow_montgomery_form_amm};
 
 impl BoxedMontyForm {
     /// Raises to the `exponent` power.
+    #[must_use]
     pub fn pow(&self, exponent: &BoxedUint) -> Self {
         self.pow_bounded_exp(exponent, exponent.bits_precision())
     }
@@ -14,6 +15,7 @@ impl BoxedMontyForm {
     /// to take into account for the exponent.
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
+    #[must_use]
     pub fn pow_bounded_exp(&self, exponent: &BoxedUint, exponent_bits: u32) -> Self {
         let z =
             pow_montgomery_form_amm(&self.montgomery_form, exponent, exponent_bits, &self.params);

--- a/src/modular/boxed_monty_form/sub.rs
+++ b/src/modular/boxed_monty_form/sub.rs
@@ -6,6 +6,7 @@ use core::ops::{Sub, SubAssign};
 
 impl BoxedMontyForm {
     /// Subtracts `rhs`.
+    #[must_use]
     pub fn sub(&self, rhs: &Self) -> Self {
         debug_assert_eq!(self.params, rhs.params);
 

--- a/src/modular/const_monty_form.rs
+++ b/src/modular/const_monty_form.rs
@@ -50,7 +50,7 @@ pub trait ConstMontyParams<const LIMBS: usize>:
 /// An integer in Montgomery form modulo `MOD`, represented using `LIMBS` limbs.
 /// The modulus is constant, so it cannot be set at runtime.
 ///
-/// Internally, the value is stored in Montgomery form (multiplied by MOD::PARAMS.one) until it is retrieved.
+/// Internally, the value is stored in Montgomery form (multiplied by `MOD::PARAMS.one`) until it is retrieved.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ConstMontyForm<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> {
     montgomery_form: Uint<LIMBS>,
@@ -80,6 +80,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     pub const MODULUS: Odd<Uint<LIMBS>> = *MOD::PARAMS.modulus();
 
     /// Instantiates a new [`ConstMontyForm`] that represents this `integer` mod `MOD`.
+    #[must_use]
     pub const fn new(integer: &Uint<LIMBS>) -> Self {
         let montgomery_form = mul_montgomery_form(
             integer,
@@ -95,6 +96,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     }
 
     /// Retrieves the integer currently encoded in this [`ConstMontyForm`], guaranteed to be reduced.
+    #[must_use]
     pub const fn retrieve(&self) -> Uint<LIMBS> {
         montgomery_retrieve(
             &self.montgomery_form,
@@ -104,6 +106,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     }
 
     /// Access the `ConstMontyForm` value in Montgomery form.
+    #[must_use]
     pub const fn as_montgomery(&self) -> &Uint<LIMBS> {
         &self.montgomery_form
     }
@@ -114,6 +117,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     }
 
     /// Create a `ConstMontyForm` from a value in Montgomery form.
+    #[must_use]
     pub const fn from_montgomery(integer: Uint<LIMBS>) -> Self {
         Self {
             montgomery_form: integer,
@@ -122,11 +126,13 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     }
 
     /// Extract the value from the `ConstMontyForm` in Montgomery form.
+    #[must_use]
     pub const fn to_montgomery(&self) -> Uint<LIMBS> {
         self.montgomery_form
     }
 
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
+    #[must_use]
     pub const fn div_by_2(&self) -> Self {
         Self {
             montgomery_form: div_by_2(&self.montgomery_form, &MOD::PARAMS.modulus),

--- a/src/modular/const_monty_form/add.rs
+++ b/src/modular/const_monty_form/add.rs
@@ -6,6 +6,7 @@ use core::ops::{Add, AddAssign};
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Adds `rhs`.
+    #[must_use]
     pub const fn add(&self, rhs: &ConstMontyForm<MOD, LIMBS>) -> Self {
         Self {
             montgomery_form: add_montgomery_form(
@@ -18,6 +19,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     }
 
     /// Double `self`.
+    #[must_use]
     pub const fn double(&self) -> Self {
         Self {
             montgomery_form: double_montgomery_form(&self.montgomery_form, &MOD::PARAMS.modulus),

--- a/src/modular/const_monty_form/invert.rs
+++ b/src/modular/const_monty_form/invert.rs
@@ -11,6 +11,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
     #[deprecated(since = "0.7.0", note = "please use `invert` instead")]
+    #[must_use]
     pub const fn inv(&self) -> CtOption<Self> {
         self.invert()
     }
@@ -20,6 +21,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     ///
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
+    #[must_use]
     pub const fn invert(&self) -> CtOption<Self> {
         let inverter = SafeGcdInverter::new_with_inverse(
             &MOD::PARAMS.modulus,
@@ -46,6 +48,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     /// This version is variable-time with respect to the value of `self`, but constant-time with
     /// respect to `MOD`.
     #[deprecated(since = "0.7.0", note = "please use `invert_vartime` instead")]
+    #[must_use]
     pub const fn inv_vartime(&self) -> Option<Self> {
         self.invert_vartime()
     }
@@ -58,6 +61,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     ///
     /// This version is variable-time with respect to the value of `self`, but constant-time with
     /// respect to `MOD`.
+    #[must_use]
     pub const fn invert_vartime(&self) -> Option<Self> {
         let inverter = SafeGcdInverter::new_with_inverse(
             &MOD::PARAMS.modulus,

--- a/src/modular/const_monty_form/lincomb.rs
+++ b/src/modular/const_monty_form/lincomb.rs
@@ -7,6 +7,7 @@ use crate::modular::lincomb::lincomb_const_monty_form;
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Calculate the sum of products of pairs `(a, b)` in `products`.
+    #[must_use]
     pub const fn lincomb(products: &[(Self, Self)]) -> Self {
         Self {
             montgomery_form: lincomb_const_monty_form(
@@ -55,7 +56,7 @@ mod tests {
                 ])
                 .retrieve(),
                 "n={n}"
-            )
+            );
         }
     }
 }

--- a/src/modular/const_monty_form/mod_symbol.rs
+++ b/src/modular/const_monty_form/mod_symbol.rs
@@ -9,6 +9,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     ///
     /// For a prime modulus, this corresponds to the Legendre symbol and indicates
     /// whether `self` is quadratic residue.
+    #[must_use]
     pub const fn jacobi_symbol(&self) -> JacobiSymbol {
         self.retrieve().jacobi_symbol(MOD::PARAMS.modulus())
     }
@@ -19,6 +20,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     /// whether `self` is quadratic residue.
     ///
     /// This method is variable-time with respect to the value of `self`.
+    #[must_use]
     pub const fn jacobi_symbol_vartime(&self) -> JacobiSymbol {
         self.retrieve().jacobi_symbol_vartime(MOD::PARAMS.modulus())
     }

--- a/src/modular/const_monty_form/mul.rs
+++ b/src/modular/const_monty_form/mul.rs
@@ -14,6 +14,7 @@ use super::{ConstMontyForm, ConstMontyParams};
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Multiplies by `rhs`.
+    #[must_use]
     pub const fn mul(&self, rhs: &Self) -> Self {
         Self {
             montgomery_form: mul_montgomery_form(
@@ -27,6 +28,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     }
 
     /// Computes the (reduced) square.
+    #[must_use]
     pub const fn square(&self) -> Self {
         Self {
             montgomery_form: square_montgomery_form(

--- a/src/modular/const_monty_form/neg.rs
+++ b/src/modular/const_monty_form/neg.rs
@@ -5,6 +5,7 @@ use core::ops::Neg;
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Negates the number.
+    #[must_use]
     pub const fn neg(&self) -> Self {
         Self {
             montgomery_form: self

--- a/src/modular/const_monty_form/pow.rs
+++ b/src/modular/const_monty_form/pow.rs
@@ -11,6 +11,7 @@ use {crate::modular::pow::multi_exponentiate_montgomery_form_slice, alloc::vec::
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Raises to the `exponent` power.
+    #[must_use]
     pub const fn pow<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,
@@ -23,6 +24,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     /// to take into account for the exponent.
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
+    #[must_use]
     pub const fn pow_bounded_exp<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,

--- a/src/modular/const_monty_form/sub.rs
+++ b/src/modular/const_monty_form/sub.rs
@@ -6,6 +6,7 @@ use core::ops::{Sub, SubAssign};
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS> {
     /// Subtracts `rhs`.
+    #[must_use]
     pub const fn sub(&self, rhs: &Self) -> Self {
         Self {
             montgomery_form: sub_montgomery_form(

--- a/src/modular/lincomb.rs
+++ b/src/modular/lincomb.rs
@@ -9,7 +9,7 @@ use crate::BoxedUint;
 
 /// Implement the coarse interleaved sum of products (Algorithm 2 for B=1) from
 /// Efficient Algorithms for Large Prime Characteristic Fields and Their Application
-/// to Bilinear Pairings by Patrick Longa. https://eprint.iacr.org/2022/367
+/// to Bilinear Pairings by Patrick Longa. <https://eprint.iacr.org/2022/367>
 ///
 /// For correct results, the un-reduced sum of products must not exceed `p•R`  where `p`
 /// is the modulus. Given a list of pairs `(a_1, b_1)..(a_k, b_k)` in Montgomery form,

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -22,6 +22,7 @@ use mul::DynMontyMultiplier;
 
 impl<const LIMBS: usize> MontyParams<LIMBS> {
     /// Instantiates a new set of `MontyParams` representing the given odd `modulus`.
+    #[must_use]
     pub const fn new(modulus: Odd<Uint<LIMBS>>) -> Self {
         // `R mod modulus` where `R = 2^BITS`.
         // Represents 1 in Montgomery form.
@@ -51,6 +52,7 @@ impl<const LIMBS: usize> MontyParams<LIMBS> {
 
 impl<const LIMBS: usize> MontyParams<LIMBS> {
     /// Instantiates a new set of `MontyParams` representing the given odd `modulus`.
+    #[must_use]
     pub const fn new_vartime(modulus: Odd<Uint<LIMBS>>) -> Self {
         // `R mod modulus` where `R = 2^BITS`.
         // Represents 1 in Montgomery form.
@@ -91,6 +93,7 @@ pub struct MontyForm<const LIMBS: usize> {
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Instantiates a new `MontyForm` that represents this `integer` mod `MOD`.
+    #[must_use]
     pub const fn new(integer: &Uint<LIMBS>, params: &MontyParams<LIMBS>) -> Self {
         let montgomery_form =
             mul_montgomery_form(integer, &params.r2, &params.modulus, params.mod_neg_inv());
@@ -101,6 +104,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Retrieves the integer currently encoded in this `MontyForm`, guaranteed to be reduced.
+    #[must_use]
     pub const fn retrieve(&self) -> Uint<LIMBS> {
         montgomery_retrieve(
             &self.montgomery_form,
@@ -110,6 +114,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Instantiates a new `MontyForm` that represents zero.
+    #[must_use]
     pub const fn zero(params: MontyParams<LIMBS>) -> Self {
         Self {
             montgomery_form: Uint::<LIMBS>::ZERO,
@@ -118,6 +123,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Instantiates a new `MontyForm` that represents 1.
+    #[must_use]
     pub const fn one(params: MontyParams<LIMBS>) -> Self {
         Self {
             montgomery_form: params.one,
@@ -126,11 +132,13 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Returns the parameter struct used to initialize this object.
+    #[must_use]
     pub const fn params(&self) -> &MontyParams<LIMBS> {
         &self.params
     }
 
     /// Access the `MontyForm` value in Montgomery form.
+    #[must_use]
     pub const fn as_montgomery(&self) -> &Uint<LIMBS> {
         &self.montgomery_form
     }
@@ -141,6 +149,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Create a `MontyForm` from a value in Montgomery form.
+    #[must_use]
     pub const fn from_montgomery(integer: Uint<LIMBS>, params: MontyParams<LIMBS>) -> Self {
         Self {
             montgomery_form: integer,
@@ -149,11 +158,13 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Extract the value from the `MontyForm` in Montgomery form.
+    #[must_use]
     pub const fn to_montgomery(&self) -> Uint<LIMBS> {
         self.montgomery_form
     }
 
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
+    #[must_use]
     pub const fn div_by_2(&self) -> Self {
         Self {
             montgomery_form: div_by_2(&self.montgomery_form, &self.params.modulus),

--- a/src/modular/monty_form/add.rs
+++ b/src/modular/monty_form/add.rs
@@ -6,6 +6,7 @@ use core::ops::{Add, AddAssign};
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Adds `rhs`.
+    #[must_use]
     pub const fn add(&self, rhs: &Self) -> Self {
         Self {
             montgomery_form: add_montgomery_form(
@@ -18,6 +19,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Double `self`.
+    #[must_use]
     pub const fn double(&self) -> Self {
         Self {
             montgomery_form: double_montgomery_form(&self.montgomery_form, &self.params.modulus),

--- a/src/modular/monty_form/invert.rs
+++ b/src/modular/monty_form/invert.rs
@@ -10,6 +10,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
     #[deprecated(since = "0.7.0", note = "please use `invert` instead")]
+    #[must_use]
     pub const fn inv(&self) -> CtOption<Self> {
         self.invert()
     }
@@ -19,6 +20,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     ///
     /// If the number was invertible, the second element of the tuple is the truthy value,
     /// otherwise it is the falsy value (in which case the first element's value is unspecified).
+    #[must_use]
     pub const fn invert(&self) -> CtOption<Self> {
         let inverter = self.params.inverter();
         let maybe_inverse = inverter.invert(&self.montgomery_form);
@@ -40,6 +42,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// This version is variable-time with respect to the value of `self`, but constant-time with
     /// respect to `self`'s `params`.
     #[deprecated(since = "0.7.0", note = "please use `invert_vartime` instead")]
+    #[must_use]
     pub const fn inv_vartime(&self) -> Option<Self> {
         self.invert_vartime()
     }
@@ -52,6 +55,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     ///
     /// This version is variable-time with respect to the value of `self`, but constant-time with
     /// respect to `self`'s `params`.
+    #[must_use]
     pub const fn invert_vartime(&self) -> Option<Self> {
         let inverter = self.params.inverter();
         if let Some(inv) = inverter.invert_vartime(&self.montgomery_form) {

--- a/src/modular/monty_form/lincomb.rs
+++ b/src/modular/monty_form/lincomb.rs
@@ -11,6 +11,11 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     ///
     /// This method will panic if `products` is empty. All terms must be associated
     /// with equivalent `MontyParams`.
+    ///
+    /// # Panics
+    /// - if `products` is empty.
+    #[must_use]
+    #[track_caller]
     pub const fn lincomb_vartime(products: &[(&Self, &Self)]) -> Self {
         assert!(!products.is_empty(), "empty products");
         let params = &products[0].0.params;
@@ -56,7 +61,7 @@ mod tests {
                 ])
                 .retrieve(),
                 "n={n}, a={a}, b={b}, c={c}, d={d}"
-            )
+            );
         }
     }
 }

--- a/src/modular/monty_form/mod_symbol.rs
+++ b/src/modular/monty_form/mod_symbol.rs
@@ -9,6 +9,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     ///
     /// For a prime modulus, this corresponds to the Legendre symbol and indicates
     /// whether `self` is quadratic residue.
+    #[must_use]
     pub const fn jacobi_symbol(&self) -> JacobiSymbol {
         self.retrieve().jacobi_symbol(self.params().modulus())
     }
@@ -19,6 +20,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// whether `self` is quadratic residue.
     ///
     /// This method is variable-time with respect to the value of `self`.
+    #[must_use]
     pub const fn jacobi_symbol_vartime(&self) -> JacobiSymbol {
         self.retrieve()
             .jacobi_symbol_vartime(self.params().modulus())

--- a/src/modular/monty_form/mul.rs
+++ b/src/modular/monty_form/mul.rs
@@ -12,6 +12,7 @@ use core::ops::{Mul, MulAssign};
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Multiplies by `rhs`.
+    #[must_use]
     pub const fn mul(&self, rhs: &Self) -> Self {
         Self {
             montgomery_form: mul_montgomery_form(
@@ -25,6 +26,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     }
 
     /// Computes the (reduced) square.
+    #[must_use]
     pub const fn square(&self) -> Self {
         Self {
             montgomery_form: square_montgomery_form(
@@ -88,7 +90,7 @@ impl<const LIMBS: usize> Square for MontyForm<LIMBS> {
 
 impl<const LIMBS: usize> SquareAssign for MontyForm<LIMBS> {
     fn square_assign(&mut self) {
-        *self = self.square()
+        *self = self.square();
     }
 }
 

--- a/src/modular/monty_form/neg.rs
+++ b/src/modular/monty_form/neg.rs
@@ -5,6 +5,7 @@ use core::ops::Neg;
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Negates the number.
+    #[must_use]
     pub const fn neg(&self) -> Self {
         Self {
             montgomery_form: self

--- a/src/modular/monty_form/pow.rs
+++ b/src/modular/monty_form/pow.rs
@@ -11,6 +11,7 @@ use {crate::modular::pow::multi_exponentiate_montgomery_form_slice, alloc::vec::
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Raises to the `exponent` power.
+    #[must_use]
     pub const fn pow<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,
@@ -23,6 +24,7 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// to take into account for the exponent.
     ///
     /// NOTE: `exponent_bits` may be leaked in the time pattern.
+    #[must_use]
     pub const fn pow_bounded_exp<const RHS_LIMBS: usize>(
         &self,
         exponent: &Uint<RHS_LIMBS>,

--- a/src/modular/monty_form/sub.rs
+++ b/src/modular/monty_form/sub.rs
@@ -6,6 +6,7 @@ use core::ops::{Sub, SubAssign};
 
 impl<const LIMBS: usize> MontyForm<LIMBS> {
     /// Subtracts `rhs`.
+    #[must_use]
     pub const fn sub(&self, rhs: &Self) -> Self {
         Self {
             montgomery_form: sub_montgomery_form(

--- a/src/modular/safegcd.rs
+++ b/src/modular/safegcd.rs
@@ -205,7 +205,7 @@ const fn jump<const VARTIME: bool>(
 
 /// Perform one step of the gcd reduction in constant time.
 /// This follows the half-delta variant of safegcd-bounds which reduces the round count.
-/// https://github.com/sipa/safegcd-bounds
+/// <https://github.com/sipa/safegcd-bounds>
 #[inline(always)]
 const fn jump_step(
     mut f: i64,
@@ -367,7 +367,7 @@ const fn shr_in_place_wide<const L: usize, const H: usize>(
 }
 
 /// Calculate the maximum number of iterations required according to
-/// safegcd-bounds: https://github.com/sipa/safegcd-bounds
+/// safegcd-bounds: <https://github.com/sipa/safegcd-bounds>
 #[inline]
 const fn iterations(bits: u32) -> u32 {
     (45907 * bits + 30179) / 19929

--- a/src/modular/safegcd/boxed.rs
+++ b/src/modular/safegcd/boxed.rs
@@ -105,10 +105,10 @@ fn invert_odd_mod_precomp<const VARTIME: bool>(
     );
     let (mut d, mut e) = (
         SignedBoxedInt::zero_with_precision(bits_precision),
-        SignedBoxedInt::from_uint(
-            e.map(|e| e.resize(bits_precision))
-                .unwrap_or_else(|| BoxedUint::one_with_precision(bits_precision)),
-        ),
+        SignedBoxedInt::from_uint(e.map_or_else(
+            || BoxedUint::one_with_precision(bits_precision),
+            |e| e.resize(bits_precision),
+        )),
     );
     let mut steps = iterations(bits_precision);
     let mut delta = 1;

--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -26,6 +26,9 @@ use serdect::serde::{
     de::{Error, Unexpected},
 };
 
+/// Non-zero limb.
+pub type NonZeroLimb = NonZero<Limb>;
+
 /// Non-zero unsigned integer.
 pub type NonZeroUint<const LIMBS: usize> = NonZero<Uint<LIMBS>>;
 
@@ -166,12 +169,16 @@ where
 
 impl NonZero<Limb> {
     /// Creates a new non-zero limb in a const context.
-    /// Panics if the value is zero.
     ///
+    /// # Panics
+    /// - if the value is zero.
+    ///
+    /// # Note
     /// In future versions of Rust it should be possible to replace this with
     /// `NonZero::new(…).unwrap()`
     // TODO: Remove when `Self::new` and `CtOption::unwrap` support `const fn`
     #[inline]
+    #[must_use]
     #[track_caller]
     pub const fn new_unwrap(n: Limb) -> Self {
         assert!(n.is_nonzero().to_bool_vartime(), "invalid value: zero");
@@ -180,18 +187,21 @@ impl NonZero<Limb> {
 
     /// Create a [`NonZero<Limb>`] from a [`NonZeroU8`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU8>` when stable
+    #[must_use]
     pub const fn from_u8(n: NonZeroU8) -> Self {
         Self(Limb::from_u8(n.get()))
     }
 
     /// Create a [`NonZero<Limb>`] from a [`NonZeroU16`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU16>` when stable
+    #[must_use]
     pub const fn from_u16(n: NonZeroU16) -> Self {
         Self(Limb::from_u16(n.get()))
     }
 
     /// Create a [`NonZero<Limb>`] from a [`NonZeroU32`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU32>` when stable
+    #[must_use]
     pub const fn from_u32(n: NonZeroU32) -> Self {
         Self(Limb::from_u32(n.get()))
     }
@@ -199,6 +209,7 @@ impl NonZero<Limb> {
     /// Create a [`NonZero<Limb>`] from a [`NonZeroU64`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU64>` when stable
     #[cfg(target_pointer_width = "64")]
+    #[must_use]
     pub const fn from_u64(n: NonZeroU64) -> Self {
         Self(Limb::from_u64(n.get()))
     }
@@ -215,6 +226,7 @@ impl<const LIMBS: usize> NonZeroUint<LIMBS> {
     // TODO: Remove when `Self::new` and `CtOption::unwrap` support `const fn`
     #[inline]
     #[track_caller]
+    #[must_use]
     pub const fn new_unwrap(n: Uint<LIMBS>) -> Self {
         assert!(n.is_nonzero().to_bool_vartime(), "invalid value: zero");
         Self(n)
@@ -225,6 +237,7 @@ impl<const LIMBS: usize> NonZeroUint<LIMBS> {
     /// # Panics
     /// - if the hex is zero, malformed, or not zero-padded accordingly for the size.
     #[track_caller]
+    #[must_use]
     pub const fn from_be_hex(hex: &str) -> Self {
         Self::new_unwrap(Uint::from_be_hex(hex))
     }
@@ -234,36 +247,42 @@ impl<const LIMBS: usize> NonZeroUint<LIMBS> {
     /// # Panics
     /// - if the hex is zero, malformed, or not zero-padded accordingly for the size.
     #[track_caller]
+    #[must_use]
     pub const fn from_le_hex(hex: &str) -> Self {
         Self::new_unwrap(Uint::from_le_hex(hex))
     }
 
     /// Create a [`NonZeroUint`] from a [`NonZeroU8`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU8>` when stable
+    #[must_use]
     pub const fn from_u8(n: NonZeroU8) -> Self {
         Self(Uint::from_u8(n.get()))
     }
 
     /// Create a [`NonZeroUint`] from a [`NonZeroU16`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU16>` when stable
+    #[must_use]
     pub const fn from_u16(n: NonZeroU16) -> Self {
         Self(Uint::from_u16(n.get()))
     }
 
     /// Create a [`NonZeroUint`] from a [`NonZeroU32`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU32>` when stable
+    #[must_use]
     pub const fn from_u32(n: NonZeroU32) -> Self {
         Self(Uint::from_u32(n.get()))
     }
 
     /// Create a [`NonZeroUint`] from a [`NonZeroU64`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU64>` when stable
+    #[must_use]
     pub const fn from_u64(n: NonZeroU64) -> Self {
         Self(Uint::from_u64(n.get()))
     }
 
     /// Create a [`NonZeroUint`] from a [`NonZeroU128`] (const-friendly)
     // TODO(tarcieri): replace with `const impl From<NonZeroU128>` when stable
+    #[must_use]
     pub const fn from_u128(n: NonZeroU128) -> Self {
         Self(Uint::from_u128(n.get()))
     }
@@ -271,12 +290,16 @@ impl<const LIMBS: usize> NonZeroUint<LIMBS> {
 
 impl<const LIMBS: usize> NonZeroInt<LIMBS> {
     /// Creates a new non-zero integer in a const context.
-    /// Panics if the value is zero.
     ///
+    /// # Panics
+    /// - if the value is zero.
+    ///
+    /// # Note
     /// In future versions of Rust it should be possible to replace this with
     /// `NonZero::new(…).unwrap()`
     // TODO: Remove when `Self::new` and `CtOption::unwrap` support `const fn`
     #[inline]
+    #[must_use]
     #[track_caller]
     pub const fn new_unwrap(n: Int<LIMBS>) -> Self {
         assert!(n.is_nonzero().to_bool_vartime(), "invalid value: zero");
@@ -284,6 +307,7 @@ impl<const LIMBS: usize> NonZeroInt<LIMBS> {
     }
 
     /// The sign and magnitude of this [`NonZeroInt`].
+    #[must_use]
     pub const fn abs_sign(&self) -> (NonZero<Uint<LIMBS>>, Choice) {
         let (abs, sign) = self.0.abs_sign();
         // Absolute value of a non-zero value is non-zero
@@ -291,8 +315,17 @@ impl<const LIMBS: usize> NonZeroInt<LIMBS> {
     }
 
     /// The magnitude of this [`NonZeroInt`].
+    #[must_use]
     pub const fn abs(&self) -> NonZero<Uint<LIMBS>> {
         self.abs_sign().0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl NonZeroBoxedUint {
+    /// Get the least significant limb as a [`NonZeroLimb`].
+    pub(crate) const fn lower_limb(&self) -> NonZeroLimb {
+        NonZero(self.0.limbs[0])
     }
 }
 
@@ -604,7 +637,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn from_be_hex_when_zero() {
-        NonZero::<U128>::from_be_hex("00000000000000000000000000000000");
+        let _ = NonZero::<U128>::from_be_hex("00000000000000000000000000000000");
     }
 
     #[test]
@@ -618,7 +651,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn from_le_hex_when_zero() {
-        NonZero::<U128>::from_le_hex("00000000000000000000000000000000");
+        let _ = NonZero::<U128>::from_le_hex("00000000000000000000000000000000");
     }
 
     #[test]

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -117,6 +117,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     pub const LIMBS: usize = LIMBS;
 
     /// Const-friendly [`Uint`] constructor.
+    #[must_use]
     pub const fn new(limbs: [Limb; LIMBS]) -> Self {
         Self { limbs }
     }
@@ -124,6 +125,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a [`Uint`] from an array of [`Word`]s (i.e. word-sized unsigned
     /// integers).
     #[inline]
+    #[must_use]
     pub const fn from_words(arr: [Word; LIMBS]) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;
@@ -139,6 +141,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create an array of [`Word`]s (i.e. word-sized unsigned integers) from
     /// a [`Uint`].
     #[inline]
+    #[must_use]
     pub const fn to_words(self) -> [Word; LIMBS] {
         let mut arr = [0; LIMBS];
         let mut i = 0;
@@ -152,6 +155,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Borrow the inner limbs as an array of [`Word`]s.
+    #[must_use]
     pub const fn as_words(&self) -> &[Word; LIMBS] {
         Limb::array_as_words(&self.limbs)
     }
@@ -168,6 +172,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Borrow the limbs of this [`Uint`].
+    #[must_use]
     pub const fn as_limbs(&self) -> &[Limb; LIMBS] {
         &self.limbs
     }
@@ -184,6 +189,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Convert this [`Uint`] into its inner limbs.
+    #[must_use]
     pub const fn to_limbs(self) -> [Limb; LIMBS] {
         self.limbs
     }
@@ -203,6 +209,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Convert to a [`NonZero<Uint<LIMBS>>`].
     ///
     /// Returns some if the original value is non-zero, and none otherwise.
+    #[must_use]
     pub const fn to_nz(&self) -> CtOption<NonZero<Self>> {
         let is_nz = self.is_nonzero();
 
@@ -214,6 +221,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Convert to a [`NonZero<Uint<LIMBS>>`].
     ///
     /// Returns Some if the original value is non-zero, and None otherwise.
+    #[must_use]
     pub const fn to_nz_vartime(&self) -> Option<NonZero<Self>> {
         if !self.is_zero_vartime() {
             Some(NonZero(*self))
@@ -225,6 +233,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Convert to a [`Odd<Uint<LIMBS>>`].
     ///
     /// Returns some if the original value is odd, and false otherwise.
+    #[must_use]
     pub const fn to_odd(&self) -> CtOption<Odd<Self>> {
         let is_odd = self.is_odd();
 
@@ -236,23 +245,26 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Interpret this object as an [`Int`] instead.
     ///
     /// Note: this is a casting operation. See [`Self::try_into_int`] for the checked equivalent.
+    #[must_use]
     pub const fn as_int(&self) -> &Int<LIMBS> {
         // SAFETY: `Int` is a `repr(transparent)` newtype for `Uint`, and this operation is intended
         // to be a reinterpreting cast between the two types.
-        #[allow(trivial_casts, unsafe_code)]
+        #[allow(unsafe_code)]
         unsafe {
-            &*(self as *const Uint<LIMBS> as *const Int<LIMBS>)
+            &*core::ptr::from_ref(self).cast::<Int<LIMBS>>()
         }
     }
 
     /// Convert this type into an [`Int`]; returns `None` if this value is greater than [`Int::MAX`].
     ///
     /// Note: this is the conversion operation. See [`Self::as_int`] for the unchecked equivalent.
+    #[must_use]
     pub const fn try_into_int(self) -> CtOption<Int<LIMBS>> {
         Int::new_from_abs_sign(self, Choice::FALSE)
     }
 
     /// Is this [`Uint`] equal to [`Uint::ZERO`]?
+    #[must_use]
     pub const fn is_zero(&self) -> Choice {
         self.is_nonzero().not()
     }

--- a/src/uint/add.rs
+++ b/src/uint/add.rs
@@ -7,12 +7,14 @@ use crate::{
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self + rhs + carry`, returning the result along with the new carry.
     #[deprecated(since = "0.7.0", note = "please use `carrying_add` instead")]
+    #[must_use]
     pub const fn adc(&self, rhs: &Self, carry: Limb) -> (Self, Limb) {
         self.carrying_add(rhs, carry)
     }
 
     /// Computes `self + rhs + carry`, returning the result along with the new carry.
     #[inline(always)]
+    #[must_use]
     pub const fn carrying_add(&self, rhs: &Self, mut carry: Limb) -> (Self, Limb) {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;
@@ -28,12 +30,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Perform saturating addition, returning `MAX` on overflow.
+    #[must_use]
     pub const fn saturating_add(&self, rhs: &Self) -> Self {
         let (res, overflow) = self.carrying_add(rhs, Limb::ZERO);
         Self::select(&res, &Self::MAX, word::choice_from_lsb(overflow.0))
     }
 
     /// Perform wrapping addition, discarding overflow.
+    #[must_use]
     pub const fn wrapping_add(&self, rhs: &Self) -> Self {
         self.carrying_add(rhs, Limb::ZERO).0
     }

--- a/src/uint/add_mod.rs
+++ b/src/uint/add_mod.rs
@@ -6,6 +6,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self + rhs mod p`.
     ///
     /// Assumes `self + rhs` as unbounded integer is `< 2p`.
+    #[must_use]
     pub const fn add_mod(&self, rhs: &Self, p: &NonZero<Self>) -> Self {
         let (w, carry) = self.carrying_add(rhs, Limb::ZERO);
         w.sub_mod_with_carry(carry, p.as_ref(), p.as_ref())
@@ -15,6 +16,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
     ///
     /// Assumes `self + rhs` as unbounded integer is `< 2p`.
+    #[must_use]
     pub const fn add_mod_special(&self, rhs: &Self, c: Limb) -> Self {
         // `Uint::carrying_add` also works with a carry greater than 1.
         let (out, carry) = self.carrying_add(rhs, c);
@@ -29,6 +31,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self + self mod p`.
     ///
     /// Assumes `self` as unbounded integer is `< p`.
+    #[must_use]
     pub const fn double_mod(&self, p: &NonZero<Self>) -> Self {
         let (w, carry) = self.overflowing_shl1();
         w.sub_mod_with_carry(carry, p.as_ref(), p.as_ref())

--- a/src/uint/bit_and.rs
+++ b/src/uint/bit_and.rs
@@ -6,6 +6,7 @@ use crate::{BitAnd, BitAndAssign, CtOption, Limb, Wrapping};
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `a & b`.
     #[inline(always)]
+    #[must_use]
     pub const fn bitand(&self, rhs: &Self) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;
@@ -20,6 +21,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Perform bitwise `AND` between `self` and the given [`Limb`], performing the `AND` operation
     /// on every limb of `self`.
+    #[must_use]
     pub const fn bitand_limb(&self, rhs: Limb) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;
@@ -36,11 +38,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub const fn wrapping_and(&self, rhs: &Self) -> Self {
         self.bitand(rhs)
     }
 
     /// Perform checked bitwise `AND`, returning a [`CtOption`] which `is_some` always
+    #[must_use]
     pub const fn checked_and(&self, rhs: &Self) -> CtOption<Self> {
         CtOption::some(self.bitand(rhs))
     }

--- a/src/uint/bit_not.rs
+++ b/src/uint/bit_not.rs
@@ -7,6 +7,7 @@ use core::ops::Not;
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `!a`.
     #[inline(always)]
+    #[must_use]
     pub const fn not(&self) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;

--- a/src/uint/bit_or.rs
+++ b/src/uint/bit_or.rs
@@ -6,6 +6,7 @@ use crate::{BitOr, BitOrAssign, CtOption, Limb, Wrapping};
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `a & b`.
     #[inline(always)]
+    #[must_use]
     pub const fn bitor(&self, rhs: &Self) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;
@@ -22,11 +23,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub const fn wrapping_or(&self, rhs: &Self) -> Self {
         self.bitor(rhs)
     }
 
     /// Perform checked bitwise `OR`, returning a [`CtOption`] which `is_some` always
+    #[must_use]
     pub const fn checked_or(&self, rhs: &Self) -> CtOption<Self> {
         CtOption::some(self.bitor(rhs))
     }

--- a/src/uint/bit_xor.rs
+++ b/src/uint/bit_xor.rs
@@ -6,6 +6,7 @@ use crate::{BitXor, BitXorAssign, CtOption, Limb, Wrapping};
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes bitwise `a ^ b`.
     #[inline(always)]
+    #[must_use]
     pub const fn bitxor(&self, rhs: &Self) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;
@@ -22,11 +23,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub const fn wrapping_xor(&self, rhs: &Self) -> Self {
         self.bitxor(rhs)
     }
 
     /// Perform checked bitwise `XOR`, returning a [`CtOption`] which `is_some` always
+    #[must_use]
     pub const fn checked_xor(&self, rhs: &Self) -> CtOption<Self> {
         CtOption::some(self.bitxor(rhs))
     }

--- a/src/uint/bits.rs
+++ b/src/uint/bits.rs
@@ -3,6 +3,7 @@ use crate::{BitOps, Choice, Uint};
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Get the value of the bit at position `index`, as a truthy or falsy `Choice`.
     /// Returns the falsy value for indices out of range.
+    #[must_use]
     pub const fn bit(&self, index: u32) -> Choice {
         self.as_uint_ref().bit(index)
     }
@@ -12,51 +13,60 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// # Remarks
     /// This operation is variable time with respect to `index` only.
     #[inline(always)]
+    #[must_use]
     pub const fn bit_vartime(&self, index: u32) -> bool {
         self.as_uint_ref().bit_vartime(index)
     }
 
     /// Calculate the number of bits needed to represent this number.
     #[inline]
+    #[must_use]
     pub const fn bits(&self) -> u32 {
         Self::BITS - self.leading_zeros()
     }
 
     /// Calculate the number of bits needed to represent this number in variable-time with respect
     /// to `self`.
+    #[must_use]
     pub const fn bits_vartime(&self) -> u32 {
         self.as_uint_ref().bits_vartime()
     }
 
     /// Calculate the number of leading zeros in the binary representation of this number.
+    #[must_use]
     pub const fn leading_zeros(&self) -> u32 {
         self.as_uint_ref().leading_zeros()
     }
 
     /// Calculate the number of leading zeros in the binary representation of this number in
     /// variable-time with respect to `self`.
+    #[must_use]
     pub const fn leading_zeros_vartime(&self) -> u32 {
         Self::BITS - self.bits_vartime()
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number.
+    #[must_use]
     pub const fn trailing_zeros(&self) -> u32 {
         self.as_uint_ref().trailing_zeros()
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number in
     /// variable-time with respect to `self`.
+    #[must_use]
     pub const fn trailing_zeros_vartime(&self) -> u32 {
         self.as_uint_ref().trailing_zeros_vartime()
     }
 
     /// Calculate the number of trailing ones in the binary representation of this number.
+    #[must_use]
     pub const fn trailing_ones(&self) -> u32 {
         self.as_uint_ref().trailing_ones()
     }
 
     /// Calculate the number of trailing ones in the binary representation of this number,
     /// variable time in `self`.
+    #[must_use]
     pub const fn trailing_ones_vartime(&self) -> u32 {
         self.as_uint_ref().trailing_ones_vartime()
     }

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -60,6 +60,7 @@ impl BoxedUint {
     }
 
     /// Get the value `0` represented as succinctly as possible.
+    #[must_use]
     pub fn zero() -> Self {
         Self {
             limbs: vec![Limb::ZERO; 1].into(),
@@ -69,11 +70,13 @@ impl BoxedUint {
     /// Get the value `0` with the given number of bits of precision.
     ///
     /// `at_least_bits_precision` is rounded up to a multiple of [`Limb::BITS`].
+    #[must_use]
     pub fn zero_with_precision(at_least_bits_precision: u32) -> Self {
         vec![Limb::ZERO; Self::limbs_for_precision(at_least_bits_precision)].into()
     }
 
     /// Get the value `1`, represented as succinctly as possible.
+    #[must_use]
     pub fn one() -> Self {
         Self {
             limbs: vec![Limb::ONE; 1].into(),
@@ -83,6 +86,7 @@ impl BoxedUint {
     /// Get the value `1` with the given number of bits of precision.
     ///
     /// `at_least_bits_precision` is rounded up to a multiple of [`Limb::BITS`].
+    #[must_use]
     pub fn one_with_precision(at_least_bits_precision: u32) -> Self {
         let mut ret = Self::zero_with_precision(at_least_bits_precision);
         ret.limbs[0] = Limb::ONE;
@@ -90,6 +94,7 @@ impl BoxedUint {
     }
 
     /// Is this [`BoxedUint`] equal to zero?
+    #[must_use]
     pub fn is_zero(&self) -> Choice {
         self.limbs
             .iter()
@@ -98,11 +103,13 @@ impl BoxedUint {
 
     /// Is this [`BoxedUint`] *NOT* equal to zero?
     #[inline]
+    #[must_use]
     pub fn is_nonzero(&self) -> Choice {
         !self.is_zero()
     }
 
     /// Is this [`BoxedUint`] equal to one?
+    #[must_use]
     pub fn is_one(&self) -> Choice {
         let mut iter = self.limbs.iter();
         let choice = iter.next().copied().unwrap_or(Limb::ZERO).ct_eq(&Limb::ONE);
@@ -113,6 +120,7 @@ impl BoxedUint {
     /// precision bits requested.
     ///
     /// That is, returns the value `2^self.bits_precision() - 1`.
+    #[must_use]
     pub fn max(at_least_bits_precision: u32) -> Self {
         vec![Limb::MAX; Self::limbs_for_precision(at_least_bits_precision)].into()
     }
@@ -153,6 +161,7 @@ impl BoxedUint {
     }
 
     /// Borrow the inner limbs as a slice of [`Word`]s.
+    #[must_use]
     pub fn as_words(&self) -> &[Word] {
         self.as_uint_ref().as_words()
     }
@@ -169,6 +178,7 @@ impl BoxedUint {
     }
 
     /// Borrow the limbs of this [`BoxedUint`].
+    #[must_use]
     pub fn as_limbs(&self) -> &[Limb] {
         self.limbs.as_ref()
     }
@@ -185,11 +195,13 @@ impl BoxedUint {
     }
 
     /// Convert this [`BoxedUint`] into its inner limbs.
+    #[must_use]
     pub fn to_limbs(&self) -> Box<[Limb]> {
         self.limbs.clone()
     }
 
     /// Convert this [`BoxedUint`] into its inner limbs.
+    #[must_use]
     pub fn into_limbs(self) -> Box<[Limb]> {
         self.limbs
     }
@@ -216,6 +228,7 @@ impl BoxedUint {
     }
 
     /// Get the number of limbs in this [`BoxedUint`].
+    #[must_use]
     pub fn nlimbs(&self) -> usize {
         self.limbs.len()
     }
@@ -223,6 +236,7 @@ impl BoxedUint {
     /// Convert to a [`NonZero<BoxedUint>`].
     ///
     /// Returns some if the original value is non-zero, and false otherwise.
+    #[must_use]
     pub fn to_nz(&self) -> CtOption<NonZero<Self>> {
         self.clone().into_nz()
     }
@@ -230,6 +244,7 @@ impl BoxedUint {
     /// Convert to an [`Odd<BoxedUint>`].
     ///
     /// Returns some if the original value is odd, and false otherwise.
+    #[must_use]
     pub fn to_odd(&self) -> CtOption<Odd<Self>> {
         self.clone().into_odd()
     }
@@ -237,6 +252,7 @@ impl BoxedUint {
     /// Convert to a [`NonZero<BoxedUint>`].
     ///
     /// Returns some if the original value is non-zero, and false otherwise.
+    #[must_use]
     pub fn into_nz(mut self) -> CtOption<NonZero<Self>> {
         let is_nz = self.is_nonzero();
 
@@ -248,6 +264,7 @@ impl BoxedUint {
     /// Convert to an [`Odd<BoxedUint>`].
     ///
     /// Returns some if the original value is odd, and false otherwise.
+    #[must_use]
     pub fn into_odd(mut self) -> CtOption<Odd<Self>> {
         let is_odd = self.is_odd();
 
@@ -258,7 +275,8 @@ impl BoxedUint {
 
     /// Widen this type's precision to the given number of bits.
     ///
-    /// Panics if `at_least_bits_precision` is smaller than the current precision.
+    /// # Panics
+    /// - if `at_least_bits_precision` is smaller than the current precision.
     #[must_use]
     #[deprecated(since = "0.7.0", note = "please use `resize` instead")]
     pub fn widen(&self, at_least_bits_precision: u32) -> BoxedUint {
@@ -271,7 +289,8 @@ impl BoxedUint {
 
     /// Shortens this type's precision to the given number of bits.
     ///
-    /// Panics if `at_least_bits_precision` is larger than the current precision.
+    /// # Panics
+    /// - if `at_least_bits_precision` is larger than the current precision.
     #[must_use]
     #[deprecated(since = "0.7.0", note = "please use `resize` instead")]
     pub fn shorten(&self, at_least_bits_precision: u32) -> BoxedUint {
@@ -474,7 +493,7 @@ impl Zero for BoxedUint {
     }
 
     fn set_zero(&mut self) {
-        self.limbs.as_mut().fill(Limb::ZERO)
+        self.limbs.as_mut().fill(Limb::ZERO);
     }
 }
 
@@ -509,7 +528,7 @@ impl num_traits::Zero for BoxedUint {
     }
 
     fn set_zero(&mut self) {
-        Zero::set_zero(self)
+        Zero::set_zero(self);
     }
 }
 
@@ -523,7 +542,7 @@ impl num_traits::One for BoxedUint {
     }
 
     fn set_one(&mut self) {
-        One::set_one(self)
+        One::set_one(self);
     }
 }
 

--- a/src/uint/boxed/add.rs
+++ b/src/uint/boxed/add.rs
@@ -10,19 +10,22 @@ use ctutils::CtEq;
 impl BoxedUint {
     /// Computes `self + rhs + carry`, returning the result along with the new carry.
     #[deprecated(since = "0.7.0", note = "please use `carrying_add` instead")]
+    #[must_use]
     pub fn adc(&self, rhs: &Self, carry: Limb) -> (Self, Limb) {
         self.carrying_add(rhs, carry)
     }
 
     /// Computes `self + rhs + carry`, returning the result along with the new carry.
     #[inline(always)]
+    #[must_use]
     pub fn carrying_add(&self, rhs: &Self, carry: Limb) -> (Self, Limb) {
-        Self::fold_limbs(self, rhs, carry, |a, b, c| a.carrying_add(b, c))
+        Self::fold_limbs(self, rhs, carry, Limb::carrying_add)
     }
 
     /// Computes `self + rhs + carry` in-place, returning the new carry.
     ///
-    /// Panics if `rhs` has a larger precision than `self`.
+    /// # Panics
+    /// - if `rhs` has a larger precision than `self`.
     #[deprecated(since = "0.7.0", note = "please use `carrying_add_assign` instead")]
     pub fn adc_assign(&mut self, rhs: impl AsRef<[Limb]>, carry: Limb) -> Limb {
         self.carrying_add_assign(rhs, carry)
@@ -30,7 +33,8 @@ impl BoxedUint {
 
     /// Computes `self + rhs + carry` in-place, returning the new carry.
     ///
-    /// Panics if `rhs` has a larger precision than `self`.
+    /// # Panics
+    /// - if `rhs` has a larger precision than `self`.
     #[inline]
     pub fn carrying_add_assign(&mut self, rhs: impl AsRef<[Limb]>, mut carry: Limb) -> Limb {
         debug_assert!(self.bits_precision() >= (rhs.as_ref().len() as u32 * Limb::BITS));
@@ -47,6 +51,7 @@ impl BoxedUint {
 
     /// Computes `self + rhs`, returning a result which is concatenated with the overflow limb which
     /// would be returned if `carrying_add` were called with the same operands.
+    #[must_use]
     pub fn concatenating_add(&self, rhs: &Self) -> Self {
         // Create a copy of `self` widened to one limb larger than the largest of `self` and `rhs`
         let nlimbs = cmp::max(self.nlimbs(), rhs.nlimbs()) + 1;
@@ -62,12 +67,14 @@ impl BoxedUint {
     /// whether an overflow occurred.
     ///
     /// If an overflow occurred, then the wrapped value is returned.
+    #[must_use]
     pub fn overflowing_add(&self, rhs: &Self) -> (Self, Choice) {
         let (ret, overflow) = self.carrying_add(rhs, Limb::ZERO);
         (ret, overflow.ct_ne(&Limb::ZERO))
     }
 
     /// Perform wrapping addition, discarding overflow.
+    #[must_use]
     pub fn wrapping_add(&self, rhs: &Self) -> Self {
         self.carrying_add(rhs, Limb::ZERO).0
     }
@@ -125,7 +132,7 @@ impl Add<&BoxedUint> for &BoxedUint {
 
 impl AddAssign<BoxedUint> for BoxedUint {
     fn add_assign(&mut self, rhs: BoxedUint) {
-        self.add_assign(&rhs)
+        self.add_assign(&rhs);
     }
 }
 

--- a/src/uint/boxed/add_mod.rs
+++ b/src/uint/boxed/add_mod.rs
@@ -6,6 +6,7 @@ impl BoxedUint {
     /// Computes `self + rhs mod p`.
     ///
     /// Assumes `self + rhs` as unbounded integer is `< 2p`.
+    #[must_use]
     pub fn add_mod(&self, rhs: &Self, p: &NonZero<Self>) -> Self {
         let mut result = self.clone();
         result.add_mod_assign(rhs, p);
@@ -28,6 +29,7 @@ impl BoxedUint {
     /// Computes `self + self mod p`.
     ///
     /// Assumes `self` as unbounded integer is `< p`.
+    #[must_use]
     pub fn double_mod(&self, p: &NonZero<Self>) -> Self {
         let (mut w, carry) = self.shl1();
         w.sub_assign_mod_with_carry(carry, p, p);

--- a/src/uint/boxed/bit_and.rs
+++ b/src/uint/boxed/bit_and.rs
@@ -6,12 +6,14 @@ use crate::{BitAnd, BitAndAssign, CtOption, Limb, Wrapping};
 impl BoxedUint {
     /// Computes bitwise `a & b`.
     #[inline(always)]
+    #[must_use]
     pub fn bitand(&self, rhs: &Self) -> Self {
-        Self::map_limbs(self, rhs, |a, b| a.bitand(b))
+        Self::map_limbs(self, rhs, Limb::bitand)
     }
 
     /// Perform bitwise `AND` between `self` and the given [`Limb`], performing the `AND` operation
     /// on every limb of `self`.
+    #[must_use]
     pub fn bitand_limb(&self, rhs: Limb) -> Self {
         Self {
             limbs: self.limbs.iter().map(|limb| limb.bitand(rhs)).collect(),
@@ -22,11 +24,13 @@ impl BoxedUint {
     ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub fn wrapping_and(&self, rhs: &Self) -> Self {
         self.bitand(rhs)
     }
 
     /// Perform checked bitwise `AND`, returning a [`CtOption`] which `is_some` always
+    #[must_use]
     pub fn checked_and(&self, rhs: &Self) -> CtOption<Self> {
         CtOption::some(self.bitand(rhs))
     }
@@ -114,14 +118,14 @@ impl BitAnd<&Wrapping<BoxedUint>> for &Wrapping<BoxedUint> {
 impl BitAndAssign for Wrapping<BoxedUint> {
     #[allow(clippy::assign_op_pattern)]
     fn bitand_assign(&mut self, other: Self) {
-        *self = Wrapping(BoxedUint::bitand(&self.0, &other.0))
+        *self = Wrapping(BoxedUint::bitand(&self.0, &other.0));
     }
 }
 
 impl BitAndAssign<&Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
     #[allow(clippy::assign_op_pattern)]
     fn bitand_assign(&mut self, other: &Self) {
-        *self = Wrapping(BoxedUint::bitand(&self.0, &other.0))
+        *self = Wrapping(BoxedUint::bitand(&self.0, &other.0));
     }
 }
 

--- a/src/uint/boxed/bit_not.rs
+++ b/src/uint/boxed/bit_not.rs
@@ -6,6 +6,7 @@ use core::ops::Not;
 
 impl BoxedUint {
     /// Computes bitwise `!a`.
+    #[must_use]
     pub fn not(&self) -> Self {
         let mut limbs = vec![Limb::ZERO; self.nlimbs()];
 

--- a/src/uint/boxed/bit_or.rs
+++ b/src/uint/boxed/bit_or.rs
@@ -5,19 +5,22 @@ use crate::{BitOr, BitOrAssign, BoxedUint, CtOption, Wrapping};
 impl BoxedUint {
     /// Computes bitwise `a & b`.
     #[inline(always)]
+    #[must_use]
     pub fn bitor(&self, rhs: &Self) -> Self {
-        Self::map_limbs(self, rhs, |a, b| a.bitor(b))
+        Self::map_limbs(self, rhs, crate::limb::Limb::bitor)
     }
 
     /// Perform wrapping bitwise `OR`.
     ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub fn wrapping_or(&self, rhs: &Self) -> Self {
         self.bitor(rhs)
     }
 
     /// Perform checked bitwise `OR`, returning a [`CtOption`] which `is_some` always
+    #[must_use]
     pub fn checked_or(&self, rhs: &Self) -> CtOption<Self> {
         CtOption::some(self.bitor(rhs))
     }
@@ -58,7 +61,7 @@ impl BitOr<&BoxedUint> for &BoxedUint {
 
 impl BitOrAssign for BoxedUint {
     fn bitor_assign(&mut self, other: Self) {
-        Self::bitor_assign(self, &other)
+        Self::bitor_assign(self, &other);
     }
 }
 
@@ -104,12 +107,12 @@ impl BitOr<&Wrapping<BoxedUint>> for &Wrapping<BoxedUint> {
 
 impl BitOrAssign for Wrapping<BoxedUint> {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(&other.0)
+        self.0.bitor_assign(&other.0);
     }
 }
 
 impl BitOrAssign<&Wrapping<BoxedUint>> for Wrapping<BoxedUint> {
     fn bitor_assign(&mut self, other: &Self) {
-        self.0.bitor_assign(&other.0)
+        self.0.bitor_assign(&other.0);
     }
 }

--- a/src/uint/boxed/bit_xor.rs
+++ b/src/uint/boxed/bit_xor.rs
@@ -6,19 +6,22 @@ use crate::{BitXor, BitXorAssign, CtOption, Wrapping};
 impl BoxedUint {
     /// Computes bitwise `a ^ b`.
     #[inline(always)]
+    #[must_use]
     pub fn bitxor(&self, rhs: &Self) -> Self {
-        Self::map_limbs(self, rhs, |a, b| a.bitxor(b))
+        Self::map_limbs(self, rhs, crate::limb::Limb::bitxor)
     }
 
-    /// Perform wrapping bitwise `XOR``.
+    /// Perform wrapping bitwise `XOR`.
     ///
     /// There's no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations
+    #[must_use]
     pub fn wrapping_xor(&self, rhs: &Self) -> Self {
         self.bitxor(rhs)
     }
 
     /// Perform checked bitwise `XOR`, returning a [`CtOption`] which `is_some` always
+    #[must_use]
     pub fn checked_xor(&self, rhs: &Self) -> CtOption<Self> {
         CtOption::some(self.bitxor(rhs))
     }

--- a/src/uint/boxed/bits.rs
+++ b/src/uint/boxed/bits.rs
@@ -5,6 +5,7 @@ use crate::{BitOps, BoxedUint, Choice, Limb};
 impl BoxedUint {
     /// Get the value of the bit at position `index`, as a truthy or falsy `Choice`.
     /// Returns the falsy value for indices out of range.
+    #[must_use]
     pub fn bit(&self, index: u32) -> Choice {
         self.as_uint_ref().bit(index)
     }
@@ -14,6 +15,7 @@ impl BoxedUint {
     /// # Remarks
     /// This operation is variable time with respect to `index` only.
     #[inline(always)]
+    #[must_use]
     pub const fn bit_vartime(&self, index: u32) -> bool {
         self.as_uint_ref().bit_vartime(index)
     }
@@ -22,56 +24,64 @@ impl BoxedUint {
     /// set bit.
     ///
     /// Use [`BoxedUint::bits_precision`] to get the total capacity of this integer.
+    #[must_use]
     pub fn bits(&self) -> u32 {
         self.bits_precision() - self.leading_zeros()
     }
 
     /// Calculate the number of bits needed to represent this number in variable-time with respect
     /// to `self`.
+    #[must_use]
     pub fn bits_vartime(&self) -> u32 {
         self.as_uint_ref().bits_vartime()
     }
 
     /// Calculate the number of leading zeros in the binary representation of this number.
+    #[must_use]
     pub const fn leading_zeros(&self) -> u32 {
         self.as_uint_ref().leading_zeros()
     }
 
     /// Get the precision of this [`BoxedUint`] in bits.
     #[inline(always)]
+    #[must_use]
     pub fn bits_precision(&self) -> u32 {
         self.limbs.len() as u32 * Limb::BITS
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number.
+    #[must_use]
     pub fn trailing_zeros(&self) -> u32 {
         self.as_uint_ref().trailing_zeros()
     }
 
     /// Calculate the number of trailing ones in the binary representation of this number.
+    #[must_use]
     pub fn trailing_ones(&self) -> u32 {
         self.as_uint_ref().trailing_ones()
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number in
     /// variable-time with respect to `self`.
+    #[must_use]
     pub fn trailing_zeros_vartime(&self) -> u32 {
         self.as_uint_ref().trailing_zeros_vartime()
     }
 
     /// Calculate the number of trailing ones in the binary representation of this number,
     /// variable time in `self`.
+    #[must_use]
     pub fn trailing_ones_vartime(&self) -> u32 {
         self.as_uint_ref().trailing_ones_vartime()
     }
 
     /// Sets the bit at `index` to 0 or 1 depending on the value of `bit_value`.
     pub(crate) fn set_bit(&mut self, index: u32, bit_value: Choice) {
-        self.as_mut_uint_ref().set_bit(index, bit_value)
+        self.as_mut_uint_ref().set_bit(index, bit_value);
     }
 
     pub(crate) fn set_bit_vartime(&mut self, index: u32, bit_value: bool) {
-        self.as_mut_uint_ref().set_bit_vartime(index, bit_value)
+        self.as_mut_uint_ref().set_bit_vartime(index, bit_value);
     }
 
     /// Clear any bits at or above a given bit position.
@@ -102,7 +112,7 @@ impl BitOps for BoxedUint {
     }
 
     fn set_bit(&mut self, index: u32, bit_value: Choice) {
-        self.set_bit(index, bit_value)
+        self.set_bit(index, bit_value);
     }
 
     fn trailing_zeros(&self) -> u32 {
@@ -122,7 +132,7 @@ impl BitOps for BoxedUint {
     }
 
     fn set_bit_vartime(&mut self, index: u32, bit_value: bool) {
-        self.set_bit_vartime(index, bit_value)
+        self.set_bit_vartime(index, bit_value);
     }
 
     fn trailing_zeros_vartime(&self) -> u32 {

--- a/src/uint/boxed/cmp.rs
+++ b/src/uint/boxed/cmp.rs
@@ -9,6 +9,7 @@ use crate::{CtAssign, CtEq, CtGt, CtLt, Limb, Uint};
 
 impl BoxedUint {
     /// Returns the Ordering between `self` and `rhs` in variable time.
+    #[must_use]
     pub fn cmp_vartime(&self, rhs: &Self) -> Ordering {
         debug_assert_eq!(self.limbs.len(), rhs.limbs.len());
         let mut i = self.limbs.len() - 1;

--- a/src/uint/boxed/ct.rs
+++ b/src/uint/boxed/ct.rs
@@ -56,7 +56,7 @@ impl CtNeg for BoxedUint {
 
     fn ct_neg_assign(&mut self, choice: Choice) {
         let self_neg = self.wrapping_neg();
-        self.ct_assign(&self_neg, choice)
+        self.ct_assign(&self_neg, choice);
     }
 }
 
@@ -87,7 +87,7 @@ impl CtSelect for BoxedUint {
 impl subtle::ConditionallyNegatable for BoxedUint {
     #[inline]
     fn conditional_negate(&mut self, choice: subtle::Choice) {
-        self.ct_neg_assign(choice.into())
+        self.ct_neg_assign(choice.into());
     }
 }
 

--- a/src/uint/boxed/from.rs
+++ b/src/uint/boxed/from.rs
@@ -71,7 +71,7 @@ impl From<Vec<Word>> for BoxedUint {
         // SAFETY: `Limb` is a `repr(transparent)` newtype for `Word`
         #[allow(unsafe_code)]
         unsafe {
-            let ptr = words.as_mut_ptr() as *mut Limb;
+            let ptr = words.as_mut_ptr().cast::<Limb>();
             let len = words.len();
             let capacity = words.capacity();
             mem::forget(words);

--- a/src/uint/boxed/invert_mod.rs
+++ b/src/uint/boxed/invert_mod.rs
@@ -8,16 +8,19 @@ use crate::{
 impl BoxedUint {
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
     #[deprecated(since = "0.7.0", note = "please use `invert_odd_mod` instead")]
+    #[must_use]
     pub fn inv_odd_mod(&self, modulus: &Odd<Self>) -> CtOption<Self> {
         self.invert_odd_mod(modulus)
     }
 
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
+    #[must_use]
     pub fn invert_odd_mod(&self, modulus: &Odd<Self>) -> CtOption<Self> {
         safegcd::boxed::invert_odd_mod(self, modulus)
     }
 
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
+    #[must_use]
     pub fn invert_odd_mod_vartime(&self, modulus: &Odd<Self>) -> Option<Self> {
         safegcd::boxed::invert_odd_mod_vartime(self, modulus)
     }
@@ -28,6 +31,7 @@ impl BoxedUint {
     /// If the inverse does not exist (`k > 0` and `self` is even, or `k > bits_precision()`),
     /// returns `Choice::FALSE` as the second element of the tuple, otherwise returns `Choice::TRUE`.
     #[deprecated(since = "0.7.0", note = "please use `invert_mod2k_vartime` instead")]
+    #[must_use]
     pub fn inv_mod2k_vartime(&self, k: u32) -> (Self, Choice) {
         self.invert_mod2k_vartime(k)
     }
@@ -37,6 +41,7 @@ impl BoxedUint {
     ///
     /// If the inverse does not exist (`k > 0` and `self` is even, or `k > bits_precision()`),
     /// returns `Choice::FALSE` as the second element of the tuple, otherwise returns `Choice::TRUE`.
+    #[must_use]
     pub fn invert_mod2k_vartime(&self, k: u32) -> (Self, Choice) {
         let bits = self.bits_precision();
 
@@ -61,6 +66,7 @@ impl BoxedUint {
     /// If the inverse does not exist (`k > 0` and `self` is even, or `k > bits_precision()`),
     /// returns `Choice::FALSE` as the second element of the tuple, otherwise returns `Choice::TRUE`.
     #[deprecated(since = "0.7.0", note = "please use `invert_mod2k` instead")]
+    #[must_use]
     pub fn inv_mod2k(&self, k: u32) -> (Self, Choice) {
         self.invert_mod2k(k)
     }
@@ -69,6 +75,7 @@ impl BoxedUint {
     ///
     /// If the inverse does not exist (`k > 0` and `self` is even, or `k > bits_precision()`),
     /// returns `Choice::FALSE` as the second element of the tuple, otherwise returns `Choice::TRUE`.
+    #[must_use]
     pub fn invert_mod2k(&self, k: u32) -> (Self, Choice) {
         let bits = self.bits_precision();
         let is_some = k.ct_lt(&(bits + 1)) & (k.ct_eq(&0) | self.is_odd());
@@ -88,6 +95,7 @@ impl BoxedUint {
     ///
     /// TODO: maybe some better documentation is needed
     #[deprecated(since = "0.7.0", note = "please use `invert_mod` instead")]
+    #[must_use]
     pub fn inv_mod(&self, modulus: &Self) -> CtOption<Self> {
         let is_nz = modulus.is_nonzero();
         let m = NonZero(Self::ct_select(
@@ -107,6 +115,7 @@ impl BoxedUint {
     /// `self` and `modulus` must have the same number of limbs, or the function will panic
     ///
     /// TODO: maybe some better documentation is needed
+    #[must_use]
     pub fn invert_mod(&self, modulus: &NonZero<Self>) -> CtOption<Self> {
         debug_assert_eq!(self.bits_precision(), modulus.bits_precision());
         let k = modulus.trailing_zeros();

--- a/src/uint/boxed/mul.rs
+++ b/src/uint/boxed/mul.rs
@@ -10,6 +10,7 @@ impl BoxedUint {
     /// Multiply `self` by `rhs`.
     ///
     /// Returns a widened output with a limb count equal to the sums of the input limb counts.
+    #[must_use]
     pub fn mul(&self, rhs: &Self) -> Self {
         self.wrapping_mul_carry(rhs.as_limbs(), self.nlimbs() + rhs.nlimbs())
             .0
@@ -24,12 +25,14 @@ impl BoxedUint {
     }
 
     /// Perform wrapping multiplication, wrapping to the width of `self`.
+    #[must_use]
     pub fn wrapping_mul(&self, rhs: &Self) -> Self {
         self.wrapping_mul_carry(rhs.as_limbs(), self.nlimbs()).0
     }
 
     /// Multiply `self` by `rhs`, wrapping to the width of `self`.
     /// Returns `CtOption::None` if the result overflowed the precision of `self`.
+    #[must_use]
     pub fn checked_mul(&self, rhs: &Self) -> CtOption<Self> {
         let (res, carry) = self.wrapping_mul_carry(rhs.as_limbs(), self.nlimbs());
         let overflow =
@@ -38,6 +41,7 @@ impl BoxedUint {
     }
 
     /// Perform saturating multiplication, returning `MAX` on overflow.
+    #[must_use]
     pub fn saturating_mul(&self, rhs: &BoxedUint) -> Self {
         let (mut res, carry) = self.wrapping_mul_carry(rhs.as_limbs(), self.nlimbs());
         let overflow =
@@ -59,17 +63,20 @@ impl BoxedUint {
     }
 
     /// Multiply `self` by itself.
+    #[must_use]
     pub fn square(&self) -> Self {
         self.wrapping_square_carry(self.nlimbs() * 2).0
     }
 
     /// Multiply `self` by itself, wrapping to the width of `self`.
+    #[must_use]
     pub fn wrapping_square(&self) -> Self {
         self.wrapping_square_carry(self.nlimbs()).0
     }
 
     /// Multiply `self` by itself, wrapping to the width of `self`.
     /// Returns `CtOption::None` if the result overflowed the precision of `self`.
+    #[must_use]
     pub fn checked_square(&self) -> CtOption<Self> {
         let (res, carry) = self.wrapping_square_carry(self.nlimbs());
         let overflow =
@@ -78,6 +85,7 @@ impl BoxedUint {
     }
 
     /// Perform saturating squaring, returning `MAX` on overflow.
+    #[must_use]
     pub fn saturating_square(&self) -> Self {
         let (mut res, carry) = self.wrapping_square_carry(self.nlimbs());
         let overflow =
@@ -138,13 +146,13 @@ impl Mul<&BoxedUint> for &BoxedUint {
 
 impl MulAssign<BoxedUint> for BoxedUint {
     fn mul_assign(&mut self, rhs: BoxedUint) {
-        self.mul_assign(&rhs)
+        self.mul_assign(&rhs);
     }
 }
 
 impl MulAssign<&BoxedUint> for BoxedUint {
     fn mul_assign(&mut self, rhs: &BoxedUint) {
-        *self = self.clone().mul(rhs)
+        *self = self.clone().mul(rhs);
     }
 }
 

--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -4,6 +4,7 @@ use crate::{BoxedUint, Limb, MulMod, NonZero, SquareMod, WideWord, Word, div_lim
 
 impl BoxedUint {
     /// Computes `self * rhs mod p` for non-zero `p`.
+    #[must_use]
     pub fn mul_mod(&self, rhs: &BoxedUint, p: &NonZero<BoxedUint>) -> BoxedUint {
         self.mul(rhs).rem(p)
     }
@@ -14,6 +15,7 @@ impl BoxedUint {
     /// For the modulus reduction, this function implements Algorithm 14.47 from
     /// the "Handbook of Applied Cryptography", by A. Menezes, P. van Oorschot,
     /// and S. Vanstone, CRC Press, 1996.
+    #[must_use]
     pub fn mul_mod_special(&self, rhs: &Self, c: Limb) -> Self {
         debug_assert_eq!(self.bits_precision(), rhs.bits_precision());
 
@@ -50,11 +52,13 @@ impl BoxedUint {
     }
 
     /// Computes `self * self mod p`.
+    #[must_use]
     pub fn square_mod(&self, p: &NonZero<BoxedUint>) -> Self {
         self.square().rem(p)
     }
 
     /// Computes `self * self mod p` in variable time with respect to `p`.
+    #[must_use]
     pub fn square_mod_vartime(&self, p: &NonZero<BoxedUint>) -> Self {
         self.square().rem_vartime(p)
     }

--- a/src/uint/boxed/neg.rs
+++ b/src/uint/boxed/neg.rs
@@ -4,6 +4,7 @@ use crate::{BoxedUint, Choice, CtAssign, Limb, WideWord, Word, WrappingNeg};
 
 impl BoxedUint {
     /// Perform wrapping negation.
+    #[must_use]
     pub fn wrapping_neg(&self) -> Self {
         let mut ret = vec![Limb::ZERO; self.nlimbs()];
         let mut carry = 1;

--- a/src/uint/boxed/neg_mod.rs
+++ b/src/uint/boxed/neg_mod.rs
@@ -5,6 +5,7 @@ use crate::{BoxedUint, CtAssign, Limb, NegMod, NonZero};
 impl BoxedUint {
     /// Computes `-a mod p`.
     /// Assumes `self` is in `[0, p)`.
+    #[must_use]
     pub fn neg_mod(&self, p: &NonZero<Self>) -> Self {
         debug_assert_eq!(self.bits_precision(), p.bits_precision());
         let is_zero = self.is_zero();
@@ -21,6 +22,7 @@ impl BoxedUint {
 
     /// Computes `-a mod p` for the special modulus
     /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
+    #[must_use]
     pub fn neg_mod_special(&self, c: Limb) -> Self {
         Self::zero_with_precision(self.bits_precision()).sub_mod_special(self, c)
     }

--- a/src/uint/boxed/pow_mod.rs
+++ b/src/uint/boxed/pow_mod.rs
@@ -7,6 +7,7 @@ use crate::{
 
 impl BoxedUint {
     /// Computes `self ^ rhs mod p` for odd `p`.
+    #[must_use]
     pub fn pow_mod(&self, rhs: &BoxedUint, p: &Odd<BoxedUint>) -> BoxedUint {
         BoxedMontyForm::new(self.clone(), &BoxedMontyParams::new(p.clone()))
             .pow(rhs)

--- a/src/uint/boxed/shl.rs
+++ b/src/uint/boxed/shl.rs
@@ -5,7 +5,9 @@ use crate::{BoxedUint, Choice, Limb, Shl, ShlAssign, ShlVartime, WrappingShl};
 impl BoxedUint {
     /// Computes `self << shift`.
     ///
-    /// Panics if `shift >= Self::BITS`.
+    /// # Panics
+    /// - if `shift >= Self::BITS`.
+    #[must_use]
     pub fn shl(&self, shift: u32) -> BoxedUint {
         let (result, overflow) = self.overflowing_shl(shift);
         assert!(!bool::from(overflow), "attempt to shift left with overflow");
@@ -14,7 +16,8 @@ impl BoxedUint {
 
     /// Computes `self <<= shift`.
     ///
-    /// Panics if `shift >= Self::BITS`.
+    /// # Panics
+    /// - if `shift >= Self::BITS`.
     pub fn shl_assign(&mut self, shift: u32) {
         let overflow = self.overflowing_shl_assign(shift);
         assert!(!bool::from(overflow), "attempt to shift left with overflow");
@@ -24,6 +27,7 @@ impl BoxedUint {
     ///
     /// Returns `self` and a truthy `Choice` if `shift >= self.bits_precision()`,
     /// or the result and a falsy `Choice` otherwise.
+    #[must_use]
     pub fn overflowing_shl(&self, shift: u32) -> (Self, Choice) {
         let mut result = self.clone();
         let overflow = result.as_mut_uint_ref().overflowing_shl_assign(shift);
@@ -33,6 +37,7 @@ impl BoxedUint {
     /// Computes `self << shift` in variable-time.
     ///
     /// Returns `None` if `shift >= self.bits_precision()`, otherwise the shifted result.
+    #[must_use]
     pub fn overflowing_shl_vartime(&self, shift: u32) -> Option<Self> {
         if shift < self.bits_precision() {
             let mut result = self.clone();
@@ -65,6 +70,7 @@ impl BoxedUint {
 
     /// Computes `self << shift` in a panic-free manner, masking off bits of `shift` which would cause the shift to
     /// exceed the type's width.
+    #[must_use]
     pub fn wrapping_shl(&self, shift: u32) -> Self {
         let mut result = self.clone();
         result.wrapping_shl_assign(shift);
@@ -80,6 +86,7 @@ impl BoxedUint {
 
     /// Computes `self << shift` in variable-time in a panic-free manner, masking off bits of `shift` which would cause
     /// the shift to exceed the type's width.
+    #[must_use]
     pub fn wrapping_shl_vartime(&self, shift: u32) -> Self {
         let mut result = self.clone();
         result.as_mut_uint_ref().wrapping_shl_assign_vartime(shift);
@@ -98,6 +105,7 @@ impl BoxedUint {
     ///
     /// When used with a fixed `shift`, this function is constant-time with respect to `self`.
     #[inline(always)]
+    #[must_use]
     pub fn shl_vartime(&self, shift: u32) -> Option<Self> {
         // This could use `UintRef::wrapping_shl_assign_vartime`, but it is faster to operate
         // on a zero'ed clone and let the compiler reuse the memory allocation when possible.

--- a/src/uint/boxed/shr.rs
+++ b/src/uint/boxed/shr.rs
@@ -5,7 +5,9 @@ use crate::{BoxedUint, Choice, Limb, Shr, ShrAssign, ShrVartime, WrappingShr};
 impl BoxedUint {
     /// Computes `self >> shift`.
     ///
-    /// Panics if `shift >= Self::BITS`.
+    /// # Panics
+    /// - if `shift >= Self::BITS`.
+    #[must_use]
     pub fn shr(&self, shift: u32) -> BoxedUint {
         let (result, overflow) = self.overflowing_shr(shift);
         assert!(
@@ -17,7 +19,8 @@ impl BoxedUint {
 
     /// Computes `self >>= shift`.
     ///
-    /// Panics if `shift >= Self::BITS`.
+    /// # Panics
+    /// - if `shift >= Self::BITS`.
     pub fn shr_assign(&mut self, shift: u32) {
         let overflow = self.overflowing_shr_assign(shift);
         assert!(
@@ -30,6 +33,7 @@ impl BoxedUint {
     ///
     /// Returns `self` and a truthy `Choice` if `shift >= self.bits_precision()`,
     /// or the result and a falsy `Choice` otherwise.
+    #[must_use]
     pub fn overflowing_shr(&self, shift: u32) -> (Self, Choice) {
         let mut result = self.clone();
         let overflow = result.overflowing_shr_assign(shift);
@@ -39,6 +43,7 @@ impl BoxedUint {
     /// Computes `self >> shift` in variable-time.
     ///
     /// Returns `None` if `shift >= self.bits_precision()`, otherwise the shifted result.
+    #[must_use]
     pub fn overflowing_shr_vartime(&self, shift: u32) -> Option<Self> {
         if shift < self.bits_precision() {
             let mut result = self.clone();
@@ -71,6 +76,7 @@ impl BoxedUint {
 
     /// Computes `self >> shift` in a panic-free manner, masking off bits of `shift` which would cause the shift to
     /// exceed the type's width.
+    #[must_use]
     pub fn wrapping_shr(&self, shift: u32) -> Self {
         let mut result = self.clone();
         result.wrapping_shr_assign(shift);
@@ -86,6 +92,7 @@ impl BoxedUint {
 
     /// Computes `self >> shift` in variable-time in a panic-free manner, masking off bits of `shift` which would cause
     /// the shift to exceed the type's width.
+    #[must_use]
     pub fn wrapping_shr_vartime(&self, shift: u32) -> Self {
         let mut result = self.clone();
         result.wrapping_shr_assign_vartime(shift);
@@ -104,6 +111,7 @@ impl BoxedUint {
     ///
     /// When used with a fixed `shift`, this function is constant-time with respect to `self`.
     #[inline(always)]
+    #[must_use]
     pub fn shr_vartime(&self, shift: u32) -> Option<Self> {
         // This could use `UintRef::wrapping_shr_assign_vartime`, but it is faster to operate
         // on a zero'ed clone and let the compiler reuse the memory allocation when possible.

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -9,6 +9,7 @@ impl BoxedUint {
     ///
     /// Callers can check if `self` is a square by squaring the result.
     #[deprecated(since = "0.7.0", note = "please use `floor_sqrt` instead")]
+    #[must_use]
     pub fn sqrt(&self) -> Self {
         self.floor_sqrt()
     }
@@ -16,6 +17,7 @@ impl BoxedUint {
     /// Computes √(`self`) in constant time.
     ///
     /// Callers can check if `self` is a square by squaring the result.
+    #[must_use]
     pub fn floor_sqrt(&self) -> Self {
         // Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.13.
         //
@@ -62,6 +64,7 @@ impl BoxedUint {
     ///
     /// Variable time with respect to `self`.
     #[deprecated(since = "0.7.0", note = "please use `floor_sqrt_vartime` instead")]
+    #[must_use]
     pub fn sqrt_vartime(&self) -> Self {
         self.floor_sqrt_vartime()
     }
@@ -71,6 +74,7 @@ impl BoxedUint {
     /// Callers can check if `self` is a square by squaring the result.
     ///
     /// Variable time with respect to `self`.
+    #[must_use]
     pub fn floor_sqrt_vartime(&self) -> Self {
         // Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.13
 
@@ -113,6 +117,7 @@ impl BoxedUint {
     /// Wrapped sqrt is just `floor(√(self))`.
     /// There’s no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations.
+    #[must_use]
     pub fn wrapping_sqrt(&self) -> Self {
         self.floor_sqrt()
     }
@@ -122,12 +127,14 @@ impl BoxedUint {
     /// This function exists so that all operations are accounted for in the wrapping operations.
     ///
     /// Variable time with respect to `self`.
+    #[must_use]
     pub fn wrapping_sqrt_vartime(&self) -> Self {
         self.floor_sqrt_vartime()
     }
 
     /// Perform checked sqrt, returning a [`CtOption`] which `is_some`
     /// only if the square root is exact.
+    #[must_use]
     pub fn checked_sqrt(&self) -> CtOption<Self> {
         let r = self.floor_sqrt();
         let s = r.wrapping_square();
@@ -138,6 +145,7 @@ impl BoxedUint {
     /// only if the square root is exact.
     ///
     /// Variable time with respect to `self`.
+    #[must_use]
     pub fn checked_sqrt_vartime(&self) -> Option<Self> {
         let r = self.floor_sqrt_vartime();
         let s = r.wrapping_square();

--- a/src/uint/boxed/sub.rs
+++ b/src/uint/boxed/sub.rs
@@ -8,19 +8,22 @@ use crate::{
 impl BoxedUint {
     /// Computes `self - (rhs + borrow)`, returning the result along with the new borrow.
     #[deprecated(since = "0.7.0", note = "please use `borrowing_sub` instead")]
+    #[must_use]
     pub fn sbb(&self, rhs: &Self, borrow: Limb) -> (Self, Limb) {
         self.borrowing_sub(rhs, borrow)
     }
 
     /// Computes `self - (rhs + borrow)`, returning the result along with the new borrow.
     #[inline(always)]
+    #[must_use]
     pub fn borrowing_sub(&self, rhs: &Self, borrow: Limb) -> (Self, Limb) {
-        Self::fold_limbs(self, rhs, borrow, |a, b, c| a.borrowing_sub(b, c))
+        Self::fold_limbs(self, rhs, borrow, Limb::borrowing_sub)
     }
 
     /// Computes `a - (b + borrow)` in-place, returning the new borrow.
     ///
-    /// Panics if `rhs` has a larger precision than `self`.
+    /// # Panics
+    /// - if `rhs` has a larger precision than `self`.
     #[deprecated(since = "0.7.0", note = "please use `borrowing_sub_assign` instead")]
     pub fn sbb_assign(&mut self, rhs: impl AsRef<[Limb]>, borrow: Limb) -> Limb {
         self.borrowing_sub_assign(rhs, borrow)
@@ -28,7 +31,8 @@ impl BoxedUint {
 
     /// Computes `a - (b + borrow)` in-place, returning the new borrow.
     ///
-    /// Panics if `rhs` has a larger precision than `self`.
+    /// # Panics
+    /// - if `rhs` has a larger precision than `self`.
     #[inline(always)]
     pub fn borrowing_sub_assign(&mut self, rhs: impl AsRef<[Limb]>, mut borrow: Limb) -> Limb {
         debug_assert!(self.bits_precision() >= (rhs.as_ref().len() as u32 * Limb::BITS));
@@ -44,6 +48,7 @@ impl BoxedUint {
     }
 
     /// Perform wrapping subtraction, discarding overflow.
+    #[must_use]
     pub fn wrapping_sub(&self, rhs: &Self) -> Self {
         self.borrowing_sub(rhs, Limb::ZERO).0
     }
@@ -112,7 +117,7 @@ impl Sub<&BoxedUint> for &BoxedUint {
 
 impl SubAssign<BoxedUint> for BoxedUint {
     fn sub_assign(&mut self, rhs: BoxedUint) {
-        self.sub_assign(&rhs)
+        self.sub_assign(&rhs);
     }
 }
 

--- a/src/uint/boxed/sub_mod.rs
+++ b/src/uint/boxed/sub_mod.rs
@@ -6,6 +6,7 @@ impl BoxedUint {
     /// Computes `self - rhs mod p`.
     ///
     /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
+    #[must_use]
     pub fn sub_mod(&self, rhs: &Self, p: &NonZero<Self>) -> Self {
         debug_assert_eq!(self.bits_precision(), p.bits_precision());
         debug_assert_eq!(rhs.bits_precision(), p.bits_precision());
@@ -40,6 +41,7 @@ impl BoxedUint {
     /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
     ///
     /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
+    #[must_use]
     pub fn sub_mod_special(&self, rhs: &Self, c: Limb) -> Self {
         let (out, borrow) = self.borrowing_sub(rhs, Limb::ZERO);
 

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -97,6 +97,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Returns the Ordering between `self` and `rhs` in variable time.
+    #[must_use]
     pub const fn cmp_vartime(&self, rhs: &Self) -> Ordering {
         let mut i = LIMBS - 1;
         loop {

--- a/src/uint/concat.rs
+++ b/src/uint/concat.rs
@@ -3,6 +3,7 @@ use crate::{Concat, ConcatMixed, Limb, Uint};
 impl<const L: usize> Uint<L> {
     /// Concatenate the two values, with `self` as least significant and `hi` as the most
     /// significant.
+    #[must_use]
     pub const fn concat<const O: usize>(&self, hi: &Self) -> Uint<O>
     where
         Self: Concat<Output = Uint<O>>,
@@ -13,6 +14,7 @@ impl<const L: usize> Uint<L> {
     /// Concatenate the two values, with `lo` as least significant and `hi`
     /// as the most significant.
     #[inline]
+    #[must_use]
     pub const fn concat_mixed<const H: usize, const O: usize>(lo: &Uint<L>, hi: &Uint<H>) -> Uint<O>
     where
         Self: ConcatMixed<Uint<H>, MixedOutput = Uint<O>>,

--- a/src/uint/ct.rs
+++ b/src/uint/ct.rs
@@ -33,7 +33,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Swap `a` and `b`
     #[inline]
     pub(crate) const fn swap(a: &mut Self, b: &mut Self) {
-        Self::conditional_swap(a, b, Choice::TRUE)
+        Self::conditional_swap(a, b, Choice::TRUE);
     }
 }
 

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -9,6 +9,7 @@ use crate::{
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self / rhs` using a pre-made reciprocal, returning the quotient
     /// and remainder.
+    #[must_use]
     pub const fn div_rem_limb_with_reciprocal(&self, reciprocal: &Reciprocal) -> (Self, Limb) {
         let mut quo = *self;
         let rem = quo
@@ -18,6 +19,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Computes `self / rhs`, returning the quotient and remainder.
+    #[must_use]
     pub const fn div_rem_limb(&self, rhs: NonZero<Limb>) -> (Self, Limb) {
         let mut quo = *self;
         let rem = quo.as_mut_uint_ref().div_rem_limb(rhs);
@@ -25,12 +27,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Computes `self % rhs` using a pre-made reciprocal.
+    #[must_use]
     pub const fn rem_limb_with_reciprocal(&self, reciprocal: &Reciprocal) -> Limb {
         self.as_uint_ref()
             .rem_limb_with_reciprocal(reciprocal, Limb::ZERO)
     }
 
     /// Computes `self % rhs` for a `Limb`-sized divisor.
+    #[must_use]
     pub const fn rem_limb(&self, rhs: NonZero<Limb>) -> Limb {
         self.as_uint_ref().rem_limb(rhs)
     }
@@ -38,6 +42,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self` / `rhs`, returning the quotient and the remainder.
     ///
     /// This function is constant-time with respect to both `self` and `rhs`.
+    #[must_use]
     pub const fn div_rem<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
@@ -54,6 +59,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
     #[inline]
+    #[must_use]
     pub const fn div_rem_vartime<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
@@ -64,6 +70,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Computes `self` % `rhs`.
+    #[must_use]
     pub const fn rem<const RHS_LIMBS: usize>(
         &self,
         rhs: &NonZero<Uint<RHS_LIMBS>>,
@@ -78,6 +85,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
     #[inline]
+    #[must_use]
     pub const fn rem_vartime(&self, rhs: &NonZero<Self>) -> Self {
         let (mut x, mut y) = (*self, *rhs.as_ref());
         UintRef::rem_wide_vartime(
@@ -89,6 +97,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes `self` % `rhs` for a double-width `Uint`.
     #[inline]
+    #[must_use]
     pub const fn rem_wide(mut lower_upper: (Self, Self), rhs: &NonZero<Self>) -> Self {
         let mut y = *rhs.as_ref();
         UintRef::rem_wide(
@@ -108,6 +117,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// When used with a fixed `rhs`, this function is constant-time with respect
     /// to `self`.
     #[inline]
+    #[must_use]
     pub const fn rem_wide_vartime(mut lower_upper: (Self, Self), rhs: &NonZero<Self>) -> Self {
         let mut y = *rhs.as_ref();
         UintRef::rem_wide_vartime(
@@ -134,6 +144,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// // As 10 % 8 = 2
     /// assert_eq!(remainder, U448::from(2_u64));
     /// ```
+    #[must_use]
     pub const fn rem2k_vartime(&self, k: u32) -> Self {
         self.restrict_bits(k)
     }
@@ -142,6 +153,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// There’s no way wrapping could ever happen.
     /// This function exists, so that all operations are accounted for in the wrapping operations.
+    #[must_use]
     pub const fn wrapping_div(&self, rhs: &NonZero<Self>) -> Self {
         self.div_rem(rhs).0
     }
@@ -150,6 +162,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// There’s no way wrapping could ever happen.
     /// This function exists, so that all operations are accounted for in the wrapping operations.
+    #[must_use]
     pub const fn wrapping_div_vartime<const RHS: usize>(&self, rhs: &NonZero<Uint<RHS>>) -> Self {
         self.div_rem_vartime(rhs).0
     }
@@ -172,6 +185,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// let zero = U448::from(0_u64);
     /// assert!(a.checked_div(&zero).is_none().to_bool(), "should be None for division by zero");
     /// ```
+    #[must_use]
     pub fn checked_div<const RHS_LIMBS: usize>(&self, rhs: &Uint<RHS_LIMBS>) -> CtOption<Self> {
         NonZero::new(*rhs).map(|rhs| {
             let (q, _r) = self.div_rem(&rhs);
@@ -180,7 +194,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// This function exists, so that all operations are accounted for in the wrapping operations.
-    /// Panics if `rhs == 0`.
+    ///
+    /// # Panics
+    /// - if `rhs == 0`.
     ///
     /// ### Usage:
     /// ```
@@ -192,6 +208,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// assert_eq!(remainder, U448::from(1_u64));
     /// ```
+    #[must_use]
     pub const fn wrapping_rem_vartime(&self, rhs: &Self) -> Self {
         let nz_rhs = rhs.to_nz().expect_copied("non-zero divisor");
         self.rem_vartime(&nz_rhs)
@@ -215,6 +232,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// assert!(a.checked_rem(&zero).is_none().to_bool(), "should be None for reduction by zero");
     /// ```
+    #[must_use]
     pub fn checked_rem<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
@@ -311,7 +329,7 @@ impl<const LIMBS: usize> Div<&NonZero<Limb>> for Wrapping<Uint<LIMBS>> {
 
 impl<const LIMBS: usize> DivAssign<&NonZero<Limb>> for Wrapping<Uint<LIMBS>> {
     fn div_assign(&mut self, rhs: &NonZero<Limb>) {
-        *self = Wrapping(self.0 / rhs)
+        *self = Wrapping(self.0 / rhs);
     }
 }
 
@@ -406,7 +424,7 @@ impl<const LIMBS: usize> RemAssign<NonZero<Limb>> for Wrapping<Uint<LIMBS>> {
 
 impl<const LIMBS: usize> RemAssign<&NonZero<Limb>> for Wrapping<Uint<LIMBS>> {
     fn rem_assign(&mut self, rhs: &NonZero<Limb>) {
-        *self = Wrapping((self.0 % rhs).into())
+        *self = Wrapping((self.0 % rhs).into());
     }
 }
 
@@ -455,7 +473,7 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Div<NonZero<Uint<RHS_LIMBS>>> f
 
 impl<const LIMBS: usize> DivAssign<&NonZero<Uint<LIMBS>>> for Uint<LIMBS> {
     fn div_assign(&mut self, rhs: &NonZero<Uint<LIMBS>>) {
-        *self /= *rhs
+        *self /= *rhs;
     }
 }
 
@@ -597,7 +615,7 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Rem<Uint<RHS_LIMBS>> for Uint<L
 
 impl<const LIMBS: usize> RemAssign<&NonZero<Uint<LIMBS>>> for Uint<LIMBS> {
     fn rem_assign(&mut self, rhs: &NonZero<Uint<LIMBS>>) {
-        *self %= *rhs
+        *self %= *rhs;
     }
 }
 
@@ -655,7 +673,7 @@ impl<const LIMBS: usize> RemAssign<NonZero<Uint<LIMBS>>> for Wrapping<Uint<LIMBS
 
 impl<const LIMBS: usize> RemAssign<&NonZero<Uint<LIMBS>>> for Wrapping<Uint<LIMBS>> {
     fn rem_assign(&mut self, rhs: &NonZero<Uint<LIMBS>>) {
-        *self = Wrapping(self.0 % rhs)
+        *self = Wrapping(self.0 % rhs);
     }
 }
 

--- a/src/uint/div_limb.rs
+++ b/src/uint/div_limb.rs
@@ -188,6 +188,7 @@ pub struct Reciprocal {
 impl Reciprocal {
     /// Pre-calculates a reciprocal for a known divisor,
     /// to be used in the single-limb division later.
+    #[must_use]
     pub const fn new(divisor: NonZero<Limb>) -> Self {
         let divisor = divisor.0;
 
@@ -209,6 +210,7 @@ impl Reciprocal {
     ///
     /// NOTE: intended for using it as a placeholder during compile-time array generation,
     /// don't rely on the contents.
+    #[must_use]
     pub const fn default() -> Self {
         Self {
             divisor_normalized: Word::MAX,
@@ -220,6 +222,7 @@ impl Reciprocal {
     }
 
     /// Get the shift value
+    #[must_use]
     pub const fn shift(&self) -> u32 {
         self.shift
     }

--- a/src/uint/encoding/der.rs
+++ b/src/uint/encoding/der.rs
@@ -76,11 +76,9 @@ pub(crate) fn count_der_be_bytes(limbs: &[Limb]) -> u32 {
         .saturating_sub(leading_zero_bytes as usize / Limb::BYTES);
 
     // Limb bytes encoded as big-endian
-    let first_nonzero_byte = limbs
-        .get(limb_index)
-        .cloned()
-        .map(|limb| limb.to_be_bytes()[leading_zero_bytes as usize % Limb::BYTES])
-        .unwrap_or(0x00);
+    let first_nonzero_byte = limbs.get(limb_index).cloned().map_or(0x00, |limb| {
+        limb.to_be_bytes()[leading_zero_bytes as usize % Limb::BYTES]
+    });
 
     // Does the given integer need a leading zero?
     let needs_leading_zero = first_nonzero_byte >= 0x80;
@@ -142,6 +140,7 @@ pub mod test {
     use crate::{ArrayEncoding, BoxedUint, U128, Uint};
     use der::{DecodeValue, EncodeValue, Header, Tag};
 
+    #[allow(clippy::panic_in_result_fn)]
     fn assert_valid_uint_value_len<const LIMBS: usize>(n: &Uint<LIMBS>) -> der::Result<()>
     where
         Uint<LIMBS>: ArrayEncoding,
@@ -171,6 +170,7 @@ pub mod test {
     }
 
     #[cfg(feature = "alloc")]
+    #[allow(clippy::panic_in_result_fn)]
     fn assert_valid_boxeduint_value_len(n: &BoxedUint) -> der::Result<()> {
         let mut buf = [0u8; 128];
         let encoded_value = {

--- a/src/uint/from.rs
+++ b/src/uint/from.rs
@@ -2,12 +2,24 @@
 
 use crate::{ConcatMixed, Limb, SplitMixed, U64, U128, Uint, WideWord, Word};
 
+macro_rules! check_limbs {
+    ($limbs:expr) => {
+        check_limbs!($limbs, 1)
+    };
+    ($limbs:expr, $min:expr) => {
+        const {
+            assert!($limbs >= 1, "number of limbs too small of supplied type");
+        }
+    };
+}
+
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a [`Uint`] from a `u8` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u8>` when stable
     #[inline]
+    #[must_use]
     pub const fn from_u8(n: u8) -> Self {
-        assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        check_limbs!(LIMBS);
         let mut limbs = [Limb::ZERO; LIMBS];
         limbs[0].0 = n as Word;
         Self { limbs }
@@ -16,8 +28,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a [`Uint`] from a `u16` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u16>` when stable
     #[inline]
+    #[must_use]
     pub const fn from_u16(n: u16) -> Self {
-        assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        check_limbs!(LIMBS);
         let mut limbs = [Limb::ZERO; LIMBS];
         limbs[0].0 = n as Word;
         Self { limbs }
@@ -27,8 +40,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     // TODO(tarcieri): replace with `const impl From<u32>` when stable
     #[allow(trivial_numeric_casts)]
     #[inline]
+    #[must_use]
     pub const fn from_u32(n: u32) -> Self {
-        assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        check_limbs!(LIMBS);
         let mut limbs = [Limb::ZERO; LIMBS];
         limbs[0].0 = n as Word;
         Self { limbs }
@@ -39,7 +53,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     #[cfg(target_pointer_width = "32")]
     #[inline]
     pub const fn from_u64(n: u64) -> Self {
-        assert!(LIMBS >= 2, "number of limbs must be two or greater");
+        check_limbs!(LIMBS, 2);
         let mut limbs = [Limb::ZERO; LIMBS];
         limbs[0].0 = (n & 0xFFFFFFFF) as u32;
         limbs[1].0 = (n >> 32) as u32;
@@ -50,8 +64,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     // TODO(tarcieri): replace with `const impl From<u64>` when stable
     #[cfg(target_pointer_width = "64")]
     #[inline]
+    #[must_use]
     pub const fn from_u64(n: u64) -> Self {
-        assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        check_limbs!(LIMBS);
         let mut limbs = [Limb::ZERO; LIMBS];
         limbs[0].0 = n;
         Self { limbs }
@@ -60,12 +75,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a [`Uint`] from a `u128` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<u128>` when stable
     #[inline]
+    #[must_use]
     pub const fn from_u128(n: u128) -> Self {
-        assert!(
-            LIMBS >= 16 / Limb::BYTES,
-            "number of limbs must be greater than zero"
-        );
-
+        check_limbs!(LIMBS, 16 / Limb::BYTES);
         let lo = U64::from_u64((n & 0xffff_ffff_ffff_ffff) as u64);
         let hi = U64::from_u64((n >> 64) as u64);
 
@@ -89,8 +101,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a [`Uint`] from a `Word` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<Word>` when stable
     #[inline]
+    #[must_use]
     pub const fn from_word(n: Word) -> Self {
-        assert!(LIMBS >= 1, "number of limbs must be greater than zero");
+        check_limbs!(LIMBS);
         let mut limbs = [Limb::ZERO; LIMBS];
         limbs[0].0 = n;
         Self { limbs }
@@ -99,8 +112,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Create a [`Uint`] from a `WideWord` (const-friendly)
     // TODO(tarcieri): replace with `const impl From<WideWord>` when stable
     #[inline]
+    #[must_use]
     pub const fn from_wide_word(n: WideWord) -> Self {
-        assert!(LIMBS >= 2, "number of limbs must be two or greater");
+        check_limbs!(LIMBS, 2);
         let mut limbs = [Limb::ZERO; LIMBS];
         limbs[0].0 = n as Word;
         limbs[1].0 = (n >> Limb::BITS) as Word;
@@ -111,8 +125,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 impl<const LIMBS: usize> From<u8> for Uint<LIMBS> {
     #[inline]
     fn from(n: u8) -> Self {
-        // TODO(tarcieri): const where clause when possible
-        debug_assert!(LIMBS > 0, "limbs must be non-zero");
+        check_limbs!(LIMBS);
         Self::from_u8(n)
     }
 }
@@ -120,8 +133,7 @@ impl<const LIMBS: usize> From<u8> for Uint<LIMBS> {
 impl<const LIMBS: usize> From<u16> for Uint<LIMBS> {
     #[inline]
     fn from(n: u16) -> Self {
-        // TODO(tarcieri): const where clause when possible
-        debug_assert!(LIMBS > 0, "limbs must be non-zero");
+        check_limbs!(LIMBS);
         Self::from_u16(n)
     }
 }
@@ -129,8 +141,7 @@ impl<const LIMBS: usize> From<u16> for Uint<LIMBS> {
 impl<const LIMBS: usize> From<u32> for Uint<LIMBS> {
     #[inline]
     fn from(n: u32) -> Self {
-        // TODO(tarcieri): const where clause when possible
-        debug_assert!(LIMBS > 0, "limbs must be non-zero");
+        check_limbs!(LIMBS);
         Self::from_u32(n)
     }
 }
@@ -138,8 +149,7 @@ impl<const LIMBS: usize> From<u32> for Uint<LIMBS> {
 impl<const LIMBS: usize> From<u64> for Uint<LIMBS> {
     #[inline]
     fn from(n: u64) -> Self {
-        // TODO(tarcieri): const where clause when possible
-        debug_assert!(LIMBS >= 8 / Limb::BYTES, "not enough limbs");
+        check_limbs!(LIMBS, 8 / Limb::BYTES);
         Self::from_u64(n)
     }
 }
@@ -147,8 +157,7 @@ impl<const LIMBS: usize> From<u64> for Uint<LIMBS> {
 impl<const LIMBS: usize> From<u128> for Uint<LIMBS> {
     #[inline]
     fn from(n: u128) -> Self {
-        // TODO(tarcieri): const where clause when possible
-        debug_assert!(LIMBS >= 16 / Limb::BYTES, "not enough limbs");
+        check_limbs!(LIMBS, 16 / Limb::BYTES);
         Self::from_u128(n)
     }
 }

--- a/src/uint/gcd.rs
+++ b/src/uint/gcd.rs
@@ -8,6 +8,7 @@ use crate::{
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Compute the greatest common divisor of `self` and `rhs`.
+    #[must_use]
     pub const fn gcd(&self, rhs: &Self) -> Self {
         let self_is_nz = self.is_nonzero();
         // Note: is non-zero by construction
@@ -18,6 +19,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Compute the greatest common divisor of `self` and `rhs`.
     ///
     /// Executes in variable time w.r.t. all input parameters.
+    #[must_use]
     pub const fn gcd_vartime(&self, rhs: &Self) -> Self {
         if self.is_zero_vartime() {
             return *rhs;
@@ -28,6 +30,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Executes the Extended GCD algorithm.
     ///
     /// Given `(self, rhs)`, computes `(g, x, y)`, s.t. `self * x + rhs * y = g = gcd(self, rhs)`.
+    #[must_use]
     pub const fn xgcd(&self, rhs: &Self) -> UintXgcdOutput<LIMBS> {
         // Make sure `self` and `rhs` are nonzero.
         let self_is_zero = self.is_nonzero().not();
@@ -72,6 +75,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
 impl<const LIMBS: usize> NonZeroUint<LIMBS> {
     /// Compute the greatest common divisor of `self` and `rhs`.
+    #[must_use]
     pub const fn gcd_unsigned(&self, rhs: &Uint<LIMBS>) -> Self {
         let lhs = self.as_ref();
 
@@ -97,6 +101,7 @@ impl<const LIMBS: usize> NonZeroUint<LIMBS> {
     /// Compute the greatest common divisor of `self` and `rhs`.
     ///
     /// Executes in variable time w.r.t. all input parameters.
+    #[must_use]
     pub const fn gcd_unsigned_vartime(&self, rhs: &Uint<LIMBS>) -> Self {
         let lhs = self.as_ref();
 
@@ -112,6 +117,7 @@ impl<const LIMBS: usize> NonZeroUint<LIMBS> {
     /// Execute the Extended GCD algorithm.
     ///
     /// Given `(self, rhs)`, computes `(g, x, y)` s.t. `self * x + rhs * y = g = gcd(self, rhs)`.
+    #[must_use]
     pub const fn xgcd(&self, rhs: &Self) -> NonZeroUintXgcdOutput<LIMBS> {
         let (mut lhs, mut rhs) = (*self.as_ref(), *rhs.as_ref());
 
@@ -136,6 +142,7 @@ impl<const LIMBS: usize> NonZeroUint<LIMBS> {
 impl<const LIMBS: usize> OddUint<LIMBS> {
     /// Compute the greatest common divisor of `self` and `rhs`.
     #[inline(always)]
+    #[must_use]
     pub const fn gcd_unsigned(&self, rhs: &Uint<LIMBS>) -> Self {
         if LIMBS == 1 {
             Self::classic_bingcd(self, rhs)
@@ -148,6 +155,7 @@ impl<const LIMBS: usize> OddUint<LIMBS> {
     ///
     /// Executes in variable time w.r.t. all input parameters.
     #[inline(always)]
+    #[must_use]
     pub const fn gcd_unsigned_vartime(&self, rhs: &Uint<LIMBS>) -> Self {
         if LIMBS == 1 {
             Self::classic_bingcd_vartime(self, rhs)
@@ -163,6 +171,7 @@ impl<const LIMBS: usize> OddUint<LIMBS> {
     /// manually test whether the classic or optimized algorithm is faster for your machine.
     #[doc(hidden)]
     #[inline(always)]
+    #[must_use]
     pub const fn bingcd(&self, rhs: &Uint<LIMBS>) -> Self {
         if LIMBS < 4 {
             self.classic_bingcd(rhs)
@@ -180,6 +189,7 @@ impl<const LIMBS: usize> OddUint<LIMBS> {
     /// manually test whether the classic or optimized algorithm is faster for your machine.
     #[doc(hidden)]
     #[inline(always)]
+    #[must_use]
     pub const fn bingcd_vartime(&self, rhs: &Uint<LIMBS>) -> Self {
         if LIMBS < 4 {
             self.classic_bingcd_vartime(rhs)
@@ -191,6 +201,7 @@ impl<const LIMBS: usize> OddUint<LIMBS> {
     /// Compute the greatest common divisor of `self` and `rhs`.
     #[doc(hidden)]
     #[inline]
+    #[must_use]
     pub const fn safegcd(&self, rhs: &Uint<LIMBS>) -> Self {
         safegcd::gcd_odd::<LIMBS, false>(self, rhs)
     }
@@ -200,6 +211,7 @@ impl<const LIMBS: usize> OddUint<LIMBS> {
     /// Executes in variable time w.r.t. all input parameters.
     #[doc(hidden)]
     #[inline]
+    #[must_use]
     pub const fn safegcd_vartime(&self, rhs: &Uint<LIMBS>) -> Self {
         safegcd::gcd_odd::<LIMBS, true>(self, rhs)
     }
@@ -207,6 +219,7 @@ impl<const LIMBS: usize> OddUint<LIMBS> {
     /// Execute the Extended GCD algorithm.
     ///
     /// Given `(self, rhs)`, computes `(g, x, y)` s.t. `self * x + rhs * y = g = gcd(self, rhs)`.
+    #[must_use]
     pub const fn xgcd(&self, rhs: &Self) -> OddUintXgcdOutput<LIMBS> {
         OddUintXgcdOutput::from_pattern_output(self.binxgcd_odd(rhs))
     }
@@ -420,7 +433,7 @@ mod tests {
 
         fn test<const LIMBS: usize>(lhs: Uint<LIMBS>, rhs: Uint<LIMBS>, target: Uint<LIMBS>) {
             assert_eq!(lhs.gcd(&rhs), target);
-            assert_eq!(lhs.gcd_vartime(&rhs), target)
+            assert_eq!(lhs.gcd_vartime(&rhs), target);
         }
 
         fn run_tests<const LIMBS: usize>() {

--- a/src/uint/invert_mod.rs
+++ b/src/uint/invert_mod.rs
@@ -94,6 +94,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// returns `Choice::FALSE` as the second element of the tuple,
     /// otherwise returns `Choice::TRUE`.
     #[deprecated(since = "0.7.0", note = "please use `invert_mod2k_vartime` instead")]
+    #[must_use]
     pub const fn inv_mod2k_vartime(&self, k: u32) -> CtOption<Self> {
         self.invert_mod2k_vartime(k)
     }
@@ -103,6 +104,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// If the inverse does not exist (`k > 0` and `self` is even, or `k > Self::BITS`),
     /// returns `CtOption::none`, otherwise returns `CtOption::some`.
+    #[must_use]
     pub const fn invert_mod2k_vartime(&self, k: u32) -> CtOption<Self> {
         if k == 0 {
             CtOption::some(Self::ZERO)
@@ -120,6 +122,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// If the inverse does not exist (`k > 0` and `self` is even, `k > Self::BITS`),
     /// returns `CtOption::none`, otherwise returns `CtOption::some`.
     #[deprecated(since = "0.7.0", note = "please use `invert_mod2k` instead")]
+    #[must_use]
     pub const fn inv_mod2k(&self, k: u32) -> CtOption<Self> {
         self.invert_mod2k(k)
     }
@@ -128,6 +131,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// If the inverse does not exist (`k > 0` and `self` is even, or `k > Self::BITS`),
     /// returns `CtOption::none`, otherwise returns `CtOption::some`.
+    #[must_use]
     pub const fn invert_mod2k(&self, k: u32) -> CtOption<Self> {
         let is_some =
             Choice::from_u32_le(k, Self::BITS).and(Choice::from_u32_nz(k).not().or(self.is_odd()));
@@ -137,11 +141,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
     #[deprecated(since = "0.7.0", note = "please use `invert_odd_mod` instead")]
+    #[must_use]
     pub const fn inv_odd_mod(&self, modulus: &Odd<Self>) -> CtOption<Self> {
         self.invert_odd_mod(modulus)
     }
 
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
+    #[must_use]
     pub const fn invert_odd_mod(&self, modulus: &Odd<Self>) -> CtOption<Self> {
         safegcd::invert_odd_mod::<LIMBS>(self, modulus)
     }
@@ -149,6 +155,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
     ///
     /// This method is variable-time with respect to `self`.
+    #[must_use]
     pub const fn invert_odd_mod_vartime(&self, modulus: &Odd<Self>) -> Option<Self> {
         safegcd::invert_odd_mod_vartime::<LIMBS>(self, modulus)
     }
@@ -157,6 +164,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Returns some if an inverse exists, otherwise none.
     #[deprecated(since = "0.7.0", note = "please use `invert_mod` instead")]
+    #[must_use]
     pub const fn inv_mod(&self, modulus: &Self) -> CtOption<Self> {
         let is_nz = modulus.is_nonzero();
         let m = NonZero(Uint::select(&Uint::ONE, modulus, is_nz));
@@ -166,6 +174,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes the multiplicative inverse of `self` mod `modulus`.
     ///
     /// Returns some if an inverse exists, otherwise none.
+    #[must_use]
     pub const fn invert_mod(&self, modulus: &NonZero<Self>) -> CtOption<Self> {
         // Decompose `modulus = s * 2^k` where `s` is odd
         let k = modulus.as_ref().trailing_zeros();

--- a/src/uint/lcm.rs
+++ b/src/uint/lcm.rs
@@ -4,6 +4,7 @@ use crate::{ConcatMixed, NonZero, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Compute the least common multiple of `self` and `rhs`.
+    #[must_use]
     pub const fn lcm<const WIDE_LIMBS: usize>(&self, rhs: &Self) -> Uint<WIDE_LIMBS>
     where
         Self: ConcatMixed<Uint<LIMBS>, MixedOutput = Uint<WIDE_LIMBS>>,

--- a/src/uint/mod_symbol.rs
+++ b/src/uint/mod_symbol.rs
@@ -7,6 +7,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// For prime `rhs`, this corresponds to the Legendre symbol and
     /// indicates whether `self` is quadratic residue modulo `rhs`.
+    #[must_use]
     pub const fn jacobi_symbol(&self, rhs: &Odd<Uint<LIMBS>>) -> JacobiSymbol {
         let (gcd, jacobi_neg) = if LIMBS < 4 {
             rhs.classic_bingcd_(self)
@@ -28,6 +29,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// indicates whether `self` is quadratic residue modulo `rhs`.
     ///
     /// This method executes in variable-time for both inputs.
+    #[must_use]
     pub const fn jacobi_symbol_vartime(&self, rhs: &Odd<Uint<LIMBS>>) -> JacobiSymbol {
         let (gcd, jacobi_neg) = if LIMBS < 4 {
             rhs.classic_bingcd_vartime_(self)

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -10,6 +10,7 @@ pub(crate) mod schoolbook;
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Multiply `self` by `rhs`, returning a concatenated "wide" result.
+    #[must_use]
     pub const fn concatenating_mul<const RHS_LIMBS: usize, const WIDE_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
@@ -24,6 +25,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Compute "wide" multiplication as a 2-tuple containing the `(lo, hi)` components of the product, whose sizes
     /// correspond to the sizes of the operands.
     #[deprecated(since = "0.7.0", note = "please use `widening_mul` instead")]
+    #[must_use]
     pub const fn split_mul<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
@@ -34,6 +36,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Compute "wide" multiplication as a 2-tuple containing the `(lo, hi)` components of the product, whose sizes
     /// correspond to the sizes of the operands.
     #[inline(always)]
+    #[must_use]
     pub const fn widening_mul<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
@@ -42,16 +45,19 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Perform wrapping multiplication, discarding overflow.
+    #[must_use]
     pub const fn wrapping_mul<const RHS_LIMBS: usize>(&self, rhs: &Uint<RHS_LIMBS>) -> Self {
         karatsuba::wrapping_mul_fixed::<LIMBS>(self.as_uint_ref(), rhs.as_uint_ref()).0
     }
 
     /// Perform saturating multiplication, returning `MAX` on overflow.
+    #[must_use]
     pub const fn saturating_mul<const RHS_LIMBS: usize>(&self, rhs: &Uint<RHS_LIMBS>) -> Self {
         ctutils::unwrap_or!(self.checked_mul(rhs), Uint::MAX, Self::select)
     }
 
     /// Perform wrapping multiplication, checking that the result fits in the original [`Uint`] size.
+    #[must_use]
     pub const fn checked_mul<const RHS_LIMBS: usize>(
         &self,
         rhs: &Uint<RHS_LIMBS>,
@@ -84,11 +90,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Square self, returning a "wide" result in two parts as (lo, hi).
     #[inline(always)]
+    #[must_use]
     pub const fn square_wide(&self) -> (Self, Self) {
         karatsuba::widening_square_fixed(self.as_uint_ref())
     }
 
     /// Square self, returning a concatenated "wide" result.
+    #[must_use]
     pub const fn widening_square<const WIDE_LIMBS: usize>(&self) -> Uint<WIDE_LIMBS>
     where
         Self: ConcatMixed<Uint<LIMBS>, MixedOutput = Uint<WIDE_LIMBS>>,
@@ -98,6 +106,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Square self, checking that the result fits in the original [`Uint`] size.
+    #[must_use]
     pub const fn checked_square(&self) -> CtOption<Uint<LIMBS>> {
         let (lo, carry) = karatsuba::wrapping_square_fixed(self.as_uint_ref());
         let overflow =
@@ -106,11 +115,13 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Perform wrapping square, discarding overflow.
+    #[must_use]
     pub const fn wrapping_square(&self) -> Uint<LIMBS> {
         karatsuba::wrapping_square_fixed(self.as_uint_ref()).0
     }
 
     /// Perform saturating squaring, returning `MAX` on overflow.
+    #[must_use]
     pub const fn saturating_square(&self) -> Self {
         ctutils::unwrap_or!(self.checked_square(), Self::MAX, Self::select)
     }
@@ -121,6 +132,7 @@ where
     Self: Concat<Output = Uint<WIDE_LIMBS>>,
 {
     /// Square self, returning a concatenated "wide" result.
+    #[must_use]
     pub const fn square(&self) -> Uint<WIDE_LIMBS> {
         let (lo, hi) = self.square_wide();
         lo.concat(&hi)
@@ -168,13 +180,13 @@ impl<const LIMBS: usize, const RHS_LIMBS: usize> Mul<&Uint<RHS_LIMBS>> for &Uint
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> MulAssign<Uint<RHS_LIMBS>> for Uint<LIMBS> {
     fn mul_assign(&mut self, rhs: Uint<RHS_LIMBS>) {
-        *self = self.mul(&rhs)
+        *self = self.mul(&rhs);
     }
 }
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> MulAssign<&Uint<RHS_LIMBS>> for Uint<LIMBS> {
     fn mul_assign(&mut self, rhs: &Uint<RHS_LIMBS>) {
-        *self = self.mul(rhs)
+        *self = self.mul(rhs);
     }
 }
 

--- a/src/uint/mul/karatsuba.rs
+++ b/src/uint/mul/karatsuba.rs
@@ -347,7 +347,7 @@ pub const fn wrapping_mul(lhs: &UintRef, rhs: &UintRef, out: &mut UintRef, add: 
             // Add `x0y` if necessary.
             if !x0.is_empty() {
                 let c = wrapping_mul(x0, y, out, true);
-                carry = carry.wrapping_add(c)
+                carry = carry.wrapping_add(c);
             }
             carry
         }

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -4,12 +4,14 @@ use crate::{Limb, MulMod, NonZero, SquareMod, Uint, WideWord, Word, div_limb::mu
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self * rhs mod p`.
+    #[must_use]
     pub fn mul_mod(&self, rhs: &Uint<LIMBS>, p: &NonZero<Uint<LIMBS>>) -> Uint<LIMBS> {
         let lo_hi = self.widening_mul(rhs);
         Self::rem_wide(lo_hi, p)
     }
 
     /// Computes `self * rhs mod p` in variable time with respect to `p`.
+    #[must_use]
     pub fn mul_mod_vartime(&self, rhs: &Uint<LIMBS>, p: &NonZero<Uint<LIMBS>>) -> Uint<LIMBS> {
         let lo_hi = self.widening_mul(rhs);
         Self::rem_wide_vartime(lo_hi, p)
@@ -21,6 +23,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// For the modulus reduction, this function implements Algorithm 14.47 from
     /// the "Handbook of Applied Cryptography", by A. Menezes, P. van Oorschot,
     /// and S. Vanstone, CRC Press, 1996.
+    #[must_use]
     pub const fn mul_mod_special(&self, rhs: &Self, c: Limb) -> Self {
         // We implicitly assume `LIMBS > 0`, because `Uint<0>` doesn't compile.
         // Still the case `LIMBS == 1` needs special handling.
@@ -52,12 +55,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Computes `self * self mod p`.
+    #[must_use]
     pub const fn square_mod(&self, p: &NonZero<Uint<LIMBS>>) -> Self {
         let lo_hi = self.square_wide();
         Self::rem_wide(lo_hi, p)
     }
 
     /// Computes `self * self mod p` in variable time with respect to `p`.
+    #[must_use]
     pub const fn square_mod_vartime(&self, p: &NonZero<Uint<LIMBS>>) -> Self {
         let lo_hi = self.square_wide();
         Self::rem_wide_vartime(lo_hi, p)

--- a/src/uint/mul_signed.rs
+++ b/src/uint/mul_signed.rs
@@ -7,6 +7,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// negated when converted from [`Uint`] to [`Int`].
     ///
     /// Note: even if `negate` is truthy, the magnitude might be zero!
+    #[must_use]
     pub const fn widening_mul_signed<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
@@ -17,6 +18,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Multiply `self` by [`Int`] `rhs`, returning a concatenated "wide" result.
+    #[must_use]
     pub const fn concatenating_mul_signed<const RHS_LIMBS: usize, const WIDE_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,
@@ -32,6 +34,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Checked multiplication of `self` with [`Int`] `rhs`.
+    #[must_use]
     pub fn checked_mul_signed<const RHS_LIMBS: usize>(
         &self,
         rhs: &Int<RHS_LIMBS>,

--- a/src/uint/neg.rs
+++ b/src/uint/neg.rs
@@ -2,6 +2,7 @@ use crate::{Choice, Limb, Uint, WideWord, Word, WrappingNeg, word};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Perform wrapping negation.
+    #[must_use]
     pub const fn wrapping_neg(&self) -> Self {
         self.carrying_neg().0
     }
@@ -10,6 +11,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Additionally return whether the carry flag is set on the addition.
     ///
     /// Note: the carry is set if and only if `self == Self::ZERO`.
+    #[must_use]
     pub const fn carrying_neg(&self) -> (Self, Choice) {
         let mut ret = [Limb::ZERO; LIMBS];
         let mut carry = 1;
@@ -24,6 +26,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Perform wrapping negation, if `negate` is truthy. Otherwise, return `self`.
+    #[must_use]
     pub const fn wrapping_neg_if(&self, negate: Choice) -> Self {
         Uint::select(self, &self.wrapping_neg(), negate)
     }

--- a/src/uint/neg_mod.rs
+++ b/src/uint/neg_mod.rs
@@ -5,6 +5,7 @@ use crate::{Limb, NegMod, NonZero, Uint, word};
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `-a mod p`.
     /// Assumes `self` is in `[0, p)`.
+    #[must_use]
     pub const fn neg_mod(&self, p: &NonZero<Self>) -> Self {
         let z = self.is_nonzero();
         let mut ret = p.as_ref().borrowing_sub(self, Limb::ZERO).0;
@@ -20,6 +21,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes `-a mod p` for the special modulus
     /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
+    #[must_use]
     pub const fn neg_mod_special(&self, c: Limb) -> Self {
         Self::ZERO.sub_mod_special(self, c)
     }

--- a/src/uint/pow.rs
+++ b/src/uint/pow.rs
@@ -7,6 +7,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self^exp`, returning a `CtOption` which is none in the case of overflow.
     ///
     /// This method is variable time in the exponent `exp`.
+    #[must_use]
     pub fn checked_pow_vartime(&self, exp: u32) -> CtOption<Self> {
         if exp == 0 {
             return CtOption::some(Self::ONE);
@@ -27,6 +28,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self^exp`.
     ///
     /// This method is variable time in the exponent `exp`.
+    #[must_use]
     pub const fn wrapping_pow_vartime(&self, exp: u32) -> Self {
         if exp == 0 {
             return Self::ONE;

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -9,7 +9,7 @@ impl<const LIMBS: usize> Random for Uint<LIMBS> {
         let mut limbs = [Limb::ZERO; LIMBS];
 
         for limb in &mut limbs {
-            *limb = Limb::try_random_from_rng(rng)?
+            *limb = Limb::try_random_from_rng(rng)?;
         }
 
         Ok(limbs.into())
@@ -216,7 +216,7 @@ mod tests {
         }
     }
 
-    /// Make sure the random_bits output is consistent across platforms
+    /// Make sure the `random_bits` output is consistent across platforms
     #[test]
     fn random_bits_platform_independence() {
         let mut rng = get_four_sequential_rng();
@@ -242,7 +242,7 @@ mod tests {
         );
     }
 
-    /// Make sure random_mod_vartime output is consistent across platforms
+    /// Make sure `random_mod_vartime` output is consistent across platforms
     #[test]
     fn random_mod_vartime_platform_independence() {
         let mut rng = get_four_sequential_rng();

--- a/src/uint/ref_type.rs
+++ b/src/uint/ref_type.rs
@@ -14,6 +14,7 @@ use crate::{Choice, Limb, Uint};
 use core::{
     fmt,
     ops::{Index, IndexMut},
+    ptr,
 };
 
 #[cfg(feature = "alloc")]
@@ -32,9 +33,9 @@ impl UintRef {
     #[inline]
     pub const fn new(limbs: &[Limb]) -> &Self {
         // SAFETY: `UintRef` is a `repr(transparent)` newtype for `[Limb]`.
-        #[allow(trivial_casts, unsafe_code)]
+        #[allow(unsafe_code)]
         unsafe {
-            &*(limbs as *const [Limb] as *const UintRef)
+            &*(ptr::from_ref(limbs) as *const UintRef)
         }
     }
 
@@ -42,9 +43,9 @@ impl UintRef {
     #[inline]
     pub const fn new_mut(limbs: &mut [Limb]) -> &mut Self {
         // SAFETY: `UintRef` is a `repr(transparent)` newtype for `[Limb]`.
-        #[allow(trivial_casts, unsafe_code)]
+        #[allow(unsafe_code)]
         unsafe {
-            &mut *(limbs as *mut [Limb] as *mut UintRef)
+            &mut *(ptr::from_mut(limbs) as *mut UintRef)
         }
     }
 

--- a/src/uint/ref_type/invert_mod.rs
+++ b/src/uint/ref_type/invert_mod.rs
@@ -11,6 +11,7 @@ impl Odd<UintRef> {
     ///
     /// Variable time with respect to the number of words in `value`, however that number will be
     /// fixed for a given integer size.
+    #[must_use]
     pub const fn invert_mod_u64(&self) -> u64 {
         let value = self.as_ref().lowest_u64();
         let x = value.wrapping_mul(3) ^ 2;

--- a/src/uint/ref_type/shl.rs
+++ b/src/uint/ref_type/shl.rs
@@ -24,9 +24,13 @@ impl UintRef {
         self.conditional_set_zero(overflow);
     }
 
-    /// Left-shifts by `shift` bits where `shift < `shift_upper_bound`, panicking if
-    /// the shift exceeds the precision. The runtime is determined by `shift_upper_bound`
-    /// which may be smaller than `self.bits_precision()`.
+    /// Left-shifts by `shift` bits where `shift < shift_upper_bound`.
+    ///
+    /// The runtime is determined by `shift_upper_bound` which may be smaller than
+    /// `self.bits_precision()`.
+    ///
+    /// # Panics
+    /// - if the shift exceeds the precision.
     #[inline(always)]
     pub(crate) const fn bounded_wrapping_shl_assign(&mut self, shift: u32, shift_upper_bound: u32) {
         assert!(shift < shift_upper_bound, "exceeded shift upper bound");
@@ -137,7 +141,8 @@ impl UintRef {
     /// Conditionally left-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning
     /// the carry.
     ///
-    /// Panics if `shift >= Limb::BITS`.
+    /// # Panics
+    /// - if `shift >= Limb::BITS`.
     #[inline]
     pub(crate) const fn conditional_shl_assign_limb_nonzero(
         &mut self,
@@ -164,15 +169,15 @@ impl UintRef {
 
     /// Left-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning the carry.
     ///
-    /// Panics if `shift >= Limb::BITS`.
+    /// # Panics
+    /// - if `shift >= Limb::BITS`.
     #[inline(always)]
     pub const fn shl_assign_limb(&mut self, shift: u32) -> Limb {
         let nz = Choice::from_u32_nz(shift);
         self.conditional_shl_assign_limb_nonzero(NonZero(nz.select_u32(1, shift)), nz)
     }
 
-    /// Left-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning
-    /// the carry.
+    /// Left-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning the carry.
     ///
     /// NOTE: this operation is variable time with respect to `shift` *ONLY*.
     ///

--- a/src/uint/ref_type/shr.rs
+++ b/src/uint/ref_type/shr.rs
@@ -29,9 +29,11 @@ impl UintRef {
         self.conditional_set_zero(overflow);
     }
 
-    /// Right-shifts by `shift` bits where `shift < `shift_upper_bound`, producing zero if
-    /// the shift exceeds the precision. The runtime is determined by `shift_upper_bound`
-    /// which may be smaller than `self.bits_precision()`.
+    /// Right-shifts by `shift` bits where `shift < shift_upper_bound`, producing zero if
+    /// the shift exceeds the precision.
+    ///
+    /// The runtime is determined by `shift_upper_bound` which may be smaller than
+    /// `self.bits_precision()`.
     #[cfg(feature = "alloc")]
     #[inline(always)]
     pub(crate) const fn bounded_wrapping_shr_assign(&mut self, shift: u32, shift_upper_bound: u32) {
@@ -159,7 +161,8 @@ impl UintRef {
     /// Conditionally right-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning
     /// the carry.
     ///
-    /// Panics if `shift >= Limb::BITS`.
+    /// # Panics
+    /// - if `shift >= Limb::BITS`.
     #[inline(always)]
     pub(crate) const fn conditional_shr_assign_limb_nonzero(
         &mut self,
@@ -186,7 +189,8 @@ impl UintRef {
 
     /// Right-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning the carry.
     ///
-    /// Panics if `shift >= Limb::BITS`.
+    /// # Panics
+    /// - if `shift >= Limb::BITS`.
     #[inline(always)]
     pub const fn shr_assign_limb(&mut self, shift: u32) -> Limb {
         let nz = Choice::from_u32_nz(shift);

--- a/src/uint/resize.rs
+++ b/src/uint/resize.rs
@@ -5,6 +5,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// truncating the upper bits if the value is too large to be
     /// represented.
     #[inline(always)]
+    #[must_use]
     pub const fn resize<const T: usize>(&self) -> Uint<T> {
         let mut res = Uint::ZERO;
         let mut i = 0;

--- a/src/uint/root.rs
+++ b/src/uint/root.rs
@@ -10,6 +10,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Callers can check if `self` is an exact power of `exp` by exponentiating the result.
     ///
     /// This method is variable time in `self` and in the exponent.
+    #[must_use]
     pub const fn floor_root_vartime(&self, exp: NonZeroU32) -> Self {
         if self.is_zero_vartime() {
             Self::ZERO
@@ -26,7 +27,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         if self.is_zero_vartime() {
             Some(Self::ZERO)
         } else {
-            NonZero(*self).checked_root_vartime(exp).map(|nz| nz.get())
+            NonZero(*self).checked_root_vartime(exp).map(NonZero::get)
         }
     }
 }
@@ -37,6 +38,7 @@ impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
     /// Callers can check if `self` is an exact power of `exp` by exponentiating the result.
     ///
     /// This method is variable time in self and in the exponent.
+    #[must_use]
     pub const fn floor_root_vartime(&self, exp: NonZeroU32) -> Self {
         // Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.14.
 
@@ -81,6 +83,7 @@ impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
     /// only if the root is exact.
     ///
     /// This method is variable time in `self` and in the exponent.
+    #[must_use]
     pub fn checked_root_vartime(&self, exp: NonZeroU32) -> Option<Self> {
         let r = self.floor_root_vartime(exp);
         let s = r.wrapping_pow_vartime(exp.get());
@@ -143,7 +146,7 @@ mod tests {
                 let rt_p1 = root.wrapping_add_limb(Limb::ONE);
                 let s3 = rt_p1.checked_pow_vartime(exp.get()).into_option();
                 assert!(
-                    s3.map(|s3| s3 > s2).unwrap_or(true),
+                    s3.is_none_or(|s3| s3 > s2),
                     "underflow, {s} exp={exp}, root={root}"
                 );
             }

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -5,7 +5,9 @@ use crate::{Choice, CtOption, Limb, NonZero, Shl, ShlAssign, ShlVartime, Uint, W
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self << shift`.
     ///
-    /// Panics if `shift >= Self::BITS`.
+    /// # Panics
+    /// - if `shift >= Self::BITS`.
+    #[must_use]
     pub const fn shl(&self, shift: u32) -> Self {
         self.overflowing_shl(shift)
             .expect_copied("`shift` within the bit size of the integer")
@@ -13,13 +15,15 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes `self << shift` in variable time.
     ///
-    /// Panics if `shift >= Self::BITS`.
-    ///
     /// NOTE: this operation is variable time with respect to `shift` *ONLY*.
     ///
     /// When used with a fixed `shift`, this function is constant-time with respect
     /// to `self`.
+    ///
+    /// # Panics
+    /// - if `shift >= Self::BITS`.
     #[inline(always)]
+    #[must_use]
     pub const fn shl_vartime(&self, shift: u32) -> Self {
         assert!(
             shift < Self::BITS,
@@ -50,13 +54,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Returns `None` if `shift >= Self::BITS`.
     #[inline]
+    #[must_use]
     pub const fn overflowing_shl(&self, shift: u32) -> CtOption<Self> {
         let overflow = Choice::from_u32_lt(shift, Self::BITS).not();
         let result = self.bounded_wrapping_shl(shift % Self::BITS, Self::BITS);
         CtOption::new(Uint::select(&result, &Self::ZERO, overflow), overflow.not())
     }
 
-    /// Computes `self << shift` where `shift < `shift_upper_bound`, returning zero
+    /// Computes `self << shift` where `shift < shift_upper_bound`, returning zero
     /// if the shift exceeds the precision. The runtime is determined by `shift_upper_bound`
     /// which may be smaller than `Self::BITS`.
     pub(crate) const fn bounded_wrapping_shl(&self, shift: u32, shift_upper_bound: u32) -> Self {
@@ -111,6 +116,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// When used with a fixed `shift`, this function is constant-time with respect
     /// to `self`.
     #[inline(always)]
+    #[must_use]
     pub const fn overflowing_shl_vartime(&self, shift: u32) -> Option<Self> {
         if shift < Self::BITS {
             Some(self.shl_vartime(shift))
@@ -128,6 +134,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// When used with a fixed `shift`, this function is constant-time with respect
     /// to `self`.
     #[inline(always)]
+    #[must_use]
     pub const fn overflowing_shl_vartime_wide(
         lower_upper: (Self, Self),
         shift: u32,
@@ -148,12 +155,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes `self << shift` in a panic-free manner, returning zero if the shift exceeds the
     /// precision.
+    #[must_use]
     pub const fn wrapping_shl(&self, shift: u32) -> Self {
         ctutils::unwrap_or!(self.overflowing_shl(shift), Self::ZERO, Self::select)
     }
 
     /// Computes `self << shift` in variable-time in a panic-free manner, returning zero if the
     /// shift exceeds the precision.
+    #[must_use]
     pub const fn wrapping_shl_vartime(&self, shift: u32) -> Self {
         if let Some(ret) = self.overflowing_shl_vartime(shift) {
             ret
@@ -165,7 +174,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Conditionally computes `self << shift` where `0 <= shift < Limb::BITS`,
     /// returning the result and the carry.
     ///
-    /// Panics if `shift >= Limb::BITS`.
+    /// # Panics
+    /// - if `shift >= Limb::BITS`.
     #[inline(always)]
     pub(crate) const fn conditional_shl_limb_nonzero(
         &self,
@@ -198,7 +208,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self << shift` where `0 <= shift < Limb::BITS`,
     /// returning the result and the carry.
     ///
-    /// Panics if `shift >= Limb::BITS`.
+    /// # Panics
+    /// - if `shift >= Limb::BITS`.
     pub(crate) const fn shl_limb(&self, shift: u32) -> (Self, Limb) {
         let nz = Choice::from_u32_nz(shift);
         self.conditional_shl_limb_nonzero(NonZero(nz.select_u32(1, shift)), nz)

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -5,7 +5,9 @@ use crate::{Choice, CtOption, Limb, NonZero, Shr, ShrAssign, ShrVartime, Uint, W
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self >> shift`.
     ///
-    /// Panics if `shift >= Self::BITS`.
+    /// # Panics
+    /// - if `shift >= Self::BITS`.
+    #[must_use]
     pub const fn shr(&self, shift: u32) -> Self {
         self.overflowing_shr(shift)
             .expect_copied("`shift` within the bit size of the integer")
@@ -13,8 +15,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes `self >> shift` in variable time.
     ///
-    /// Panics if `shift >= Self::BITS`.
+    /// # Panics
+    /// - if `shift >= Self::BITS`.
     #[inline(always)]
+    #[must_use]
     pub const fn shr_vartime(&self, shift: u32) -> Self {
         assert!(
             shift < Self::BITS,
@@ -44,13 +48,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Returns `None` if `shift >= Self::BITS`.
     #[inline]
+    #[must_use]
     pub const fn overflowing_shr(&self, shift: u32) -> CtOption<Self> {
         let overflow = Choice::from_u32_lt(shift, Self::BITS).not();
         let result = self.bounded_wrapping_shr(shift % Self::BITS, Self::BITS);
         CtOption::new(Uint::select(&result, &Self::ZERO, overflow), overflow.not())
     }
 
-    /// Computes `self >> shift` where `shift < `shift_upper_bound`, returning zero
+    /// Computes `self >> shift` where `shift < shift_upper_bound`, returning zero
     /// if the shift exceeds the precision. The runtime is determined by `shift_upper_bound`
     /// which may be smaller than `Self::BITS`.
     pub(crate) const fn bounded_wrapping_shr(&self, shift: u32, shift_upper_bound: u32) -> Self {
@@ -124,6 +129,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// When used with a fixed `shift`, this function is constant-time with respect to `self`.
     #[inline(always)]
+    #[must_use]
     pub const fn overflowing_shr_vartime(&self, shift: u32) -> Option<Self> {
         if shift < Self::BITS {
             Some(self.shr_vartime(shift))
@@ -141,6 +147,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// When used with a fixed `shift`, this function is constant-time with respect
     /// to `self`.
     #[inline(always)]
+    #[must_use]
     pub const fn overflowing_shr_vartime_wide(
         lower_upper: (Self, Self),
         shift: u32,
@@ -161,12 +168,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes `self >> shift` in a panic-free manner, returning zero if the shift exceeds the
     /// precision.
+    #[must_use]
     pub const fn wrapping_shr(&self, shift: u32) -> Self {
         ctutils::unwrap_or!(self.overflowing_shr(shift), Self::ZERO, Self::select)
     }
 
     /// Computes `self >> shift` in variable-time in a panic-free manner, returning zero if the
     /// shift exceeds the precision.
+    #[must_use]
     pub const fn wrapping_shr_vartime(&self, shift: u32) -> Self {
         if let Some(ret) = self.overflowing_shr_vartime(shift) {
             ret
@@ -200,7 +209,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Conditionally right-shifts by `shift` bits where `0 < shift < Limb::BITS`, returning
     /// the carry.
     ///
-    /// Panics if `shift >= Limb::BITS`.
+    /// # Panics
+    /// - if `shift >= Limb::BITS`.
     #[inline(always)]
     pub(crate) const fn conditional_shr_limb_nonzero(
         &self,
@@ -233,7 +243,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self >> shift` where `0 <= shift < Limb::BITS`,
     /// returning the result and the carry.
     ///
-    /// Panics if `shift >= Limb::BITS`.
+    /// # Panics
+    /// - if `shift >= Limb::BITS`.
     pub(crate) const fn shr_limb(&self, shift: u32) -> (Self, Limb) {
         let nz = Choice::from_u32_nz(shift);
         self.conditional_shr_limb_nonzero(NonZero(nz.select_u32(1, shift)), nz)

--- a/src/uint/split.rs
+++ b/src/uint/split.rs
@@ -2,6 +2,7 @@ use crate::{Limb, Split, SplitMixed, Uint};
 
 impl<const I: usize> Uint<I> {
     /// Split this number in half into low and high components.
+    #[must_use]
     pub const fn split<const O: usize>(&self) -> (Uint<O>, Uint<O>)
     where
         Self: Split<Output = Uint<O>>,
@@ -11,6 +12,7 @@ impl<const I: usize> Uint<I> {
 
     /// Split this number into low and high components respectively.
     #[inline]
+    #[must_use]
     pub const fn split_mixed<const L: usize, const H: usize>(&self) -> (Uint<L>, Uint<H>)
     where
         Self: SplitMixed<Uint<L>, Uint<H>>,

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -7,6 +7,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Callers can check if `self` is a square by squaring the result.
     #[deprecated(since = "0.7.0", note = "please use `floor_sqrt` instead")]
+    #[must_use]
     pub const fn sqrt(&self) -> Self {
         self.floor_sqrt()
     }
@@ -14,6 +15,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `floor(√(self))` in constant time.
     ///
     /// Callers can check if `self` is a square by squaring the result.
+    #[must_use]
     pub const fn floor_sqrt(&self) -> Self {
         let self_is_nz = self.is_nonzero();
         let root_nz = NonZero(Self::select(&Self::ONE, self, self_is_nz))
@@ -28,6 +30,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ///
     /// Variable time with respect to `self`.
     #[deprecated(since = "0.7.0", note = "please use `floor_sqrt_vartime` instead")]
+    #[must_use]
     pub const fn sqrt_vartime(&self) -> Self {
         self.floor_sqrt_vartime()
     }
@@ -37,6 +40,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Callers can check if `self` is a square by squaring the result.
     ///
     /// Variable time with respect to `self`.
+    #[must_use]
     pub const fn floor_sqrt_vartime(&self) -> Self {
         if self.is_zero_vartime() {
             Self::ZERO
@@ -48,6 +52,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Wrapped sqrt is just `floor(√(self))`.
     /// There’s no way wrapping could ever happen.
     /// This function exists so that all operations are accounted for in the wrapping operations.
+    #[must_use]
     pub const fn wrapping_sqrt(&self) -> Self {
         self.floor_sqrt()
     }
@@ -57,12 +62,14 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// This function exists so that all operations are accounted for in the wrapping operations.
     ///
     /// Variable time with respect to `self`.
+    #[must_use]
     pub const fn wrapping_sqrt_vartime(&self) -> Self {
         self.floor_sqrt_vartime()
     }
 
     /// Perform checked sqrt, returning a [`CtOption`] which `is_some`
     /// only if the square root is exact.
+    #[must_use]
     pub fn checked_sqrt(&self) -> CtOption<Self> {
         let self_is_nz = self.is_nonzero();
         NonZero(Self::select(&Self::ONE, self, self_is_nz))
@@ -78,7 +85,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         if self.is_zero_vartime() {
             Some(Self::ZERO)
         } else {
-            NonZero(*self).checked_sqrt_vartime().map(|nz| nz.get())
+            NonZero(*self).checked_sqrt_vartime().map(NonZero::get)
         }
     }
 }
@@ -87,6 +94,7 @@ impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
     /// Computes `floor(√(self))` in constant time.
     ///
     /// Callers can check if `self` is a square by squaring the result.
+    #[must_use]
     pub const fn floor_sqrt(&self) -> Self {
         // Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.13.
         //
@@ -124,6 +132,7 @@ impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
     /// Callers can check if `self` is a square by squaring the result.
     ///
     /// Variable time with respect to `self`.
+    #[must_use]
     pub const fn floor_sqrt_vartime(&self) -> Self {
         // Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.13
 
@@ -157,6 +166,7 @@ impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
 
     /// Perform checked sqrt, returning a [`CtOption`] which `is_some`
     /// only if the square root is exact.
+    #[must_use]
     pub fn checked_sqrt(&self) -> CtOption<Self> {
         let r = self.floor_sqrt();
         let s = r.wrapping_square();
@@ -165,6 +175,7 @@ impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
 
     /// Perform checked sqrt, returning an [`Option`] which `is_some`
     /// only if the square root is exact.
+    #[must_use]
     pub fn checked_sqrt_vartime(&self) -> Option<Self> {
         let r = self.floor_sqrt_vartime();
         let s = r.wrapping_square();

--- a/src/uint/sub.rs
+++ b/src/uint/sub.rs
@@ -6,12 +6,14 @@ use crate::{Checked, CheckedSub, CtOption, Limb, Sub, SubAssign, Wrapping, Wrapp
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self - (rhs + borrow)`, returning the result along with the new borrow.
     #[deprecated(since = "0.7.0", note = "please use `borrowing_sub` instead")]
+    #[must_use]
     pub const fn sbb(&self, rhs: &Self, borrow: Limb) -> (Self, Limb) {
         self.borrowing_sub(rhs, borrow)
     }
 
     /// Computes `self - (rhs + borrow)`, returning the result along with the new borrow.
     #[inline(always)]
+    #[must_use]
     pub const fn borrowing_sub(&self, rhs: &Self, mut borrow: Limb) -> (Self, Limb) {
         let mut limbs = [Limb::ZERO; LIMBS];
         let mut i = 0;
@@ -27,6 +29,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Perform saturating subtraction, returning `ZERO` on underflow.
+    #[must_use]
     pub const fn saturating_sub(&self, rhs: &Self) -> Self {
         let (res, underflow) = self.borrowing_sub(rhs, Limb::ZERO);
         Self::select(&res, &Self::ZERO, word::choice_from_mask(underflow.0))
@@ -34,6 +37,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Perform wrapping subtraction, discarding underflow and wrapping around
     /// the boundary of the type.
+    #[must_use]
     pub const fn wrapping_sub(&self, rhs: &Self) -> Self {
         self.borrowing_sub(rhs, Limb::ZERO).0
     }
@@ -65,13 +69,13 @@ impl<const LIMBS: usize> Sub<&Uint<LIMBS>> for Uint<LIMBS> {
 
 impl<const LIMBS: usize> SubAssign<Uint<LIMBS>> for Uint<LIMBS> {
     fn sub_assign(&mut self, rhs: Uint<LIMBS>) {
-        *self = self.sub(&rhs)
+        *self = self.sub(&rhs);
     }
 }
 
 impl<const LIMBS: usize> SubAssign<&Uint<LIMBS>> for Uint<LIMBS> {
     fn sub_assign(&mut self, rhs: &Uint<LIMBS>) {
-        *self = self.sub(rhs)
+        *self = self.sub(rhs);
     }
 }
 

--- a/src/uint/sub_mod.rs
+++ b/src/uint/sub_mod.rs
@@ -6,6 +6,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self - rhs mod p`.
     ///
     /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
+    #[must_use]
     pub const fn sub_mod(&self, rhs: &Self, p: &NonZero<Self>) -> Self {
         let (out, mask) = self.borrowing_sub(rhs, Limb::ZERO);
 
@@ -32,6 +33,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// `p = MAX+1-c` where `c` is small enough to fit in a single [`Limb`].
     ///
     /// Assumes `self - rhs` as unbounded signed integer is in `[-p, p)`.
+    #[must_use]
     pub const fn sub_mod_special(&self, rhs: &Self, c: Limb) -> Self {
         let (out, borrow) = self.borrowing_sub(rhs, Limb::ZERO);
 

--- a/tests/monty_form.rs
+++ b/tests/monty_form.rs
@@ -168,7 +168,7 @@ proptest! {
             BigUint::from_be_bytes(normal_form_inv.to_be_bytes().as_ref()),
             r_num_modular_inv,
             "num_modular ≠ crypto_bigint"
-        )
+        );
     }
 
     #[test]
@@ -207,7 +207,7 @@ proptest! {
             BigUint::from_be_bytes(normal_form_inv.to_be_bytes().as_ref()),
             r_num_modular_inv,
             "num_modular ≠ crypto_bigint"
-        )
+        );
     }
 
     #[test]
@@ -246,7 +246,7 @@ proptest! {
             BigUint::from_be_bytes(normal_form_inv.to_be_bytes().as_ref()),
             r_num_modular_inv,
             "num_modular ≠ crypto_bigint"
-        )
+        );
     }
 
     #[test]
@@ -285,7 +285,7 @@ proptest! {
             BigUint::from_be_bytes(normal_form_inv.to_be_bytes().as_ref()),
             r_num_modular_inv,
             "num_modular ≠ crypto_bigint"
-        )
+        );
     }
 
     #[test]


### PR DESCRIPTION
- Moves lints to Cargo.toml
- Adds and fixes some of the `clippy::pedantic` lints we were failing
- Applies `cargo clippy --fix`
- Manual fixes of the ones which couldn't be auto-applied