### PR TITLE
Add `UintRef` to public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,7 @@ pub use crate::{
     uint::{
         div_limb::Reciprocal,
         encoding::{EncodedUint, TryFromSliceError},
+        ref_type::UintRef,
         *,
     },
     word::{WideWord, Word},

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -10,7 +10,7 @@ pub use num_traits::{
     WrappingSub,
 };
 
-use crate::{Choice, CtOption, Limb, NonZero, Odd, Reciprocal, modular::Retrieve};
+use crate::{Choice, CtOption, Limb, NonZero, Odd, Reciprocal, UintRef, modular::Retrieve};
 use core::fmt::{self, Debug};
 
 #[cfg(feature = "rand_core")]
@@ -166,7 +166,8 @@ pub trait Signed:
 
 /// Unsigned [`Integer`]s.
 pub trait Unsigned:
-    AddMod<Output = Self>
+    AsRef<UintRef>
+    + AddMod<Output = Self>
     + BitOps
     + Div<NonZero<Self>, Output = Self>
     + for<'a> Div<&'a NonZero<Self>, Output = Self>

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -47,7 +47,7 @@ mod mul_signed;
 mod neg;
 mod neg_mod;
 mod pow;
-mod ref_type;
+pub(crate) mod ref_type;
 mod resize;
 mod root;
 mod shl;
@@ -196,14 +196,16 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Borrow the limbs of this [`Uint`] as a [`UintRef`].
-    #[inline(always)]
-    pub(crate) const fn as_uint_ref(&self) -> &UintRef {
+    #[inline]
+    #[must_use]
+    pub const fn as_uint_ref(&self) -> &UintRef {
         UintRef::new(&self.limbs)
     }
 
     /// Mutably borrow the limbs of this [`Uint`] as a [`UintRef`].
-    #[inline(always)]
-    pub(crate) const fn as_mut_uint_ref(&mut self) -> &mut UintRef {
+    #[inline]
+    #[must_use]
+    pub const fn as_mut_uint_ref(&mut self) -> &mut UintRef {
         UintRef::new_mut(&mut self.limbs)
     }
 

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -207,19 +207,21 @@ impl BoxedUint {
     }
 
     /// Borrow the limbs of this [`BoxedUint`] as a [`UintRef`].
-    #[inline(always)]
-    pub(crate) const fn as_uint_ref(&self) -> &UintRef {
+    #[inline]
+    #[must_use]
+    pub const fn as_uint_ref(&self) -> &UintRef {
         UintRef::new(&self.limbs)
     }
 
     /// Mutably borrow the limbs of this [`BoxedUint`] as a [`UintRef`].
-    #[inline(always)]
-    pub(crate) const fn as_mut_uint_ref(&mut self) -> &mut UintRef {
+    #[inline]
+    #[must_use]
+    pub const fn as_mut_uint_ref(&mut self) -> &mut UintRef {
         UintRef::new_mut(&mut self.limbs)
     }
 
     /// Mutably borrow a subset the limbs of this [`BoxedUint`] as a [`UintRef`].
-    #[inline(always)]
+    #[inline]
     pub(crate) fn as_mut_uint_ref_range<R>(&mut self, range: R) -> &mut UintRef
     where
         [Limb]: IndexMut<R, Output = [Limb]>,

--- a/src/uint/ref_type/add.rs
+++ b/src/uint/ref_type/add.rs
@@ -22,6 +22,9 @@ impl UintRef {
     }
 
     /// Perform an in-place carrying add of another limb slice, returning the carried limb value.
+    ///
+    /// # Panics
+    /// If `self` and `rhs` have different lengths.
     #[inline]
     #[track_caller]
     pub const fn carrying_add_assign_slice(&mut self, rhs: &[Limb], mut carry: Limb) -> Limb {
@@ -50,6 +53,9 @@ impl UintRef {
     }
 
     /// Perform an in-place carrying add of another limb slice, returning the carried limb value.
+    ///
+    /// # Panics
+    /// If `self` and `rhs` have different lengths.
     #[inline]
     #[track_caller]
     pub const fn conditional_add_assign_slice(

--- a/src/uint/ref_type/bits.rs
+++ b/src/uint/ref_type/bits.rs
@@ -4,6 +4,7 @@ use crate::{Choice, Limb, traits::BitOps, word};
 impl UintRef {
     /// Get the precision of this number in bits.
     #[allow(clippy::cast_possible_truncation)]
+    #[must_use]
     pub const fn bits_precision(&self) -> u32 {
         self.0.len() as u32 * Limb::BITS
     }
@@ -12,6 +13,7 @@ impl UintRef {
     /// Returns the falsy value for indices out of range.
     #[inline(always)]
     #[allow(clippy::cast_possible_truncation)]
+    #[must_use]
     pub const fn bit(&self, index: u32) -> Choice {
         let limb_num = index / Limb::BITS;
         let index_in_limb = index % Limb::BITS;
@@ -35,6 +37,7 @@ impl UintRef {
     /// # Remarks
     /// This operation is variable time with respect to `index` only.
     #[inline(always)]
+    #[must_use]
     pub const fn bit_vartime(&self, index: u32) -> bool {
         let limb_num = (index / Limb::BITS) as usize;
         let index_in_limb = index % Limb::BITS;
@@ -50,6 +53,7 @@ impl UintRef {
     ///
     /// Use [`UintRef::bits_precision`] to get the total capacity of this integer.
     #[inline(always)]
+    #[must_use]
     pub const fn bits(&self) -> u32 {
         self.bits_precision() - self.leading_zeros()
     }
@@ -58,6 +62,7 @@ impl UintRef {
     /// to `self`.
     #[inline(always)]
     #[allow(clippy::cast_possible_truncation)]
+    #[must_use]
     pub const fn bits_vartime(&self) -> u32 {
         let mut i = self.0.len() - 1;
         while i > 0 && self.0[i].0 == 0 {
@@ -100,6 +105,7 @@ impl UintRef {
     }
 
     /// Calculate the number of leading zeros in the binary representation of this number.
+    #[must_use]
     pub const fn leading_zeros(&self) -> u32 {
         let mut count = 0;
         let mut i = self.0.len();
@@ -118,6 +124,7 @@ impl UintRef {
 
     /// Calculate the number of trailing zeros in the binary representation of this number.
     #[inline(always)]
+    #[must_use]
     pub const fn trailing_zeros(&self) -> u32 {
         let mut count = 0;
         let mut i = 0;
@@ -137,6 +144,7 @@ impl UintRef {
     /// Calculate the number of trailing zeros in the binary representation of this number, in
     /// variable-time with respect to `self`.
     #[inline(always)]
+    #[must_use]
     pub const fn trailing_zeros_vartime(&self) -> u32 {
         let mut count = 0;
         let mut i = 0;
@@ -155,6 +163,7 @@ impl UintRef {
 
     /// Calculate the number of trailing ones in the binary representation of this number.
     #[inline(always)]
+    #[must_use]
     pub const fn trailing_ones(&self) -> u32 {
         let mut count = 0;
         let mut i = 0;
@@ -174,6 +183,7 @@ impl UintRef {
     /// Calculate the number of trailing ones in the binary representation of this number, in
     /// variable-time with respect to `self`.
     #[inline(always)]
+    #[must_use]
     pub const fn trailing_ones_vartime(&self) -> u32 {
         let mut count = 0;
         let mut i = 0;

--- a/src/uint/ref_type/div.rs
+++ b/src/uint/ref_type/div.rs
@@ -14,7 +14,8 @@ use crate::{
 impl UintRef {
     /// Computes `self` / `rhs`, returning the quotient in `self` and the remainder in `rhs`.
     ///
-    /// This function will panic if the divisor is zero.
+    /// # Panics
+    /// If the divisor is zero.
     #[inline(always)]
     pub const fn div_rem(&mut self, rhs: &mut Self) {
         let (x, y) = (self, rhs);
@@ -47,7 +48,10 @@ impl UintRef {
     /// Computes `self` / `rhs`, returning the quotient in `self` and the remainder in `rhs`.
     ///
     /// This function operates in variable-time with respect to `rhs`. For a fixed divisor,
-    /// it operates in constant-time. It will panic if the divisor is zero.
+    /// it operates in constant-time
+    ///
+    /// # Panics
+    /// If the divisor is zero.
     #[allow(clippy::cast_possible_truncation)]
     pub const fn div_rem_vartime(&mut self, rhs: &mut Self) {
         let (x, y) = (self, rhs);
@@ -87,10 +91,11 @@ impl UintRef {
 
     /// Computes `x_lower_upper` % `rhs`, returning the remainder in `rhs`.
     ///
-    /// This function will panic if the divisor is zero.
-    ///
     /// The `x_lower_upper` tuple represents a wide integer. The size of `x_lower_upper.1` must be
     /// at least as large as `rhs`. `x_lower_upper` is left in an indeterminate state.
+    ///
+    /// # Panics
+    /// If the divisor is zero.
     #[inline(always)]
     pub const fn rem_wide(x_lower_upper: (&mut Self, &mut Self), rhs: &mut Self) {
         let (x_lo, x) = x_lower_upper;
@@ -129,10 +134,13 @@ impl UintRef {
     /// Computes `x_lower_upper` % `rhs`, returning the remainder in `rhs`.
     ///
     /// This function operates in variable-time with respect to `rhs`. For a fixed divisor,
-    /// it operates in constant-time. It will panic if the divisor is zero.
+    /// it operates in constant-time.
     ///
     /// The `x_lower_upper` tuple represents a wide integer. The size of `x_lower_upper.1`
     /// must be at least as large as `rhs`. `x_lower_upper` is left in an indeterminate state.
+    ///
+    /// # Panics
+    /// If the divisor is zero.
     #[inline(always)]
     #[allow(clippy::cast_possible_truncation)]
     pub const fn rem_wide_vartime(x_lower_upper: (&mut Self, &mut Self), rhs: &mut Self) {

--- a/src/uint/ref_type/invert_mod.rs
+++ b/src/uint/ref_type/invert_mod.rs
@@ -23,28 +23,6 @@ impl Odd<UintRef> {
     }
 }
 
-impl UintRef {
-    #[inline(always)]
-    pub const fn lowest_u64(&self) -> u64 {
-        #[cfg(target_pointer_width = "32")]
-        {
-            debug_assert!(self.nlimbs() >= 1);
-            let mut ret = self.0[0].0 as u64;
-
-            if self.nlimbs() >= 2 {
-                ret |= (self.0[1].0 as u64) << 32;
-            }
-
-            ret
-        }
-
-        #[cfg(target_pointer_width = "64")]
-        {
-            self.0[0].0
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::U128;

--- a/src/uint/ref_type/shl.rs
+++ b/src/uint/ref_type/shl.rs
@@ -182,6 +182,9 @@ impl UintRef {
     /// NOTE: this operation is variable time with respect to `shift` *ONLY*.
     ///
     /// When used with a fixed `shift`, this function is constant-time with respect to `self`.
+    ///
+    /// # Panics
+    /// If the shift size is equal to or larger than the width of the integer.
     #[inline(always)]
     pub const fn shl_assign_limb_vartime(&mut self, shift: u32) -> Limb {
         assert!(shift < Limb::BITS);

--- a/src/uint/ref_type/shr.rs
+++ b/src/uint/ref_type/shr.rs
@@ -204,6 +204,9 @@ impl UintRef {
     /// NOTE: this operation is variable time with respect to `shift` *ONLY*.
     ///
     /// When used with a fixed `shift`, this function is constant-time with respect to `self`.
+    ///
+    /// # Panics
+    /// If the shift size is equal to or larger than the width of the integer.
     #[inline(always)]
     pub const fn shr_assign_limb_vartime(&mut self, shift: u32) -> Limb {
         assert!(shift < Limb::BITS);

--- a/src/uint/ref_type/slice.rs
+++ b/src/uint/ref_type/slice.rs
@@ -35,6 +35,7 @@ impl UintRef {
     /// Split the limb slice at a fixed position, producing head and tail slices.
     #[inline]
     #[track_caller]
+    #[must_use]
     pub const fn split_at(&self, mid: usize) -> (&Self, &Self) {
         let (a, b) = self.0.split_at(mid);
         (UintRef::new(a), UintRef::new(b))
@@ -51,6 +52,7 @@ impl UintRef {
     /// Access a limb slice up to a number of elements `len`.
     #[inline]
     #[track_caller]
+    #[must_use]
     pub const fn leading(&self, len: usize) -> &Self {
         Self::new(self.0.split_at(len).0)
     }
@@ -71,6 +73,7 @@ impl UintRef {
 
     /// Determine if the slice has zero limbs.
     #[inline]
+    #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/src/uint/ref_type/sub.rs
+++ b/src/uint/ref_type/sub.rs
@@ -2,13 +2,18 @@ use super::UintRef;
 use crate::Limb;
 
 impl UintRef {
-    /// Perform an in-place borrowing subtraction of another [`UintRef`], returning the carried limb value.
+    /// Perform an in-place borrowing subtraction of another [`UintRef`], returning the carried limb
+    /// value.
     #[inline]
     pub const fn borrowing_sub_assign(&mut self, rhs: &Self, borrow: Limb) -> Limb {
         self.borrowing_sub_assign_slice(&rhs.0, borrow)
     }
 
-    /// Perform an in-place borrowing subtraction of another limb slice, returning the borrowed limb value.
+    /// Perform an in-place borrowing subtraction of another limb slice, returning the borrowed limb
+    /// value.
+    ///
+    /// # Panics
+    /// If `self` and `rhs` have different lengths.
     #[inline]
     pub const fn borrowing_sub_assign_slice(&mut self, rhs: &[Limb], mut borrow: Limb) -> Limb {
         assert!(self.0.len() == rhs.len(), "length mismatch");


### PR DESCRIPTION
In #812 I removed `UintRef` from the public API to give it some time to mature (perhaps not super helpful in an unstable development release series), but it seems mature enough now.

It's very useful to expose as a common abstraction for writing `const fn` in-place algorithms that work on either the stack on the heap whereas algorithms written with generics currently can't be `const fn` and also don't have access to private helper methods.

This commit adds it (back) to the public API, restores some methods that were feature-gated to being unconditional because previously they would've be dead code, and adds an `AsRef<UintRef>` bound to `Unsigned` so it's possible to get `UintRef` from any `Unsigned`.