### PR TITLE
Add `UintRef::{to_nz, to_nz_vartime}`

### DIFF
--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -1,35 +1,22 @@
-//! [`Uint`] comparisons.
+//! [`Uint`] comparison operations.
 //!
-//! By default, these are all constant-time.
+//! Constant-time unless explicitly noted otherwise.
 
 use super::Uint;
 use crate::{Choice, CtEq, Limb, word};
 use core::cmp::Ordering;
 
 impl<const LIMBS: usize> Uint<LIMBS> {
-    /// Returns the truthy value if `self`!=0 or the falsy value otherwise.
+    /// Returns [`Choice::TRUE`] if `self` != `0` or [`Choice::FALSE`] otherwise.
     #[inline]
     pub(crate) const fn is_nonzero(&self) -> Choice {
-        let mut b = 0;
-        let mut i = 0;
-        while i < LIMBS {
-            b |= self.limbs[i].0;
-            i += 1;
-        }
-        Limb(b).is_nonzero()
+        self.as_uint_ref().is_nonzero()
     }
 
     /// Determine in variable time whether the `self` is zero.
     #[inline]
     pub(crate) const fn is_zero_vartime(&self) -> bool {
-        let mut i = 0;
-        while i < LIMBS {
-            if self.limbs[i].0 != 0 {
-                return false;
-            }
-            i += 1;
-        }
-        true
+        self.as_uint_ref().is_zero_vartime()
     }
 
     /// Returns the truthy value if `self` is odd or the falsy value otherwise.

--- a/src/uint/ref_type/cmp.rs
+++ b/src/uint/ref_type/cmp.rs
@@ -1,0 +1,40 @@
+//! [`UintRef`] comparison operations.
+//!
+//! Constant time unless explicitly noted otherwise.
+
+use super::UintRef;
+use crate::Limb;
+use ctutils::Choice;
+
+impl UintRef {
+    /// Are all of limbs equal to `0`?
+    #[must_use]
+    pub const fn is_zero(&self) -> Choice {
+        self.is_nonzero().not()
+    }
+
+    /// Returns [`Choice::TRUE`] if `self` != `0` or [`Choice::FALSE`] otherwise.
+    #[inline]
+    pub(crate) const fn is_nonzero(&self) -> Choice {
+        let mut b = 0;
+        let mut i = 0;
+        while i < self.nlimbs() {
+            b |= self.0[i].0;
+            i += 1;
+        }
+        Limb(b).is_nonzero()
+    }
+
+    /// Determine in variable time whether the `self` is zero.
+    #[inline]
+    pub(crate) const fn is_zero_vartime(&self) -> bool {
+        let mut i = 0;
+        while i < self.nlimbs() {
+            if self.0[i].0 != 0 {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+}


### PR DESCRIPTION
Adds conversion methods for constructing `NonZero<&mut UintRef>` in constant-time and both `NonZero<&UintRef>` and `NonZero<&mut UintRef>` in variable time, returning `CtOption` and `Option` respectively.

It's only possible to construct `NonZero<&mut UintRef>` in variable-time because we still need to return a same-length slice in the `CtOption`, but one which is non-zero. This is accomplished by conditionally setting the lowest limb to `1` in the event the provided `UintRef` is all-zeroes.

That's probably okay, because in many cases we want `&mut UintRef` anyway.