### PR TITLE
CI: test on WASM using wasm32-wasip1/wasmtime

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -111,6 +111,7 @@ jobs:
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
         if: ${{ matrix.deps != '' }}
+      - run: cargo check --target ${{ matrix.target }} --all-features # ensure it builds with all features
       - run: cargo test --target ${{ matrix.target }} --no-default-features ${{ matrix.args }}
       - run: cargo test --target ${{ matrix.target }}  ${{ matrix.args }}
       - run: cargo test --target ${{ matrix.target }} --all-features ${{ matrix.args }}
@@ -160,6 +161,23 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - run: rustup component add miri && cargo miri setup
       - run: cargo miri test --target ${{ matrix.target }} --no-default-features --lib
+
+  # Test WASM using `wasmtime`
+  test-wasm:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_WASM32_WASIP1_RUNNER: "wasmtime"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: bytecodealliance/actions/wasmtime/setup@v1
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: wasm32-wasip1
+      - run: cargo test --target wasm32-wasip1 --no-default-features
+      - run: cargo test --target wasm32-wasip1
+      - run: cargo test --target wasm32-wasip1 --all-features
+      - run: cargo test --target wasm32-wasip1 --all-features --release
 
   # Generate code coverage and report to codecov.io
   coverage:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,13 +33,15 @@ zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 chacha20 = { version = "0.10.0-rc.6", default-features = false, features = ["rng"] }
-criterion = { version = "0.7", features = ["html_reports"] }
 hex-literal = "1"
 num-bigint = "0.4"
 num-integer = "0.1"
 num-modular = { version = "0.6", features = ["num-bigint", "num-integer", "num-traits"] }
-proptest = "1.9"
 rand_core = "0.10.0-rc-3"
+
+[target.'cfg(any(unix, windows))'.dev-dependencies]
+criterion = { version = "0.7", features = ["html_reports"] }
+proptest = "1.9"
 
 [features]
 default = ["rand_core"]

--- a/tests/boxed_monty_form.rs
+++ b/tests/boxed_monty_form.rs
@@ -1,6 +1,6 @@
 //! Equivalence tests between `crypto_bigint::BoxedMontyForm` and `num-bigint`.
 
-#![cfg(feature = "alloc")]
+#![cfg(all(any(unix, windows), feature = "alloc"))]
 
 mod common;
 

--- a/tests/boxed_uint.rs
+++ b/tests/boxed_uint.rs
@@ -1,6 +1,6 @@
 //! Equivalence tests between `crypto_bigint::BoxedUint` and `num_bigint::BigUint`.
 
-#![cfg(feature = "alloc")]
+#![cfg(all(any(unix, windows), feature = "alloc"))]
 
 mod common;
 

--- a/tests/const_monty_form.rs
+++ b/tests/const_monty_form.rs
@@ -1,5 +1,7 @@
 //! Equivalence tests between `crypto_bigint::ConstMontyForm` and `num-bigint`.
 
+#![cfg(any(unix, windows))]
+
 mod common;
 
 use common::to_biguint;

--- a/tests/int.rs
+++ b/tests/int.rs
@@ -1,5 +1,7 @@
 //! Equivalence tests between `crypto_bigint::Int` and `num_bigint::BigInt`.
 
+#![cfg(any(unix, windows))]
+
 mod common;
 
 use common::{to_bigint, to_biguint};

--- a/tests/monty_form.rs
+++ b/tests/monty_form.rs
@@ -1,5 +1,7 @@
 //! Equivalence tests between `crypto_bigint::MontyForm` and `num-bigint`.
 
+#![cfg(any(unix, windows))]
+
 mod common;
 
 use common::to_biguint;

--- a/tests/safegcd.rs
+++ b/tests/safegcd.rs
@@ -1,5 +1,7 @@
 //! Equivalence tests for Bernstein-Yang inversions.
 
+#![cfg(any(unix, windows))]
+
 mod common;
 
 use common::to_biguint;

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -1,5 +1,7 @@
 //! Equivalence tests between `crypto_bigint::Uint` and `num_bigint::BigUint`.
 
+#![cfg(any(unix, windows))]
+
 mod common;
 
 use common::to_biguint;


### PR DESCRIPTION
Using this target and `wasmtime` we can run all of the tests except for the proptests