### PR TITLE
`Odd<UintRef>` improvements

### DIFF
--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -32,6 +32,9 @@ pub type NonZeroLimb = NonZero<Limb>;
 /// Non-zero unsigned integer.
 pub type NonZeroUint<const LIMBS: usize> = NonZero<Uint<LIMBS>>;
 
+/// Non-zero unsigned integer reference.
+pub type NonZeroUintRef = NonZero<UintRef>;
+
 /// Non-zero signed integer.
 pub type NonZeroInt<const LIMBS: usize> = NonZero<Int<LIMBS>>;
 
@@ -287,18 +290,30 @@ impl<const LIMBS: usize> NonZeroUint<LIMBS> {
         Self(Uint::from_u128(n.get()))
     }
 
-    /// Borrow this `NonZero<Uint>` as a `&NonZero<UintRef>`.
+    /// Borrow this `NonZero<Uint>` as a `&NonZeroUintRef`.
     #[inline]
     #[must_use]
-    pub const fn as_uint_ref(&self) -> &NonZero<UintRef> {
+    pub const fn as_uint_ref(&self) -> &NonZeroUintRef {
         self.0.as_uint_ref().as_nz_unchecked()
     }
 
-    /// Mutably borrow this `NonZero<Uint>` as a `&mut NonZero<UintRef>`.
+    /// Mutably borrow this `NonZero<Uint>` as a `&mut NonZeroUintRef`.
     #[inline]
     #[must_use]
-    pub const fn as_mut_uint_ref(&mut self) -> &mut NonZero<UintRef> {
+    pub const fn as_mut_uint_ref(&mut self) -> &mut NonZeroUintRef {
         self.0.as_mut_uint_ref().as_mut_nz_unchecked()
+    }
+}
+
+impl<const LIMBS: usize> AsRef<NonZeroUintRef> for NonZeroUint<LIMBS> {
+    fn as_ref(&self) -> &NonZeroUintRef {
+        self.as_uint_ref()
+    }
+}
+
+impl<const LIMBS: usize> AsMut<NonZeroUintRef> for NonZeroUint<LIMBS> {
+    fn as_mut(&mut self) -> &mut NonZeroUintRef {
+        self.as_mut_uint_ref()
     }
 }
 
@@ -337,23 +352,37 @@ impl<const LIMBS: usize> NonZeroInt<LIMBS> {
 
 #[cfg(feature = "alloc")]
 impl NonZeroBoxedUint {
-    /// Borrow this `NonZero<BoxedUint>` as a `&NonZero<UintRef>`.
+    /// Borrow this `NonZeroBoxedUint` as a `&NonZeroUintRef`.
     #[inline]
     #[must_use]
-    pub fn as_uint_ref(&self) -> &NonZero<UintRef> {
+    pub fn as_uint_ref(&self) -> &NonZeroUintRef {
         self.0.as_uint_ref().as_nz_unchecked()
     }
 
-    /// Mutably borrow this `NonZero<BoxedUint>` as a `&mut NonZero<UintRef>`.
+    /// Mutably borrow this `NonZeroBoxedUint` as a `&mut NonZeroUintRef`.
     #[inline]
     #[must_use]
-    pub fn as_mut_uint_ref(&mut self) -> &mut NonZero<UintRef> {
+    pub fn as_mut_uint_ref(&mut self) -> &mut NonZeroUintRef {
         self.0.as_mut_uint_ref().as_mut_nz_unchecked()
     }
 
     /// Get the least significant limb as a [`NonZeroLimb`].
     pub(crate) const fn lower_limb(&self) -> NonZeroLimb {
         NonZero(self.0.limbs[0])
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl AsRef<NonZeroUintRef> for NonZeroBoxedUint {
+    fn as_ref(&self) -> &NonZeroUintRef {
+        self.as_uint_ref()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl AsMut<NonZeroUintRef> for NonZeroBoxedUint {
+    fn as_mut(&mut self) -> &mut NonZeroUintRef {
+        self.as_mut_uint_ref()
     }
 }
 

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -9,19 +9,23 @@ use core::cmp::Ordering;
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Returns [`Choice::TRUE`] if `self` != `0` or [`Choice::FALSE`] otherwise.
     #[inline]
-    pub(crate) const fn is_nonzero(&self) -> Choice {
+    #[must_use]
+    pub const fn is_nonzero(&self) -> Choice {
         self.as_uint_ref().is_nonzero()
     }
 
     /// Determine in variable time whether the `self` is zero.
     #[inline]
-    pub(crate) const fn is_zero_vartime(&self) -> bool {
+    #[must_use]
+    pub const fn is_zero_vartime(&self) -> bool {
         self.as_uint_ref().is_zero_vartime()
     }
 
     /// Returns the truthy value if `self` is odd or the falsy value otherwise.
-    pub(crate) const fn is_odd(&self) -> Choice {
-        word::choice_from_lsb(self.limbs[0].0 & 1)
+    #[inline]
+    #[must_use]
+    pub const fn is_odd(&self) -> Choice {
+        self.as_uint_ref().is_odd()
     }
 
     /// Returns the truthy value if `self == rhs` or the falsy value otherwise.

--- a/src/uint/ref_type.rs
+++ b/src/uint/ref_type.rs
@@ -11,7 +11,7 @@ mod shr;
 mod slice;
 mod sub;
 
-use crate::{Choice, CtOption, Limb, NonZero, Uint, Word};
+use crate::{Choice, CtOption, Limb, NonZero, Odd, Uint, Word};
 use core::{
     fmt,
     ops::{Index, IndexMut},
@@ -181,7 +181,6 @@ impl UintRef {
         if self.is_zero_vartime() {
             return None;
         }
-
         Some(self.as_nz_unchecked())
     }
 
@@ -191,15 +190,15 @@ impl UintRef {
         if self.is_zero_vartime() {
             return None;
         }
-
         Some(self.as_mut_nz_unchecked())
     }
 
-    /// Perform an unsafe pointer cast to [`NonZero`] without first checking that the contained
-    /// value is non-zero.
+    /// Cast to [`NonZero`] without first checking that the contained value is non-zero.
     ///
-    /// # Safety
-    /// The caller must ensure `self` is non-zero.
+    /// # Panics
+    /// We don't explicitly flag this function as `unsafe` because it doesn't have a memory safety
+    /// impact, however functions called with `NonZero` arguments assume this value is non-zero
+    /// and may panic if given a zero value.
     #[inline]
     #[must_use]
     #[allow(unsafe_code)]
@@ -208,17 +207,88 @@ impl UintRef {
         unsafe { &*(ptr::from_ref(self) as *const NonZero<Self>) }
     }
 
-    /// Perform an unsafe pointer cast to [`NonZero`] without first checking that the contained
-    /// value is non-zero.
+    /// Cast to [`NonZero`] without first checking that the contained value is non-zero.
     ///
-    /// # Safety
-    /// The caller must ensure `self` is non-zero.
+    /// # Panics
+    /// We don't explicitly flag this function as `unsafe` because it doesn't have a memory safety
+    /// impact, however functions called with `NonZero` arguments assume this value is non-zero
+    /// and may panic if given a zero value.
     #[inline]
     #[must_use]
     #[allow(unsafe_code)]
     pub(crate) const fn as_mut_nz_unchecked(&mut self) -> &mut NonZero<Self> {
         // SAFETY: `NonZero` is a `repr(transparent)` newtype
         unsafe { &mut *(ptr::from_mut(self) as *mut NonZero<Self>) }
+    }
+
+    /// Conditionally construct a [`Odd`] from this reference.
+    ///
+    /// To ensure constant-time operation, we need a placeholder value which is used in the event
+    /// we return the [`CtOption`] equivalent of `None` which is identical in length to `self`.
+    /// And since we're working with reference types, there's only one place to get that: `self`.
+    ///
+    /// So, this function requires a mutable reference so in the event the provided value is even
+    /// it can change it to be odd.
+    ///
+    /// # Panics
+    /// If `self.nlimbs()` is zero.
+    #[inline]
+    #[must_use]
+    pub const fn to_mut_odd_ref(&mut self) -> CtOption<&mut Odd<Self>> {
+        assert!(!self.0.is_empty(), "cannot be used with empty slices");
+        let is_odd = self.is_odd();
+
+        // If `self` is even, set the first limb to `1` to make it odd.
+        self.0[0] = Limb::select(Limb::ONE, self.0[0], is_odd);
+
+        CtOption::new(self.as_mut_odd_unchecked(), is_odd)
+    }
+
+    /// Construct a [`Odd`] reference, returning [`None`] in the event `self` is `0`.
+    #[inline]
+    #[must_use]
+    pub const fn as_odd_vartime(&self) -> Option<&Odd<Self>> {
+        if self.is_zero_vartime() {
+            return None;
+        }
+        Some(self.as_odd_unchecked())
+    }
+
+    /// Construct a mutable [`Odd`] reference, returning [`None`] in the event `self` is `0`.
+    #[must_use]
+    pub const fn as_mut_odd_vartime(&mut self) -> Option<&mut Odd<Self>> {
+        if self.is_zero_vartime() {
+            return None;
+        }
+        Some(self.as_mut_odd_unchecked())
+    }
+
+    /// Cast to [`Odd`] without first checking that the contained value is actually odd.
+    ///
+    /// # Panics
+    /// We don't explicitly flag this function as `unsafe` because it doesn't have a memory safety
+    /// impact, however functions called with `Odd` arguments assume this value is actually odd
+    /// and may panic if given a zero value.
+    #[inline]
+    #[must_use]
+    #[allow(unsafe_code)]
+    pub(crate) const fn as_odd_unchecked(&self) -> &Odd<Self> {
+        // SAFETY: `Odd` is a `repr(transparent)` newtype
+        unsafe { &*(ptr::from_ref(self) as *const Odd<Self>) }
+    }
+
+    /// Cast to [`Odd`] without first checking that the contained value is actually odd.
+    ///
+    /// # Panics
+    /// We don't explicitly flag this function as `unsafe` because it doesn't have a memory safety
+    /// impact, however functions called with `Odd` arguments assume this value is non-zero
+    /// and may panic if given a zero value.
+    #[inline]
+    #[must_use]
+    #[allow(unsafe_code)]
+    pub(crate) const fn as_mut_odd_unchecked(&mut self) -> &mut Odd<Self> {
+        // SAFETY: `Odd` is a `repr(transparent)` newtype
+        unsafe { &mut *(ptr::from_mut(self) as *mut Odd<Self>) }
     }
 
     /// Get the least significant 64-bits.

--- a/src/uint/ref_type/cmp.rs
+++ b/src/uint/ref_type/cmp.rs
@@ -3,19 +3,22 @@
 //! Constant time unless explicitly noted otherwise.
 
 use super::UintRef;
-use crate::Limb;
+use crate::{Limb, word};
 use ctutils::Choice;
 
 impl UintRef {
-    /// Are all of limbs equal to `0`?
+    /// Returns the truthy value if `self` is odd or the falsy value otherwise.
+    #[inline]
     #[must_use]
-    pub const fn is_zero(&self) -> Choice {
-        self.is_nonzero().not()
+    pub const fn is_odd(&self) -> Choice {
+        debug_assert!(self.nlimbs() >= 1, "should have limbs");
+        word::choice_from_lsb(self.0[0].0 & 1)
     }
 
     /// Returns [`Choice::TRUE`] if `self` != `0` or [`Choice::FALSE`] otherwise.
     #[inline]
-    pub(crate) const fn is_nonzero(&self) -> Choice {
+    #[must_use]
+    pub const fn is_nonzero(&self) -> Choice {
         let mut b = 0;
         let mut i = 0;
         while i < self.nlimbs() {
@@ -23,6 +26,13 @@ impl UintRef {
             i += 1;
         }
         Limb(b).is_nonzero()
+    }
+
+    /// Are all of limbs equal to `0`?
+    #[inline]
+    #[must_use]
+    pub const fn is_zero(&self) -> Choice {
+        self.is_nonzero().not()
     }
 
     /// Determine in variable time whether the `self` is zero.


### PR DESCRIPTION
Similar PR to what #1117 did for `NonZeroUintRef` but for `Odd<UintRef>` a.k.a. `OddUintRef` (a newly added type alias, as of this PR).

- Adds functions to `UintRef` for obtaining `OddUintRef` in both constant and variable time
- Adds functions to `OddUint` and `OddBoxedUint` to obtain `OddUintRef` infallibly, including `AsRef` and `AsMut` impls
- Also adds `AsRef` and `AsMut` impls to `NonZeroUint` and `NonZeroBoxedUint` for obtaining `NonZeroUintRef` for consistency