### PR TITLE
Revert "Make vartime inversion return an `Option` instead of `CtOption`"

### DIFF
--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -801,7 +801,7 @@ fn bench_invert_mod(c: &mut Criterion) {
                 loop {
                     let x = U256::random_from_rng(&mut rng);
                     let inv_x = x.invert_odd_mod_vartime(&m);
-                    if inv_x.is_some() {
+                    if inv_x.is_some().into() {
                         break (x, m);
                     }
                 }

--- a/src/modular/const_monty_form/invert.rs
+++ b/src/modular/const_monty_form/invert.rs
@@ -49,7 +49,7 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     /// respect to `MOD`.
     #[deprecated(since = "0.7.0", note = "please use `invert_vartime` instead")]
     #[must_use]
-    pub const fn inv_vartime(&self) -> Option<Self> {
+    pub const fn inv_vartime(&self) -> CtOption<Self> {
         self.invert_vartime()
     }
 
@@ -62,31 +62,32 @@ impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstMontyForm<MOD, LIMBS
     /// This version is variable-time with respect to the value of `self`, but constant-time with
     /// respect to `MOD`.
     #[must_use]
-    pub const fn invert_vartime(&self) -> Option<Self> {
+    pub const fn invert_vartime(&self) -> CtOption<Self> {
         let inverter = SafeGcdInverter::new_with_inverse(
             &MOD::PARAMS.modulus,
             MOD::PARAMS.mod_inv,
             &MOD::PARAMS.r2,
         );
-        if let Some(inv) = inverter.invert_vartime(&self.montgomery_form) {
-            Some(Self {
-                montgomery_form: inv,
-                phantom: PhantomData,
-            })
-        } else {
-            None
-        }
+
+        let maybe_inverse = inverter.invert_vartime(&self.montgomery_form);
+
+        let ret = Self {
+            montgomery_form: maybe_inverse.to_inner_unchecked(),
+            phantom: PhantomData,
+        };
+
+        CtOption::new(ret, maybe_inverse.is_some())
     }
 }
 
 impl<MOD: ConstMontyParams<LIMBS>, const LIMBS: usize> Invert for ConstMontyForm<MOD, LIMBS> {
-    type Output = Self;
+    type Output = CtOption<Self>;
 
-    fn invert(&self) -> CtOption<Self::Output> {
+    fn invert(&self) -> Self::Output {
         self.invert()
     }
 
-    fn invert_vartime(&self) -> Option<Self::Output> {
+    fn invert_vartime(&self) -> Self::Output {
         self.invert_vartime()
     }
 }

--- a/src/modular/safegcd.rs
+++ b/src/modular/safegcd.rs
@@ -14,7 +14,7 @@ pub(crate) mod boxed;
 
 use core::fmt;
 
-use crate::{Choice, CtOption, I64, Int, Limb, NonZero, Odd, U64, Uint, primitives::u32_min};
+use crate::{Choice, CtOption, I64, Int, Limb, Odd, U64, Uint, primitives::u32_min};
 
 const GCD_BATCH_SIZE: u32 = 62;
 
@@ -84,61 +84,36 @@ impl<const LIMBS: usize> SafeGcdInverter<LIMBS> {
     /// Returns either the adjusted modular multiplicative inverse for the argument or `None`
     /// depending on invertibility of the argument, i.e. its coprimality with the modulus.
     pub const fn invert(&self, value: &Uint<LIMBS>) -> CtOption<Uint<LIMBS>> {
-        let is_nz = value.is_nonzero();
-        let nz = NonZero(Uint::select(&Uint::ONE, value, is_nz));
-        invert_odd_mod_precomp::<LIMBS, false>(&nz, &self.modulus, self.inverse, &self.adjuster)
-            .filter_by(is_nz)
+        invert_odd_mod_precomp::<LIMBS, false>(value, &self.modulus, self.inverse, &self.adjuster)
     }
 
     /// Returns either the adjusted modular multiplicative inverse for the argument or `None`
     /// depending on invertibility of the argument, i.e. its coprimality with the modulus.
     ///
     /// This version is variable-time with respect to `value`.
-    pub const fn invert_vartime(&self, value: &Uint<LIMBS>) -> Option<Uint<LIMBS>> {
-        if let Some(nz) = value.to_nz_vartime() {
-            invert_odd_mod_precomp::<LIMBS, true>(&nz, &self.modulus, self.inverse, &self.adjuster)
-                .into_option_copied()
-        } else {
-            None
-        }
+    pub const fn invert_vartime(&self, value: &Uint<LIMBS>) -> CtOption<Uint<LIMBS>> {
+        invert_odd_mod_precomp::<LIMBS, true>(value, &self.modulus, self.inverse, &self.adjuster)
     }
 }
 
 #[inline]
-pub const fn invert_odd_mod<const LIMBS: usize>(
+pub const fn invert_odd_mod<const LIMBS: usize, const VARTIME: bool>(
     a: &Uint<LIMBS>,
     m: &Odd<Uint<LIMBS>>,
 ) -> CtOption<Uint<LIMBS>> {
-    let is_nz = a.is_nonzero();
-    let nz = NonZero(Uint::select(&Uint::ONE, a, is_nz));
     let mi = m.as_uint_ref().invert_mod_u64();
-    invert_odd_mod_precomp::<LIMBS, false>(&nz, m, mi, &Uint::ONE).filter_by(is_nz)
-}
-
-#[inline]
-pub const fn invert_odd_mod_vartime<const LIMBS: usize>(
-    a: &Uint<LIMBS>,
-    m: &Odd<Uint<LIMBS>>,
-) -> Option<Uint<LIMBS>> {
-    if let Some(nz) = a.to_nz_vartime() {
-        let mi = m.as_uint_ref().invert_mod_u64();
-        invert_odd_mod_precomp::<LIMBS, true>(&nz, m, mi, &Uint::ONE).into_option_copied()
-    } else {
-        None
-    }
+    invert_odd_mod_precomp::<LIMBS, VARTIME>(a, m, mi, &Uint::ONE)
 }
 
 /// Calculate the multiplicative inverse of `a` modulo `m`.
 const fn invert_odd_mod_precomp<const LIMBS: usize, const VARTIME: bool>(
-    a: &NonZero<Uint<LIMBS>>,
+    a: &Uint<LIMBS>,
     m: &Odd<Uint<LIMBS>>,
     mi: u64,
     e: &Uint<LIMBS>,
 ) -> CtOption<Uint<LIMBS>> {
-    let (mut f, mut g) = (
-        SignedInt::from_uint(m.get_copy()),
-        SignedInt::from_uint(a.get_copy()),
-    );
+    let a_nonzero = a.is_nonzero();
+    let (mut f, mut g) = (SignedInt::from_uint(*m.as_ref()), SignedInt::from_uint(*a));
     let (mut d, mut e) = (SignedInt::<LIMBS>::ZERO, SignedInt::from_uint(*e));
     let mut steps = iterations(Uint::<LIMBS>::BITS);
     let mut delta = 1;
@@ -156,7 +131,7 @@ const fn invert_odd_mod_precomp<const LIMBS: usize, const VARTIME: bool>(
     }
 
     let d = d.norm(f.is_negative(), m.as_ref());
-    CtOption::new(d, Uint::eq(&f.magnitude, &Uint::ONE))
+    CtOption::new(d, Uint::eq(&f.magnitude, &Uint::ONE).and(a_nonzero))
 }
 
 /// Calculate the greatest common denominator of odd `f`, and `g`.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -995,11 +995,11 @@ pub trait Invert {
     type Output;
 
     /// Computes the inverse.
-    fn invert(&self) -> CtOption<Self::Output>;
+    fn invert(&self) -> Self::Output;
 
     /// Computes the inverse in variable-time.
-    fn invert_vartime(&self) -> Option<Self::Output> {
-        self.invert().into_option()
+    fn invert_vartime(&self) -> Self::Output {
+        self.invert()
     }
 }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -20,6 +20,9 @@ use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "zeroize")]
 use zeroize::DefaultIsZeroes;
 
+#[cfg(doc)]
+use crate::{NonZeroUint, OddUint};
+
 #[macro_use]
 mod macros;
 
@@ -209,7 +212,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         UintRef::new_mut(&mut self.limbs)
     }
 
-    /// Convert to a [`NonZero<Uint<LIMBS>>`].
+    /// Convert to a [`NonZeroUint<LIMBS>`].
     ///
     /// Returns some if the original value is non-zero, and none otherwise.
     #[must_use]
@@ -221,9 +224,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         CtOption::new(NonZero(ret), is_nz)
     }
 
-    /// Convert to a [`NonZero<Uint<LIMBS>>`].
+    /// Convert to a [`NonZeroUint<LIMBS>`].
     ///
-    /// Returns Some if the original value is non-zero, and None otherwise.
+    /// Returns Some if the original value is non-zero, and none otherwise.
     #[must_use]
     pub const fn to_nz_vartime(&self) -> Option<NonZero<Self>> {
         if !self.is_zero_vartime() {
@@ -233,7 +236,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
     }
 
-    /// Convert to a [`Odd<Uint<LIMBS>>`].
+    /// Convert to a [`OddUint<LIMBS>`].
     ///
     /// Returns some if the original value is odd, and false otherwise.
     #[must_use]
@@ -269,7 +272,15 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Is this [`Uint`] equal to [`Uint::ZERO`]?
     #[must_use]
     pub const fn is_zero(&self) -> Choice {
-        self.is_nonzero().not()
+        let mut ret = Choice::TRUE;
+        let mut n = 0;
+
+        while n < LIMBS {
+            ret = ret.and(self.limbs[n].is_zero());
+            n += 1;
+        }
+
+        ret
     }
 }
 

--- a/src/uint/boxed/invert_mod.rs
+++ b/src/uint/boxed/invert_mod.rs
@@ -16,13 +16,13 @@ impl BoxedUint {
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
     #[must_use]
     pub fn invert_odd_mod(&self, modulus: &Odd<Self>) -> CtOption<Self> {
-        safegcd::boxed::invert_odd_mod(self, modulus)
+        safegcd::boxed::invert_odd_mod::<false>(self, modulus)
     }
 
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
     #[must_use]
-    pub fn invert_odd_mod_vartime(&self, modulus: &Odd<Self>) -> Option<Self> {
-        safegcd::boxed::invert_odd_mod_vartime(self, modulus)
+    pub fn invert_odd_mod_vartime(&self, modulus: &Odd<Self>) -> CtOption<Self> {
+        safegcd::boxed::invert_odd_mod::<true>(self, modulus)
     }
 
     /// Computes 1/`self` mod `2^k`.

--- a/src/uint/invert_mod.rs
+++ b/src/uint/invert_mod.rs
@@ -149,15 +149,15 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
     #[must_use]
     pub const fn invert_odd_mod(&self, modulus: &Odd<Self>) -> CtOption<Self> {
-        safegcd::invert_odd_mod::<LIMBS>(self, modulus)
+        safegcd::invert_odd_mod::<LIMBS, false>(self, modulus)
     }
 
     /// Computes the multiplicative inverse of `self` mod `modulus`, where `modulus` is odd.
     ///
     /// This method is variable-time with respect to `self`.
     #[must_use]
-    pub const fn invert_odd_mod_vartime(&self, modulus: &Odd<Self>) -> Option<Self> {
-        safegcd::invert_odd_mod_vartime::<LIMBS>(self, modulus)
+    pub const fn invert_odd_mod_vartime(&self, modulus: &Odd<Self>) -> CtOption<Self> {
+        safegcd::invert_odd_mod::<LIMBS, true>(self, modulus)
     }
 
     /// Computes the multiplicative inverse of `self` mod `modulus`.

--- a/tests/monty_form.rs
+++ b/tests/monty_form.rs
@@ -6,8 +6,8 @@ mod common;
 
 use common::to_biguint;
 use crypto_bigint::{
-    Bounded, Constants, EncodedUint, Encoding, Integer, Invert, Monty, NonZero, Odd, U128, U256,
-    U512, U1024, U2048, U4096, Unsigned,
+    Bounded, Constants, CtOption, EncodedUint, Encoding, Integer, Invert, Monty, NonZero, Odd,
+    U128, U256, U512, U1024, U2048, U4096, Unsigned,
     modular::{MontyForm, MontyParams},
 };
 use num_bigint::BigUint;
@@ -52,7 +52,7 @@ fn random_invertible_uint<T>(
 ) -> Result<(T, <T as Unsigned>::Monty, <T as Unsigned>::Monty, BigUint), TestCaseError>
 where
     T: Unsigned + Bounded + Encoding,
-    <T as Unsigned>::Monty: Invert<Output = T::Monty>,
+    <T as Unsigned>::Monty: Invert<Output = CtOption<T::Monty>>,
 {
     let r = T::from_be_bytes(bytes.clone());
     let rm = <T as Unsigned>::Monty::new(r.clone(), &monty_params);


### PR DESCRIPTION
This reverts commit b9ba08f54e9ad95f6f353ed114ce6e25ae6da621 (#1097).

This changed `Invert::invert` trait method to use `ctutils::CtOption` explicitly.

`elliptic-curve` uses this `Invert` trait to express its inversions, including the ability to fully customize `Invert::Output` to express infallible inversions of `NonZeroScalar` which simply return `Self`.

It's also still using `subtle::CtOption` to handle the fallible cases as we're still using `subtle` in the public API until a decision is made upstream in `ff`/`group`:

https://github.com/zkcrypto/ff/issues/148

I also think we should still potentially leave the door open to supporting such infallible inversions in `crypto-bigint`, for e.g. `NonZero<ConstMontyForm<MOD, _>>` where `MOD: ConstMontyParams + PrimeField` or something like that.