### PR TITLE
Impl `ToOwned<Owned = BoxedUint>` for `UintRef`

### DIFF
--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -33,7 +33,12 @@ use crate::{
     Word, Zero, modular::BoxedMontyForm,
 };
 use alloc::{boxed::Box, vec, vec::Vec};
-use core::{fmt, iter::repeat, ops::IndexMut};
+use core::{
+    borrow::{Borrow, BorrowMut},
+    fmt,
+    iter::repeat,
+    ops::IndexMut,
+};
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -451,6 +456,18 @@ impl AsRef<UintRef> for BoxedUint {
 
 impl AsMut<UintRef> for BoxedUint {
     fn as_mut(&mut self) -> &mut UintRef {
+        self.as_mut_uint_ref()
+    }
+}
+
+impl Borrow<UintRef> for BoxedUint {
+    fn borrow(&self) -> &UintRef {
+        self.as_uint_ref()
+    }
+}
+
+impl BorrowMut<UintRef> for BoxedUint {
+    fn borrow_mut(&mut self) -> &mut UintRef {
         self.as_mut_uint_ref()
     }
 }

--- a/src/uint/boxed/from.rs
+++ b/src/uint/boxed/from.rs
@@ -1,6 +1,6 @@
 //! `From`-like conversions for [`BoxedUint`].
 
-use crate::{BoxedUint, Limb, Odd, U64, U128, Uint, Word};
+use crate::{BoxedUint, Limb, Odd, U64, U128, Uint, UintRef, Word};
 use alloc::{boxed::Box, vec::Vec};
 use core::mem;
 
@@ -120,5 +120,14 @@ impl<const LIMBS: usize> From<&Odd<Uint<LIMBS>>> for Odd<BoxedUint> {
     #[inline]
     fn from(uint: &Odd<Uint<LIMBS>>) -> Odd<BoxedUint> {
         Odd(BoxedUint::from(&uint.0))
+    }
+}
+
+impl From<&UintRef> for BoxedUint {
+    fn from(uint_ref: &UintRef) -> BoxedUint {
+        debug_assert!(uint_ref.nlimbs() >= 1, "empty `UintRef`");
+        BoxedUint {
+            limbs: uint_ref.as_limbs().into(),
+        }
     }
 }

--- a/src/uint/mul/karatsuba.rs
+++ b/src/uint/mul/karatsuba.rs
@@ -109,8 +109,8 @@ pub const fn widening_mul_fixed<const LHS: usize, const RHS: usize>(
     if LHS < MIN_STARTING_LIMBS || RHS < MIN_STARTING_LIMBS {
         let (mut lo, mut hi) = (Uint::ZERO, Uint::ZERO);
         schoolbook::mul_wide(
-            lhs.as_slice(),
-            rhs.as_slice(),
+            lhs.as_limbs(),
+            rhs.as_limbs(),
             lo.as_mut_limbs(),
             hi.as_mut_limbs(),
         );
@@ -200,7 +200,7 @@ pub const fn wrapping_mul_fixed<const LHS: usize>(
     // Handle smaller integer sizes
     if LHS < MIN_STARTING_LIMBS || rhs.nlimbs() < MIN_STARTING_LIMBS {
         let mut lo = Uint::ZERO;
-        let carry = schoolbook::wrapping_mul_add(lhs.as_slice(), rhs.as_slice(), lo.as_mut_limbs());
+        let carry = schoolbook::wrapping_mul_add(lhs.as_limbs(), rhs.as_limbs(), lo.as_mut_limbs());
         return (lo, carry);
     }
     // Because only matching limbs are considered, any LHS <= RHS is treated as a fixed-size
@@ -268,7 +268,7 @@ pub const fn widening_square_fixed<const LIMBS: usize>(
     // Handle smaller integer sizes
     if LIMBS < MIN_STARTING_LIMBS {
         let (mut lo, mut hi) = (Uint::ZERO, Uint::ZERO);
-        schoolbook::square_wide(uint.as_slice(), lo.as_mut_limbs(), hi.as_mut_limbs());
+        schoolbook::square_wide(uint.as_limbs(), lo.as_mut_limbs(), hi.as_mut_limbs());
         (lo, hi)
     }
     // Forward to optimized implementations or the dynamic implementation. This choice should
@@ -414,7 +414,7 @@ pub const fn wrapping_mul(lhs: &UintRef, rhs: &UintRef, out: &mut UintRef, add: 
 
     // Handle smaller sized integers
     if split < MIN_STARTING_LIMBS {
-        return schoolbook::wrapping_mul_add(lhs.as_slice(), rhs.as_slice(), out.as_mut_slice());
+        return schoolbook::wrapping_mul_add(lhs.as_limbs(), rhs.as_limbs(), out.as_mut_limbs());
     }
 
     // Select an optimized implementation for a fixed number of limbs
@@ -491,7 +491,7 @@ pub(crate) const fn wrapping_square(uint: &UintRef, out: &mut UintRef) -> Limb {
 
     // Handle smaller integer sizes
     if x.nlimbs() <= MIN_STARTING_LIMBS {
-        return schoolbook::wrapping_square(x.as_slice(), out.as_mut_slice());
+        return schoolbook::wrapping_square(x.as_limbs(), out.as_mut_limbs());
     }
 
     // Select an optimized 'split' such that a wide multiplication will not

--- a/src/uint/ref_type.rs
+++ b/src/uint/ref_type.rs
@@ -18,8 +18,8 @@ use core::{
     ptr,
 };
 
-#[cfg(all(doc, feature = "alloc"))]
-use crate::BoxedUint;
+#[cfg(feature = "alloc")]
+use {crate::BoxedUint, alloc::borrow::ToOwned};
 
 /// Unsigned integer reference type.
 ///
@@ -69,13 +69,13 @@ impl UintRef {
     /// Borrow the inner `&[Limb]` slice.
     #[inline]
     #[must_use]
-    pub const fn as_slice(&self) -> &[Limb] {
+    pub const fn as_limbs(&self) -> &[Limb] {
         &self.0
     }
 
     /// Mutably borrow the inner `&mut [Limb]` slice.
     #[inline]
-    pub const fn as_mut_slice(&mut self) -> &mut [Limb] {
+    pub const fn as_mut_limbs(&mut self) -> &mut [Limb] {
         &mut self.0
     }
 
@@ -315,14 +315,14 @@ impl UintRef {
 impl AsRef<[Limb]> for UintRef {
     #[inline]
     fn as_ref(&self) -> &[Limb] {
-        self.as_slice()
+        self.as_limbs()
     }
 }
 
 impl AsMut<[Limb]> for UintRef {
     #[inline]
     fn as_mut(&mut self) -> &mut [Limb] {
-        self.as_mut_slice()
+        self.as_mut_limbs()
     }
 }
 
@@ -339,6 +339,15 @@ impl IndexMut<usize> for UintRef {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Limb {
         self.0.index_mut(index)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl ToOwned for UintRef {
+    type Owned = BoxedUint;
+
+    fn to_owned(&self) -> BoxedUint {
+        BoxedUint::from(self)
     }
 }
 

--- a/src/uint/ref_type/add.rs
+++ b/src/uint/ref_type/add.rs
@@ -49,7 +49,7 @@ impl UintRef {
         carry: Limb,
         choice: Choice,
     ) -> Limb {
-        self.conditional_add_assign_slice(rhs.as_slice(), carry, choice)
+        self.conditional_add_assign_slice(rhs.as_limbs(), carry, choice)
     }
 
     /// Perform an in-place carrying add of another limb slice, returning the carried limb value.


### PR DESCRIPTION
When the `alloc` feature is enabled, supports boxing `UintRef` using `to_owned`