### PR TITLE
`UintRef { limbs: ... }`

### DIFF
--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -845,7 +845,7 @@ impl RadixDivisionParams {
                 remain_mut
                     .leading_mut(RADIX_ENCODING_LIMBS_LARGE - 1)
                     .copy_from(limbs_rem);
-                remain_mut.0[RADIX_ENCODING_LIMBS_LARGE - 1] = rem_high;
+                remain_mut.limbs[RADIX_ENCODING_LIMBS_LARGE - 1] = rem_high;
                 remain_mut.shr_assign_limb_vartime(self.shift_large);
 
                 (remain_mut, out_idx.saturating_sub(self.digits_large))

--- a/src/uint/mul.rs
+++ b/src/uint/mul.rs
@@ -261,14 +261,14 @@ pub(crate) const fn wrapping_mul_overflow(
     let mut j = lhs.nlimbs();
     let mut k = rhs.nlimbs().saturating_sub(1);
     while k > j {
-        rhs_tail = rhs_tail.bitor(rhs.0[k]);
+        rhs_tail = rhs_tail.bitor(rhs.limbs[k]);
         k -= 1;
     }
     while i < lhs.nlimbs() {
         j = lhs.nlimbs() - i;
         if j < rhs.nlimbs() {
-            rhs_tail = rhs_tail.bitor(rhs.0[j]);
-            overflow = overflow.or(lhs.0[i].is_nonzero().and(rhs_tail.is_nonzero()));
+            rhs_tail = rhs_tail.bitor(rhs.limbs[j]);
+            overflow = overflow.or(lhs.limbs[i].is_nonzero().and(rhs_tail.is_nonzero()));
         }
         i += 1;
     }

--- a/src/uint/mul/karatsuba.rs
+++ b/src/uint/mul/karatsuba.rs
@@ -64,8 +64,8 @@ pub const fn widening_mul_fixed<const LHS: usize, const RHS: usize>(
         let (mut l0c, mut l1c) = (Limb::ZERO, Limb::ZERO);
         let mut i = 0;
         while i < HALF {
-            (l0.limbs[i], l0c) = x0.0[i].carrying_add(x1.0[i], l0c);
-            (l1.limbs[i], l1c) = y0.0[i].carrying_add(y1.0[i], l1c);
+            (l0.limbs[i], l0c) = x0.limbs[i].carrying_add(x1.limbs[i], l0c);
+            (l1.limbs[i], l1c) = y0.limbs[i].carrying_add(y1.limbs[i], l1c);
             i += 1;
         }
         let z1 = widening_mul_fixed(l0.as_uint_ref(), l1.as_uint_ref());
@@ -456,7 +456,7 @@ pub(crate) const fn wrapping_square(uint: &UintRef, out: &mut UintRef) -> Limb {
             if tail.is_empty() {
                 Limb::ZERO
             } else {
-                tail.0[0]
+                tail.limbs[0]
             }
         } else {
             let (z01, z2) = hi.split_at_mut(LIMBS);

--- a/src/uint/ref_type/add.rs
+++ b/src/uint/ref_type/add.rs
@@ -7,8 +7,8 @@ impl UintRef {
     #[track_caller]
     pub const fn add_assign_limb(&mut self, mut rhs: Limb) -> Limb {
         let mut i = 0;
-        while i < self.0.len() {
-            (self.0[i], rhs) = self.0[i].overflowing_add(rhs);
+        while i < self.limbs.len() {
+            (self.limbs[i], rhs) = self.limbs[i].overflowing_add(rhs);
             i += 1;
         }
         rhs
@@ -18,7 +18,7 @@ impl UintRef {
     #[inline]
     #[track_caller]
     pub const fn carrying_add_assign(&mut self, rhs: &Self, carry: Limb) -> Limb {
-        self.carrying_add_assign_slice(&rhs.0, carry)
+        self.carrying_add_assign_slice(&rhs.limbs, carry)
     }
 
     /// Perform an in-place carrying add of another limb slice, returning the carried limb value.
@@ -29,12 +29,12 @@ impl UintRef {
     #[track_caller]
     pub const fn carrying_add_assign_slice(&mut self, rhs: &[Limb], mut carry: Limb) -> Limb {
         assert!(
-            self.0.len() == rhs.len(),
+            self.limbs.len() == rhs.len(),
             "length mismatch in carrying_add_assign_slice"
         );
         let mut i = 0;
-        while i < self.0.len() {
-            (self.0[i], carry) = self.0[i].carrying_add(rhs[i], carry);
+        while i < self.limbs.len() {
+            (self.limbs[i], carry) = self.limbs[i].carrying_add(rhs[i], carry);
             i += 1;
         }
         carry
@@ -65,13 +65,13 @@ impl UintRef {
         choice: Choice,
     ) -> Limb {
         assert!(
-            self.0.len() == rhs.len(),
+            self.limbs.len() == rhs.len(),
             "length mismatch in conditional_add_assign_slice"
         );
         let mut i = 0;
-        while i < self.0.len() {
-            (self.0[i], carry) =
-                self.0[i].carrying_add(Limb::select(Limb::ZERO, rhs[i], choice), carry);
+        while i < self.limbs.len() {
+            (self.limbs[i], carry) =
+                self.limbs[i].carrying_add(Limb::select(Limb::ZERO, rhs[i], choice), carry);
             i += 1;
         }
         carry

--- a/src/uint/ref_type/cmp.rs
+++ b/src/uint/ref_type/cmp.rs
@@ -12,7 +12,7 @@ impl UintRef {
     #[must_use]
     pub const fn is_odd(&self) -> Choice {
         debug_assert!(self.nlimbs() >= 1, "should have limbs");
-        word::choice_from_lsb(self.0[0].0 & 1)
+        word::choice_from_lsb(self.limbs[0].0 & 1)
     }
 
     /// Returns [`Choice::TRUE`] if `self` != `0` or [`Choice::FALSE`] otherwise.
@@ -22,7 +22,7 @@ impl UintRef {
         let mut b = 0;
         let mut i = 0;
         while i < self.nlimbs() {
-            b |= self.0[i].0;
+            b |= self.limbs[i].0;
             i += 1;
         }
         Limb(b).is_nonzero()
@@ -40,7 +40,7 @@ impl UintRef {
     pub(crate) const fn is_zero_vartime(&self) -> bool {
         let mut i = 0;
         while i < self.nlimbs() {
-            if self.0[i].0 != 0 {
+            if self.limbs[i].0 != 0 {
                 return false;
             }
             i += 1;

--- a/src/uint/ref_type/ct.rs
+++ b/src/uint/ref_type/ct.rs
@@ -7,13 +7,13 @@ impl CtAssign for UintRef {
     #[inline]
     fn ct_assign(&mut self, other: &Self, choice: Choice) {
         debug_assert_eq!(self.bits_precision(), other.bits_precision());
-        self.0.ct_assign(&other.0, choice);
+        self.limbs.ct_assign(&other.limbs, choice);
     }
 }
 
 impl CtEq for UintRef {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
-        self.0.ct_eq(&other.0)
+        self.limbs.ct_eq(&other.limbs)
     }
 }

--- a/src/uint/ref_type/invert_mod.rs
+++ b/src/uint/ref_type/invert_mod.rs
@@ -7,7 +7,7 @@ impl Odd<UintRef> {
     ///
     /// For better understanding the implementation, the following paper is recommended:
     /// J. Hurchalla, "An Improved Integer Multiplicative Inverse (modulo 2^w)",
-    /// <https://arxiv.org/pdf/2204.04342.pdf>
+    /// <https://arxiv.org/pdf/2204.limbs4342.pdf>
     ///
     /// Variable time with respect to the number of words in `value`, however that number will be
     /// fixed for a given integer size.

--- a/src/uint/ref_type/shl.rs
+++ b/src/uint/ref_type/shl.rs
@@ -67,11 +67,11 @@ impl UintRef {
         let mut i = self.nlimbs();
         while i > shift {
             i -= 1;
-            self.0[i] = Limb::select(self.0[i], self.0[i - shift], c);
+            self.limbs[i] = Limb::select(self.limbs[i], self.limbs[i - shift], c);
         }
         while i > 0 {
             i -= 1;
-            self.0[i] = Limb::select(self.0[i], Limb::ZERO, c);
+            self.limbs[i] = Limb::select(self.limbs[i], Limb::ZERO, c);
         }
     }
 
@@ -88,11 +88,11 @@ impl UintRef {
         let mut i = self.nlimbs();
         while i > shift {
             i -= 1;
-            self.0[i] = self.0[i - shift];
+            self.limbs[i] = self.limbs[i - shift];
         }
         while i > 0 {
             i -= 1;
-            self.0[i] = Limb::ZERO;
+            self.limbs[i] = Limb::ZERO;
         }
     }
 
@@ -114,9 +114,9 @@ impl UintRef {
             let mut carry = Limb::ZERO;
             let mut i = shift_limbs as usize;
             while i < self.nlimbs() {
-                (self.0[i], carry) = (
-                    self.0[i].shl(rem).bitor(carry),
-                    self.0[i].shr(Limb::BITS - rem),
+                (self.limbs[i], carry) = (
+                    self.limbs[i].shl(rem).bitor(carry),
+                    self.limbs[i].shr(Limb::BITS - rem),
                 );
                 i += 1;
             }
@@ -130,8 +130,8 @@ impl UintRef {
         let mut carry = Limb::ZERO;
         let mut i = 0;
         while i < self.nlimbs() {
-            let (limb, new_carry) = self.0[i].shl1();
-            self.0[i] = limb.bitor(carry);
+            let (limb, new_carry) = self.limbs[i].shl1();
+            self.limbs[i] = limb.bitor(carry);
             carry = new_carry;
             i += 1;
         }
@@ -157,9 +157,13 @@ impl UintRef {
 
         let mut i = 0;
         while i < self.nlimbs() {
-            (self.0[i], carry) = (
-                Limb::select(self.0[i], self.0[i].shl(lshift).bitor(carry), choice),
-                self.0[i].shr(rshift),
+            (self.limbs[i], carry) = (
+                Limb::select(
+                    self.limbs[i],
+                    self.limbs[i].shl(lshift).bitor(carry),
+                    choice,
+                ),
+                self.limbs[i].shr(rshift),
             );
             i += 1;
         }
@@ -199,7 +203,10 @@ impl UintRef {
 
         let mut i = 0;
         while i < self.nlimbs() {
-            (self.0[i], carry) = (self.0[i].shl(lshift).bitor(carry), self.0[i].shr(rshift));
+            (self.limbs[i], carry) = (
+                self.limbs[i].shl(lshift).bitor(carry),
+                self.limbs[i].shr(rshift),
+            );
             i += 1;
         }
 

--- a/src/uint/ref_type/shr.rs
+++ b/src/uint/ref_type/shr.rs
@@ -70,11 +70,11 @@ impl UintRef {
         let shift = shift as usize;
         let mut i = 0;
         while i < self.nlimbs().saturating_sub(shift) {
-            self.0[i] = Limb::select(self.0[i], self.0[i + shift], c);
+            self.limbs[i] = Limb::select(self.limbs[i], self.limbs[i + shift], c);
             i += 1;
         }
         while i < self.nlimbs() {
-            self.0[i] = Limb::select(self.0[i], Limb::ZERO, c);
+            self.limbs[i] = Limb::select(self.limbs[i], Limb::ZERO, c);
             i += 1;
         }
     }
@@ -107,11 +107,11 @@ impl UintRef {
         let shift = shift as usize;
         let mut i = 0;
         while i < self.nlimbs().saturating_sub(shift) {
-            self.0[i] = self.0[i + shift];
+            self.limbs[i] = self.limbs[i + shift];
             i += 1;
         }
         while i < self.nlimbs() {
-            self.0[i] = Limb::ZERO;
+            self.limbs[i] = Limb::ZERO;
             i += 1;
         }
     }
@@ -135,9 +135,9 @@ impl UintRef {
             let mut i = self.nlimbs().saturating_sub(shift_limbs as usize);
             while i > 0 {
                 i -= 1;
-                (self.0[i], carry) = (
-                    self.0[i].shr(rem).bitor(carry),
-                    self.0[i].shl(Limb::BITS - rem),
+                (self.limbs[i], carry) = (
+                    self.limbs[i].shr(rem).bitor(carry),
+                    self.limbs[i].shl(Limb::BITS - rem),
                 );
             }
         }
@@ -152,8 +152,8 @@ impl UintRef {
         let mut i = self.nlimbs();
         while i > 0 {
             i -= 1;
-            let (limb, new_carry) = self.0[i].shr1();
-            self.0[i] = limb.bitor(carry);
+            let (limb, new_carry) = self.limbs[i].shr1();
+            self.limbs[i] = limb.bitor(carry);
             carry = new_carry;
         }
         word::choice_from_lsb(carry.0 >> Limb::HI_BIT)
@@ -179,9 +179,13 @@ impl UintRef {
         let mut i = self.nlimbs();
         while i > 0 {
             i -= 1;
-            (self.0[i], carry) = (
-                Limb::select(self.0[i], self.0[i].shr(rshift).bitor(carry), choice),
-                self.0[i].shl(lshift),
+            (self.limbs[i], carry) = (
+                Limb::select(
+                    self.limbs[i],
+                    self.limbs[i].shr(rshift).bitor(carry),
+                    choice,
+                ),
+                self.limbs[i].shl(lshift),
             );
         }
 
@@ -222,7 +226,10 @@ impl UintRef {
         let mut i = self.nlimbs();
         while i > 0 {
             i -= 1;
-            (self.0[i], carry) = (self.0[i].shr(rshift).bitor(carry), self.0[i].shl(lshift));
+            (self.limbs[i], carry) = (
+                self.limbs[i].shr(rshift).bitor(carry),
+                self.limbs[i].shl(lshift),
+            );
         }
 
         carry

--- a/src/uint/ref_type/slice.rs
+++ b/src/uint/ref_type/slice.rs
@@ -9,7 +9,7 @@ impl UintRef {
     #[inline(always)]
     #[track_caller]
     pub const fn copy_from(&mut self, rhs: &UintRef) {
-        self.copy_from_slice(&rhs.0);
+        self.copy_from_slice(&rhs.limbs);
     }
 
     /// Copy the contents from a limb slice.
@@ -20,10 +20,10 @@ impl UintRef {
     #[track_caller]
     pub const fn copy_from_slice(&mut self, limbs: &[Limb]) {
         // TODO core::slice::copy_from_slice should eventually be const
-        debug_assert!(self.0.len() == limbs.len(), "length mismatch");
+        debug_assert!(self.limbs.len() == limbs.len(), "length mismatch");
         let mut i = 0;
-        while i < self.0.len() {
-            self.0[i] = limbs[i];
+        while i < self.limbs.len() {
+            self.limbs[i] = limbs[i];
             i += 1;
         }
     }
@@ -32,8 +32,8 @@ impl UintRef {
     #[inline(always)]
     pub const fn fill(&mut self, limb: Limb) {
         let mut i = 0;
-        while i < self.0.len() {
-            self.0[i] = limb;
+        while i < self.limbs.len() {
+            self.limbs[i] = limb;
             i += 1;
         }
     }
@@ -43,7 +43,7 @@ impl UintRef {
     #[track_caller]
     #[must_use]
     pub const fn split_at(&self, mid: usize) -> (&Self, &Self) {
-        let (a, b) = self.0.split_at(mid);
+        let (a, b) = self.limbs.split_at(mid);
         (UintRef::new(a), UintRef::new(b))
     }
 
@@ -51,7 +51,7 @@ impl UintRef {
     #[inline]
     #[track_caller]
     pub const fn split_at_mut(&mut self, mid: usize) -> (&mut Self, &mut Self) {
-        let (a, b) = self.0.split_at_mut(mid);
+        let (a, b) = self.limbs.split_at_mut(mid);
         (UintRef::new_mut(a), UintRef::new_mut(b))
     }
 
@@ -60,27 +60,27 @@ impl UintRef {
     #[track_caller]
     #[must_use]
     pub const fn leading(&self, len: usize) -> &Self {
-        Self::new(self.0.split_at(len).0)
+        Self::new(self.limbs.split_at(len).0)
     }
 
     /// Access a mutable limb slice up to a number of elements `len`.
     #[inline]
     #[track_caller]
     pub const fn leading_mut(&mut self, len: usize) -> &mut Self {
-        Self::new_mut(self.0.split_at_mut(len).0)
+        Self::new_mut(self.limbs.split_at_mut(len).0)
     }
 
     /// Access a mutable limb slice starting from the index `start`.
     #[inline]
     #[track_caller]
     pub const fn trailing_mut(&mut self, start: usize) -> &mut Self {
-        Self::new_mut(self.0.split_at_mut(start).1)
+        Self::new_mut(self.limbs.split_at_mut(start).1)
     }
 
     /// Determine if the slice has zero limbs.
     #[inline]
     #[must_use]
     pub const fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.limbs.is_empty()
     }
 }

--- a/src/uint/ref_type/sub.rs
+++ b/src/uint/ref_type/sub.rs
@@ -6,7 +6,7 @@ impl UintRef {
     /// value.
     #[inline]
     pub const fn borrowing_sub_assign(&mut self, rhs: &Self, borrow: Limb) -> Limb {
-        self.borrowing_sub_assign_slice(&rhs.0, borrow)
+        self.borrowing_sub_assign_slice(&rhs.limbs, borrow)
     }
 
     /// Perform an in-place borrowing subtraction of another limb slice, returning the borrowed limb
@@ -16,10 +16,10 @@ impl UintRef {
     /// If `self` and `rhs` have different lengths.
     #[inline]
     pub const fn borrowing_sub_assign_slice(&mut self, rhs: &[Limb], mut borrow: Limb) -> Limb {
-        assert!(self.0.len() == rhs.len(), "length mismatch");
+        assert!(self.limbs.len() == rhs.len(), "length mismatch");
         let mut i = 0;
-        while i < self.0.len() {
-            (self.0[i], borrow) = self.0[i].borrowing_sub(rhs[i], borrow);
+        while i < self.limbs.len() {
+            (self.limbs[i], borrow) = self.limbs[i].borrowing_sub(rhs[i], borrow);
             i += 1;
         }
         borrow


### PR DESCRIPTION
Changes `UintRef` from a tuple struct to having a `limbs` field like every other `*Uint` type.

I don't know why I made it a tuple struct in the first place but now the inconsistency is driving me insane.