### PR TITLE
Bump `ctutils` to v0.4 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.4.0-pre.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9648048880cb5c7ac08f184a42cad58d81a49205b5f46e636270dc9a5b73fe"
+checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
 dependencies = [
  "cmov",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 exclude = [".codecov.yml", ".github", ".gitignore"]
 
 [dependencies]
-ctutils = "0.4.0-pre.5"
+ctutils = "0.4"
 num-traits = { version = "0.2.19", default-features = false }
 
 # optional dependencies


### PR DESCRIPTION
Release PR: RustCrypto/utils#1410