### PR TITLE
Add `Unsigned::as(_mut)_uint_ref`

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -167,6 +167,7 @@ pub trait Signed:
 /// Unsigned [`Integer`]s.
 pub trait Unsigned:
     AsRef<UintRef>
+    + AsMut<UintRef>
     + AddMod<Output = Self>
     + BitOps
     + Div<NonZero<Self>, Output = Self>
@@ -188,6 +189,13 @@ pub trait Unsigned:
     /// The corresponding Montgomery representation,
     /// optimized for the performance of modular operations at the price of a conversion overhead.
     type Monty: Monty<Integer = Self>;
+
+    /// Borrow the limbs of this unsigned integer as a [`UintRef`].
+    #[must_use]
+    fn as_uint_ref(&self) -> &UintRef;
+
+    /// Mutably borrow the limbs of this unsigned integer as a [`UintRef`].
+    fn as_mut_uint_ref(&mut self) -> &mut UintRef;
 
     /// Returns an integer with the first limb set to `limb`, and the same precision as `other`.
     #[must_use]

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -356,6 +356,14 @@ impl<const LIMBS: usize> Integer for Uint<LIMBS> {
 impl<const LIMBS: usize> Unsigned for Uint<LIMBS> {
     type Monty = MontyForm<LIMBS>;
 
+    fn as_uint_ref(&self) -> &UintRef {
+        self.as_uint_ref()
+    }
+
+    fn as_mut_uint_ref(&mut self) -> &mut UintRef {
+        self.as_mut_uint_ref()
+    }
+
     fn from_limb_like(limb: Limb, _other: &Self) -> Self {
         Self::from(limb)
     }

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -495,6 +495,14 @@ impl Integer for BoxedUint {
 impl Unsigned for BoxedUint {
     type Monty = BoxedMontyForm;
 
+    fn as_uint_ref(&self) -> &UintRef {
+        self.as_uint_ref()
+    }
+
+    fn as_mut_uint_ref(&mut self) -> &mut UintRef {
+        self.as_mut_uint_ref()
+    }
+
     fn from_limb_like(limb: Limb, other: &Self) -> Self {
         let mut ret = Self::zero_with_precision(other.bits_precision());
         ret.limbs[0] = limb;


### PR DESCRIPTION
Adds methods for obtaining `UintRef` in addition to the existing `AsRef<UintRef>` bounds (which might have inference problems), and also adds an `AsMut<UintRef>` bound to `Unsigned`.