### PR TITLE
Have `Monty::params` return `GenericMontyParams`

### DIFF
--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -127,9 +127,21 @@ impl BoxedMontyParams {
     }
 }
 
+impl AsRef<GenericMontyParams<BoxedUint>> for BoxedMontyParams {
+    fn as_ref(&self) -> &GenericMontyParams<BoxedUint> {
+        &self.0
+    }
+}
+
 impl Debug for BoxedMontyParams {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.debug_struct(f.debug_struct("BoxedMontyParams"))
+    }
+}
+
+impl From<GenericMontyParams<BoxedUint>> for BoxedMontyParams {
+    fn from(params: GenericMontyParams<BoxedUint>) -> Self {
+        Self(params.into())
     }
 }
 
@@ -294,8 +306,8 @@ impl Monty for BoxedMontyForm {
         BoxedMontyForm::one(params)
     }
 
-    fn params(&self) -> &Self::Params {
-        &self.params
+    fn params(&self) -> &GenericMontyParams<BoxedUint> {
+        self.params.as_ref()
     }
 
     fn as_montgomery(&self) -> &Self::Integer {

--- a/src/modular/monty_params.rs
+++ b/src/modular/monty_params.rs
@@ -70,6 +70,12 @@ impl<U: Unsigned> GenericMontyParams<U> {
     }
 }
 
+impl<U: Unsigned> AsRef<Self> for GenericMontyParams<U> {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 impl<U: Unsigned> CtAssign for GenericMontyParams<U> {
     fn ct_assign(&mut self, other: &Self, choice: Choice) {
         self.modulus.ct_assign(&other.modulus, choice);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -10,7 +10,10 @@ pub use num_traits::{
     WrappingSub,
 };
 
-use crate::{Choice, CtOption, Limb, NonZero, Odd, Reciprocal, UintRef, modular::Retrieve};
+use crate::{
+    Choice, CtOption, Limb, NonZero, Odd, Reciprocal, UintRef,
+    modular::{GenericMontyParams, Retrieve},
+};
 use core::fmt::{self, Debug};
 
 #[cfg(feature = "rand_core")]
@@ -1137,7 +1140,15 @@ pub trait Monty:
     type Multiplier<'a>: Debug + Clone + MontyMultiplier<'a, Monty = Self>;
 
     /// The precomputed data needed for this representation.
-    type Params: 'static + Clone + Debug + Eq + Sized + Send + Sync;
+    type Params: 'static
+        + AsRef<GenericMontyParams<Self::Integer>>
+        + From<GenericMontyParams<Self::Integer>>
+        + Clone
+        + Debug
+        + Eq
+        + Sized
+        + Send
+        + Sync;
 
     /// Create the precomputed data for Montgomery representation of integers modulo `modulus`,
     /// variable time in `modulus`.
@@ -1158,7 +1169,7 @@ pub trait Monty:
 
     /// Returns the parameter struct used to initialize this object.
     #[must_use]
-    fn params(&self) -> &Self::Params;
+    fn params(&self) -> &GenericMontyParams<Self::Integer>;
 
     /// Access the value in Montgomery form.
     #[must_use]


### PR DESCRIPTION
Previously it wasn't possible to actually retrieve any of the parameters in a generic context. Returning a struct instead of an associated type makes that possible.

It's a bit confusing because there's still a `Monty::Params` type which is different: this is needed to gloss over the distinction between `BoxedMontyParams` which contains an
`Arc<GenericMontyParams<BoxedUint>>`.

To do that, it adds an `AsRef<GenericMontyParams<Self::Integer>>` bound to represent that bit of indirection, and also a
`From<GenericMontyParams<U>>` bound to make generic conversions possible.

A generic impl of `AsRef<GenericMontyParams<U>>` is also added to `GenericMontyParams<U>>` which suffices for the `MontyParams` type alias.

Now `Monty::params` returns a concrete generic type rather than an associated type, which means we can put any shared functionality we want in `GenericMontyParams`.

cc @andrewwhitehead 