### PR TITLE
Have `Monty::zero` and `Monty::one` borrow params

### DIFF
--- a/src/modular/boxed_monty_form.rs
+++ b/src/modular/boxed_monty_form.rs
@@ -64,19 +64,19 @@ impl BoxedMontyForm {
 
     /// Instantiates a new `ConstMontyForm` that represents zero.
     #[must_use]
-    pub fn zero(params: BoxedMontyParams) -> Self {
+    pub fn zero(params: &BoxedMontyParams) -> Self {
         Self {
             montgomery_form: BoxedUint::zero_with_precision(params.bits_precision()),
-            params,
+            params: params.clone(),
         }
     }
 
     /// Instantiates a new `ConstMontyForm` that represents 1.
     #[must_use]
-    pub fn one(params: BoxedMontyParams) -> Self {
+    pub fn one(params: &BoxedMontyParams) -> Self {
         Self {
             montgomery_form: params.one().clone(),
-            params,
+            params: params.clone(),
         }
     }
 
@@ -121,11 +121,11 @@ impl BoxedMontyForm {
 
     /// Create a [`BoxedMontyForm`] from a value in Montgomery form.
     #[must_use]
-    pub fn from_montgomery(integer: BoxedUint, params: BoxedMontyParams) -> Self {
+    pub fn from_montgomery(integer: BoxedUint, params: &BoxedMontyParams) -> Self {
         debug_assert_eq!(integer.bits_precision(), params.bits_precision());
         Self {
             montgomery_form: integer,
-            params,
+            params: params.clone(),
         }
     }
 
@@ -172,11 +172,11 @@ impl Monty for BoxedMontyForm {
         BoxedMontyForm::new(value, params)
     }
 
-    fn zero(params: Self::Params) -> Self {
+    fn zero(params: &Self::Params) -> Self {
         BoxedMontyForm::zero(params)
     }
 
-    fn one(params: Self::Params) -> Self {
+    fn one(params: &Self::Params) -> Self {
         BoxedMontyForm::one(params)
     }
 
@@ -197,6 +197,10 @@ impl Monty for BoxedMontyForm {
         self.montgomery_form
             .limbs
             .copy_from_slice(&other.montgomery_form.limbs);
+    }
+
+    fn into_montgomery(self) -> Self::Integer {
+        self.montgomery_form
     }
 
     fn double(&self) -> Self {
@@ -248,8 +252,8 @@ mod tests {
     fn div_by_2() {
         let modulus = Odd::new(BoxedUint::from(9u8)).unwrap();
         let params = BoxedMontyParams::new(modulus);
-        let zero = BoxedMontyForm::zero(params.clone());
-        let one = BoxedMontyForm::one(params.clone());
+        let zero = BoxedMontyForm::zero(&params);
+        let one = BoxedMontyForm::one(&params);
         let two = one.add(&one);
 
         assert_eq!(zero.div_by_2(), zero);
@@ -260,7 +264,7 @@ mod tests {
     fn as_montgomery_mut() {
         let modulus = Odd::new(BoxedUint::from(9u8)).unwrap();
         let params = BoxedMontyParams::new(modulus);
-        let one = BoxedMontyForm::one(params.clone());
+        let one = BoxedMontyForm::one(&params);
         let two = one.add(&one);
         let four = two.mul(&two);
         let mut x = two.clone();

--- a/src/modular/monty_form.rs
+++ b/src/modular/monty_form.rs
@@ -52,19 +52,19 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
 
     /// Instantiates a new `MontyForm` that represents zero.
     #[must_use]
-    pub const fn zero(params: MontyParams<LIMBS>) -> Self {
+    pub const fn zero(params: &MontyParams<LIMBS>) -> Self {
         Self {
             montgomery_form: Uint::<LIMBS>::ZERO,
-            params,
+            params: *params,
         }
     }
 
     /// Instantiates a new `MontyForm` that represents 1.
     #[must_use]
-    pub const fn one(params: MontyParams<LIMBS>) -> Self {
+    pub const fn one(params: &MontyParams<LIMBS>) -> Self {
         Self {
             montgomery_form: params.one,
-            params,
+            params: *params,
         }
     }
 
@@ -87,10 +87,10 @@ impl<const LIMBS: usize> MontyForm<LIMBS> {
 
     /// Create a `MontyForm` from a value in Montgomery form.
     #[must_use]
-    pub const fn from_montgomery(integer: Uint<LIMBS>, params: MontyParams<LIMBS>) -> Self {
+    pub const fn from_montgomery(integer: Uint<LIMBS>, params: &MontyParams<LIMBS>) -> Self {
         Self {
             montgomery_form: integer,
-            params,
+            params: *params,
         }
     }
 
@@ -130,11 +130,11 @@ impl<const LIMBS: usize> Monty for MontyForm<LIMBS> {
         MontyForm::new(&value, params)
     }
 
-    fn zero(params: Self::Params) -> Self {
+    fn zero(params: &Self::Params) -> Self {
         MontyForm::zero(params)
     }
 
-    fn one(params: Self::Params) -> Self {
+    fn one(params: &Self::Params) -> Self {
         MontyForm::one(params)
     }
 
@@ -144,6 +144,10 @@ impl<const LIMBS: usize> Monty for MontyForm<LIMBS> {
 
     fn as_montgomery(&self) -> &Self::Integer {
         &self.montgomery_form
+    }
+
+    fn into_montgomery(self) -> Self::Integer {
+        self.montgomery_form
     }
 
     fn copy_montgomery_from(&mut self, other: &Self) {

--- a/src/modular/monty_form/mul.rs
+++ b/src/modular/monty_form/mul.rs
@@ -196,14 +196,14 @@ mod tests {
 
     #[test]
     fn test_mul_zero() {
-        let res = N_MOD.mul(&MontyForm::zero(PARAMS));
+        let res = N_MOD.mul(&MontyForm::zero(&PARAMS));
         let expected = U256::ZERO;
         assert_eq!(res.retrieve(), expected);
     }
 
     #[test]
     fn test_mul_one() {
-        let res = N_MOD.mul(&MontyForm::one(PARAMS));
+        let res = N_MOD.mul(&MontyForm::one(&PARAMS));
         assert_eq!(res.retrieve(), N);
     }
 

--- a/src/modular/pow.rs
+++ b/src/modular/pow.rs
@@ -47,7 +47,7 @@ where
     U: Unsigned,
     <U::Monty as Monty>::Multiplier<'a>: AmmMultiplier<'a>,
 {
-    let one = U::Monty::one(params.clone()).as_montgomery().clone();
+    let one = params.as_ref().one().clone();
 
     if exponent_bits == 0 {
         return one; // 1 in Montgomery form

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1167,11 +1167,11 @@ pub trait Monty:
 
     /// Returns zero in this representation.
     #[must_use]
-    fn zero(params: Self::Params) -> Self;
+    fn zero(params: &Self::Params) -> Self;
 
     /// Returns one in this representation.
     #[must_use]
-    fn one(params: Self::Params) -> Self;
+    fn one(params: &Self::Params) -> Self;
 
     /// Returns the parameter struct used to initialize this object.
     #[must_use]
@@ -1184,6 +1184,10 @@ pub trait Monty:
     /// Copy the Montgomery representation from `other` into `self`.
     /// NOTE: the parameters remain unchanged.
     fn copy_montgomery_from(&mut self, other: &Self);
+
+    /// Move the Montgomery form result out of `self` and return it.
+    #[must_use]
+    fn into_montgomery(self) -> Self::Integer;
 
     /// Performs doubling, returning `self + self`.
     #[must_use]

--- a/tests/monty_form.rs
+++ b/tests/monty_form.rs
@@ -144,7 +144,7 @@ proptest! {
         // Inversion works in monty form
         assert_eq!(
             one_monty,
-            MontyForm::one(*monty_params),
+            MontyForm::one(monty_params),
             "a*a⁻¹ ≠ 1 (monty form)\nmodulus: {:0128b}",
             monty_params.modulus()
         );
@@ -183,7 +183,7 @@ proptest! {
         // Inversion works in monty form
         assert_eq!(
             one_monty,
-            MontyForm::one(*monty_params),
+            MontyForm::one(monty_params),
             "a*a⁻¹ ≠ 1 (monty form)\nmodulus: {:0256b}",
             monty_params.modulus()
         );
@@ -222,7 +222,7 @@ proptest! {
         // Inversion works in monty form
         assert_eq!(
             one_monty,
-            MontyForm::one(*monty_params),
+            MontyForm::one(monty_params),
             "a*a⁻¹ ≠ 1 (monty form)\nmodulus: {:01024b}",
             monty_params.modulus()
         );
@@ -261,7 +261,7 @@ proptest! {
         // Inversion works in monty form
         assert_eq!(
             one_monty,
-            MontyForm::one(*monty_params),
+            MontyForm::one(monty_params),
             "a*a⁻¹ ≠ 1 (monty form)\nmodulus: {:02048b}",
             monty_params.modulus()
         );


### PR DESCRIPTION
This is more or less a followup to #1087 which had `BoxedMontyForm::new` auto-clone its params (since it's an `Arc` and that's cheap).

This does the same for these trait methods, where previously to use them you always had to clone the params yourself.