### PR TITLE
impl ConstantTimeGreater and ConstantTimeLess for ConstMontyForm

### DIFF
--- a/src/modular/const_monty_form/ct.rs
+++ b/src/modular/const_monty_form/ct.rs
@@ -39,7 +39,7 @@ where
     MOD: ConstMontyParams<LIMBS>,
 {
     fn ct_gt(&self, other: &Self) -> Choice {
-        self.montgomery_form.ct_gt(&other.montgomery_form)
+        self.retrieve().ct_gt(&other.retrieve())
     }
 }
 
@@ -48,7 +48,7 @@ where
     MOD: ConstMontyParams<LIMBS>,
 {
     fn ct_lt(&self, other: &Self) -> Choice {
-        self.montgomery_form.ct_lt(&other.montgomery_form)
+        self.retrieve().ct_lt(&other.retrieve())
     }
 }
 

--- a/src/modular/const_monty_form/ct.rs
+++ b/src/modular/const_monty_form/ct.rs
@@ -2,7 +2,7 @@
 
 use super::{ConstMontyForm, ConstMontyParams};
 use crate::{Choice, CtAssign, CtEq};
-use ctutils::{CtAssignSlice, CtEqSlice, CtSelectUsingCtAssign};
+use ctutils::{CtAssignSlice, CtEqSlice, CtGt, CtLt, CtSelectUsingCtAssign};
 
 #[cfg(feature = "subtle")]
 use crate::CtSelect;
@@ -34,6 +34,24 @@ impl<MOD, const LIMBS: usize> CtEqSlice for ConstMontyForm<MOD, LIMBS> where
 {
 }
 
+impl<MOD, const LIMBS: usize> CtGt for ConstMontyForm<MOD, LIMBS>
+where
+    MOD: ConstMontyParams<LIMBS>,
+{
+    fn ct_gt(&self, other: &Self) -> Choice {
+        self.montgomery_form.ct_gt(&other.montgomery_form)
+    }
+}
+
+impl<MOD, const LIMBS: usize> CtLt for ConstMontyForm<MOD, LIMBS>
+where
+    MOD: ConstMontyParams<LIMBS>,
+{
+    fn ct_lt(&self, other: &Self) -> Choice {
+        self.montgomery_form.ct_lt(&other.montgomery_form)
+    }
+}
+
 impl<MOD, const LIMBS: usize> CtSelectUsingCtAssign for ConstMontyForm<MOD, LIMBS> where
     MOD: ConstMontyParams<LIMBS>
 {
@@ -56,5 +74,25 @@ where
 {
     fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
         CtSelect::ct_select(a, b, choice.into())
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<MOD, const LIMBS: usize> subtle::ConstantTimeGreater for ConstMontyForm<MOD, LIMBS>
+where
+    MOD: ConstMontyParams<LIMBS>,
+{
+    fn ct_gt(&self, other: &Self) -> subtle::Choice {
+        CtGt::ct_gt(self, other).into()
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl<MOD, const LIMBS: usize> subtle::ConstantTimeLess for ConstMontyForm<MOD, LIMBS>
+where
+    MOD: ConstMontyParams<LIMBS>,
+{
+    fn ct_lt(&self, other: &Self) -> subtle::Choice {
+        CtLt::ct_lt(self, other).into()
     }
 }


### PR DESCRIPTION
Implements `ctutils::CtGt`, `ctutils::CtLt`, `subtle::ConstantTimeGreater`, and `subtle::ConstantTimeLess`  for `ConstMontyForm`.

Addresses the following TODOs in `elliptic-curves` ([L722](https://github.com/RustCrypto/elliptic-curves/blob/cd6425facdd9bb2a26dd097e9270b9eef2e064ac/primefield/src/monty.rs#L722), [L732](https://github.com/RustCrypto/elliptic-curves/blob/cd6425facdd9bb2a26dd097e9270b9eef2e064ac/primefield/src/monty.rs#L732), [L764](https://github.com/RustCrypto/elliptic-curves/blob/cd6425facdd9bb2a26dd097e9270b9eef2e064ac/primefield/src/monty.rs#L764), [L774](https://github.com/RustCrypto/elliptic-curves/blob/cd6425facdd9bb2a26dd097e9270b9eef2e064ac/primefield/src/monty.rs#L774))