### PR TITLE
Add support for exact division

### DIFF
--- a/benches/boxed_uint.rs
+++ b/benches/boxed_uint.rs
@@ -232,6 +232,42 @@ fn bench_division(c: &mut Criterion) {
         );
     });
 
+    group.bench_function("boxed_div_exact", |b| {
+        b.iter_batched(
+            || {
+                (
+                    BoxedUint::max(UINT_BITS),
+                    NonZero::new(BoxedUint::random_bits_with_precision(
+                        &mut rng,
+                        UINT_BITS / 2,
+                        UINT_BITS,
+                    ))
+                    .unwrap(),
+                )
+            },
+            |(x, y)| black_box(x.div_exact(&y)),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("boxed_div_exact_vartime", |b| {
+        b.iter_batched(
+            || {
+                (
+                    BoxedUint::max(UINT_BITS),
+                    NonZero::new(BoxedUint::random_bits_with_precision(
+                        &mut rng,
+                        UINT_BITS / 2,
+                        UINT_BITS,
+                    ))
+                    .unwrap(),
+                )
+            },
+            |(x, y)| black_box(x.div_exact_vartime(&y)),
+            BatchSize::SmallInput,
+        );
+    });
+
     group.finish();
 }
 

--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -393,6 +393,44 @@ fn bench_division(c: &mut Criterion) {
         );
     });
 
+    group.bench_function("div exact, U256/U128", |b| {
+        b.iter_batched(
+            || {
+                (
+                    U256::random_from_rng(&mut rng),
+                    NonZero::<U128>::random_from_rng(&mut rng),
+                )
+            },
+            |(x, y)| x.div_exact(&y),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("div exact, U256/U128 (in U256)", |b| {
+        b.iter_batched(
+            || {
+                let x = U256::random_from_rng(&mut rng);
+                let y_half = U128::random_from_rng(&mut rng);
+                let y: U256 = (y_half, U128::ZERO).into();
+                (x, NonZero::new(y).unwrap())
+            },
+            |(x, y)| x.div_exact(&y),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("div exact, U256/U128 (in U512)", |b| {
+        b.iter_batched(
+            || {
+                let x = U256::random_from_rng(&mut rng);
+                let y: U512 = U128::random_from_rng(&mut rng).resize();
+                (x, NonZero::new(y).unwrap())
+            },
+            |(x, y)| x.div_exact(&y),
+            BatchSize::SmallInput,
+        );
+    });
+
     group.bench_function("div/rem_vartime, U256/U128, full size", |b| {
         b.iter_batched(
             || {
@@ -401,6 +439,18 @@ fn bench_division(c: &mut Criterion) {
                 (x, NonZero::new(y).unwrap())
             },
             |(x, y)| x.div_rem_vartime(&y),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("div exact vartime, U256/U128, full size", |b| {
+        b.iter_batched(
+            || {
+                let x = U256::random_from_rng(&mut rng);
+                let y = U256::from((NonZero::<U128>::random_from_rng(&mut rng).get(), U128::ZERO));
+                (x, NonZero::new(y).unwrap())
+            },
+            |(x, y)| x.div_exact_vartime(&y),
             BatchSize::SmallInput,
         );
     });
@@ -506,6 +556,19 @@ fn bench_division(c: &mut Criterion) {
                 (x, NonZero::new(y).unwrap())
             },
             |(x, y)| x.div_rem_vartime(&y),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("div exact vartime, U256/Limb, full size", |b| {
+        b.iter_batched(
+            || {
+                let x = U256::random_from_rng(&mut rng);
+                let y_small = Limb::random_from_rng(&mut rng);
+                let y = U256::from_word(y_small.0);
+                (x, NonZero::new(y).unwrap())
+            },
+            |(x, y)| x.div_exact_vartime(&y),
             BatchSize::SmallInput,
         );
     });

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -13,6 +13,7 @@ mod div;
 mod encoding;
 mod from;
 mod gcd;
+mod invert_mod;
 mod mul;
 mod neg;
 mod shl;

--- a/src/limb/div.rs
+++ b/src/limb/div.rs
@@ -42,6 +42,30 @@ impl Limb {
         let rem = self.div_rem(rhs_nz).1;
         CtOption::new(rem, is_nz)
     }
+
+    /// Exactly divides `self` by `rhs`, returning `CtOption::none()` if `self` is not divisible by `rhs`.
+    #[must_use]
+    pub const fn div_exact(&self, rhs: NonZero<Limb>) -> CtOption<Self> {
+        let mut quo = *self;
+        let mut div = rhs.get_copy();
+        let exact = UintRef::new_mut(slice::from_mut(&mut quo))
+            .div_exact(UintRef::new_mut(slice::from_mut(&mut div)));
+        CtOption::new(quo, exact)
+    }
+
+    /// Exactly divides `self` by `rhs`, returning `CtOption::none()` if `self` is not divisible by `rhs`.
+    ///
+    /// This is variable-time only with respect to `rhs`.
+    ///
+    /// When used with a fixed `rhs`, this function is constant-time with respect to `self`.
+    #[must_use]
+    pub const fn div_exact_vartime(&self, rhs: NonZero<Limb>) -> CtOption<Self> {
+        let mut quo = *self;
+        let mut div = rhs.get_copy();
+        let exact = UintRef::new_mut(slice::from_mut(&mut quo))
+            .div_exact_vartime(UintRef::new_mut(slice::from_mut(&mut div)));
+        CtOption::new(quo, exact)
+    }
 }
 
 impl CheckedDiv for Limb {
@@ -285,6 +309,17 @@ mod tests {
         let n = Limb::from_u32(0xffff_ffff);
         let d = NonZero::new(Limb::from_u32(0xfffe)).expect("ensured non-zero");
         assert_eq!(n.div_rem(d), (Limb::from_u32(0x10002), Limb::from_u32(0x3)));
+
+        assert_eq!(n.div_exact(d).into_option(), None);
+        assert_eq!(n.div_exact_vartime(d).into_option(), None);
+
+        let d = NonZero::new(Limb::from_u32(0xffff)).expect("ensured non-zero");
+        assert_eq!(n.div_rem(d), (Limb::from_u32(0x10001), Limb::from_u32(0)));
+        assert_eq!(n.div_exact(d).into_option(), Some(Limb::from_u32(0x10001)));
+        assert_eq!(
+            n.div_exact_vartime(d).into_option(),
+            Some(Limb::from_u32(0x10001))
+        );
     }
 
     #[test]

--- a/src/limb/invert_mod.rs
+++ b/src/limb/invert_mod.rs
@@ -1,0 +1,17 @@
+use super::Limb;
+use crate::{Odd, primitives};
+
+impl Odd<Limb> {
+    /// Returns the multiplicative inverse of the argument modulo 2^N, where
+    /// 2^N is the capacity of a [`Limb`].
+    pub(crate) const fn multiplicative_inverse(self) -> Limb {
+        cpubits::cpubits! {
+            32 => {
+                Limb(primitives::u32_invert_odd(self.as_ref().0))
+            }
+            64 => {
+                Limb(primitives::u64_invert_odd(self.as_ref().0))
+            }
+        }
+    }
+}

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -94,6 +94,43 @@ pub(crate) const fn u32_bits(n: u32) -> u32 {
     u32::BITS - n.leading_zeros()
 }
 
+cpubits::cpubits! {
+    32 => {
+        /// Returns the multiplicative inverse of the argument modulo 2^32.
+        ///
+        /// For correct results, the input `value` must be odd.
+        #[must_use]
+        pub(crate) const fn u32_invert_odd(value: u32) -> u32 {
+            debug_assert!(value & 1 == 1, "value must be odd");
+            let x = value.wrapping_mul(3) ^ 2;
+            let y = 1u32.wrapping_sub(x.wrapping_mul(value));
+            let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
+            let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
+            x.wrapping_mul(y.wrapping_add(1))
+        }
+    }
+}
+
+/// Returns the multiplicative inverse of the argument modulo 2^64. The implementation is based
+/// on the Hurchalla's method for computing the multiplicative inverse modulo a power of two, and
+/// is essentially an optimized Newton iteration.
+///
+/// For correct results, the input `value` must be odd.
+///
+/// For better understanding the implementation, the following paper is recommended:
+/// J. Hurchalla, "An Improved Integer Multiplicative Inverse (modulo 2^w)",
+/// <https://arxiv.org/pdf/2204.limbs4342.pdf>
+#[must_use]
+pub(crate) const fn u64_invert_odd(value: u64) -> u64 {
+    debug_assert!(value & 1 == 1, "value must be odd");
+    let x = value.wrapping_mul(3) ^ 2;
+    let y = 1u64.wrapping_sub(x.wrapping_mul(value));
+    let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
+    let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
+    let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
+    x.wrapping_mul(y.wrapping_add(1))
+}
+
 #[cfg(test)]
 mod tests {
     use super::{u32_max, u32_min, u32_rem};
@@ -132,5 +169,18 @@ mod tests {
         assert_eq!(u32_rem(4, 5), 4);
         assert_eq!(u32_rem(7, 5), 2);
         assert_eq!(u32_rem(101, 5), 1);
+    }
+
+    cpubits::cpubits! {
+        32 => {
+            #[test]
+            fn test_u32_invert_odd() {
+                use super::u32_invert_odd;
+
+                assert_eq!(u32_invert_odd(1), 1);
+                assert_eq!(u32_invert_odd(5).wrapping_mul(5), 1);
+                assert_eq!(u32_invert_odd(u32::MAX).wrapping_mul(u32::MAX), 1);
+            }
+        }
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -112,14 +112,14 @@ cpubits::cpubits! {
 }
 
 /// Returns the multiplicative inverse of the argument modulo 2^64. The implementation is based
-/// on the Hurchalla's method for computing the multiplicative inverse modulo a power of two, and
+/// on Hurchalla's method for computing the multiplicative inverse modulo a power of two, and
 /// is essentially an optimized Newton iteration.
 ///
 /// For correct results, the input `value` must be odd.
 ///
 /// For better understanding the implementation, the following paper is recommended:
 /// J. Hurchalla, "An Improved Integer Multiplicative Inverse (modulo 2^w)",
-/// <https://arxiv.org/pdf/2204.limbs4342.pdf>
+/// <https://arxiv.org/abs/2204.04342>
 #[must_use]
 pub(crate) const fn u64_invert_odd(value: u64) -> u64 {
     debug_assert!(value & 1 == 1, "value must be odd");

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -94,6 +94,22 @@ pub(crate) const fn u32_bits(n: u32) -> u32 {
     u32::BITS - n.leading_zeros()
 }
 
+/// Return a `Choice` representing whether `a < b`.
+#[allow(clippy::cast_possible_truncation)]
+#[cfg(target_pointer_width = "32")]
+#[inline]
+pub(crate) const fn usize_lt(a: usize, b: usize) -> Choice {
+    Choice::from_u32_lt(a as u32, b as u32)
+}
+
+/// Return a `Choice` representing whether `a < b`.
+#[allow(clippy::cast_possible_truncation)]
+#[cfg(target_pointer_width = "64")]
+#[inline]
+pub(crate) const fn usize_lt(a: usize, b: usize) -> Choice {
+    Choice::from_u64_lt(a as u64, b as u64)
+}
+
 cpubits::cpubits! {
     32 => {
         /// Returns the multiplicative inverse of the argument modulo 2^32.
@@ -133,7 +149,7 @@ pub(crate) const fn u64_invert_odd(value: u64) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{u32_max, u32_min, u32_rem};
+    use super::{u32_max, u32_min, u32_rem, usize_lt};
     use crate::Word;
 
     #[test]
@@ -169,6 +185,14 @@ mod tests {
         assert_eq!(u32_rem(4, 5), 4);
         assert_eq!(u32_rem(7, 5), 2);
         assert_eq!(u32_rem(101, 5), 1);
+    }
+
+    #[test]
+    fn test_usize_const_lt() {
+        assert!(usize_lt(0, 5).to_bool_vartime());
+        assert!(!usize_lt(7, 0).to_bool_vartime());
+        assert!(!usize_lt(7, 5).to_bool_vartime());
+        assert!(!usize_lt(7, 7).to_bool_vartime());
     }
 
     cpubits::cpubits! {

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -63,6 +63,15 @@ impl BoxedUint {
         rem
     }
 
+    /// Exactly divides `self` by `rhs`, returning `CtOption::none()` if `self` is not divisible by `rhs`.
+    #[must_use]
+    pub fn div_exact<Rhs: ToUnsigned + ?Sized>(&self, rhs: &NonZero<Rhs>) -> CtOption<Self> {
+        let mut quo = self.clone();
+        let mut div = rhs.to_unsigned().get();
+        let exact = quo.as_mut_uint_ref().div_exact(div.as_mut_uint_ref());
+        CtOption::new(quo, exact)
+    }
+
     /// Computes self / rhs, returns the quotient and remainder.
     ///
     /// Variable-time with respect to `rhs`
@@ -119,6 +128,20 @@ impl BoxedUint {
         let mut rem = rhs.get();
         self.as_mut_uint_ref().div_rem_vartime(rem.as_mut());
         rem
+    }
+
+    /// Exactly divides `self` by `rhs`, returning `CtOption::none()` if `self` is not divisible by `rhs`.
+    #[must_use]
+    pub fn div_exact_vartime<Rhs: ToUnsigned + ?Sized>(
+        &self,
+        rhs: &NonZero<Rhs>,
+    ) -> CtOption<Self> {
+        let mut quo = self.clone();
+        let mut div = rhs.to_unsigned().get();
+        let exact = quo
+            .as_mut_uint_ref()
+            .div_exact_vartime(div.as_mut_uint_ref());
+        CtOption::new(quo, exact)
     }
 
     /// Wrapped division is just normal division i.e. `self` / `rhs`

--- a/src/uint/boxed/lcm.rs
+++ b/src/uint/boxed/lcm.rs
@@ -8,7 +8,9 @@ impl Lcm for BoxedUint {
     fn lcm(&self, rhs: &Self) -> Self {
         let (lhs_nz, _) = self.to_nz_or_one();
         let gcd_nz = lhs_nz.gcd(rhs);
-        self.wrapping_div(&gcd_nz).concatenating_mul(rhs)
+        self.div_exact(&gcd_nz)
+            .expect("invalid gcd")
+            .concatenating_mul(rhs)
     }
 
     fn lcm_vartime(&self, rhs: &Self) -> Self {
@@ -16,7 +18,9 @@ impl Lcm for BoxedUint {
             return BoxedUint::zero_with_precision(self.bits_precision() + rhs.bits_precision());
         };
         let gcd_nz = lhs_nz.gcd_vartime(rhs);
-        self.wrapping_div_vartime(&gcd_nz).concatenating_mul(rhs)
+        self.div_exact_vartime(&gcd_nz)
+            .expect("invalid gcd")
+            .concatenating_mul(rhs)
     }
 }
 

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -52,18 +52,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         (x, y)
     }
 
-    /// Exactly divides `self` by `rhs`, returning `CtOption::none()` if `self` is not divisible by `rhs`.
-    #[must_use]
-    pub const fn div_exact<const RHS_LIMBS: usize>(
-        &self,
-        rhs: &NonZero<Uint<RHS_LIMBS>>,
-    ) -> CtOption<Self> {
-        let mut quo = *self;
-        let mut div = rhs.get_copy();
-        let exact = quo.as_mut_uint_ref().div_exact(div.as_mut_uint_ref());
-        CtOption::new(quo, exact)
-    }
-
     /// Computes `self` / `rhs`, returning the quotient and the remainder.
     ///
     /// This is variable-time only with respect to `rhs`.
@@ -82,11 +70,22 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     }
 
     /// Exactly divides `self` by `rhs`, returning `CtOption::none()` if `self` is not divisible by `rhs`.
+    #[must_use]
+    pub const fn div_exact<const RHS_LIMBS: usize>(
+        &self,
+        rhs: &NonZero<Uint<RHS_LIMBS>>,
+    ) -> CtOption<Self> {
+        let mut quo = *self;
+        let mut div = rhs.get_copy();
+        let exact = quo.as_mut_uint_ref().div_exact(div.as_mut_uint_ref());
+        CtOption::new(quo, exact)
+    }
+
+    /// Exactly divides `self` by `rhs`, returning `CtOption::none()` if `self` is not divisible by `rhs`.
     ///
     /// This is variable-time only with respect to `rhs`.
     ///
-    /// When used with a fixed `rhs`, this function is constant-time with respect
-    /// to `self`.
+    /// When used with a fixed `rhs`, this function is constant-time with respect to `self`.
     #[must_use]
     pub const fn div_exact_vartime<const RHS_LIMBS: usize>(
         &self,

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -52,6 +52,18 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         (x, y)
     }
 
+    /// Exactly divides `self` by `rhs`, returning `CtOption::none()` if `self` is not divisible by `rhs`.
+    #[must_use]
+    pub const fn div_exact<const RHS_LIMBS: usize>(
+        &self,
+        rhs: &NonZero<Uint<RHS_LIMBS>>,
+    ) -> CtOption<Self> {
+        let mut quo = *self;
+        let mut div = rhs.get_copy();
+        let exact = quo.as_mut_uint_ref().div_exact(div.as_mut_uint_ref());
+        CtOption::new(quo, exact)
+    }
+
     /// Computes `self` / `rhs`, returning the quotient and the remainder.
     ///
     /// This is variable-time only with respect to `rhs`.
@@ -67,6 +79,25 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         let (mut x, mut y) = (*self, *rhs.as_ref());
         UintRef::div_rem_vartime(x.as_mut_uint_ref(), y.as_mut_uint_ref());
         (x, y)
+    }
+
+    /// Exactly divides `self` by `rhs`, returning `CtOption::none()` if `self` is not divisible by `rhs`.
+    ///
+    /// This is variable-time only with respect to `rhs`.
+    ///
+    /// When used with a fixed `rhs`, this function is constant-time with respect
+    /// to `self`.
+    #[must_use]
+    pub const fn div_exact_vartime<const RHS_LIMBS: usize>(
+        &self,
+        rhs: &NonZero<Uint<RHS_LIMBS>>,
+    ) -> CtOption<Self> {
+        let mut quo = *self;
+        let mut div = rhs.get_copy();
+        let exact = quo
+            .as_mut_uint_ref()
+            .div_exact_vartime(div.as_mut_uint_ref());
+        CtOption::new(quo, exact)
     }
 
     /// Computes self / rhs, assigning the quotient to `self` and returning the remainder.
@@ -538,6 +569,10 @@ mod tests {
             let (q, r) = lhs.div_rem_vartime(&rhs);
             assert_eq!(U256::from(*e), q);
             assert_eq!(U256::from(*ee), r);
+            let q = lhs.div_exact(&rhs).into_option();
+            assert_eq!(if *ee == 0 { Some(U256::from(*e)) } else { None }, q);
+            let q = lhs.div_exact_vartime(&rhs).into_option();
+            assert_eq!(if *ee == 0 { Some(U256::from(*e)) } else { None }, q);
         }
     }
 
@@ -562,6 +597,10 @@ mod tests {
                 assert_eq!(q, num);
                 let (q, _) = n.div_rem_vartime(&den);
                 assert_eq!(q, num);
+                let q = n.div_exact(&den).into_option();
+                assert_eq!(q, Some(num));
+                let q = n.div_exact_vartime(&den).into_option();
+                assert_eq!(q, Some(num));
             }
         }
     }

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -10,7 +10,7 @@ use crate::{DecodeError, EncodedSize, Encoding, Limb, Word};
 use core::{fmt, ops::Deref};
 
 #[cfg(feature = "alloc")]
-use crate::{Choice, NonZero, Reciprocal, UintRef, WideWord, bitlen};
+use crate::{NonZero, Reciprocal, UintRef, WideWord, bitlen};
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
 
@@ -874,12 +874,11 @@ impl RadixDivisionParams {
 
                 // Divide by the large divisor
                 let limbs_hi = limbs.shl_assign_limb_vartime(self.shift_large);
-                let rem_high = limbs.div_rem_large_shifted(
+                let rem_high = limbs.div_rem_large_shifted::<true>(
                     limbs_hi,
                     div_large,
                     RADIX_ENCODING_LIMBS_LARGE as u32,
                     self.recip_large,
-                    Choice::TRUE,
                 );
                 let limbs_rem;
                 // At this point, the limbs at and above RADIX_ENCODING_LIMBS_LARGE represent

--- a/src/uint/lcm.rs
+++ b/src/uint/lcm.rs
@@ -11,7 +11,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     {
         let (lhs_nz, _) = self.to_nz_or_one();
         let gcd_nz = lhs_nz.gcd_unsigned(rhs);
-        self.wrapping_div(&gcd_nz).concatenating_mul(rhs)
+        self.div_exact(&gcd_nz)
+            .expect_copied("invalid gcd")
+            .concatenating_mul(rhs)
     }
 
     /// Compute the least common multiple of `self` and `rhs`.
@@ -26,7 +28,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
             return Uint::ZERO;
         };
         let gcd_nz = lhs_nz.gcd_unsigned_vartime(rhs);
-        self.wrapping_div_vartime(&gcd_nz).concatenating_mul(rhs)
+        self.div_exact_vartime(&gcd_nz)
+            .expect_copied("invalid gcd")
+            .concatenating_mul(rhs)
     }
 }
 

--- a/src/uint/ref_type/div.rs
+++ b/src/uint/ref_type/div.rs
@@ -5,7 +5,7 @@
 
 use super::UintRef;
 use crate::{
-    Choice, Limb, NonZero, bitlen,
+    Choice, Limb, NonZero, Odd, bitlen,
     div_limb::{Reciprocal, div2by1, div3by2},
     primitives::u32_min,
     word,
@@ -18,7 +18,6 @@ impl UintRef {
     /// # Panics
     /// If the divisor is zero.
     #[inline(always)]
-    #[allow(clippy::integer_division_remainder_used, reason = "needs triage")]
     pub(crate) const fn div_rem(&mut self, rhs: &mut Self) {
         let (x, y) = (self, rhs);
 
@@ -38,7 +37,7 @@ impl UintRef {
         y.unbounded_shl_assign(yz);
 
         // Shift the dividend to align the words
-        let lshift = yz % Limb::BITS;
+        let lshift = yz & (Limb::BITS - 1);
         let x_hi = x.shl_assign_limb(lshift);
 
         Self::div_rem_shifted(x, x_hi, y, ywords);
@@ -99,7 +98,6 @@ impl UintRef {
     /// # Panics
     /// If the divisor is zero.
     #[inline(always)]
-    #[allow(clippy::integer_division_remainder_used, reason = "needs triage")]
     pub(crate) const fn rem_wide(x_lower_upper: (&mut Self, &mut Self), rhs: &mut Self) {
         let (x_lo, x) = x_lower_upper;
         let y = rhs;
@@ -122,7 +120,7 @@ impl UintRef {
         y.unbounded_shl_assign(yz);
 
         // Shift the dividend to align the words
-        let lshift = yz % Limb::BITS;
+        let lshift = yz & (Limb::BITS - 1);
         let x_lo_carry = x_lo.shl_assign_limb(lshift);
         let x_hi = x.shl_assign_limb(lshift);
         x.limbs[0] = x.limbs[0].bitor(x_lo_carry);
@@ -600,5 +598,124 @@ impl UintRef {
         }
         (_, hi.0) = div2by1(self.limbs[0].shl(lshift).0, hi.0, reciprocal);
         hi.shr(lshift)
+    }
+
+    /// Exactly divides `self` by `rhs`, returning `Choice::FALSE` if `self` is not divisible by `rhs`.
+    ///
+    /// If the division is not exact then `self` is left in an indeterminate state.
+    /// The divisor `rhs` is right-shifted to produce an odd integer.
+    ///
+    /// # Panics
+    /// If the divisor is zero.
+    #[inline(always)]
+    pub(crate) const fn div_exact(&mut self, rhs: &mut UintRef) -> Choice {
+        let x_prec = self.bits_precision();
+        let y_bits = rhs.bits();
+        assert!(y_bits > 0, "zero divisor");
+        let tz = rhs.trailing_zeros();
+        let excess_z = Choice::from_u32_lt(x_prec, tz);
+        let tz = excess_z.select_u32(tz, x_prec);
+        rhs.shr_assign(tz);
+
+        let div2s_exact = self.ensure_trailing_zeros(tz).and(excess_z.not());
+        self.shr_assign(tz);
+
+        let y = Odd::new_ref_unchecked(rhs);
+        let y_inv = Limb(y.invert_mod_u64());
+        let ywords = (y_bits - tz).div_ceil(Limb::BITS);
+        Self::div_exact_odd_with_inverse(self, y, y_inv, ywords, Choice::FALSE).and(div2s_exact)
+    }
+
+    /// Exactly divides `self` by `rhs`, returning `Choice::FALSE` if `self` is not divisible by `rhs`.
+    ///
+    /// If the division is not exact then `self` is left in an indeterminate state.
+    /// The divisor `rhs` is right-shifted to produce an odd integer.
+    ///
+    /// # Panics
+    /// If the divisor is zero.
+    #[inline(always)]
+    pub(crate) const fn div_exact_vartime(&mut self, rhs: &mut UintRef) -> Choice {
+        let x_prec = self.bits_precision();
+        let y_bits = rhs.bits_vartime();
+        assert!(y_bits > 0, "zero divisor");
+        let tz = rhs.trailing_zeros_vartime();
+        if tz > x_prec {
+            // Divisor exceeds dividend precision
+            return Choice::FALSE;
+        }
+        let rhs = rhs.leading_mut(y_bits.div_ceil(Limb::BITS) as usize);
+        rhs.unbounded_shr_assign_vartime(tz);
+
+        let div2s_exact = self.ensure_trailing_zeros(tz);
+        self.unbounded_shr_assign_vartime(tz);
+
+        let ywords = (y_bits - tz).div_ceil(Limb::BITS);
+        let y = Odd::new_ref_unchecked(rhs.leading(ywords as usize));
+        let y_inv = Limb(y.invert_mod_u64());
+        Self::div_exact_odd_with_inverse(self, y, y_inv, ywords, Choice::TRUE).and(div2s_exact)
+    }
+
+    /// Exactly divides `x` by `y`, returning `Choice::FALSE` if `x` is not divisible by `y`.
+    ///
+    /// This method performs a Hensel division, subtracting from the least significant bits
+    /// and calculating `q,r s.t. x = qy + r•2^N`.
+    const fn div_exact_odd_with_inverse(
+        x: &mut UintRef,
+        y: &Odd<UintRef>,
+        y_inv: Limb,
+        ywords: u32,
+        vartime: Choice,
+    ) -> Choice {
+        let xc = x.nlimbs();
+        let y = y.as_ref();
+        let mut is_exact = Choice::TRUE;
+        let mut xi = 0;
+
+        while xi < xc {
+            let y_remain = u32_min((xc - xi) as u32, y.nlimbs() as u32);
+            // This loop is a no-op once there are fewer words remaining than the size of the divisor
+            let done = Choice::from_u32_lt(y_remain, ywords);
+            if vartime.and(done).to_bool_vartime() {
+                break;
+            }
+
+            let quo = Limb::select(x.limbs[xi].wrapping_mul(y_inv), Limb::ZERO, done);
+            x.limbs[xi] = quo;
+
+            let (_adj, mut carry) = quo.widening_mul(y.limbs[0]);
+            let mut sub;
+            let mut borrow = Limb::ZERO;
+
+            let mut yi = 1;
+            while yi < y_remain as usize {
+                (sub, carry) = quo.carrying_mul_add(y.limbs[yi], Limb::ZERO, carry);
+                (x.limbs[xi + yi], borrow) = x.limbs[xi + yi].borrowing_sub(sub, borrow);
+                yi += 1;
+            }
+
+            let mut i = xi + yi;
+            while i < xc {
+                (x.limbs[i], borrow) = x.limbs[i].borrowing_sub(carry, borrow);
+                carry = Limb::ZERO;
+                i += 1;
+            }
+            is_exact = is_exact.and(carry.wrapping_sub(borrow).is_zero());
+
+            xi += 1;
+        }
+
+        // Set the upper limbs to zero if vartime
+        x.trailing_mut(xi).fill(Limb::ZERO);
+
+        is_exact
+    }
+
+    // Check that `self` can be cleanly divided by 2^zs: the bottom zs bits are zero.
+    const fn ensure_trailing_zeros(&self, zs: u32) -> Choice {
+        let z_words = (zs >> Limb::LOG2_BITS) as usize;
+        let z_bits = zs & (Limb::BITS - 1);
+        self.leading(z_words)
+            .is_zero()
+            .and(self.limbs[z_words].restrict_bits(z_bits).is_zero())
     }
 }

--- a/src/uint/ref_type/div.rs
+++ b/src/uint/ref_type/div.rs
@@ -612,24 +612,35 @@ impl UintRef {
         let x_prec = self.bits_precision();
         let y_bits = rhs.bits();
         assert!(y_bits > 0, "zero divisor");
+
         let tz = rhs.trailing_zeros();
+        // Track whether there are more zeros in the divisor than bits in the dividend
         let excess_z = Choice::from_u32_lt(x_prec, tz);
         let tz = excess_z.select_u32(tz, x_prec);
+
+        // Shift the divisor such that it is odd
         rhs.shr_assign(tz);
 
+        // Check that the dividend evenly divides by 2^tz, and shift it to match the divisor
         let div2s_exact = self.ensure_trailing_zeros(tz).and(excess_z.not());
         self.shr_assign(tz);
 
         let y = Odd::new_ref_unchecked(rhs);
         let y_inv = Limb(y.invert_mod_u64());
         let ywords = (y_bits - tz).div_ceil(Limb::BITS);
-        Self::div_exact_odd_with_inverse(self, y, y_inv, ywords, Choice::FALSE).and(div2s_exact)
+        let is_exact = Self::div_exact_odd_with_inverse(self, y, y_inv, ywords, Choice::FALSE)
+            .and(div2s_exact);
+
+        // Restore the divisor
+        rhs.shl_assign(tz);
+
+        is_exact
     }
 
     /// Exactly divides `self` by `rhs`, returning `Choice::FALSE` if `self` is not divisible by `rhs`.
     ///
-    /// If the division is not exact then `self` is left in an indeterminate state.
-    /// The divisor `rhs` is right-shifted to produce an odd integer.
+    /// The quotient is left in `self`, but is not guaranteed to be in a usable state unless
+    /// the return value is `Choice::TRUE`.
     ///
     /// # Panics
     /// If the divisor is zero.
@@ -638,27 +649,47 @@ impl UintRef {
         let x_prec = self.bits_precision();
         let y_bits = rhs.bits_vartime();
         assert!(y_bits > 0, "zero divisor");
+
         let tz = rhs.trailing_zeros_vartime();
         if tz > x_prec {
-            // Divisor exceeds dividend precision
+            // The divisor exceeds the dividend precision. Short circuit based on public
+            // information (the divisor and the input size in limbs)
             return Choice::FALSE;
         }
+        // Reduce the divisor to its populated limbs and shift it such that it is odd
         let rhs = rhs.leading_mut(y_bits.div_ceil(Limb::BITS) as usize);
         rhs.unbounded_shr_assign_vartime(tz);
 
+        // Check that the dividend evenly divides by 2^tz, and shift it to match the divisor
         let div2s_exact = self.ensure_trailing_zeros(tz);
         self.unbounded_shr_assign_vartime(tz);
 
         let ywords = (y_bits - tz).div_ceil(Limb::BITS);
         let y = Odd::new_ref_unchecked(rhs.leading(ywords as usize));
         let y_inv = Limb(y.invert_mod_u64());
-        Self::div_exact_odd_with_inverse(self, y, y_inv, ywords, Choice::TRUE).and(div2s_exact)
+        let is_exact =
+            Self::div_exact_odd_with_inverse(self, y, y_inv, ywords, Choice::TRUE).and(div2s_exact);
+
+        // Restore the divisor
+        rhs.shl_assign(tz);
+
+        is_exact
     }
 
     /// Exactly divides `x` by `y`, returning `Choice::FALSE` if `x` is not divisible by `y`.
     ///
+    /// The quotient is left in `self`, but is not guaranteed to be in a usable state unless
+    /// the return value is `Choice::TRUE`.
+    ///
     /// This method performs a Hensel division, subtracting from the least significant bits
-    /// and calculating `q,r s.t. x = qy + r•2^N`.
+    /// and calculating an LSB quotient and remainder `(q,r) s.t. x = qy + r•2^N`. When the remainder
+    /// is zero, the calculated quotient corresponds to the traditional division quotient.
+    ///
+    /// For constant-time operation, this acts as if the divisor `y` is as small as one limb,
+    /// performing loops without updates to the quotient for larger divisors when vartime operation
+    /// is not specified.
+    #[allow(clippy::cast_possible_truncation)]
+    #[inline(always)]
     const fn div_exact_odd_with_inverse(
         x: &mut UintRef,
         y: &Odd<UintRef>,
@@ -668,7 +699,7 @@ impl UintRef {
     ) -> Choice {
         let xc = x.nlimbs();
         let y = y.as_ref();
-        let mut is_exact = Choice::TRUE;
+        let mut meta_carry = Limb::ZERO;
         let mut xi = 0;
 
         while xi < xc {
@@ -676,41 +707,43 @@ impl UintRef {
             // This loop is a no-op once there are fewer words remaining than the size of the divisor
             let done = Choice::from_u32_lt(y_remain, ywords);
             if vartime.and(done).to_bool_vartime() {
+                // Set the upper limbs to zero
+                x.trailing_mut(xi).fill(Limb::ZERO);
                 break;
             }
 
+            // Compute the quotient limb that will clear the low dividend limb
             let quo = Limb::select(x.limbs[xi].wrapping_mul(y_inv), Limb::ZERO, done);
             x.limbs[xi] = quo;
 
-            let (_adj, mut carry) = quo.widening_mul(y.limbs[0]);
+            let (_, mut carry) = quo.widening_mul(y.limbs[0]);
             let mut sub;
             let mut borrow = Limb::ZERO;
-
             let mut yi = 1;
+
             while yi < y_remain as usize {
                 (sub, carry) = quo.carrying_mul_add(y.limbs[yi], Limb::ZERO, carry);
                 (x.limbs[xi + yi], borrow) = x.limbs[xi + yi].borrowing_sub(sub, borrow);
                 yi += 1;
             }
 
-            let mut i = xi + yi;
-            while i < xc {
-                (x.limbs[i], borrow) = x.limbs[i].borrowing_sub(carry, borrow);
-                carry = Limb::ZERO;
-                i += 1;
+            meta_carry = meta_carry.wrapping_add(carry);
+
+            if xi + yi < xc {
+                (x.limbs[xi + yi], borrow) = x.limbs[xi + yi].borrowing_sub(meta_carry, borrow);
+                meta_carry = borrow.wrapping_neg();
+            } else {
+                meta_carry = meta_carry.wrapping_sub(borrow);
             }
-            is_exact = is_exact.and(carry.wrapping_sub(borrow).is_zero());
 
             xi += 1;
         }
 
-        // Set the upper limbs to zero if vartime
-        x.trailing_mut(xi).fill(Limb::ZERO);
-
-        is_exact
+        meta_carry.is_zero()
     }
 
     // Check that `self` can be cleanly divided by 2^zs: the bottom zs bits are zero.
+    #[inline(always)]
     const fn ensure_trailing_zeros(&self, zs: u32) -> Choice {
         let z_words = (zs >> Limb::LOG2_BITS) as usize;
         let z_bits = zs & (Limb::BITS - 1);

--- a/src/uint/ref_type/div.rs
+++ b/src/uint/ref_type/div.rs
@@ -185,7 +185,7 @@ impl UintRef {
         let reciprocal = Reciprocal::new(y.limbs[ysize - 1].to_nz().expect_copied("zero divisor"));
 
         // Perform the core division algorithm
-        x_hi = Self::rem_wide_large_shifted(
+        x_hi = Self::rem_wide_large_shifted::<true>(
             (x_lo, x),
             x_hi,
             y,
@@ -194,7 +194,6 @@ impl UintRef {
                 ysize as u32
             },
             reciprocal,
-            Choice::TRUE,
         );
 
         // Copy the remainder to the divisor
@@ -226,7 +225,7 @@ impl UintRef {
         debug_assert!(reciprocal.shift() == 0);
 
         // Perform the core division algorithm
-        x_hi = Self::div_rem_large_shifted(x, x_hi, y, ywords, reciprocal, Choice::FALSE);
+        x_hi = Self::div_rem_large_shifted::<false>(x, x_hi, y, ywords, reciprocal);
 
         // Calculate quotient and remainder for the case where the divisor is a single word.
         let limb_div = Choice::from_u32_eq(1, ywords);
@@ -276,13 +275,12 @@ impl UintRef {
     /// is set, and `x_hi` holds the top bits of the dividend.
     #[inline(always)]
     #[allow(clippy::cast_possible_truncation)]
-    pub(crate) const fn div_rem_large_shifted(
+    pub(crate) const fn div_rem_large_shifted<const VARTIME: bool>(
         &mut self,
         mut x_hi: Limb,
         y: &Self,
         ywords: u32,
         reciprocal: Reciprocal,
-        vartime: Choice,
     ) -> Limb {
         let x = self;
         let xsize = x.nlimbs();
@@ -306,7 +304,7 @@ impl UintRef {
 
             // This loop is a no-op once xi is smaller than the number of words in the divisor
             let done = Choice::from_u32_lt(xi as u32, ywords - 1);
-            if vartime.and(done).to_bool_vartime() {
+            if VARTIME && done.to_bool_vartime() {
                 break;
             }
             quo = word::select(quo, 0, done);
@@ -371,7 +369,7 @@ impl UintRef {
         let reciprocal = Reciprocal::new(y.limbs[ysize - 1].to_nz().expect_copied("zero divisor"));
 
         // Perform the core division algorithm
-        x_hi = Self::div_rem_large_shifted(x, x_hi, y, ysize as u32, reciprocal, Choice::TRUE);
+        x_hi = Self::div_rem_large_shifted::<true>(x, x_hi, y, ysize as u32, reciprocal);
 
         // Copy the remainder to divisor
         y.leading_mut(ysize - 1).copy_from(x.leading(ysize - 1));
@@ -405,7 +403,7 @@ impl UintRef {
         debug_assert!(reciprocal.shift() == 0);
 
         // Perform the core division algorithm
-        x_hi = Self::rem_wide_large_shifted((x_lo, x), x_hi, y, ywords, reciprocal, Choice::FALSE);
+        x_hi = Self::rem_wide_large_shifted::<false>((x_lo, x), x_hi, y, ywords, reciprocal);
 
         // Calculate remainder for the case where the divisor is a single word.
         let limb_div = Choice::from_u32_eq(1, ywords);
@@ -440,13 +438,12 @@ impl UintRef {
     /// is set, and `x_hi` holds the top bits of the dividend.
     #[inline(always)]
     #[allow(clippy::cast_possible_truncation)]
-    const fn rem_wide_large_shifted(
+    const fn rem_wide_large_shifted<const VARTIME: bool>(
         x: (&Self, &mut Self),
         mut x_hi: Limb,
         y: &Self,
         ywords: u32,
         reciprocal: Reciprocal,
-        vartime: Choice,
     ) -> Limb {
         assert!(
             y.nlimbs() <= x.1.nlimbs(),
@@ -479,7 +476,7 @@ impl UintRef {
 
             // This loop is a no-op once xi is smaller than the number of words in the divisor
             let done = Choice::from_u32_lt(xi as u32, ywords - 1);
-            if vartime.and(done).to_bool_vartime() {
+            if VARTIME && done.to_bool_vartime() {
                 break;
             }
             quo = word::select(quo, 0, done);
@@ -628,8 +625,8 @@ impl UintRef {
         let y = Odd::new_ref_unchecked(rhs);
         let y_inv = y.invert_mod_limb();
         let ywords = (y_bits - tz).div_ceil(Limb::BITS);
-        let is_exact = Self::div_exact_odd_with_inverse(self, y, y_inv, ywords, Choice::FALSE)
-            .and(div2s_exact);
+        let is_exact =
+            Self::div_exact_odd_with_inverse::<false>(self, y, y_inv, ywords).and(div2s_exact);
 
         // Restore the divisor
         rhs.shl_assign(tz);
@@ -668,7 +665,7 @@ impl UintRef {
         let y = Odd::new_ref_unchecked(rhs.leading(ywords as usize));
         let y_inv = y.invert_mod_limb();
         let is_exact =
-            Self::div_exact_odd_with_inverse(self, y, y_inv, ywords, Choice::TRUE).and(div2s_exact);
+            Self::div_exact_odd_with_inverse::<true>(self, y, y_inv, ywords).and(div2s_exact);
 
         // Restore the divisor
         rhs.shl_assign(tz);
@@ -690,12 +687,11 @@ impl UintRef {
     /// is not specified.
     #[allow(clippy::cast_possible_truncation)]
     #[inline(always)]
-    const fn div_exact_odd_with_inverse(
+    const fn div_exact_odd_with_inverse<const VARTIME: bool>(
         x: &mut UintRef,
         y: &Odd<UintRef>,
         y_inv: Limb,
         ywords: u32,
-        vartime: Choice,
     ) -> Choice {
         let xc = x.nlimbs();
         let y = y.as_ref();
@@ -706,7 +702,7 @@ impl UintRef {
             let y_remain = u32_min((xc - xi) as u32, y.nlimbs() as u32);
             // This loop is a no-op once there are fewer words remaining than the size of the divisor
             let done = Choice::from_u32_lt(y_remain, ywords);
-            if vartime.and(done).to_bool_vartime() {
+            if VARTIME && done.to_bool_vartime() {
                 // Set the upper limbs to zero
                 x.trailing_mut(xi).fill(Limb::ZERO);
                 break;

--- a/src/uint/ref_type/div.rs
+++ b/src/uint/ref_type/div.rs
@@ -7,7 +7,7 @@ use super::UintRef;
 use crate::{
     Choice, Limb, NonZero, Odd, bitlen,
     div_limb::{Reciprocal, div2by1, div3by2},
-    primitives::u32_min,
+    primitives::{u32_min, usize_lt},
     word,
 };
 
@@ -624,7 +624,7 @@ impl UintRef {
 
         let y = Odd::new_ref_unchecked(rhs);
         let y_inv = y.invert_mod_limb();
-        let ywords = (y_bits - tz).div_ceil(Limb::BITS);
+        let ywords = bitlen::to_limbs(y_bits - tz);
         let is_exact =
             Self::div_exact_odd_with_inverse::<false>(self, y, y_inv, ywords).and(div2s_exact);
 
@@ -654,21 +654,21 @@ impl UintRef {
             return Choice::FALSE;
         }
         // Reduce the divisor to its populated limbs and shift it such that it is odd
-        let rhs = rhs.leading_mut(y_bits.div_ceil(Limb::BITS) as usize);
+        let rhs = rhs.leading_mut(bitlen::to_limbs(y_bits));
         rhs.unbounded_shr_assign_vartime(tz);
 
         // Check that the dividend evenly divides by 2^tz, and shift it to match the divisor
         let div2s_exact = self.ensure_trailing_zeros(tz);
         self.unbounded_shr_assign_vartime(tz);
 
-        let ywords = (y_bits - tz).div_ceil(Limb::BITS);
-        let y = Odd::new_ref_unchecked(rhs.leading(ywords as usize));
+        let ywords = bitlen::to_limbs(y_bits - tz);
+        let y = Odd::new_ref_unchecked(rhs.leading(ywords));
         let y_inv = y.invert_mod_limb();
         let is_exact =
             Self::div_exact_odd_with_inverse::<true>(self, y, y_inv, ywords).and(div2s_exact);
 
         // Restore the divisor
-        rhs.shl_assign(tz);
+        rhs.unbounded_shl_assign_vartime(tz);
 
         is_exact
     }
@@ -685,23 +685,23 @@ impl UintRef {
     /// For constant-time operation, this acts as if the divisor `y` is as small as one limb,
     /// performing loops without updates to the quotient for larger divisors when vartime operation
     /// is not specified.
-    #[allow(clippy::cast_possible_truncation)]
     #[inline(always)]
     const fn div_exact_odd_with_inverse<const VARTIME: bool>(
         x: &mut UintRef,
         y: &Odd<UintRef>,
         y_inv: Limb,
-        ywords: u32,
+        ywords: usize,
     ) -> Choice {
         let xc = x.nlimbs();
         let y = y.as_ref();
+        let yc = y.nlimbs();
         let mut meta_carry = Limb::ZERO;
         let mut xi = 0;
 
         while xi < xc {
-            let y_remain = u32_min((xc - xi) as u32, y.nlimbs() as u32);
+            let y_remain = if yc < (xc - xi) { yc } else { xc - xi };
             // This loop is a no-op once there are fewer words remaining than the size of the divisor
-            let done = Choice::from_u32_lt(y_remain, ywords);
+            let done = usize_lt(y_remain, ywords);
             if VARTIME && done.to_bool_vartime() {
                 // Set the upper limbs to zero
                 x.trailing_mut(xi).fill(Limb::ZERO);
@@ -717,7 +717,7 @@ impl UintRef {
             let mut borrow = Limb::ZERO;
             let mut yi = 1;
 
-            while yi < y_remain as usize {
+            while yi < y_remain {
                 (sub, carry) = quo.carrying_mul_add(y.limbs[yi], Limb::ZERO, carry);
                 (x.limbs[xi + yi], borrow) = x.limbs[xi + yi].borrowing_sub(sub, borrow);
                 yi += 1;

--- a/src/uint/ref_type/div.rs
+++ b/src/uint/ref_type/div.rs
@@ -626,7 +626,7 @@ impl UintRef {
         self.shr_assign(tz);
 
         let y = Odd::new_ref_unchecked(rhs);
-        let y_inv = Limb(y.invert_mod_u64());
+        let y_inv = y.invert_mod_limb();
         let ywords = (y_bits - tz).div_ceil(Limb::BITS);
         let is_exact = Self::div_exact_odd_with_inverse(self, y, y_inv, ywords, Choice::FALSE)
             .and(div2s_exact);
@@ -666,7 +666,7 @@ impl UintRef {
 
         let ywords = (y_bits - tz).div_ceil(Limb::BITS);
         let y = Odd::new_ref_unchecked(rhs.leading(ywords as usize));
-        let y_inv = Limb(y.invert_mod_u64());
+        let y_inv = y.invert_mod_limb();
         let is_exact =
             Self::div_exact_odd_with_inverse(self, y, y_inv, ywords, Choice::TRUE).and(div2s_exact);
 

--- a/src/uint/ref_type/invert_mod.rs
+++ b/src/uint/ref_type/invert_mod.rs
@@ -1,25 +1,19 @@
 use super::UintRef;
-use crate::Odd;
+use crate::{Limb, Odd, primitives};
 
 impl Odd<UintRef> {
-    /// Returns the multiplicative inverse of the argument modulo 2^64. The implementation is based
-    /// on the Hurchalla's method for computing the multiplicative inverse modulo a power of two.
-    ///
-    /// For better understanding the implementation, the following paper is recommended:
-    /// J. Hurchalla, "An Improved Integer Multiplicative Inverse (modulo 2^w)",
-    /// <https://arxiv.org/pdf/2204.limbs4342.pdf>
-    ///
-    /// Variable time with respect to the number of words in `value`, however that number will be
-    /// fixed for a given integer size.
+    /// Returns the multiplicative inverse of the argument modulo 2^N, where 2^N
+    /// is the capacity of a [`Limb`].
+    #[must_use]
+    pub(crate) const fn invert_mod_limb(&self) -> Limb {
+        Odd::new_unchecked(self.as_ref().limbs[0]).multiplicative_inverse()
+    }
+
+    /// Returns the multiplicative inverse of the argument modulo 2^64.
     #[must_use]
     pub const fn invert_mod_u64(&self) -> u64 {
         let value = self.as_ref().lowest_u64();
-        let x = value.wrapping_mul(3) ^ 2;
-        let y = 1u64.wrapping_sub(x.wrapping_mul(value));
-        let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
-        let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
-        let (x, y) = (x.wrapping_mul(y.wrapping_add(1)), y.wrapping_mul(y));
-        x.wrapping_mul(y.wrapping_add(1))
+        primitives::u64_invert_odd(value)
     }
 }
 

--- a/tests/boxed_uint.rs
+++ b/tests/boxed_uint.rs
@@ -121,7 +121,7 @@ proptest! {
         let b_bi = to_biguint(&b);
         let (expected_quotient, expected_remainder) = a_bi.div_rem(&b_bi);
 
-        let div = &NonZero::new(b).unwrap();
+        let div = NonZero::new(b).unwrap();
         let (actual_quotient, actual_remainder) = a.div_rem(&div);
         prop_assert_eq!(expected_quotient, to_biguint(&actual_quotient));
         prop_assert_eq!(expected_remainder, to_biguint(&actual_remainder));

--- a/tests/boxed_uint.rs
+++ b/tests/boxed_uint.rs
@@ -13,7 +13,7 @@ use crypto_bigint::{
 use num_bigint::BigUint;
 use num_integer::Integer as _;
 use num_modular::ModularUnaryOps;
-use num_traits::identities::One;
+use num_traits::{Zero, identities::One};
 use proptest::prelude::*;
 
 #[allow(clippy::cast_possible_truncation)]
@@ -119,28 +119,34 @@ proptest! {
 
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);
-        let expected_quotient = &a_bi / &b_bi;
-        let expected_remainder = a_bi % b_bi;
+        let (expected_quotient, expected_remainder) = a_bi.div_rem(&b_bi);
 
-        let (actual_quotient, actual_remainder) = a.div_rem(&NonZero::new(b).unwrap());
+        let div = &NonZero::new(b).unwrap();
+        let (actual_quotient, actual_remainder) = a.div_rem(&div);
         prop_assert_eq!(expected_quotient, to_biguint(&actual_quotient));
         prop_assert_eq!(expected_remainder, to_biguint(&actual_remainder));
+
+        let (quotient_vartime, remainder_vartime) = a.div_rem_vartime(&div);
+        prop_assert_eq!(actual_quotient, quotient_vartime);
+        prop_assert_eq!(actual_remainder, remainder_vartime);
     }
 
     #[test]
-    fn div_rem_vartime((a, mut b) in uint_pair()) {
+    fn div_exact((a, mut b) in uint_pair()) {
         if b.is_zero().into() {
             b = b.wrapping_add(Limb::ONE);
         }
 
         let a_bi = to_biguint(&a);
         let b_bi = to_biguint(&b);
-        let expected_quotient = &a_bi / &b_bi;
-        let expected_remainder = a_bi % b_bi;
+        let (expected_quotient, expected_remainder) = a_bi.div_rem(&b_bi);
+        let expected = if expected_remainder.is_zero() { Some(expected_quotient) } else { None };
 
-        let (actual_quotient, actual_remainder) = a.div_rem_vartime(&NonZero::new(b).unwrap());
-        prop_assert_eq!(expected_quotient, to_biguint(&actual_quotient));
-        prop_assert_eq!(expected_remainder, to_biguint(&actual_remainder));
+        let div = NonZero::new(b).unwrap();
+        let actual = a.div_exact(&div).into_option();
+        prop_assert_eq!(&expected, &actual.as_ref().map(to_biguint));
+        let actual_vartime = a.div_exact_vartime(&div).into_option();
+        prop_assert_eq!(expected, actual_vartime.as_ref().map(to_biguint));
     }
 
     #[test]

--- a/tests/uint.rs
+++ b/tests/uint.rs
@@ -316,6 +316,22 @@ proptest! {
     }
 
     #[test]
+    fn div_exact(a in uint(), b in uint()) {
+        let a_bi = to_biguint(&a);
+        let b_bi = to_biguint(&b);
+
+        if !b_bi.is_zero() {
+            let (q, r) = a_bi.div_rem(&b_bi);
+            let expected = if r.is_zero() { Some(to_uint(q)) } else { None };
+            let b_nz = NonZero::new(b).unwrap();
+            let actual = a.div_exact(&b_nz).into_option();
+            prop_assert_eq!(expected, actual);
+            let actual_vartime = a.div_exact_vartime(&b_nz).into_option();
+            prop_assert_eq!(expected, actual_vartime);
+        }
+    }
+
+    #[test]
     fn rem_wide(a in uint(), b in uint(), c in uint()) {
         let ab_bi = to_biguint(&a) * to_biguint(&b);
         let c_bi = to_biguint(&c);


### PR DESCRIPTION
This adds `div_exact` and `div_exact_vartime` methods for `Uint`, `BoxedUint`, and `Limb`. There is currently no trait support.

For cases where it applies, exact division can be much faster than div/rem. In my tests this is about 40% faster for a 4096-bit `BoxedUint`.

The algorithm is similar to `DivideByWord` in [Modern Computer Arithmetic](https://arxiv.org/pdf/1004.4710) but I don't have a reference for the adjustments to support a multi-word divisor.