### PR TITLE
Avoid incorrect creation of an `Odd<BoxedUint>` in `invert_mod2k`

### DIFF
--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -259,6 +259,19 @@ impl BoxedUint {
         (NonZero::new_unchecked(nz), !is_zero)
     }
 
+    /// Convert to an [`Odd<BoxedUint>`], defaulting to one.
+    ///
+    /// Returns a pair consisting of an [`Odd<BoxedUint>`], and a [`Choice`]
+    /// indicating whether the original value was odd (and preserved).
+    #[inline(always)]
+    #[must_use]
+    pub(crate) fn to_odd_or_one(&self) -> (Odd<Self>, Choice) {
+        let is_odd = self.is_odd();
+        let mut odd = self.clone();
+        odd.as_mut_uint_ref().conditional_set_one(is_odd.not());
+        (Odd::new_unchecked(odd), is_odd)
+    }
+
     /// Construct an [`Odd`] reference, returning [`None`] in the event `self` is even.
     #[must_use]
     pub fn as_odd_vartime(&self) -> Option<&Odd<Self>> {

--- a/src/uint/boxed/invert_mod.rs
+++ b/src/uint/boxed/invert_mod.rs
@@ -1,8 +1,8 @@
 //! [`BoxedUint`] modular inverse (i.e. reciprocal) operations.
 
 use crate::{
-    BoxedUint, Choice, CtEq, CtLt, CtOption, CtSelect, Integer, InvertMod, Limb, NonZero, Odd, U64,
-    bitlen, modular::safegcd, uint::invert_mod::expand_invert_mod2k,
+    BoxedUint, Choice, CtEq, CtLt, CtOption, CtSelect, InvertMod, Limb, NonZero, Odd, U64, bitlen,
+    modular::safegcd, uint::invert_mod::expand_invert_mod2k,
 };
 
 impl BoxedUint {
@@ -50,13 +50,8 @@ impl BoxedUint {
         } else if k > bits {
             (Self::zero_with_precision(bits), Choice::FALSE)
         } else {
-            let is_some = self.is_odd();
-            let inv = Odd::new_unchecked(Self::ct_select(
-                &Self::one_with_precision(bits),
-                self,
-                is_some,
-            ))
-            .invert_mod2k_vartime(k);
+            let (odd, is_some) = self.to_odd_or_one();
+            let inv = odd.invert_mod2k_vartime(k);
             (inv, is_some)
         }
     }
@@ -78,13 +73,9 @@ impl BoxedUint {
     #[must_use]
     pub fn invert_mod2k(&self, k: u32) -> (Self, Choice) {
         let bits = self.bits_precision();
-        let is_some = k.ct_lt(&(bits + 1)) & (k.ct_eq(&0) | self.is_odd());
-        let mut inv = Odd::new_unchecked(Self::ct_select(
-            &Self::one_with_precision(bits),
-            self,
-            is_some,
-        ))
-        .invert_mod_precision();
+        let (odd, is_odd) = self.to_odd_or_one();
+        let is_some = k.ct_lt(&(bits + 1)) & (k.ct_eq(&0) | is_odd);
+        let mut inv = odd.invert_mod_precision();
         inv.restrict_bits(k);
         (inv, is_some)
     }


### PR DESCRIPTION
This fixes an issue where `Odd::new_unchecked` could be used on an even value prior to calling `invert_mod_precision`. This does not currently create an issue in practice because the result, while incorrect, is reduced to zero bits in that specific case.