### PR TITLE
Faster `floor_sqrt`, `checked_sqrt`

### DIFF
--- a/benches/uint.rs
+++ b/benches/uint.rs
@@ -982,6 +982,14 @@ fn bench_sqrt(c: &mut Criterion) {
         );
     });
 
+    group.bench_function("floor_sqrt, one Limb", |b| {
+        b.iter_batched(
+            || Uint::new([Limb::random_from_rng(&mut rng)]),
+            |x| x.floor_sqrt(),
+            BatchSize::SmallInput,
+        );
+    });
+
     group.bench_function("floor_sqrt_vartime, U256 one Limb", |b| {
         b.iter_batched(
             || U256::from_word(Limb::random_from_rng(&mut rng).0),

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -8,7 +8,7 @@ pub(crate) use ref_type::UintRef;
 use crate::{
     Bounded, Choice, ConstOne, ConstZero, Constants, CtEq, CtOption, EncodedUint, FixedInteger,
     Int, Integer, Limb, NonZero, Odd, One, Unsigned, UnsignedWithMontyForm, Word, Zero,
-    limb::nlimbs, modular::FixedMontyForm, primitives::u32_bits, traits::sealed::Sealed,
+    limb::nlimbs, modular::FixedMontyForm, traits::sealed::Sealed,
 };
 use core::fmt;
 
@@ -108,10 +108,6 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Total size of the represented integer in bits.
     #[allow(clippy::cast_possible_truncation)]
     pub const BITS: u32 = LIMBS as u32 * Limb::BITS;
-
-    /// `floor(log2(Self::BITS))`.
-    // Note: assumes the type of `BITS` is `u32`. Any way to assert that?
-    pub(crate) const LOG2_BITS: u32 = u32_bits(Self::BITS) - 1;
 
     /// Total size of the represented integer in bytes.
     pub const BYTES: usize = LIMBS * Limb::BYTES;

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -158,7 +158,7 @@ impl FloorSquareRoot for NonZero<BoxedUint> {
 #[cfg(test)]
 #[allow(clippy::integer_division_remainder_used, reason = "test")]
 mod tests {
-    use crate::{BoxedUint, CheckedSquareRoot, Limb};
+    use crate::{BoxedUint, CheckedSquareRoot, FloorSquareRoot, Limb};
 
     #[cfg(feature = "rand_core")]
     use {
@@ -279,14 +279,16 @@ mod tests {
                 Some(&r)
             );
             let nz_l = l.as_nz_vartime().unwrap();
-            let nz_r = r.as_nz_vartime().unwrap();
+            let nz_r = r.to_nz().unwrap();
+            assert_eq!(FloorSquareRoot::floor_sqrt(nz_l), nz_r);
+            assert_eq!(FloorSquareRoot::floor_sqrt_vartime(nz_l), nz_r);
             assert_eq!(
                 CheckedSquareRoot::checked_sqrt(nz_l).into_option().as_ref(),
-                Some(nz_r)
+                Some(&nz_r)
             );
             assert_eq!(
                 CheckedSquareRoot::checked_sqrt_vartime(nz_l).as_ref(),
-                Some(nz_r)
+                Some(&nz_r)
             );
         }
     }

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -1,8 +1,6 @@
 //! [`BoxedUint`] square root operations.
 
-use crate::{
-    BitOps, BoxedUint, CheckedSquareRoot, CtAssign, CtEq, CtGt, CtOption, FloorSquareRoot, Limb,
-};
+use crate::{BoxedUint, CheckedSquareRoot, Choice, CtOption, FloorSquareRoot, NonZero};
 
 impl BoxedUint {
     /// Computes `floor(√(self))` in constant time.
@@ -19,43 +17,9 @@ impl BoxedUint {
     /// Callers can check if `self` is a square by squaring the result.
     #[must_use]
     pub fn floor_sqrt(&self) -> Self {
-        // Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.13.
-        //
-        // See Hast, "Note on computation of integer square roots"
-        // for the proof of the sufficiency of the bound on iterations.
-        // https://github.com/RustCrypto/crypto-bigint/files/12600669/ct_sqrt.pdf
-
-        // The initial guess: `x_0 = 2^ceil(b/2)`, where `2^(b-1) <= self < b`.
-        // Will not overflow since `b <= BITS`.
-        let mut x = Self::one_with_precision(self.bits_precision());
-        x.unbounded_shl_assign_vartime((self.bits() + 1) >> 1); // ≥ √(`self`)
-
-        let mut nz_x = x.clone();
-        let mut quo = Self::zero_with_precision(self.bits_precision());
-        let mut rem = Self::zero_with_precision(self.bits_precision());
-        let mut i = 0;
-
-        // Repeat enough times to guarantee result has stabilized.
-        // TODO (#378): the tests indicate that just `Self::LOG2_BITS` may be enough.
-        while i < self.log2_bits() + 2 {
-            let x_nonzero = x.is_nonzero();
-            nz_x.ct_assign(&x, x_nonzero);
-
-            // Calculate `x_{i+1} = floor((x_i + self / x_i) / 2)`
-            quo.limbs.copy_from_slice(&self.limbs);
-            rem.limbs.copy_from_slice(&nz_x.limbs);
-            quo.as_mut_uint_ref().div_rem(rem.as_mut_uint_ref());
-            x.conditional_carrying_add_assign(&quo, x_nonzero);
-            x.shr1_assign();
-
-            i += 1;
-        }
-
-        // At this point `x_prev == x_{n}` and `x == x_{n+1}`
-        // where `n == i - 1 == LOG2_BITS + 1 == floor(log2(BITS)) + 1`.
-        // Thus, according to Hast, `sqrt(self) = min(x_n, x_{n+1})`.
-        x.ct_assign(&nz_x, x.ct_gt(&nz_x));
-        x
+        let mut root = self.clone();
+        root.floor_sqrt_assign();
+        root
     }
 
     /// Computes `floor(√(self))`.
@@ -76,42 +40,9 @@ impl BoxedUint {
     /// Variable time with respect to `self`.
     #[must_use]
     pub fn floor_sqrt_vartime(&self) -> Self {
-        // Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.13
-
-        if self.is_zero_vartime() {
-            return Self::zero_with_precision(self.bits_precision());
-        }
-
-        // The initial guess: `x_0 = 2^ceil(b/2)`, where `2^(b-1) <= self < b`.
-        // Will not overflow since `b <= BITS`.
-        // The initial value of `x` is always greater than zero.
-        let mut x = Self::one_with_precision(self.bits_precision());
-        x.unbounded_shl_assign_vartime((self.bits() + 1) >> 1); // ≥ √(`self`)
-
-        let mut quo = Self::zero_with_precision(self.bits_precision());
-        let mut rem = Self::zero_with_precision(self.bits_precision());
-
-        loop {
-            // Calculate `x_{i+1} = floor((x_i + self / x_i) / 2)`
-            quo.limbs.copy_from_slice(&self.limbs);
-            rem.limbs.copy_from_slice(&x.limbs);
-            quo.as_mut_uint_ref().div_rem_vartime(rem.as_mut_uint_ref());
-            quo.carrying_add_assign(&x, Limb::ZERO);
-            quo.shr1_assign();
-
-            // If `quo` is the same as `x` or greater, we reached convergence
-            // (`x` is guaranteed to either go down or oscillate between
-            // `sqrt(self)` and `sqrt(self) + 1`)
-            if !x.cmp_vartime(&quo).is_gt() {
-                break;
-            }
-            x.limbs.copy_from_slice(&quo.limbs);
-            if x.is_zero_vartime() {
-                break;
-            }
-        }
-
-        x
+        let mut root = self.clone();
+        root.floor_sqrt_assign_vartime();
+        root
     }
 
     /// Wrapped sqrt is just `floor(√(self))`.
@@ -136,9 +67,9 @@ impl BoxedUint {
     /// only if the square root is exact.
     #[must_use]
     pub fn checked_sqrt(&self) -> CtOption<Self> {
-        let r = self.floor_sqrt();
-        let s = r.wrapping_square();
-        CtOption::new(r, self.ct_eq(&s))
+        let mut root = self.clone();
+        let exact = root.floor_sqrt_assign();
+        CtOption::new(root, exact)
     }
 
     /// Perform checked sqrt, returning an [`Option`] which `is_some`
@@ -147,13 +78,34 @@ impl BoxedUint {
     /// Variable time with respect to `self`.
     #[must_use]
     pub fn checked_sqrt_vartime(&self) -> Option<Self> {
-        let r = self.floor_sqrt_vartime();
-        let s = r.wrapping_square();
-        if self.cmp_vartime(&s).is_eq() {
-            Some(r)
+        let mut root = self.clone();
+        if root.floor_sqrt_assign_vartime() {
+            Some(root)
         } else {
             None
         }
+    }
+
+    /// Computes √(`self`) in constant time.
+    ///
+    /// Callers can check if `self` is a square by squaring the result.
+    fn floor_sqrt_assign(&mut self) -> Choice {
+        let size = self.nlimbs();
+        let mut buf = Self::zero_with_precision(self.bits_precision() * 2);
+        self.as_mut_uint_ref()
+            .sqrt_assign(buf.as_mut_uint_ref().split_at_mut(size))
+    }
+
+    /// Computes √(`self`).
+    ///
+    /// Callers can check if `self` is a square by squaring the result.
+    ///
+    /// Variable time with respect to `self`.
+    pub fn floor_sqrt_assign_vartime(&mut self) -> bool {
+        let size = self.nlimbs();
+        let mut buf = Self::zero_with_precision(self.bits_precision() * 2);
+        self.as_mut_uint_ref()
+            .sqrt_assign_vartime(buf.as_mut_uint_ref().split_at_mut(size))
     }
 }
 
@@ -176,6 +128,30 @@ impl FloorSquareRoot for BoxedUint {
 
     fn floor_sqrt_vartime(&self) -> Self {
         self.floor_sqrt_vartime()
+    }
+}
+
+impl CheckedSquareRoot for NonZero<BoxedUint> {
+    type Output = Self;
+
+    fn checked_sqrt(&self) -> CtOption<Self> {
+        self.as_ref().checked_sqrt().map(NonZero::new_unchecked)
+    }
+
+    fn checked_sqrt_vartime(&self) -> Option<Self> {
+        self.as_ref()
+            .checked_sqrt_vartime()
+            .map(NonZero::new_unchecked)
+    }
+}
+
+impl FloorSquareRoot for NonZero<BoxedUint> {
+    fn floor_sqrt(&self) -> Self {
+        NonZero::new_unchecked(self.as_ref().floor_sqrt())
+    }
+
+    fn floor_sqrt_vartime(&self) -> Self {
+        NonZero::new_unchecked(self.as_ref().floor_sqrt_vartime())
     }
 }
 
@@ -205,7 +181,7 @@ mod tests {
         for i in 0..half.limbs.len() / 2 {
             half.limbs[i] = Limb::MAX;
         }
-        let u256_max = !BoxedUint::zero_with_precision(256);
+        let u256_max = BoxedUint::max(256);
         assert_eq!(u256_max.floor_sqrt(), half);
 
         // Test edge cases that use up the maximum number of iterations.

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -158,7 +158,7 @@ impl FloorSquareRoot for NonZero<BoxedUint> {
 #[cfg(test)]
 #[allow(clippy::integer_division_remainder_used, reason = "test")]
 mod tests {
-    use crate::{BoxedUint, Limb};
+    use crate::{BoxedUint, CheckedSquareRoot, Limb};
 
     #[cfg(feature = "rand_core")]
     use {
@@ -270,8 +270,24 @@ mod tests {
             let r = BoxedUint::from(*e);
             assert_eq!(l.floor_sqrt(), r);
             assert_eq!(l.floor_sqrt_vartime(), r);
-            assert!(l.checked_sqrt().is_some().to_bool());
-            assert!(l.checked_sqrt_vartime().is_some());
+            assert_eq!(
+                CheckedSquareRoot::checked_sqrt(&l).into_option().as_ref(),
+                Some(&r)
+            );
+            assert_eq!(
+                CheckedSquareRoot::checked_sqrt_vartime(&l).as_ref(),
+                Some(&r)
+            );
+            let nz_l = l.as_nz_vartime().unwrap();
+            let nz_r = r.as_nz_vartime().unwrap();
+            assert_eq!(
+                CheckedSquareRoot::checked_sqrt(nz_l).into_option().as_ref(),
+                Some(nz_r)
+            );
+            assert_eq!(
+                CheckedSquareRoot::checked_sqrt_vartime(nz_l).as_ref(),
+                Some(nz_r)
+            );
         }
     }
 
@@ -325,7 +341,7 @@ mod tests {
     #[cfg(feature = "rand_core")]
     #[test]
     fn fuzz() {
-        use crate::{CheckedSquareRoot, ConcatenatingSquare};
+        use crate::ConcatenatingSquare;
 
         let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
         let rounds = if cfg!(miri) { 10 } else { 50 };

--- a/src/uint/boxed/sqrt.rs
+++ b/src/uint/boxed/sqrt.rs
@@ -14,7 +14,8 @@ impl BoxedUint {
 
     /// Computes √(`self`) in constant time.
     ///
-    /// Callers can check if `self` is a square by squaring the result.
+    /// Callers can check if `self` is a square by squaring the result, or use
+    /// `checked_sqrt`.
     #[must_use]
     pub fn floor_sqrt(&self) -> Self {
         let mut root = self.clone();
@@ -35,7 +36,8 @@ impl BoxedUint {
 
     /// Computes √(`self`).
     ///
-    /// Callers can check if `self` is a square by squaring the result.
+    /// Callers can check if `self` is a square by squaring the result, or use
+    /// `checked_sqrt_vartime`.
     ///
     /// Variable time with respect to `self`.
     #[must_use]
@@ -86,9 +88,8 @@ impl BoxedUint {
         }
     }
 
-    /// Computes √(`self`) in constant time.
-    ///
-    /// Callers can check if `self` is a square by squaring the result.
+    /// Assigns `floor(√(self))` to `self` in constant time, and returns a [`Choice`]
+    /// indicating whether the square root is exact.
     fn floor_sqrt_assign(&mut self) -> Choice {
         let size = self.nlimbs();
         let mut buf = Self::zero_with_precision(self.bits_precision() * 2);
@@ -96,9 +97,8 @@ impl BoxedUint {
             .sqrt_assign(buf.as_mut_uint_ref().split_at_mut(size))
     }
 
-    /// Computes √(`self`).
-    ///
-    /// Callers can check if `self` is a square by squaring the result.
+    /// Assigns `floor(√(self))` to `self`, and returns a [`bool`]
+    /// indicating whether the square root is exact.
     ///
     /// Variable time with respect to `self`.
     pub fn floor_sqrt_assign_vartime(&mut self) -> bool {

--- a/src/uint/ref_type.rs
+++ b/src/uint/ref_type.rs
@@ -10,6 +10,7 @@ mod mul;
 mod shl;
 mod shr;
 mod slice;
+mod sqrt;
 mod sub;
 
 use crate::{Choice, Limb, NonZero, Odd, Uint, Word};

--- a/src/uint/ref_type/add.rs
+++ b/src/uint/ref_type/add.rs
@@ -115,3 +115,45 @@ impl UintRef {
         self.trailing_mut(i).add_assign_limb(carry)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{Choice, Limb, UintRef, Unsigned};
+
+    #[test]
+    fn carrying_add_assign_mixed() {
+        let mut a = [Limb::MAX];
+        let carry =
+            UintRef::new_mut(&mut a).carrying_add_assign(Limb::ONE.as_uint_ref(), Limb::ZERO);
+        assert_eq!((a, carry), ([Limb::ZERO], Limb::ONE));
+
+        let mut a = [Limb::MAX];
+        let carry = UintRef::new_mut(&mut a).conditional_add_assign(
+            Limb::ONE.as_uint_ref(),
+            Limb::ZERO,
+            Choice::FALSE,
+        );
+        assert_eq!((a, carry), ([Limb::MAX], Limb::ZERO));
+
+        let mut a = [Limb::MAX];
+        let carry = UintRef::new_mut(&mut a).conditional_add_assign(
+            Limb::ONE.as_uint_ref(),
+            Limb::ZERO,
+            Choice::TRUE,
+        );
+        assert_eq!((a, carry), ([Limb::ZERO], Limb::ONE));
+
+        let mut a = [Limb::MAX, Limb::MAX];
+        let carry =
+            UintRef::new_mut(&mut a).carrying_add_assign(Limb::ZERO.as_uint_ref(), Limb::ONE);
+        assert_eq!((a, carry), ([Limb::ZERO, Limb::ZERO], Limb::ONE));
+
+        let mut a = [Limb::MAX, Limb::MAX];
+        let carry = UintRef::new_mut(&mut a).conditional_add_assign(
+            Limb::MAX.as_uint_ref(),
+            Limb::ONE,
+            Choice::TRUE,
+        );
+        assert_eq!((a, carry), ([Limb::MAX, Limb::ZERO], Limb::ONE));
+    }
+}

--- a/src/uint/ref_type/add.rs
+++ b/src/uint/ref_type/add.rs
@@ -4,7 +4,6 @@ use crate::{Choice, Limb};
 impl UintRef {
     /// Perform an in-place carrying add of a limb, returning the carried limb value.
     #[inline]
-    #[track_caller]
     pub const fn add_assign_limb(&mut self, mut rhs: Limb) -> Limb {
         let mut i = 0;
         while i < self.limbs.len() {
@@ -15,6 +14,9 @@ impl UintRef {
     }
 
     /// Perform an in-place carrying add of another [`UintRef`], returning the carried limb value.
+    ///
+    /// # Panics
+    /// If `self` is shorter than `rhs`.
     #[inline]
     #[track_caller]
     pub const fn carrying_add_assign(&mut self, rhs: &Self, carry: Limb) -> Limb {
@@ -24,23 +26,30 @@ impl UintRef {
     /// Perform an in-place carrying add of another limb slice, returning the carried limb value.
     ///
     /// # Panics
-    /// If `self` and `rhs` have different lengths.
+    /// If `self` is shorter than `rhs`.
     #[inline]
     #[track_caller]
     pub const fn carrying_add_assign_slice(&mut self, rhs: &[Limb], mut carry: Limb) -> Limb {
         assert!(
-            self.limbs.len() == rhs.len(),
+            self.limbs.len() >= rhs.len(),
             "length mismatch in carrying_add_assign_slice"
         );
         let mut i = 0;
-        while i < self.limbs.len() {
+        while i < rhs.len() {
             (self.limbs[i], carry) = self.limbs[i].carrying_add(rhs[i], carry);
+            i += 1;
+        }
+        while i < self.limbs.len() {
+            (self.limbs[i], carry) = self.limbs[i].overflowing_add(carry);
             i += 1;
         }
         carry
     }
 
     /// Perform an in-place carrying add of another limb slice, returning the carried limb value.
+    ///
+    /// # Panics
+    /// If `self` is shorter than `rhs`.
     #[inline]
     #[track_caller]
     pub const fn conditional_add_assign(
@@ -55,7 +64,7 @@ impl UintRef {
     /// Perform an in-place carrying add of another limb slice, returning the carried limb value.
     ///
     /// # Panics
-    /// If `self` and `rhs` have different lengths.
+    /// If `self` is shorter than `rhs`.
     #[inline]
     #[track_caller]
     pub const fn conditional_add_assign_slice(
@@ -65,15 +74,44 @@ impl UintRef {
         choice: Choice,
     ) -> Limb {
         assert!(
-            self.limbs.len() == rhs.len(),
+            self.limbs.len() >= rhs.len(),
             "length mismatch in conditional_add_assign_slice"
         );
         let mut i = 0;
-        while i < self.limbs.len() {
+        while i < rhs.len() {
             (self.limbs[i], carry) =
                 self.limbs[i].carrying_add(Limb::select(Limb::ZERO, rhs[i], choice), carry);
             i += 1;
         }
+        while i < self.limbs.len() {
+            (self.limbs[i], carry) = self.limbs[i].overflowing_add(carry);
+            i += 1;
+        }
         carry
+    }
+
+    /// Perform an in-place carrying add of another [`UintRef`] multiplied by
+    /// a limb, returning the carried limb value.
+    ///
+    /// # Panics
+    /// If `self` is shorter than `rhs`.
+    #[inline]
+    #[track_caller]
+    pub const fn carrying_add_assign_mul_limb(
+        &mut self,
+        rhs: &Self,
+        rhs_mul: Limb,
+        mut carry: Limb,
+    ) -> Limb {
+        assert!(
+            self.limbs.len() >= rhs.limbs.len(),
+            "length mismatch in carrying_add_assign_mul_limb"
+        );
+        let mut i = 0;
+        while i < rhs.limbs.len() {
+            (self.limbs[i], carry) = rhs.limbs[i].carrying_mul_add(rhs_mul, self.limbs[i], carry);
+            i += 1;
+        }
+        self.trailing_mut(i).add_assign_limb(carry)
     }
 }

--- a/src/uint/ref_type/mul.rs
+++ b/src/uint/ref_type/mul.rs
@@ -6,7 +6,7 @@ impl UintRef {
     /// Compute the wrapping product of `self` and `rhs`, placing the result into `out`
     /// and returning a `Choice` indicating whether overflow occurred.
     #[inline(always)]
-    pub fn overflowing_mul(&self, rhs: &UintRef, out: &mut UintRef) -> Choice {
+    pub const fn overflowing_mul(&self, rhs: &UintRef, out: &mut UintRef) -> Choice {
         let carry = self.wrapping_mul(rhs, out);
         self.check_mul_overflow(rhs, carry.is_nonzero())
     }
@@ -14,7 +14,7 @@ impl UintRef {
     /// Compute the wrapping squaring of `self`, placing the result into `out`
     /// and returning a `Choice` indicating whether overflow occurred.
     #[inline(always)]
-    pub fn overflowing_square(&self, out: &mut UintRef) -> Choice {
+    pub const fn overflowing_square(&self, out: &mut UintRef) -> Choice {
         let carry = self.wrapping_square(out);
         self.check_square_overflow(carry.is_nonzero())
     }
@@ -22,14 +22,14 @@ impl UintRef {
     /// Compute the wrapping product of `self` and `rhs`, placing the result into `out`
     /// and returning a carry Limb.
     #[inline(always)]
-    pub fn wrapping_mul(&self, rhs: &UintRef, out: &mut UintRef) -> Limb {
+    pub const fn wrapping_mul(&self, rhs: &UintRef, out: &mut UintRef) -> Limb {
         karatsuba::wrapping_mul(self, rhs, out, false)
     }
 
     /// Compute the wrapping squaring of `self`, placing the result into `out` and returning
     /// a carry Limb.
     #[inline(always)]
-    pub fn wrapping_square(&self, out: &mut UintRef) -> Limb {
+    pub const fn wrapping_square(&self, out: &mut UintRef) -> Limb {
         karatsuba::wrapping_square(self, out)
     }
 

--- a/src/uint/ref_type/sqrt.rs
+++ b/src/uint/ref_type/sqrt.rs
@@ -6,34 +6,41 @@ use crate::{Choice, Limb, NonZero, Uint, WideWord, Word, word};
 impl UintRef {
     #[inline]
     pub(crate) const fn sqrt_assign(&mut self, buf: (&mut UintRef, &mut UintRef)) -> Choice {
-        assert!(buf.0.nlimbs() >= self.nlimbs() && buf.1.nlimbs() >= self.nlimbs());
+        let len = self.nlimbs();
+        assert!(buf.0.nlimbs() >= len && buf.1.nlimbs() >= len);
 
-        if self.nlimbs() == 0 {
-            return Choice::TRUE;
+        match len {
+            0 => Choice::TRUE,
+            1 => {
+                let rem;
+                (self.limbs[0].0, rem) = sqrt_rem_word(self.limbs[0].0);
+                Limb(rem).is_zero()
+            }
+            _ => {
+                let mut bits = self.bits();
+                let is_zero = Choice::from_u32_nz(bits).not();
+                // Set first limb to 1 if the input is zero
+                self.limbs[0] = Limb::select(self.limbs[0], Limb::ONE, is_zero);
+                bits = is_zero.select_u32(bits, 1);
+
+                // Shift such that at least one of the top two bits are non-zero
+                let s_shift = (self.bits_precision() - bits) >> 1;
+                self.shl_assign(s_shift * 2);
+
+                // Compute root and uncorrected remainder, placing them in buf.0 and buf.1
+                self.sqrt_rem_normalized::<false>(buf.0, buf.1);
+
+                // Copy the shifted root to self and correct it
+                self.copy_from(buf.0.leading(self.nlimbs()));
+                self.shr_assign(s_shift);
+
+                // Set root to zero if self was zero
+                self.limbs[0] = Limb::select(self.limbs[0], Limb::ZERO, is_zero);
+
+                // Check if there is a remainder
+                buf.1.is_zero()
+            }
         }
-
-        let mut bits = self.bits();
-        let is_zero = Choice::from_u32_nz(bits).not();
-        // Set first limb to 1 if the input is zero
-        self.limbs[0] = Limb::select(self.limbs[0], Limb::ONE, is_zero);
-        bits = is_zero.select_u32(bits, 1);
-
-        // Shift such that at least one of the top two bits are non-zero
-        let s_shift = (self.bits_precision() - bits) >> 1;
-        self.shl_assign(s_shift * 2);
-
-        // Compute root and uncorrected remainder, placing them in buf.0 and buf.1
-        self.sqrt_rem_normalized(buf.0, buf.1);
-
-        // Copy the shifted root to self and correct it
-        self.copy_from(buf.0.leading(self.nlimbs()));
-        self.shr_assign(s_shift);
-
-        // Set root to zero if self was zero
-        self.limbs[0] = Limb::select(self.limbs[0], Limb::ZERO, is_zero);
-
-        // Check if there is a remainder
-        buf.1.is_zero()
     }
 
     #[inline]
@@ -44,58 +51,42 @@ impl UintRef {
         }
 
         let words = bits.div_ceil(Limb::BITS);
-        let lz = words * Limb::BITS - bits;
         assert!(buf.0.nlimbs() >= words as usize && buf.1.nlimbs() >= words as usize);
-
-        // Shift such that at least one of the top two bits are non-zero
-        let s_shift = lz >> 1;
-        self.shl_assign_limb_vartime(s_shift * 2);
 
         // Only consider the populated limbs
         let out = self.leading_mut(words as usize);
 
-        // Compute root and uncorrected remainder, placing them in buf.0 and buf.1
-        out.sqrt_rem_normalized(buf.0, buf.1);
+        if words <= 2 {
+            // No shifts needed
+            sqrt_rem_small::<true>(out.as_limbs(), buf.0.as_mut_limbs(), buf.1.as_mut_limbs());
+            out.copy_from(buf.0.leading(out.nlimbs()));
+        } else {
+            // Shift such that at least one of the top two bits are non-zero
+            let lz = words * Limb::BITS - bits;
+            let s_shift = lz >> 1;
+            out.shl_assign_limb_vartime(s_shift * 2);
 
-        // Copy the shifted root to self and correct it
-        out.copy_from(buf.0.leading(out.nlimbs()));
-        out.shr_assign_limb_vartime(s_shift);
+            // Compute root and uncorrected remainder, placing them in buf.0 and buf.1
+            out.sqrt_rem_normalized::<true>(buf.0, buf.1);
+
+            // Copy the shifted root to self and correct it
+            out.copy_from(buf.0.leading(out.nlimbs()));
+            out.shr_assign_limb_vartime(s_shift);
+        }
 
         // Check if there is a remainder
         buf.1.is_zero_vartime()
     }
 
-    /// Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.12
+    /// Corresponds to Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.12
     #[allow(clippy::cast_possible_truncation)]
-    const fn sqrt_rem_normalized(&self, s: &mut UintRef, r: &mut UintRef) {
+    const fn sqrt_rem_normalized<const VARTIME: bool>(&self, s: &mut UintRef, r: &mut UintRef) {
         let len = self.nlimbs();
 
-        // Handle base case of a square root <= 3 limbs
+        // Handle base case of a square root < 4 limbs
+        // Unlike the source material, we do not handle 4 limbs in the base case sqrt function
         if len < 4 {
-            if len == 0 {
-                // no input
-                return;
-            }
-
-            // Compute root, remainder for a single word
-            let (s1, r1) = sqrt_rem_word(self.limbs[len - 1].0);
-            if len == 1 {
-                (s.limbs[0].0, r.limbs[0].0) = (s1, r1);
-                return;
-            }
-
-            // Expand to root, remainder for two words
-            let (s1, r1) = sqrt_rem_expand(s1, r1 as WideWord, self.limbs[len - 2].0);
-            if len == 2 {
-                s.limbs[0].0 = s1 as Word;
-                (r.limbs[0].0, r.limbs[1].0) = word::split_wide(r1);
-                return;
-            }
-
-            // Expand to root, remainder for three words
-            let (s1, r1) = sqrt_rem_expand(s1 as Word, r1, self.limbs[len - 3].0);
-            (s.limbs[0].0, s.limbs[1].0) = word::split_wide(s1);
-            (r.limbs[0].0, r.limbs[1].0) = word::split_wide(r1);
+            sqrt_rem_small::<VARTIME>(self.as_limbs(), s.as_mut_limbs(), r.as_mut_limbs());
             return;
         }
 
@@ -104,60 +95,62 @@ impl UintRef {
         let (a_lo, a_hi) = self.split_at(l * 2);
         let (a0, a1) = a_lo.split_at(l);
 
-        // Compute (s', r') <- SqrtRem(a3ß + a2), storing s' and r' in the high (+l) limbs of s, r
-        a_hi.sqrt_rem_normalized(s.trailing_mut(l), r.trailing_mut(l));
+        // (s', r') = SqrtRem(a3•B + a2), leaving `l` spare low limbs in each
+        a_hi.sqrt_rem_normalized::<VARTIME>(s.trailing_mut(l), r.trailing_mut(l));
 
-        let (s0, s1) = s.split_at_mut(l);
-        let (s1, s2) = s1.split_at_mut(rt_len);
+        // Split up buffers
+        let (s, s_tail) = s.split_at_mut(l + rt_len);
+        let (s_lo, s_hi) = s.split_at_mut(l);
+        let (r, r_tail) = r.split_at_mut(l + rt_len + 1);
 
         // Set u = s' and shift to the top
-        let u = s2.leading_mut(rt_len + 1);
-        u.leading_mut(rt_len).copy_from(s1);
+        let u = s_tail.leading_mut(rt_len + 1);
+        u.leading_mut(rt_len).copy_from(s_hi);
         u.limbs[rt_len] = Limb::ZERO;
         let ulz = u.leading_zeros();
         u.shl_assign(ulz);
         let uwords = u.nlimbs() as u32 - ((ulz - 1) >> Limb::LOG2_BITS);
 
-        // Set q = r'B + a1 and shift to match u
-        let q = r.leading_mut(l + rt_len + 1);
-        q.leading_mut(l).copy_from(a1);
+        // Set r = r'B + a1 and shift to match u
+        r.leading_mut(l).copy_from(a1);
         let lshift = (ulz - 1) & (Limb::BITS - 1);
-        let q_hi = q.shl_assign_limb(lshift);
+        let r_hi = r.shl_assign_limb(lshift);
 
-        // Divide q/u, setting q to the quotient and u to the remainder
-        q.div_rem_shifted(q_hi, u, uwords);
-        q.unbounded_shr_assign_by_limbs(uwords - 1);
+        // Divide r/u, setting r to the quotient and u to the remainder
+        r.div_rem_shifted(r_hi, u, uwords);
+        r.unbounded_shr_assign_by_limbs(uwords - 1);
         u.shr_assign_limb(lshift);
+        let (r_lo, r_hi) = r.split_at_mut(l);
 
-        s0.copy_from(q.leading(l));
-        let q_hi = q.limbs[l];
-        s1.add_assign_limb(q_hi);
+        // s = s'B + q
+        s_lo.copy_from(r_lo);
+        let q_hi = r_hi.limbs[0];
+        s_hi.add_assign_limb(q_hi);
         debug_assert!(q_hi.0 & !1 == 0);
 
-        let (r, r_tail) = r.split_at_mut(l + rt_len + 1);
-        let (r_lo, r_hi) = r.split_at_mut(l);
+        // r = uB + a0
         r_lo.copy_from(a0);
         r_hi.copy_from(u);
 
         // Compute q^2
-        let q2 = s2.leading_mut(l * 2);
+        let q2 = s_tail.leading_mut(l * 2);
         q2.fill(Limb::ZERO);
-        s0.wrapping_square(q2);
+        s_lo.wrapping_square(q2);
 
-        // Subtract q^2 from r, producing a borrow if r < 0
+        // r -= q^2, producing a borrow if r < 0
         let (r0, r1) = r.split_at_mut(l * 2);
         let borrow = r0.borrowing_sub_assign(q2, Limb::ZERO);
         let swap = r1.borrowing_sub_assign_limb(q_hi, borrow).lsb_to_choice();
+        let s_carry = Limb::select(Limb::ZERO, Limb::ONE, swap);
 
         // s -= 1 if r < 0
-        let (s, s_tail) = s.split_at_mut(l + rt_len);
-        s.borrowing_sub_assign_limb(Limb::select(Limb::ZERO, Limb::ONE, swap), Limb::ZERO);
+        s.borrowing_sub_assign_limb(s_carry, Limb::ZERO);
 
         // r += 2s + 1 if r < 0
-        let s_mul = Limb::select(Limb::ZERO, Limb(2), swap);
-        let s_carry = s_mul.shr(1);
+        let s_mul = s_carry.shl(1);
         r.carrying_add_assign_mul_limb(s, s_mul, s_carry);
 
+        // Clear upper limbs of the result buffers
         s_tail.fill(Limb::ZERO);
         r_tail.fill(Limb::ZERO);
     }
@@ -176,44 +169,105 @@ const fn sqrt_rem_word(value: Word) -> (Word, Word) {
     while m != 0 {
         let b = y | m;
         y >>= 1;
-        let cmp = word::choice_from_le(b, x);
-        x = word::select(x, x.wrapping_sub(b), cmp);
-        y = word::select(y, y | m, cmp);
+        let mask = word::choice_to_mask(word::choice_from_le(b, x));
+        x = x.wrapping_sub(b & mask);
+        y |= m & mask;
         m >>= 2;
     }
     (y, x)
 }
 
-/// Compute the square root and remainder of a [`WideWord`].
+/// Compute the root and remainder for `n+1` limbs, given the root and remainder
+/// for `n` limbs (n=1 or 2). The input value must be normalized such that at least one of the
+/// top two bits is set, producing an `s1` with at least `Word::BITS/2` bits.
 ///
-/// `value` must be non-zero and normalized such that at least one of the top
-/// two bits is set.
-#[inline]
+/// This is essentially a specialized version of the root expansion portion of `sqrt_rem_normalized`.
 #[allow(clippy::cast_possible_truncation)]
-const fn sqrt_rem_expand(s1: Word, r1: WideWord, next: Word) -> (WideWord, WideWord) {
+#[inline]
+const fn sqrt_rem_expand_by_word(s1: Word, r1: WideWord, next: Word) -> (WideWord, WideWord) {
     const HALF_WIDTH: u32 = Word::BITS >> 1;
+    debug_assert!((s1 >> (HALF_WIDTH - 1)) > 0);
 
+    // Split the lower word into lower and upper halves
     let (a0, a1) = (
         (next & ((1 << HALF_WIDTH) - 1)) as WideWord,
         (next >> HALF_WIDTH) as WideWord,
     );
     let d = (r1 << HALF_WIDTH) | a1;
+
+    // Divide by (r1B + a1) by s1 (not 2s1 which could overflow a limb)
     let (q, _) = Uint::<2>::from_wide_word(d).div_rem_limb(NonZero::<Limb>::new_unwrap(Limb(s1)));
-    let q = q.limbs[0].0 as WideWord >> 1;
-    let u = Limb((d - 2 * q * s1 as WideWord) as _);
+    // Correct the quotient
+    let q = (q.limbs[0].0 >> 1) as WideWord;
+    // Recompute the remainder u
+    let u = Limb((d - (q << 1) * s1 as WideWord) as _);
+    // Set s = s1B + q
     let s = ((s1 as WideWord) << HALF_WIDTH) + q;
-    let q2 = q.pow(2);
+
+    // Set r' = uB + a0
     let r_pre = ((u.0 as WideWord) << HALF_WIDTH) | a0;
-    let swap = word::choice_from_wide_lt(r_pre, q2);
-    let s = word::select_wide(s, s - 1, swap);
-    let r = word::select_wide(r_pre, r_pre.wrapping_add(2 * s + 1), swap) - q2;
+    let q2 = q.pow(2);
+    let swap = word::choice_to_wide_mask(word::choice_from_wide_lt(r_pre, q2));
+
+    // Subtract 1 from s if r' < q^2
+    let s = s - (swap & 1);
+    // Set r = r' - q2, adding back 2s + 1 if r would be negative
+    let r = r_pre.wrapping_add(((s << 1) | 1) & swap) - q2;
+
     (s, r)
+}
+
+/// Compute the square root and remainder for a 1 to 3 limb input, which must be normalized.
+/// This is the base case square root calcuation.
+#[allow(clippy::cast_possible_truncation)]
+#[inline]
+const fn sqrt_rem_small<const VARTIME: bool>(value: &[Limb], s: &mut [Limb], r: &mut [Limb]) {
+    let len = value.len();
+    assert!(len < 4, "value exceeds maximum size for sqrt_rem_small");
+
+    if len == 0 {
+        return;
+    }
+
+    if len == 1 {
+        let base = value[0].0;
+        (s[0].0, r[0].0) = if VARTIME {
+            let root = base.isqrt();
+            (root, base.wrapping_sub(root.wrapping_pow(2)))
+        } else {
+            sqrt_rem_word(base)
+        };
+        return;
+    }
+
+    // Compute root, remainder for two words
+    let (s1, r1) = {
+        if VARTIME {
+            let base = word::join(value[len - 2].0, value[len - 1].0);
+            let root = base.isqrt();
+            (root as Word, base.wrapping_sub(root.wrapping_pow(2)))
+        } else {
+            let (s0, r0) = sqrt_rem_word(value[len - 1].0);
+            let (s1, r1) = sqrt_rem_expand_by_word(s0, r0 as WideWord, value[len - 2].0);
+            (s1 as Word, r1)
+        }
+    };
+    if len == 2 {
+        s[0].0 = s1;
+        (r[0].0, r[1].0) = word::split_wide(r1);
+        return;
+    }
+
+    // Expand to root, remainder for three words
+    let (s1, r1) = sqrt_rem_expand_by_word(s1, r1, value[len - 3].0);
+    (s[0].0, s[1].0) = word::split_wide(s1);
+    (r[0].0, r[1].0) = word::split_wide(r1);
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{sqrt_rem_expand, sqrt_rem_word};
-    use crate::{WideWord, Word};
+    use super::{sqrt_rem_expand_by_word, sqrt_rem_word};
+    use crate::{WideWord, Word, word};
 
     #[test]
     fn sqrt_rem_word_expected() {
@@ -230,26 +284,18 @@ mod tests {
     }
 
     #[test]
-    fn sqrt_expand_expected() {
-        fn check(s1: Word, r1: WideWord, next: Word, s2: WideWord, r2: WideWord) {
-            let (s_res, r_res) = sqrt_rem_expand(s1, r1, next);
-            assert_eq!(s2, s_res);
-            assert_eq!(r2, r_res);
+    fn sqrt_rem_expand_by_word_expected() {
+        fn check(val: WideWord) {
+            let (lo, hi) = word::split_wide(val);
+            let s1 = hi.isqrt();
+            let r1 = (hi - s1.pow(2)) as WideWord;
+            let (s, r) = sqrt_rem_expand_by_word(s1, r1, lo);
+            assert_eq!(s, val.isqrt());
+            assert_eq!(r, val - s.pow(2));
         }
 
-        check(
-            622260355,
-            205765663,
-            1685072410847819194,
-            2672587875032468269,
-            3184677644130930641,
-        );
-        check(
-            2672587875032468269,
-            3184677644130930641,
-            15850601984282720829,
-            0x2516f0832a538b2d98869e21,
-            0x4a2de10654a7165b310d39fc,
-        );
+        check(1 << (WideWord::BITS - 1));
+        check(2 << (WideWord::BITS - 2));
+        check(WideWord::MAX);
     }
 }

--- a/src/uint/ref_type/sqrt.rs
+++ b/src/uint/ref_type/sqrt.rs
@@ -218,7 +218,7 @@ const fn sqrt_rem_expand_by_word(s1: Word, r1: WideWord, next: Word) -> (WideWor
 }
 
 /// Compute the square root and remainder for a 1 to 3 limb input, which must be normalized.
-/// This is the base case square root calcuation.
+/// This is the base case square root calculation.
 #[allow(clippy::cast_possible_truncation)]
 #[inline]
 const fn sqrt_rem_small<const VARTIME: bool>(value: &[Limb], s: &mut [Limb], r: &mut [Limb]) {

--- a/src/uint/ref_type/sqrt.rs
+++ b/src/uint/ref_type/sqrt.rs
@@ -288,7 +288,7 @@ mod tests {
         fn check(val: WideWord) {
             let (lo, hi) = word::split_wide(val);
             let s1 = hi.isqrt();
-            let r1 = (hi - s1.pow(2)) as WideWord;
+            let r1 = WideWord::from(hi - s1.pow(2));
             let (s, r) = sqrt_rem_expand_by_word(s1, r1, lo);
             assert_eq!(s, val.isqrt());
             assert_eq!(r, val - s.pow(2));

--- a/src/uint/ref_type/sqrt.rs
+++ b/src/uint/ref_type/sqrt.rs
@@ -1,0 +1,255 @@
+//! Square root calculation.
+
+use super::UintRef;
+use crate::{Choice, Limb, NonZero, Uint, WideWord, Word, word};
+
+impl UintRef {
+    #[inline]
+    pub(crate) const fn sqrt_assign(&mut self, buf: (&mut UintRef, &mut UintRef)) -> Choice {
+        assert!(buf.0.nlimbs() >= self.nlimbs() && buf.1.nlimbs() >= self.nlimbs());
+
+        if self.nlimbs() == 0 {
+            return Choice::TRUE;
+        }
+
+        let mut bits = self.bits();
+        let is_zero = Choice::from_u32_nz(bits).not();
+        // Set first limb to 1 if the input is zero
+        self.limbs[0] = Limb::select(self.limbs[0], Limb::ONE, is_zero);
+        bits = is_zero.select_u32(bits, 1);
+
+        // Shift such that at least one of the top two bits are non-zero
+        let s_shift = (self.bits_precision() - bits) >> 1;
+        self.shl_assign(s_shift * 2);
+
+        // Compute root and uncorrected remainder, placing them in buf.0 and buf.1
+        self.sqrt_rem_normalized(buf.0, buf.1);
+
+        // Copy the shifted root to self and correct it
+        self.copy_from(buf.0.leading(self.nlimbs()));
+        self.shr_assign(s_shift);
+
+        // Set root to zero if self was zero
+        self.limbs[0] = Limb::select(self.limbs[0], Limb::ZERO, is_zero);
+
+        // Check if there is a remainder
+        buf.1.is_zero()
+    }
+
+    #[inline]
+    pub(crate) const fn sqrt_assign_vartime(&mut self, buf: (&mut UintRef, &mut UintRef)) -> bool {
+        let bits = self.bits_vartime();
+        if bits == 0 {
+            return true;
+        }
+
+        let words = bits.div_ceil(Limb::BITS);
+        let lz = words * Limb::BITS - bits;
+        assert!(buf.0.nlimbs() >= words as usize && buf.1.nlimbs() >= words as usize);
+
+        // Shift such that at least one of the top two bits are non-zero
+        let s_shift = lz >> 1;
+        self.shl_assign_limb_vartime(s_shift * 2);
+
+        // Only consider the populated limbs
+        let out = self.leading_mut(words as usize);
+
+        // Compute root and uncorrected remainder, placing them in buf.0 and buf.1
+        out.sqrt_rem_normalized(buf.0, buf.1);
+
+        // Copy the shifted root to self and correct it
+        out.copy_from(buf.0.leading(out.nlimbs()));
+        out.shr_assign_limb_vartime(s_shift);
+
+        // Check if there is a remainder
+        buf.1.is_zero_vartime()
+    }
+
+    /// Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.12
+    #[allow(clippy::cast_possible_truncation)]
+    const fn sqrt_rem_normalized(&self, s: &mut UintRef, r: &mut UintRef) {
+        let len = self.nlimbs();
+
+        // Handle base case of a square root <= 3 limbs
+        if len < 4 {
+            if len == 0 {
+                // no input
+                return;
+            }
+
+            // Compute root, remainder for a single word
+            let (s1, r1) = sqrt_rem_word(self.limbs[len - 1].0);
+            if len == 1 {
+                (s.limbs[0].0, r.limbs[0].0) = (s1, r1);
+                return;
+            }
+
+            // Expand to root, remainder for two words
+            let (s1, r1) = sqrt_rem_expand(s1, r1 as WideWord, self.limbs[len - 2].0);
+            if len == 2 {
+                s.limbs[0].0 = s1 as Word;
+                (r.limbs[0].0, r.limbs[1].0) = word::split_wide(r1);
+                return;
+            }
+
+            // Expand to root, remainder for three words
+            let (s1, r1) = sqrt_rem_expand(s1 as Word, r1, self.limbs[len - 3].0);
+            (s.limbs[0].0, s.limbs[1].0) = word::split_wide(s1);
+            (r.limbs[0].0, r.limbs[1].0) = word::split_wide(r1);
+            return;
+        }
+
+        let l = len >> 2;
+        let rt_len = (len - l * 2).div_ceil(2);
+        let (a_lo, a_hi) = self.split_at(l * 2);
+        let (a0, a1) = a_lo.split_at(l);
+
+        // Compute (s', r') <- SqrtRem(a3ß + a2), storing s' and r' in the high (+l) limbs of s, r
+        a_hi.sqrt_rem_normalized(s.trailing_mut(l), r.trailing_mut(l));
+
+        let (s0, s1) = s.split_at_mut(l);
+        let (s1, s2) = s1.split_at_mut(rt_len);
+
+        // Set u = s' and shift to the top
+        let u = s2.leading_mut(rt_len + 1);
+        u.leading_mut(rt_len).copy_from(s1);
+        u.limbs[rt_len] = Limb::ZERO;
+        let ulz = u.leading_zeros();
+        u.shl_assign(ulz);
+        let uwords = u.nlimbs() as u32 - ((ulz - 1) >> Limb::LOG2_BITS);
+
+        // Set q = r'B + a1 and shift to match u
+        let q = r.leading_mut(l + rt_len + 1);
+        q.leading_mut(l).copy_from(a1);
+        let lshift = (ulz - 1) & (Limb::BITS - 1);
+        let q_hi = q.shl_assign_limb(lshift);
+
+        // Divide q/u, setting q to the quotient and u to the remainder
+        q.div_rem_shifted(q_hi, u, uwords);
+        q.unbounded_shr_assign_by_limbs(uwords - 1);
+        u.shr_assign_limb(lshift);
+
+        s0.copy_from(q.leading(l));
+        let q_hi = q.limbs[l];
+        s1.add_assign_limb(q_hi);
+        debug_assert!(q_hi.0 & !1 == 0);
+
+        let (r, r_tail) = r.split_at_mut(l + rt_len + 1);
+        let (r_lo, r_hi) = r.split_at_mut(l);
+        r_lo.copy_from(a0);
+        r_hi.copy_from(u);
+
+        // Compute q^2
+        let q2 = s2.leading_mut(l * 2);
+        q2.fill(Limb::ZERO);
+        s0.wrapping_square(q2);
+
+        // Subtract q^2 from r, producing a borrow if r < 0
+        let (r0, r1) = r.split_at_mut(l * 2);
+        let borrow = r0.borrowing_sub_assign(q2, Limb::ZERO);
+        let swap = r1.borrowing_sub_assign_limb(q_hi, borrow).lsb_to_choice();
+
+        // s -= 1 if r < 0
+        let (s, s_tail) = s.split_at_mut(l + rt_len);
+        s.borrowing_sub_assign_limb(Limb::select(Limb::ZERO, Limb::ONE, swap), Limb::ZERO);
+
+        // r += 2s + 1 if r < 0
+        let s_mul = Limb::select(Limb::ZERO, Limb(2), swap);
+        let s_carry = s_mul.shr(1);
+        r.carrying_add_assign_mul_limb(s, s_mul, s_carry);
+
+        s_tail.fill(Limb::ZERO);
+        r_tail.fill(Limb::ZERO);
+    }
+}
+
+/// Compute the square root and remainder of a [`Word`].
+///
+/// Adapted from Hacker's Delight 2E by Henry S. Warren Jr.,
+/// Fig. 11-4, "Integer square root, hardware algorithm"
+/// based on Toepler's algorithm.
+#[inline]
+const fn sqrt_rem_word(value: Word) -> (Word, Word) {
+    let mut m = 1 << (Word::BITS - 2);
+    let mut x = value;
+    let mut y = 0;
+    while m != 0 {
+        let b = y | m;
+        y >>= 1;
+        let cmp = word::choice_from_le(b, x);
+        x = word::select(x, x.wrapping_sub(b), cmp);
+        y = word::select(y, y | m, cmp);
+        m >>= 2;
+    }
+    (y, x)
+}
+
+/// Compute the square root and remainder of a [`WideWord`].
+///
+/// `value` must be non-zero and normalized such that at least one of the top
+/// two bits is set.
+#[inline]
+#[allow(clippy::cast_possible_truncation)]
+const fn sqrt_rem_expand(s1: Word, r1: WideWord, next: Word) -> (WideWord, WideWord) {
+    const HALF_WIDTH: u32 = Word::BITS >> 1;
+
+    let (a0, a1) = (
+        (next & ((1 << HALF_WIDTH) - 1)) as WideWord,
+        (next >> HALF_WIDTH) as WideWord,
+    );
+    let d = (r1 << HALF_WIDTH) | a1;
+    let (q, _) = Uint::<2>::from_wide_word(d).div_rem_limb(NonZero::<Limb>::new_unwrap(Limb(s1)));
+    let q = q.limbs[0].0 as WideWord >> 1;
+    let u = Limb((d - 2 * q * s1 as WideWord) as _);
+    let s = ((s1 as WideWord) << HALF_WIDTH) + q;
+    let q2 = q.pow(2);
+    let r_pre = ((u.0 as WideWord) << HALF_WIDTH) | a0;
+    let swap = word::choice_from_wide_lt(r_pre, q2);
+    let s = word::select_wide(s, s - 1, swap);
+    let r = word::select_wide(r_pre, r_pre.wrapping_add(2 * s + 1), swap) - q2;
+    (s, r)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sqrt_rem_expand, sqrt_rem_word};
+    use crate::{WideWord, Word};
+
+    #[test]
+    fn sqrt_rem_word_expected() {
+        fn check(val: Word) {
+            let (root, rem) = sqrt_rem_word(val);
+            let check = root.pow(2) + rem;
+            assert_eq!(check, val, "val: {val}, root: {root}, rem: {rem}");
+        }
+
+        check(0);
+        check(1);
+        check(2);
+        check(Word::MAX);
+    }
+
+    #[test]
+    fn sqrt_expand_expected() {
+        fn check(s1: Word, r1: WideWord, next: Word, s2: WideWord, r2: WideWord) {
+            let (s_res, r_res) = sqrt_rem_expand(s1, r1, next);
+            assert_eq!(s2, s_res);
+            assert_eq!(r2, r_res);
+        }
+
+        check(
+            622260355,
+            205765663,
+            1685072410847819194,
+            2672587875032468269,
+            3184677644130930641,
+        );
+        check(
+            2672587875032468269,
+            3184677644130930641,
+            15850601984282720829,
+            0x2516f0832a538b2d98869e21,
+            0x4a2de10654a7165b310d39fc,
+        );
+    }
+}

--- a/src/uint/ref_type/sub.rs
+++ b/src/uint/ref_type/sub.rs
@@ -82,3 +82,46 @@ impl UintRef {
         borrow.lsb_to_choice()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{Choice, Limb, UintRef, Unsigned};
+
+    #[test]
+    fn borrowing_sub_assign_mixed() {
+        let mut a = [Limb::MAX];
+        let borrow =
+            UintRef::new_mut(&mut a).borrowing_sub_assign(Limb::MAX.as_uint_ref(), Limb::MAX);
+        assert_eq!((a, borrow), ([Limb::MAX], Limb::MAX));
+
+        let mut a = [Limb::MAX];
+        let borrow = UintRef::new_mut(&mut a)
+            .conditional_borrowing_sub_assign(Limb::MAX.as_uint_ref(), Choice::FALSE);
+        assert_eq!((a, borrow.to_bool()), ([Limb::MAX], false));
+
+        let mut a = [Limb::MAX - Limb::ONE];
+        let borrow = UintRef::new_mut(&mut a)
+            .conditional_borrowing_sub_assign(Limb::MAX.as_uint_ref(), Choice::TRUE);
+        assert_eq!((a, borrow.to_bool()), ([Limb::MAX], true));
+
+        let mut a = [Limb::MAX - Limb::ONE, Limb::ONE];
+        let borrow =
+            UintRef::new_mut(&mut a).borrowing_sub_assign(Limb::MAX.as_uint_ref(), Limb::ZERO);
+        assert_eq!((a, borrow), ([Limb::MAX, Limb::ZERO], Limb::ZERO));
+
+        let mut a = [Limb::MAX - Limb::ONE, Limb::ZERO];
+        let borrow =
+            UintRef::new_mut(&mut a).borrowing_sub_assign(Limb::MAX.as_uint_ref(), Limb::ZERO);
+        assert_eq!((a, borrow), ([Limb::MAX, Limb::MAX], Limb::MAX));
+
+        let mut a = [Limb::MAX - Limb::ONE, Limb::ONE];
+        let borrow = UintRef::new_mut(&mut a)
+            .conditional_borrowing_sub_assign(Limb::MAX.as_uint_ref(), Choice::TRUE);
+        assert_eq!((a, borrow.to_bool()), ([Limb::MAX, Limb::ZERO], false));
+
+        let mut a = [Limb::MAX - Limb::ONE, Limb::ZERO];
+        let borrow = UintRef::new_mut(&mut a)
+            .conditional_borrowing_sub_assign(Limb::MAX.as_uint_ref(), Choice::TRUE);
+        assert_eq!((a, borrow.to_bool()), ([Limb::MAX, Limb::MAX], true));
+    }
+}

--- a/src/uint/ref_type/sub.rs
+++ b/src/uint/ref_type/sub.rs
@@ -3,9 +3,25 @@ use crate::Limb;
 use ctutils::Choice;
 
 impl UintRef {
+    /// Perform an in-place borrowing sub of a limb, returning the borrowed limb value.
+    #[inline]
+    pub const fn borrowing_sub_assign_limb(&mut self, mut rhs: Limb, mut borrow: Limb) -> Limb {
+        let mut i = 0;
+        while i < self.limbs.len() {
+            (self.limbs[i], borrow) = self.limbs[i].borrowing_sub(rhs, borrow);
+            rhs = Limb::ZERO;
+            i += 1;
+        }
+        borrow
+    }
+
     /// Perform an in-place borrowing subtraction of another [`UintRef`], returning the carried limb
     /// value.
+    ///
+    /// # Panics
+    /// If `self` is shorter than `rhs`.
     #[inline]
+    #[track_caller]
     pub const fn borrowing_sub_assign(&mut self, rhs: &Self, borrow: Limb) -> Limb {
         self.borrowing_sub_assign_slice(&rhs.limbs, borrow)
     }
@@ -14,13 +30,21 @@ impl UintRef {
     /// value.
     ///
     /// # Panics
-    /// If `self` and `rhs` have different lengths.
+    /// If `self` is shorter than `rhs`.
     #[inline]
+    #[track_caller]
     pub const fn borrowing_sub_assign_slice(&mut self, rhs: &[Limb], mut borrow: Limb) -> Limb {
-        assert!(self.limbs.len() == rhs.len(), "length mismatch");
+        assert!(
+            self.limbs.len() >= rhs.len(),
+            "length mismatch in borrowing_sub_assign_slice"
+        );
         let mut i = 0;
-        while i < self.limbs.len() {
+        while i < rhs.len() {
             (self.limbs[i], borrow) = self.limbs[i].borrowing_sub(rhs[i], borrow);
+            i += 1;
+        }
+        while i < self.limbs.len() {
+            (self.limbs[i], borrow) = self.limbs[i].borrowing_sub(Limb::ZERO, borrow);
             i += 1;
         }
         borrow
@@ -28,20 +52,31 @@ impl UintRef {
 
     /// Perform in-place wrapping subtraction, returning the truthy value as the second element of
     /// the tuple if an underflow has occurred.
-    pub(crate) fn conditional_borrowing_sub_assign(
+    ///
+    /// # Panics
+    /// If `self` is shorter than `rhs`.
+    #[track_caller]
+    pub(crate) const fn conditional_borrowing_sub_assign(
         &mut self,
         rhs: &Self,
         choice: Choice,
     ) -> Choice {
-        debug_assert!(self.bits_precision() <= rhs.bits_precision());
+        assert!(
+            self.limbs.len() >= rhs.limbs.len(),
+            "length mismatch in conditional_borrowing_sub_assign"
+        );
         let mask = Limb::select(Limb::ZERO, Limb::MAX, choice);
         let mut borrow = Limb::ZERO;
 
-        for i in 0..self.nlimbs() {
-            let masked_rhs = *rhs.limbs.get(i).unwrap_or(&Limb::ZERO) & mask;
-            let (limb, b) = self.limbs[i].borrowing_sub(masked_rhs, borrow);
-            self.limbs[i] = limb;
-            borrow = b;
+        let mut i = 0;
+        while i < rhs.limbs.len() {
+            let masked_rhs = rhs.limbs[i].bitand(mask);
+            (self.limbs[i], borrow) = self.limbs[i].borrowing_sub(masked_rhs, borrow);
+            i += 1;
+        }
+        while i < self.limbs.len() {
+            (self.limbs[i], borrow) = self.limbs[i].borrowing_sub(Limb::ZERO, borrow);
+            i += 1;
         }
 
         borrow.lsb_to_choice()

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -16,7 +16,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Computes `floor(√(self))` in constant time.
     ///
-    /// Callers can check if `self` is a square by squaring the result.
+    /// Callers can check if `self` is a square by squaring the result, or use
+    /// `checked_sqrt`.
     #[must_use]
     pub const fn floor_sqrt(&self) -> Self {
         let mut root = *self;
@@ -88,18 +89,18 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
     }
 
-    /// Computes `floor(√(self))`
-    ///
-    /// Callers can check if `self` is a square by squaring the result.
+    /// Assigns `floor(√(self))` to `self` and returns a [`Choice`] indicating
+    /// whether the square root is exact.
     const fn floor_sqrt_assign(&mut self) -> Choice {
         let mut buf = (Uint::<LIMBS>::ZERO, Uint::<LIMBS>::ZERO);
         self.as_mut_uint_ref()
             .sqrt_assign((buf.0.as_mut_uint_ref(), buf.1.as_mut_uint_ref()))
     }
 
-    /// Computes `floor(√(self))`
+    /// Assigns `floor(√(self))` to `self` and returns a [`bool`] indicating
+    /// whether the square root is exact.
     ///
-    /// Callers can check if `self` is a square by squaring the result.
+    /// Variable time with respect to `self`.
     const fn floor_sqrt_assign_vartime(&mut self) -> bool {
         let mut buf = (Uint::<LIMBS>::ZERO, Uint::<LIMBS>::ZERO);
         self.as_mut_uint_ref()
@@ -110,7 +111,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
     /// Computes `floor(√(self))` in constant time.
     ///
-    /// Callers can check if `self` is a square by squaring the result.
+    /// Callers can check if `self` is a square by squaring the result, or
+    /// use `checked_sqrt`.
     #[must_use]
     pub const fn floor_sqrt(&self) -> Self {
         NonZero::new_unchecked(self.as_ref().floor_sqrt())
@@ -118,7 +120,8 @@ impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
 
     /// Computes `floor(√(self))`.
     ///
-    /// Callers can check if `self` is a square by squaring the result.
+    /// Callers can check if `self` is a square by squaring the result, or
+    /// use `checked_sqrt_vartime`.
     ///
     /// Variable time with respect to `self`.
     #[must_use]
@@ -194,9 +197,9 @@ mod tests {
 
     #[cfg(feature = "rand_core")]
     use {
-        crate::{Random, U512},
+        crate::{CheckedAdd, CheckedSquareRoot, FloorSquareRoot, Random, RandomBits, U512},
         chacha20::ChaCha8Rng,
-        rand_core::{Rng, SeedableRng},
+        rand_core::SeedableRng,
     };
 
     #[test]
@@ -301,12 +304,9 @@ mod tests {
     #[cfg(feature = "rand_core")]
     #[test]
     fn fuzz() {
-        use crate::{CheckedSquareRoot, FloorSquareRoot};
-
         let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
         for _ in 0..50 {
-            let t = u64::from(rng.next_u32());
-            let s = U256::from(t);
+            let s = U256::random_bits(&mut rng, 128);
             let s2 = s.checked_square().unwrap();
             assert_eq!(FloorSquareRoot::floor_sqrt(&s2), s);
             assert_eq!(FloorSquareRoot::floor_sqrt_vartime(&s2), s);
@@ -318,6 +318,13 @@ mod tests {
                 assert_eq!(FloorSquareRoot::floor_sqrt_vartime(&nz).get(), s);
                 assert!(CheckedSquareRoot::checked_sqrt(&nz).is_some().to_bool());
                 assert!(CheckedSquareRoot::checked_sqrt_vartime(&nz).is_some());
+            }
+
+            if let Some(sx) = s2.checked_add(&U256::ONE).into_option() {
+                assert_eq!(FloorSquareRoot::floor_sqrt(&sx), s);
+                assert_eq!(FloorSquareRoot::floor_sqrt_vartime(&sx), s);
+                assert!(CheckedSquareRoot::checked_sqrt(&sx).is_none().to_bool());
+                assert!(CheckedSquareRoot::checked_sqrt_vartime(&sx).is_none());
             }
         }
 

--- a/src/uint/sqrt.rs
+++ b/src/uint/sqrt.rs
@@ -1,6 +1,8 @@
 //! [`Uint`] square root operations.
 
-use crate::{CheckedSquareRoot, CtEq, CtOption, FloorSquareRoot, Limb, NonZero, Uint};
+use ctutils::Choice;
+
+use crate::{CheckedSquareRoot, CtOption, FloorSquareRoot, NonZero, Uint};
 
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `floor(√(self))` in constant time.
@@ -17,9 +19,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Callers can check if `self` is a square by squaring the result.
     #[must_use]
     pub const fn floor_sqrt(&self) -> Self {
-        let (self_nz, self_is_nz) = self.to_nz_or_one();
-        let root_nz = self_nz.floor_sqrt();
-        Self::select(&Self::ZERO, root_nz.as_ref(), self_is_nz)
+        let mut root = *self;
+        root.floor_sqrt_assign();
+        root
     }
 
     /// Computes `floor(√(self))`.
@@ -40,11 +42,9 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Variable time with respect to `self`.
     #[must_use]
     pub const fn floor_sqrt_vartime(&self) -> Self {
-        if let Some(self_nz) = self.as_nz_vartime() {
-            self_nz.floor_sqrt_vartime().get_copy()
-        } else {
-            Self::ZERO
-        }
+        let mut root = *self;
+        root.floor_sqrt_assign_vartime();
+        root
     }
 
     /// Wrapped sqrt is just `floor(√(self))`.
@@ -69,22 +69,41 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// only if the square root is exact.
     #[must_use]
     pub fn checked_sqrt(&self) -> CtOption<Self> {
-        let (self_nz, self_is_nz) = self.to_nz_or_one();
-        self_nz
-            .checked_sqrt()
-            .map(|nz| Self::select(&Self::ZERO, nz.as_ref(), self_is_nz))
+        let mut root = *self;
+        let exact = root.floor_sqrt_assign();
+        CtOption::new(root, exact)
     }
 
     /// Perform checked sqrt, returning an [`Option`] which `is_some`
     /// only if the square root is exact.
     ///
     /// Variable time with respect to `self`.
+    #[must_use]
     pub fn checked_sqrt_vartime(&self) -> Option<Self> {
-        if let Some(self_nz) = self.as_nz_vartime() {
-            self_nz.checked_sqrt_vartime().map(NonZero::get)
+        let mut root = *self;
+        if root.floor_sqrt_assign_vartime() {
+            Some(root)
         } else {
-            Some(Self::ZERO)
+            None
         }
+    }
+
+    /// Computes `floor(√(self))`
+    ///
+    /// Callers can check if `self` is a square by squaring the result.
+    const fn floor_sqrt_assign(&mut self) -> Choice {
+        let mut buf = (Uint::<LIMBS>::ZERO, Uint::<LIMBS>::ZERO);
+        self.as_mut_uint_ref()
+            .sqrt_assign((buf.0.as_mut_uint_ref(), buf.1.as_mut_uint_ref()))
+    }
+
+    /// Computes `floor(√(self))`
+    ///
+    /// Callers can check if `self` is a square by squaring the result.
+    const fn floor_sqrt_assign_vartime(&mut self) -> bool {
+        let mut buf = (Uint::<LIMBS>::ZERO, Uint::<LIMBS>::ZERO);
+        self.as_mut_uint_ref()
+            .sqrt_assign_vartime((buf.0.as_mut_uint_ref(), buf.1.as_mut_uint_ref()))
     }
 }
 
@@ -94,37 +113,7 @@ impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
     /// Callers can check if `self` is a square by squaring the result.
     #[must_use]
     pub const fn floor_sqrt(&self) -> Self {
-        // Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.13.
-        //
-        // See Hast, "Note on computation of integer square roots"
-        // for the proof of the sufficiency of the bound on iterations.
-        // https://github.com/RustCrypto/crypto-bigint/files/12600669/ct_sqrt.pdf
-
-        let rt_bits = self.as_ref().bits().div_ceil(2);
-        // The initial guess: `x_0 = 2^ceil(b/2)`, where `2^(b-1) <= self < 2^b`.
-        // Will not overflow since `b <= BITS`.
-        let mut x = Uint::<LIMBS>::ZERO.set_bit_vartime(rt_bits, true);
-        // Compute `self.0 / x_0` by shifting.
-        let mut q = self.as_ref().shr(rt_bits);
-        // The first division has been performed.
-        let mut i = 1;
-
-        loop {
-            // Calculate `x_{i+1} = floor((x_i + self_nz / x_i) / 2)`, leaving `x` unmodified
-            // if it would increase.
-            x = Uint::select(&x.wrapping_add(&q).shr1(), &x, Uint::lt(&x, &q));
-
-            // We repeat enough times to guarantee the result has stabilized.
-            // TODO (#378): the tests indicate that just `Self::LOG2_BITS` may be enough.
-            i += 1;
-            if i >= Uint::<LIMBS>::LOG2_BITS + 2 {
-                return x.to_nz().expect_copied("ensured non-zero");
-            }
-
-            (q, _) = self
-                .as_ref()
-                .div_rem(x.to_nz().expect_ref("ensured non-zero"));
-        }
+        NonZero::new_unchecked(self.as_ref().floor_sqrt())
     }
 
     /// Computes `floor(√(self))`.
@@ -134,56 +123,23 @@ impl<const LIMBS: usize> NonZero<Uint<LIMBS>> {
     /// Variable time with respect to `self`.
     #[must_use]
     pub const fn floor_sqrt_vartime(&self) -> Self {
-        // Uses Brent & Zimmermann, Modern Computer Arithmetic, v0.5.9, Algorithm 1.13
-
-        let bits = self.as_ref().bits_vartime();
-        if bits <= Limb::BITS {
-            let rt = self.as_ref().limbs[0].0.isqrt();
-            return Uint::from_word(rt)
-                .to_nz()
-                .expect_copied("ensured non-zero");
-        }
-        let rt_bits = bits.div_ceil(2);
-
-        // The initial guess: `x_0 = 2^ceil(b/2)`, where `2^(b-1) <= self < b`.
-        // Will not overflow since `b <= BITS`.
-        let mut x = Uint::ZERO.set_bit_vartime(rt_bits, true);
-        // Compute `self / x_0` by shifting.
-        let mut q = self.as_ref().shr_vartime(rt_bits);
-
-        loop {
-            // Terminate if `x_{i+1}` >= `x`.
-            if q.cmp_vartime(&x).is_ge() {
-                return x.to_nz().expect_copied("ensured non-zero");
-            }
-            // Calculate `x_{i+1} = floor((x_i + self / x_i) / 2)`
-            x = x.wrapping_add(&q).shr_vartime(1);
-            q = self
-                .as_ref()
-                .wrapping_div_vartime(x.to_nz().expect_ref("ensured non-zero"));
-        }
+        NonZero::new_unchecked(self.as_ref().floor_sqrt_vartime())
     }
 
     /// Perform checked sqrt, returning a [`CtOption`] which `is_some`
     /// only if the square root is exact.
     #[must_use]
     pub fn checked_sqrt(&self) -> CtOption<Self> {
-        let r = self.floor_sqrt();
-        let s = r.wrapping_square();
-        CtOption::new(r, self.as_ref().ct_eq(&s))
+        self.as_ref().checked_sqrt().map(NonZero::new_unchecked)
     }
 
     /// Perform checked sqrt, returning an [`Option`] which `is_some`
     /// only if the square root is exact.
     #[must_use]
     pub fn checked_sqrt_vartime(&self) -> Option<Self> {
-        let r = self.floor_sqrt_vartime();
-        let s = r.wrapping_square();
-        if self.as_ref().cmp_vartime(&s).is_eq() {
-            Some(r)
-        } else {
-            None
-        }
+        self.as_ref()
+            .checked_sqrt_vartime()
+            .map(NonZero::new_unchecked)
     }
 }
 

--- a/src/word.rs
+++ b/src/word.rs
@@ -29,6 +29,12 @@ cpubits::cpubits! {
         pub(crate) const fn choice_from_wide_le(x: WideWord, y: WideWord) -> Choice {
             Choice::from_u64_le(x, y)
         }
+
+        /// Returns the truthy value if `x < y` and the falsy value otherwise.
+        #[inline]
+        pub(crate) const fn choice_from_wide_lt(x: WideWord, y: WideWord) -> Choice {
+            Choice::from_u64_lt(x, y)
+        }
     }
     64 => {
         /// Unsigned integer type that the [`Limb`][`crate::Limb`] newtype wraps.
@@ -55,6 +61,11 @@ cpubits::cpubits! {
             Choice::from_u128_le(x, y)
         }
 
+        /// Returns the truthy value if `x < y` and the falsy value otherwise.
+        #[inline]
+        pub(crate) const fn choice_from_wide_lt(x: WideWord, y: WideWord) -> Choice {
+            Choice::from_u128_lt(x, y)
+        }
     }
 }
 


### PR DESCRIPTION
- An algorithm which scales better for large integers is used (approx O(2n)) - this is algorithm 1.12 in Modern Computer Arithmetic rather than 1.13
- Addition and subtraction methods in `UintRef` are adjusted to accept an `rhs` smaller than `self`. This was inconsistently applied before
- Performance is much better, about 70% improved for `U256` and 95% for a 4096-bit `BoxedUint`
- `checked_sqrt` no longer performs an additional squaring, so its performance matches `floor_sqrt`