### PR TITLE
Extract `bitlen` module with bytes/limbs conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ proptest = "1.11"
 default = ["rand_core"]
 alloc = ["serdect?/alloc"]
 
+der = ["dep:der", "hybrid-array"]
 extra-sizes = []
 getrandom = ["dep:getrandom", "rand_core"]
 rand_core = ["dep:rand_core"]

--- a/src/bitlen.rs
+++ b/src/bitlen.rs
@@ -1,0 +1,72 @@
+//! Bit calculations.
+//!
+//! These provide a single place to handle bits-to-bytes conversions and the `u32`/`usize`
+//! discrepancy that can only be solved by panics or casting.
+
+use crate::Limb;
+
+/// Calculate a `u32` representing a number of bits from the given number of bytes as a `usize`.
+#[cfg_attr(not(feature = "alloc"), allow(dead_code))]
+pub(crate) const fn from_bytes(nbytes: usize) -> u32 {
+    checked_mul(nbytes, 8)
+}
+
+/// Calculate a `u32` representing a number of bits in an integer with the given number of limbs.
+pub(crate) const fn from_limbs(nlimbs: usize) -> u32 {
+    checked_mul(nlimbs, Limb::BITS)
+}
+
+/// Calculate a `usize` representing the number of bytes required to store the given number of bits
+/// represented as a `u32` (i.e. rounding up).
+#[cfg_attr(not(feature = "alloc"), allow(dead_code))]
+pub(crate) const fn to_bytes(nbits: u32) -> usize {
+    u32_to_usize(nbits.div_ceil(8))
+}
+
+/// Calculate a `usize` representing the number of limbs required to store the given number of bits
+/// represented as a `u32` (i.e. rounding up).
+pub(crate) const fn to_limbs(nbits: u32) -> usize {
+    u32_to_usize(nbits.div_ceil(Limb::BITS))
+}
+
+const fn u32_to_usize(n: u32) -> usize {
+    const {
+        // Ensure cast from `u32` to `usize` won't overflow
+        assert!(usize::BITS >= u32::BITS, "usize too small");
+    }
+
+    n as usize
+}
+
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "assertion ensures panic instead of truncation"
+)]
+const fn usize_to_u32(n: usize) -> u32 {
+    assert!(n < u32_to_usize(u32::MAX), "u32 overflow");
+    n as u32
+}
+
+const fn checked_mul(size: usize, n: u32) -> u32 {
+    usize_to_u32(size).checked_mul(n).expect("u32 overflow")
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn from_bytes() {
+        assert_eq!(super::from_bytes(0), 0);
+        assert_eq!(super::from_bytes(1), 8);
+        assert_eq!(super::from_bytes(2), 16);
+    }
+
+    #[test]
+    fn to_bytes() {
+        assert_eq!(super::to_bytes(0), 0);
+        assert_eq!(super::to_bytes(1), 1);
+        assert_eq!(super::to_bytes(8), 1);
+        assert_eq!(super::to_bytes(9), 2);
+        assert_eq!(super::to_bytes(16), 2);
+        assert_eq!(super::to_bytes(17), 3);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,7 @@ pub mod modular;
 
 #[cfg(feature = "hybrid-array")]
 mod array;
+mod bitlen;
 mod checked;
 mod int;
 mod jacobi;

--- a/src/modular/safegcd.rs
+++ b/src/modular/safegcd.rs
@@ -12,9 +12,8 @@
 #[cfg(feature = "alloc")]
 pub(crate) mod boxed;
 
+use crate::{Choice, CtOption, I64, Int, Limb, Odd, U64, Uint, bitlen, primitives::u32_min};
 use core::fmt;
-
-use crate::{Choice, CtOption, I64, Int, Limb, Odd, U64, Uint, primitives::u32_min};
 
 const GCD_BATCH_SIZE: u32 = 62;
 
@@ -331,7 +330,7 @@ const fn shr_in_place_wide<const L: usize, const H: usize>(
     let copy = hi.shl_vartime(Uint::<H>::BITS - shift);
     *hi = hi.shr_vartime(shift);
     *lo = lo.shr_vartime(shift);
-    let mut offs = shift.div_ceil(Limb::BITS) as usize;
+    let mut offs = bitlen::to_limbs(shift);
     lo.limbs[L - offs] = lo.limbs[L - offs].bitor(copy.limbs[H - offs]);
     loop {
         offs -= 1;

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -7,7 +7,7 @@ pub(crate) use ref_type::UintRef;
 
 use crate::{
     Bounded, Choice, ConstOne, ConstZero, Constants, CtEq, CtOption, EncodedUint, FixedInteger,
-    Int, Integer, Limb, NonZero, Odd, One, Unsigned, UnsignedWithMontyForm, Word, Zero,
+    Int, Integer, Limb, NonZero, Odd, One, Unsigned, UnsignedWithMontyForm, Word, Zero, bitlen,
     limb::nlimbs, modular::FixedMontyForm, traits::sealed::Sealed,
 };
 use core::fmt;
@@ -106,8 +106,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     };
 
     /// Total size of the represented integer in bits.
-    #[allow(clippy::cast_possible_truncation)]
-    pub const BITS: u32 = LIMBS as u32 * Limb::BITS;
+    pub const BITS: u32 = bitlen::from_limbs(LIMBS);
 
     /// Total size of the represented integer in bytes.
     pub const BYTES: usize = LIMBS * Limb::BYTES;

--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -32,7 +32,7 @@ mod rand;
 
 use crate::{
     Choice, CtAssign, CtEq, CtOption, Integer, Limb, NonZero, Odd, One, Resize, UintRef, Unsigned,
-    UnsignedWithMontyForm, Word, Zero, modular::BoxedMontyForm, traits::sealed::Sealed,
+    UnsignedWithMontyForm, Word, Zero, bitlen, modular::BoxedMontyForm, traits::sealed::Sealed,
 };
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::{
@@ -61,10 +61,6 @@ pub struct BoxedUint {
 }
 
 impl BoxedUint {
-    fn limbs_for_precision(at_least_bits_precision: u32) -> usize {
-        at_least_bits_precision.div_ceil(Limb::BITS) as usize
-    }
-
     /// Get the value `0` represented as succinctly as possible.
     #[must_use]
     pub fn zero() -> Self {
@@ -78,7 +74,7 @@ impl BoxedUint {
     /// `at_least_bits_precision` is rounded up to a multiple of [`Limb::BITS`].
     #[must_use]
     pub fn zero_with_precision(at_least_bits_precision: u32) -> Self {
-        vec![Limb::ZERO; Self::limbs_for_precision(at_least_bits_precision)].into()
+        vec![Limb::ZERO; bitlen::to_limbs(at_least_bits_precision)].into()
     }
 
     /// Get the value `1`, represented as succinctly as possible.
@@ -128,7 +124,7 @@ impl BoxedUint {
     /// That is, returns the value `2^self.bits_precision() - 1`.
     #[must_use]
     pub fn max(at_least_bits_precision: u32) -> Self {
-        vec![Limb::MAX; Self::limbs_for_precision(at_least_bits_precision)].into()
+        vec![Limb::MAX; bitlen::to_limbs(at_least_bits_precision)].into()
     }
 
     /// Create a [`BoxedUint`] from an array of [`Word`]s (i.e. word-sized unsigned
@@ -148,7 +144,7 @@ impl BoxedUint {
         words: impl IntoIterator<Item = Word>,
         at_least_bits_precision: u32,
     ) -> Self {
-        let size = Self::limbs_for_precision(at_least_bits_precision);
+        let size = bitlen::to_limbs(at_least_bits_precision);
         Self {
             limbs: words
                 .into_iter()
@@ -362,7 +358,7 @@ impl Resize for BoxedUint {
     type Output = BoxedUint;
 
     fn resize_unchecked(self, at_least_bits_precision: u32) -> Self::Output {
-        let new_len = Self::limbs_for_precision(at_least_bits_precision);
+        let new_len = bitlen::to_limbs(at_least_bits_precision);
         if new_len == self.limbs.len() {
             self
         } else {

--- a/src/uint/boxed/bits.rs
+++ b/src/uint/boxed/bits.rs
@@ -1,6 +1,6 @@
 //! Bit manipulation functions.
 
-use crate::{BitOps, BoxedUint, Choice, Limb};
+use crate::{BitOps, BoxedUint, Choice, Limb, bitlen};
 
 impl BoxedUint {
     /// Get the value of the bit at position `index`, as a truthy or falsy `Choice`.
@@ -45,9 +45,8 @@ impl BoxedUint {
     /// Get the precision of this [`BoxedUint`] in bits.
     #[inline(always)]
     #[must_use]
-    #[allow(clippy::cast_possible_truncation)]
     pub fn bits_precision(&self) -> u32 {
-        self.limbs.len() as u32 * Limb::BITS
+        bitlen::from_limbs(self.limbs.len())
     }
 
     /// Calculate the number of trailing zeros in the binary representation of this number.

--- a/src/uint/boxed/div.rs
+++ b/src/uint/boxed/div.rs
@@ -3,7 +3,7 @@
 use crate::{
     BoxedUint, CheckedDiv, CtAssign, CtOption, Div, DivAssign, DivRemLimb, DivVartime, Integer,
     Limb, NonZero, Reciprocal, Rem, RemAssign, RemLimb, RemMixed, ToUnsigned, UintRef, Unsigned,
-    Wrapping,
+    Wrapping, bitlen,
 };
 
 impl BoxedUint {
@@ -82,7 +82,7 @@ impl BoxedUint {
     #[must_use]
     pub fn rem_vartime<Rhs: ToUnsigned + ?Sized>(&self, rhs: &NonZero<Rhs>) -> Rhs::Unsigned {
         let xc = self.limbs.len();
-        let yc = rhs.as_ref().as_ref().bits_vartime().div_ceil(Limb::BITS) as usize;
+        let yc = bitlen::to_limbs(rhs.as_ref().as_ref().bits_vartime());
 
         match yc {
             0 => unreachable!("zero divisor"),

--- a/src/uint/boxed/encoding.rs
+++ b/src/uint/boxed/encoding.rs
@@ -1,7 +1,7 @@
 //! Const-friendly decoding operations for [`BoxedUint`].
 
 use super::BoxedUint;
-use crate::{CtEq, CtOption, DecodeError, Encoding, Limb, Word, uint::encoding};
+use crate::{CtEq, CtOption, DecodeError, Encoding, Limb, Word, bitlen, uint::encoding};
 use alloc::{boxed::Box, string::String, vec::Vec};
 
 #[cfg(feature = "serde")]
@@ -22,11 +22,7 @@ impl BoxedUint {
     /// - Returns [`DecodeError::Precision`] if the size of the decoded integer is larger than
     ///   `bits_precision`.
     pub fn from_be_slice(bytes: &[u8], bits_precision: u32) -> Result<Self, DecodeError> {
-        if bytes.is_empty() && bits_precision == 0 {
-            return Ok(Self::zero());
-        }
-
-        if bytes.len() > (bits_precision as usize).div_ceil(8) {
+        if bytes.len() > bitlen::to_bytes(bits_precision) {
             return Err(DecodeError::InputSize);
         }
 
@@ -53,7 +49,7 @@ impl BoxedUint {
     #[must_use]
     #[allow(clippy::cast_possible_truncation, clippy::missing_panics_doc)]
     pub fn from_be_slice_vartime(bytes: &[u8]) -> Self {
-        let bits_precision = (bytes.len() as u32).saturating_mul(8);
+        let bits_precision = bitlen::from_bytes(bytes.len());
 
         // TODO(tarcieri): avoid panic
         Self::from_be_slice(bytes, bits_precision).expect("precision should be large enough")
@@ -73,11 +69,7 @@ impl BoxedUint {
     /// - Returns [`DecodeError::Precision`] if the size of the decoded integer is larger than
     ///   `bits_precision`.
     pub fn from_le_slice(bytes: &[u8], bits_precision: u32) -> Result<Self, DecodeError> {
-        if bytes.is_empty() && bits_precision == 0 {
-            return Ok(Self::zero());
-        }
-
-        if bytes.len() > (bits_precision as usize).div_ceil(8) {
+        if bytes.len() > bitlen::to_bytes(bits_precision) {
             return Err(DecodeError::InputSize);
         }
 
@@ -104,7 +96,7 @@ impl BoxedUint {
     #[must_use]
     #[allow(clippy::cast_possible_truncation, clippy::missing_panics_doc)]
     pub fn from_le_slice_vartime(bytes: &[u8]) -> Self {
-        let bits_precision = (bytes.len() as u32).saturating_mul(8);
+        let bits_precision = bitlen::from_bytes(bytes.len());
 
         // TODO(tarcieri): avoid panic
         Self::from_le_slice(bytes, bits_precision).expect("precision should be large enough")
@@ -283,13 +275,11 @@ impl Encoding for BoxedUint {
     }
 
     fn from_be_bytes(bytes: Self::Repr) -> Self {
-        BoxedUint::from_be_slice(&bytes, (bytes.len() * 8).try_into().expect("overflow"))
-            .expect("decode error")
+        BoxedUint::from_be_slice_vartime(&bytes)
     }
 
     fn from_le_bytes(bytes: Self::Repr) -> Self {
-        BoxedUint::from_le_slice(&bytes, (bytes.len() * 8).try_into().expect("overflow"))
-            .expect("decode error")
+        BoxedUint::from_le_slice_vartime(&bytes)
     }
 }
 

--- a/src/uint/boxed/encoding/serde.rs
+++ b/src/uint/boxed/encoding/serde.rs
@@ -9,10 +9,12 @@ impl<'de> Deserialize<'de> for BoxedUint {
     {
         let slice = serdect::slice::deserialize_hex_or_bin_vec(deserializer)?;
 
-        #[allow(clippy::cast_possible_truncation)]
-        let bit_precision = (slice.len() as u32).checked_mul(8).ok_or(Error::custom(
-            "Deserialized value overflows u32 bit precision!",
-        ))?;
+        let bit_precision = u32::try_from(slice.len())
+            .ok()
+            .and_then(|nbytes| nbytes.checked_mul(8))
+            .ok_or(Error::custom(
+                "Deserialized value overflows u32 bit precision!",
+            ))?;
 
         Self::from_le_slice(&slice, bit_precision).map_err(Error::custom)
     }

--- a/src/uint/boxed/invert_mod.rs
+++ b/src/uint/boxed/invert_mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     BoxedUint, Choice, CtEq, CtLt, CtOption, CtSelect, Integer, InvertMod, Limb, NonZero, Odd, U64,
-    modular::safegcd, uint::invert_mod::expand_invert_mod2k,
+    bitlen, modular::safegcd, uint::invert_mod::expand_invert_mod2k,
 };
 
 impl BoxedUint {
@@ -149,12 +149,11 @@ impl Odd<BoxedUint> {
     /// Compute a quadratic inversion, `self^-1 mod 2^k` where `k <= bits_precision()`.
     ///
     /// This method is variable-time in `k` only.
-    #[allow(clippy::integer_division_remainder_used, reason = "vartime")]
     pub(crate) fn invert_mod2k_vartime(&self, k: u32) -> BoxedUint {
         let bits = self.bits_precision();
         assert!(k <= bits);
 
-        let k_limbs = k.div_ceil(Limb::BITS) as usize;
+        let k_limbs = bitlen::to_limbs(k);
         let inv_64 = U64::from_u64(self.as_uint_ref().invert_mod_u64());
         let mut inv = BoxedUint::from_words_with_precision(*inv_64.as_words(), bits);
 
@@ -162,9 +161,8 @@ impl Odd<BoxedUint> {
             // trim to k_limbs
             inv.as_mut_uint_ref().trailing_mut(k_limbs).fill(Limb::ZERO);
         } else {
-            // expand to k_limbs
-            #[allow(clippy::cast_possible_truncation)]
-            let mut scratch = BoxedUint::zero_with_precision(k_limbs as u32 * 2 * Limb::BITS);
+            // expand to k_limbss
+            let mut scratch = BoxedUint::zero_with_precision(2 * bitlen::from_limbs(k_limbs));
 
             expand_invert_mod2k(
                 self.as_uint_ref(),
@@ -175,10 +173,12 @@ impl Odd<BoxedUint> {
         }
 
         // clear bits in the high limb if necessary
-        let k_bits = k % Limb::BITS;
+        let k_bits = k & (Limb::BITS - 1);
+
         if k_bits > 0 {
             inv.limbs[k_limbs - 1] = inv.limbs[k_limbs - 1].restrict_bits(k_bits);
         }
+
         inv
     }
 }

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -1,6 +1,6 @@
 //! Const-friendly decoding/encoding operations for [`Uint`].
 
-#[cfg(all(feature = "der", feature = "hybrid-array"))]
+#[cfg(feature = "der")]
 mod der;
 #[cfg(feature = "rlp")]
 mod rlp;
@@ -10,7 +10,7 @@ use crate::{DecodeError, EncodedSize, Encoding, Limb, Word};
 use core::{fmt, ops::Deref};
 
 #[cfg(feature = "alloc")]
-use crate::{Choice, NonZero, Reciprocal, UintRef, WideWord};
+use crate::{Choice, NonZero, Reciprocal, UintRef, WideWord, bitlen};
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
 
@@ -723,8 +723,7 @@ pub(crate) fn radix_encode_limbs_mut_to_string(radix: u32, limbs: &mut UintRef) 
 
     let mut out;
     if radix.is_power_of_two() {
-        let bits = radix.trailing_zeros() as usize;
-        let size = (limbs.nlimbs() * Limb::BITS as usize).div_ceil(bits);
+        let size = bitlen::from_limbs(limbs.nlimbs()).div_ceil(radix.trailing_zeros()) as usize;
         out = vec![0u8; size];
         radix_encode_limbs_by_shifting(radix, limbs, &mut out[..]);
     } else {

--- a/src/uint/encoding/der.rs
+++ b/src/uint/encoding/der.rs
@@ -85,8 +85,10 @@ pub(crate) fn count_der_be_bytes(limbs: &[Limb]) -> u32 {
     let needs_leading_zero = first_nonzero_byte >= 0x80;
 
     // Number of bytes in all limbs
-    #[allow(clippy::cast_possible_truncation)]
-    let max_len = (Limb::BYTES * limbs.len()) as u32;
+    let max_len = Limb::BYTES
+        .checked_mul(limbs.len())
+        .and_then(|bytes| u32::try_from(bytes).ok())
+        .expect("u32 overflow"); // TODO(tarcieri): don't panic
 
     // If all bytes are zeros:
     if leading_zero_bytes == max_len {
@@ -101,9 +103,8 @@ pub(crate) fn count_der_be_bytes(limbs: &[Limb]) -> u32 {
 
 #[cfg(feature = "alloc")]
 pub mod allocating {
+    use crate::{BoxedUint, bitlen, encoding::der::count_der_be_bytes};
     use der::{DecodeValue, EncodeValue, FixedTag, Length, Tag, asn1::UintRef as Asn1UintRef};
-
-    use crate::{BoxedUint, encoding::der::count_der_be_bytes};
 
     impl EncodeValue for BoxedUint {
         fn value_len(&self) -> der::Result<Length> {
@@ -124,9 +125,7 @@ pub mod allocating {
             header: der::Header,
         ) -> der::Result<Self> {
             let value = Asn1UintRef::decode_value(reader, header)?;
-
-            #[allow(clippy::cast_possible_truncation)]
-            let bits_precision = value.as_bytes().len() as u32 * 8;
+            let bits_precision = bitlen::from_bytes(value.as_bytes().len());
 
             let value = BoxedUint::from_be_slice(value.as_bytes(), bits_precision)
                 .map_err(|_| Asn1UintRef::TAG.value_error())?;
@@ -141,8 +140,11 @@ pub mod allocating {
 
 #[cfg(test)]
 pub mod test {
-    use crate::{ArrayEncoding, BoxedUint, U128, Uint};
+    use crate::{ArrayEncoding, U128, Uint};
     use der::{DecodeValue, EncodeValue, Header, Tag};
+
+    #[cfg(feature = "alloc")]
+    use crate::BoxedUint;
 
     #[allow(clippy::cast_possible_truncation, clippy::panic_in_result_fn)]
     fn assert_valid_uint_value_len<const LIMBS: usize>(n: &Uint<LIMBS>) -> der::Result<()>

--- a/src/uint/invert_mod.rs
+++ b/src/uint/invert_mod.rs
@@ -1,6 +1,7 @@
 use super::Uint;
 use crate::{
-    Choice, CtOption, InvertMod, Limb, NonZero, Odd, U64, UintRef, modular::safegcd, mul::karatsuba,
+    Choice, CtOption, InvertMod, Limb, NonZero, Odd, U64, UintRef, bitlen, modular::safegcd,
+    mul::karatsuba,
 };
 
 /// Perform a modified recursive Hensel quadratic modular inversion to calculate
@@ -223,11 +224,10 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
     /// Compute a quadratic inversion, `self^-1 mod 2^k` where `k <= Self::BITS`.
     ///
     /// This method is variable-time in `k` only.
-    #[allow(clippy::integer_division_remainder_used, reason = "vartime")]
     pub(crate) const fn invert_mod2k_vartime(&self, k: u32) -> Uint<LIMBS> {
         assert!(k <= Self::BITS);
 
-        let k_limbs = k.div_ceil(Limb::BITS) as usize;
+        let k_limbs = bitlen::to_limbs(k);
         let mut inv = U64::from_u64(self.as_uint_ref().invert_mod_u64()).resize::<LIMBS>();
 
         if k_limbs <= U64::LIMBS {
@@ -245,6 +245,7 @@ impl<const LIMBS: usize> Odd<Uint<LIMBS>> {
         }
 
         // clear bits in the high limb if necessary
+        #[allow(clippy::integer_division_remainder_used, reason = "TODO")]
         let k_bits = k % Limb::BITS;
         if k_bits > 0 {
             inv.limbs[k_limbs - 1] = inv.limbs[k_limbs - 1].restrict_bits(k_bits);

--- a/src/uint/rand.rs
+++ b/src/uint/rand.rs
@@ -1,7 +1,9 @@
 //! Random number generator support
 
 use super::Uint;
-use crate::{CtLt, Encoding, Limb, NonZero, Random, RandomBits, RandomBitsError, RandomMod};
+use crate::{
+    CtLt, Encoding, Limb, NonZero, Random, RandomBits, RandomBitsError, RandomMod, bitlen,
+};
 use rand_core::{Rng, TryRng};
 
 impl<const LIMBS: usize> Random for Uint<LIMBS> {
@@ -38,7 +40,7 @@ where
         return Ok(());
     }
 
-    let n_bytes = n_bits.div_ceil(u8::BITS) as usize;
+    let n_bytes = bitlen::to_bytes(n_bits);
     let hi_mask = u8::MAX >> ((u8::BITS - (n_bits % u8::BITS)) % u8::BITS);
 
     let mut buffer = x.to_le_bytes();

--- a/src/uint/ref_type/bits.rs
+++ b/src/uint/ref_type/bits.rs
@@ -1,12 +1,11 @@
 use super::UintRef;
-use crate::{Choice, Limb, traits::BitOps, word};
+use crate::{Choice, Limb, bitlen, traits::BitOps, word};
 
 impl UintRef {
     /// Get the precision of this number in bits.
-    #[allow(clippy::cast_possible_truncation)]
     #[must_use]
     pub const fn bits_precision(&self) -> u32 {
-        self.limbs.len() as u32 * Limb::BITS
+        bitlen::from_limbs(self.limbs.len())
     }
 
     /// Get the value of the bit at position `index`, as a truthy or falsy [`Choice`].

--- a/src/uint/ref_type/div.rs
+++ b/src/uint/ref_type/div.rs
@@ -5,7 +5,7 @@
 
 use super::UintRef;
 use crate::{
-    Choice, Limb, NonZero,
+    Choice, Limb, NonZero, bitlen,
     div_limb::{Reciprocal, div2by1, div3by2},
     primitives::u32_min,
     word,
@@ -54,11 +54,10 @@ impl UintRef {
     ///
     /// # Panics
     /// If the divisor is zero.
-    #[allow(clippy::cast_possible_truncation)]
     pub(crate) const fn div_rem_vartime(&mut self, rhs: &mut Self) {
         let (x, y) = (self, rhs);
         let xsize = x.nlimbs();
-        let ywords = y.bits_vartime().div_ceil(Limb::BITS) as usize;
+        let ywords = bitlen::to_limbs(y.bits_vartime());
 
         match (xsize, ywords) {
             (_, 0) => panic!("zero divisor"),
@@ -88,6 +87,7 @@ impl UintRef {
         x.div_rem_large_vartime(y.leading_mut(ywords));
 
         // Shift the quotient to the low limbs within dividend
+        #[allow(clippy::cast_possible_truncation, reason = "TODO")]
         x.unbounded_shr_assign_by_limbs_vartime((ywords - 1) as u32);
     }
 
@@ -145,11 +145,10 @@ impl UintRef {
     /// # Panics
     /// If the divisor is zero.
     #[inline(always)]
-    #[allow(clippy::cast_possible_truncation)]
     pub(crate) const fn rem_wide_vartime(x_lower_upper: (&mut Self, &mut Self), rhs: &mut Self) {
         let (x_lo, x) = x_lower_upper;
         let xsize = x.nlimbs();
-        let ysize = rhs.bits_vartime().div_ceil(Limb::BITS) as usize;
+        let ysize = bitlen::to_limbs(rhs.bits_vartime());
         let y = rhs.leading_mut(ysize);
 
         match (xsize, ysize) {
@@ -192,7 +191,10 @@ impl UintRef {
             (x_lo, x),
             x_hi,
             y,
-            ysize as u32,
+            #[allow(clippy::cast_possible_truncation, reason = "TODO")]
+            {
+                ysize as u32
+            },
             reciprocal,
             Choice::TRUE,
         );


### PR DESCRIPTION
Adds a crate-internal module with the following infallible functions that always panic in the event of overflow/truncation rather than silently permitting it:

- `bitlen::from_bytes`
- `bitlen::from_limbs`
- `bitlen::to_bytes`
- `bitlen::to_limbs`

These wrap up the casting strategy for handling `usize` <=> `u32` conversions and checked arithmetic needed when converting from a number of bytes or a number of limbs represented as a `usize` to a number of bits represented as a `u32` and back.

Eliminates several `allow(clippy::cast_possible_truncation)` usages by handling the relevant concerns in a single place.

This does not appear to have a negative impact on benchmarks.