### PR TITLE
Fix BoxedUint bitor-assign with wider rhs

### DIFF
--- a/src/uint/boxed.rs
+++ b/src/uint/boxed.rs
@@ -361,6 +361,21 @@ impl BoxedUint {
         limbs.into()
     }
 
+    /// Resize this value in place without checking whether the current value fits.
+    ///
+    /// If `at_least_bits_precision` is below the current precision, high limbs
+    /// are truncated. If it is above the current precision, new high limbs are
+    /// zero.
+    pub(crate) fn resize_in_place_unchecked(&mut self, at_least_bits_precision: u32) {
+        let new_len = bitlen::to_limbs(at_least_bits_precision);
+
+        if new_len != self.limbs.len() {
+            let mut limbs = core::mem::take(&mut self.limbs).into_vec();
+            limbs.resize(new_len, Limb::ZERO);
+            *self = Self::from(limbs);
+        }
+    }
+
     /// Returns `true` if the integer's bit size is smaller or equal to `bits`.
     pub(crate) fn is_within_bits(&self, bits: u32) -> bool {
         bits >= self.bits_precision() || bits >= self.bits()
@@ -370,15 +385,9 @@ impl BoxedUint {
 impl Resize for BoxedUint {
     type Output = BoxedUint;
 
-    fn resize_unchecked(self, at_least_bits_precision: u32) -> Self::Output {
-        let new_len = bitlen::to_limbs(at_least_bits_precision);
-        if new_len == self.limbs.len() {
-            self
-        } else {
-            let mut limbs = self.limbs.into_vec();
-            limbs.resize(new_len, Limb::ZERO);
-            Self::from(limbs)
-        }
+    fn resize_unchecked(mut self, at_least_bits_precision: u32) -> Self::Output {
+        self.resize_in_place_unchecked(at_least_bits_precision);
+        self
     }
 
     fn try_resize(self, at_least_bits_precision: u32) -> Option<BoxedUint> {

--- a/src/uint/boxed/bit_or.rs
+++ b/src/uint/boxed/bit_or.rs
@@ -68,9 +68,7 @@ impl BitOrAssign for BoxedUint {
 impl BitOrAssign<&BoxedUint> for BoxedUint {
     fn bitor_assign(&mut self, other: &Self) {
         if other.limbs.len() > self.limbs.len() {
-            let mut limbs = core::mem::take(&mut self.limbs).into_vec();
-            limbs.resize(other.limbs.len(), Limb::ZERO);
-            self.limbs = limbs.into_boxed_slice();
+            self.resize_in_place_unchecked(other.bits_precision());
         }
 
         for (a, b) in self.limbs.iter_mut().zip(other.limbs.iter()) {

--- a/src/uint/boxed/bit_or.rs
+++ b/src/uint/boxed/bit_or.rs
@@ -1,13 +1,13 @@
 //! [`BoxedUint`] bitwise OR operations.
 
-use crate::{BitOr, BitOrAssign, BoxedUint, CtOption};
+use crate::{BitOr, BitOrAssign, BoxedUint, CtOption, Limb};
 
 impl BoxedUint {
     /// Computes bitwise `a | b`.
     #[inline(always)]
     #[must_use]
     pub fn bitor(&self, rhs: &Self) -> Self {
-        Self::map_limbs(self, rhs, crate::limb::Limb::bitor)
+        Self::map_limbs(self, rhs, Limb::bitor)
     }
 
     /// Perform wrapping bitwise `OR`.
@@ -67,8 +67,30 @@ impl BitOrAssign for BoxedUint {
 
 impl BitOrAssign<&BoxedUint> for BoxedUint {
     fn bitor_assign(&mut self, other: &Self) {
+        if other.limbs.len() > self.limbs.len() {
+            let mut limbs = core::mem::take(&mut self.limbs).into_vec();
+            limbs.resize(other.limbs.len(), Limb::ZERO);
+            self.limbs = limbs.into_boxed_slice();
+        }
+
         for (a, b) in self.limbs.iter_mut().zip(other.limbs.iter()) {
             *a |= *b;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{BitOrAssign, BoxedUint, Limb};
+
+    #[test]
+    fn bitor_assign_preserves_wider_rhs_limbs() {
+        let mut lhs = BoxedUint::zero_with_precision(Limb::BITS);
+        let rhs = BoxedUint::max(Limb::BITS * 2);
+        let expected = lhs.bitor(&rhs);
+
+        lhs.bitor_assign(&rhs);
+
+        assert_eq!(lhs, expected);
     }
 }


### PR DESCRIPTION
## Summary

`BoxedUint` supports mixed-precision bitwise OR by returning a result sized to the wider operand. The `BitOrAssign<&BoxedUint>` implementation did not follow that behavior: it only ORed the overlapping limb prefix. If rhs had more limbs than lhs, the high rhs limbs were dropped.

## Fix

Grow the lhs limb buffer only when rhs is wider, padding new limbs with zero, then OR rhs limbs into lhs in place. Equal-width and narrower-rhs assignments do not allocate. Wider-rhs assignment replaces the boxed slice because `BoxedUint` stores limbs as a fixed-length `Box<[Limb]>`.

## Tests

Added `bitor_assign_preserves_wider_rhs_limbs`, which OR-assigns a one-limb lhs with a two-limb max rhs and checks that the assignment result matches non-assignment bitwise OR.

-----
This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The issue was identified primarily by the Codex coding agent, and manually reviewed before submission.