### PR TITLE
Enforce UintRef slice length checks in release builds

### DIFF
--- a/src/uint/ref_type/slice.rs
+++ b/src/uint/ref_type/slice.rs
@@ -30,7 +30,7 @@ impl UintRef {
     #[track_caller]
     pub const fn copy_from_slice(&mut self, limbs: &[Limb]) {
         // TODO core::slice::copy_from_slice should eventually be const
-        debug_assert!(self.limbs.len() == limbs.len(), "length mismatch");
+        assert!(self.limbs.len() == limbs.len(), "length mismatch");
         let mut i = 0;
         while i < self.limbs.len() {
             self.limbs[i] = limbs[i];
@@ -45,7 +45,7 @@ impl UintRef {
     #[inline(always)]
     #[track_caller]
     pub const fn conditional_copy_from_slice(&mut self, limbs: &[Limb], copy: Choice) {
-        debug_assert!(self.limbs.len() == limbs.len(), "length mismatch");
+        assert!(self.limbs.len() == limbs.len(), "length mismatch");
         let mut i = 0;
         while i < self.limbs.len() {
             self.limbs[i] = Limb::select(self.limbs[i], limbs[i], copy);
@@ -118,5 +118,25 @@ impl UintRef {
     #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.limbs.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UintRef;
+    use crate::{Choice, Limb};
+
+    #[test]
+    #[should_panic(expected = "length mismatch")]
+    fn copy_from_slice_rejects_mismatched_lengths() {
+        let mut dst = [Limb::ZERO];
+        UintRef::new_mut(&mut dst).copy_from_slice(&[Limb::ONE, Limb(2)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "length mismatch")]
+    fn conditional_copy_from_slice_rejects_mismatched_lengths() {
+        let mut dst = [Limb::ZERO];
+        UintRef::new_mut(&mut dst).conditional_copy_from_slice(&[Limb::ONE, Limb(2)], Choice::TRUE);
     }
 }


### PR DESCRIPTION
## Summary

`UintRef::copy_from_slice` documents that it panics when `self.nlimbs() != limbs.len()`, but the check used `debug_assert!`, so optimized builds did not enforce that contract:

https://github.com/RustCrypto/crypto-bigint/blob/4c6f87d35dce6bdfc60113f64ab5dfe396db89ef/src/uint/ref_type/slice.rs#L25-L33

`UintRef::conditional_copy_from_slice` has the same runtime length check pattern and its `# Panics` docs also state a limb-count mismatch panic, though the current wording says `rhs.nlimbs()` despite taking a limb slice:

https://github.com/RustCrypto/crypto-bigint/blob/4c6f87d35dce6bdfc60113f64ab5dfe396db89ef/src/uint/ref_type/slice.rs#L41-L48

## Fix

Use `assert!` for both length checks so debug and release builds preserve the documented panic behavior.

## Tests

Added regression tests for mismatched lengths in both slice-copy APIs and verified them in release mode:

```text
cargo test --release --all-features uint::ref_type::slice::tests -- --nocapture
```

-----
This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The issue was identified primarily by the Codex coding agent, and manually reviewed before submission.
