### PR TITLE
Reject oversized fixed-width DER integers

### DIFF
--- a/src/uint/encoding/der.rs
+++ b/src/uint/encoding/der.rs
@@ -25,13 +25,16 @@ where
 
     fn try_from(bytes: Asn1UintRef<'a>) -> der::Result<Uint<LIMBS>> {
         let mut array = Array::default();
-        let len: usize = bytes.len().try_into()?;
-        if len > array.len() {
-            return Err(Tag::Integer.length_error().into());
-        }
+        let len = usize::try_from(bytes.len())?;
+        let offset = array
+            .len()
+            .checked_sub(len)
+            .ok_or_else(|| Tag::Integer.length_error())?;
+        let out = array
+            .get_mut(offset..)
+            .ok_or_else(|| Tag::Integer.length_error())?;
 
-        let offset = array.len() - len;
-        array[offset..].copy_from_slice(bytes.as_bytes());
+        out.copy_from_slice(bytes.as_bytes());
         Ok(Uint::from_be_byte_array(array))
     }
 }

--- a/src/uint/encoding/der.rs
+++ b/src/uint/encoding/der.rs
@@ -25,7 +25,12 @@ where
 
     fn try_from(bytes: Asn1UintRef<'a>) -> der::Result<Uint<LIMBS>> {
         let mut array = Array::default();
-        let offset = array.len().saturating_sub(bytes.len().try_into()?);
+        let len: usize = bytes.len().try_into()?;
+        if len > array.len() {
+            return Err(Tag::Integer.length_error().into());
+        }
+
+        let offset = array.len() - len;
         array[offset..].copy_from_slice(bytes.as_bytes());
         Ok(Uint::from_be_byte_array(array))
     }
@@ -142,6 +147,7 @@ pub mod allocating {
 pub mod test {
     use crate::{ArrayEncoding, U128, Uint};
     use der::{DecodeValue, EncodeValue, Header, Tag};
+    extern crate std;
 
     #[cfg(feature = "alloc")]
     use crate::BoxedUint;
@@ -225,5 +231,15 @@ pub mod test {
         assert_valid_value_len_hex("0fdcba9876543210fedcba9876543210");
         assert_valid_value_len_hex("7fdcba9876543210fedcba9876543210");
         assert_valid_value_len_hex("fedcba9876543210fedcba9876543210");
+    }
+
+    #[test]
+    fn fixed_uint_rejects_oversized_integer_without_panic() {
+        use der::Decode;
+
+        let mut der = vec![0x02, 17, 0x01];
+        der.extend_from_slice(&[0u8; 16]);
+
+        assert!(U128::from_der(&der).is_err());
     }
 }


### PR DESCRIPTION
## Summary

Fixed-width `Uint` DER decoding converts an ASN.1 INTEGER into a fixed-size byte array:

https://github.com/RustCrypto/crypto-bigint/blob/4c6f87d35dce6bdfc60113f64ab5dfe396db89ef/src/uint/encoding/der.rs#L20-L30

Before this change, an oversized canonical positive INTEGER could compute an offset with `saturating_sub(0)` and then panic while copying too many bytes into the fixed-width array.

## Fix

Check the decoded INTEGER byte length before copying. If it is wider than the fixed-width `Uint` target, return `Tag::Integer.length_error()` instead of unwinding.

## Tests

Added a regression test that decodes a 17-byte positive INTEGER as `U128` and verifies the operation returns an error without panicking.

Verified with:

```text
cargo test --all-features uint::encoding::der::test::fixed_uint_rejects_oversized_integer_without_panic -- --exact
```

-----
This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The issue was identified primarily by the Codex coding agent, and manually reviewed before submission.
