### PR TITLE
Update MontyParams CtEq to match PartialEq

### DIFF
--- a/src/modular/boxed_monty_form/ct.rs
+++ b/src/modular/boxed_monty_form/ct.rs
@@ -35,6 +35,7 @@ impl CtEq for BoxedMontyParams {
             & self.one().ct_eq(other.one())
             & self.r2().ct_eq(other.r2())
             & self.mod_inv().ct_eq(&other.mod_inv())
+            & self.mod_leading_zeros().ct_eq(&other.mod_leading_zeros())
     }
 }
 impl CtEqSlice for BoxedMontyParams {}

--- a/src/modular/monty_params.rs
+++ b/src/modular/monty_params.rs
@@ -104,6 +104,7 @@ impl<U: Unsigned> CtEq for MontyParams<U> {
             & self.one.ct_eq(&other.one)
             & self.r2.ct_eq(&other.r2)
             & self.mod_inv.ct_eq(&other.mod_inv)
+            & self.mod_leading_zeros.ct_eq(&other.mod_leading_zeros)
     }
 }
 impl<U: Unsigned> CtEqSlice for MontyParams<U> {}
@@ -338,5 +339,39 @@ pub(crate) mod boxed {
         fn from(params: MontyParams<crate::uint::boxed::BoxedUint>) -> Self {
             Self(params.into())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FixedMontyParams;
+    use crate::{CtEq, Odd, U128};
+
+    #[cfg(feature = "alloc")]
+    use super::boxed::BoxedMontyParams;
+    #[cfg(feature = "alloc")]
+    use crate::{BoxedUint, Resize};
+
+    #[test]
+    fn ct_eq_matches_partial_eq_for_mod_leading_zeros() {
+        let params = FixedMontyParams::new_vartime(Odd::new(U128::from(3u8)).unwrap());
+        let mut other = params;
+        other.mod_leading_zeros = 0;
+
+        assert_ne!(params, other);
+        assert!(!CtEq::ct_eq(&params, &other).to_bool_vartime());
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn boxed_ct_eq_matches_partial_eq_for_mod_leading_zeros() {
+        let modulus = Odd::new(BoxedUint::from(3u8).resize(128)).unwrap();
+        let params = BoxedMontyParams::new_vartime(modulus);
+        let mut other = params.as_ref().clone();
+        other.mod_leading_zeros = 0;
+        let other = BoxedMontyParams::from(other);
+
+        assert_ne!(params, other);
+        assert!(!CtEq::ct_eq(&params, &other).to_bool_vartime());
     }
 }


### PR DESCRIPTION
MontyParams derives PartialEq/Eq over all fields, but the runtime parameter CtEq implementations omitted the cached mod_leading_zeros field. That allowed internally constructible parameter values to compare unequal with == while CtEq returned true.

This updates generic MontyParams and BoxedMontyParams CtEq to include mod_leading_zeros, and adds regression tests for values that differ only in that field.

Testing:
- cargo test --all-features mod_leading_zeros -- --nocapture

-----
This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The vulnerability was identified primarily by the Codex coding agent, and manually reviewed before submission.