### PR TITLE
Canonicalize modulus-one residues

### DIFF
--- a/src/int/invert_mod.rs
+++ b/src/int/invert_mod.rs
@@ -9,13 +9,12 @@ impl<const LIMBS: usize> Int<LIMBS> {
         let (abs, sgn) = self.abs_sign();
         let maybe_inv = abs.invert_odd_mod(modulus);
         let abs_inv = maybe_inv.as_inner_unchecked();
+        let neg_inv = modulus.wrapping_sub(abs_inv);
+        let neg_inv = Uint::select(&neg_inv, abs_inv, abs_inv.is_nonzero().not());
 
         // Note: when `self` is negative and modulus is non-zero, then
         // self^{-1} % modulus = modulus - |self|^{-1} % modulus
-        CtOption::new(
-            Uint::select(abs_inv, &modulus.wrapping_sub(abs_inv), sgn),
-            maybe_inv.is_some(),
-        )
+        CtOption::new(Uint::select(abs_inv, &neg_inv, sgn), maybe_inv.is_some())
     }
 
     /// Computes the multiplicative inverse of `self` mod `modulus`.
@@ -26,13 +25,12 @@ impl<const LIMBS: usize> Int<LIMBS> {
         let (abs, sgn) = self.abs_sign();
         let maybe_inv = abs.invert_mod(modulus);
         let abs_inv = maybe_inv.as_inner_unchecked();
+        let neg_inv = modulus.as_ref().wrapping_sub(abs_inv);
+        let neg_inv = Uint::select(&neg_inv, abs_inv, abs_inv.is_nonzero().not());
 
         // Note: when `self` is negative and modulus is non-zero, then
         // self^{-1} % modulus = modulus - |self|^{-1} % modulus
-        CtOption::new(
-            Uint::select(abs_inv, &modulus.as_ref().wrapping_sub(abs_inv), sgn),
-            maybe_inv.is_some(),
-        )
+        CtOption::new(Uint::select(abs_inv, &neg_inv, sgn), maybe_inv.is_some())
     }
 }
 
@@ -49,7 +47,23 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{I1024, U1024};
+    use crate::{I256, I1024, U256, U1024};
+
+    #[test]
+    fn negative_inverse_modulus_one_is_canonical_zero() {
+        let odd_modulus = U256::ONE.to_odd().unwrap();
+        let modulus = U256::ONE.to_nz().unwrap();
+
+        assert_eq!(
+            Option::<U256>::from(I256::MINUS_ONE.invert_odd_mod(&odd_modulus)),
+            Some(U256::ZERO)
+        );
+        assert_eq!(
+            Option::<U256>::from(I256::MINUS_ONE.invert_mod(&modulus)),
+            Some(U256::ZERO)
+        );
+        assert_eq!(Option::<U256>::from(I256::ZERO.invert_mod(&modulus)), None);
+    }
 
     #[test]
     fn test_invert_odd() {

--- a/src/modular/monty_params.rs
+++ b/src/modular/monty_params.rs
@@ -155,6 +155,7 @@ impl<const LIMBS: usize> FixedMontyParams<LIMBS> {
         let one = Uint::<LIMBS>::MAX
             .rem(modulus.as_nz_ref())
             .wrapping_add(&Uint::ONE);
+        let one = Uint::select(&one, &Uint::ZERO, Uint::eq(&one, modulus.as_ref()));
 
         // `R^2 mod modulus`, used to convert integers to Montgomery form.
         let r2 = one.square_mod(modulus.as_nz_ref());
@@ -185,6 +186,7 @@ impl<const LIMBS: usize> FixedMontyParams<LIMBS> {
         let one = Uint::<LIMBS>::MAX
             .rem_vartime(modulus.as_nz_ref())
             .wrapping_add(&Uint::ONE);
+        let one = Uint::select(&one, &Uint::ZERO, Uint::eq(&one, modulus.as_ref()));
 
         // `R^2 mod modulus`, used to convert integers to Montgomery form.
         let r2 = one.square_mod_vartime(modulus.as_nz_ref());
@@ -231,9 +233,12 @@ pub(crate) mod boxed {
 
             // `R mod modulus` where `R = 2^BITS`.
             // Represents 1 in Montgomery form.
-            let one = crate::uint::boxed::BoxedUint::max(bits_precision)
+            let mut one = crate::uint::boxed::BoxedUint::max(bits_precision)
                 .rem(modulus.as_nz_ref())
                 .wrapping_add(Limb::ONE);
+            if one == *modulus.as_ref() {
+                one = crate::uint::boxed::BoxedUint::zero_with_precision(bits_precision);
+            }
 
             // `R^2 mod modulus`, used to convert integers to Montgomery form.
             let r2 = one.square_mod(modulus.as_nz_ref());
@@ -265,9 +270,12 @@ pub(crate) mod boxed {
 
             // `R mod modulus` where `R = 2^BITS`.
             // Represents 1 in Montgomery form.
-            let one = crate::uint::boxed::BoxedUint::max(bits_precision)
+            let mut one = crate::uint::boxed::BoxedUint::max(bits_precision)
                 .rem_vartime(modulus.as_nz_ref())
                 .wrapping_add(Limb::ONE);
+            if one == *modulus.as_ref() {
+                one = crate::uint::boxed::BoxedUint::zero_with_precision(bits_precision);
+            }
 
             // `R^2 mod modulus`, used to convert integers to Montgomery form.
             let r2 = one.square_mod_vartime(modulus.as_nz_ref());

--- a/tests/boxed_monty_form.rs
+++ b/tests/boxed_monty_form.rs
@@ -24,6 +24,22 @@ fn reduce(n: &BoxedUint, p: BoxedMontyParams) -> BoxedMontyForm {
     BoxedMontyForm::new(n_reduced, &p)
 }
 
+#[test]
+fn one_modulus_one_is_canonical_zero() {
+    let modulus = Odd::new(BoxedUint::one_with_precision(128)).unwrap();
+    let params = BoxedMontyParams::new(modulus.clone());
+    assert_eq!(
+        BoxedMontyForm::one(&params).retrieve(),
+        BoxedUint::zero_with_precision(128)
+    );
+
+    let params = BoxedMontyParams::new_vartime(modulus);
+    assert_eq!(
+        BoxedMontyForm::one(&params).retrieve(),
+        BoxedUint::zero_with_precision(128)
+    );
+}
+
 prop_compose! {
     /// Generate a random `BoxedUint`.
     fn uint()(mut bytes in any::<Vec<u8>>()) -> BoxedUint {

--- a/tests/fixed_monty_form.rs
+++ b/tests/fixed_monty_form.rs
@@ -29,6 +29,22 @@ fn reduce(n: &U256, p: MontyParams256) -> MontyForm256 {
     MontyForm256::new(&n_reduced, &p)
 }
 
+#[test]
+fn one_modulus_one_is_canonical_zero() {
+    let modulus = Odd::new(U128::ONE).unwrap();
+    let params = FixedMontyParams::new(modulus);
+    let form = FixedMontyForm::one(&params);
+
+    assert_eq!(params.one(), &U128::ZERO);
+    assert_eq!(form.retrieve(), U128::ZERO);
+
+    let params = FixedMontyParams::new_vartime(modulus);
+    let form = FixedMontyForm::one(&params);
+
+    assert_eq!(params.one(), &U128::ZERO);
+    assert_eq!(form.retrieve(), U128::ZERO);
+}
+
 prop_compose! {
     fn uint()(bytes in any::<[u8; 32]>()) -> U256 {
         U256::from_le_slice(&bytes)


### PR DESCRIPTION
Closes #1279.

Modulus 1 has only one canonical residue, 0. Several accepted modulus-one paths could return 1 instead:

- Montgomery parameter constructors computed `R mod 1` as 1 for the stored Montgomery-form `one` value.
- Signed modular inversion negated an absolute inverse of zero into `modulus - 0`.

This canonicalizes those accepted modulus-one cases to zero while preserving the existing constructor and inversion APIs. The regression tests cover fixed Montgomery params, boxed Montgomery params, and negative signed inversion modulo 1.

Testing:

- `cargo test --all-features modulus_one -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

-----
This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The vulnerability was identified primarily by the Codex coding agent, and manually reviewed before submission.