### PR TITLE
Handle power-of-two moduli in mul_mod_special

### DIFF
--- a/src/uint/boxed/mul_mod.rs
+++ b/src/uint/boxed/mul_mod.rs
@@ -22,6 +22,10 @@ impl BoxedUint {
     pub fn mul_mod_special(&self, rhs: &Self, c: Limb) -> Self {
         debug_assert_eq!(self.bits_precision(), rhs.bits_precision());
 
+        if c.is_zero().into() {
+            return self.wrapping_mul(rhs);
+        }
+
         if self.nlimbs() == 1 {
             let reduced = mul_rem(
                 self.limbs[0],
@@ -93,7 +97,7 @@ fn mac_by_limb(a: &UintRef, b: &UintRef, c: Limb, carry: Limb) -> (BoxedUint, Li
 
 #[cfg(all(test, feature = "rand_core"))]
 mod tests {
-    use crate::{BoxedUint, ConcatenatingMul, Limb, NonZero, Random, RandomMod};
+    use crate::{BoxedUint, ConcatenatingMul, Limb, NonZero, Random, RandomMod, Resize};
     use rand_core::SeedableRng;
 
     #[test]
@@ -146,6 +150,20 @@ mod tests {
                     assert_eq!(c, expected, "incorrect result");
                 }
             }
+        }
+    }
+
+    #[test]
+    fn mul_mod_special_zero_c_is_wrapping_multiplication() {
+        for bits in [Limb::BITS, 2 * Limb::BITS, 4 * Limb::BITS] {
+            let a = BoxedUint::from(0x1234_5678u32).resize(bits);
+            let b = BoxedUint::from(0xfedc_ba91u32).resize(bits);
+
+            assert_eq!(
+                a.mul_mod_special(&b, Limb::ZERO),
+                a.wrapping_mul(&b),
+                "c = 0 represents the power-of-two modulus"
+            );
         }
     }
 }

--- a/src/uint/mul_mod.rs
+++ b/src/uint/mul_mod.rs
@@ -25,6 +25,10 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// and S. Vanstone, CRC Press, 1996.
     #[must_use]
     pub const fn mul_mod_special(&self, rhs: &Self, c: Limb) -> Self {
+        if c.is_zero().to_bool_vartime() {
+            return self.wrapping_mul(rhs);
+        }
+
         // We implicitly assume `LIMBS > 0`, because `Uint<0>` doesn't compile.
         // Still the case `LIMBS == 1` needs special handling.
         if LIMBS == 1 {
@@ -162,5 +166,26 @@ mod tests {
             test_size::<8>();
             test_size::<16>();
         }
+    }
+
+    #[test]
+    fn mul_mod_special_zero_c_is_wrapping_multiplication() {
+        let a = Uint::<1>::from_u32(0x1234_5678);
+        let b = Uint::<1>::from_u32(0xfedc_ba91);
+
+        assert_eq!(
+            a.mul_mod_special(&b, Limb::ZERO),
+            a.wrapping_mul(&b),
+            "c = 0 represents the power-of-two modulus"
+        );
+
+        let a = Uint::<2>::from_u32(0x1234_5678);
+        let b = Uint::<2>::from_u32(0xfedc_ba91);
+
+        assert_eq!(
+            a.mul_mod_special(&b, Limb::ZERO),
+            a.wrapping_mul(&b),
+            "c = 0 represents the power-of-two modulus"
+        );
     }
 }


### PR DESCRIPTION
Closes #1281.

`mul_mod_special` computes multiplication modulo `MAX + 1 - c`, i.e. `2^bits - c`. When `c = 0`, that modulus is `2^bits`, so reduction is ordinary fixed-width wrapping multiplication.

The one-limb fixed and boxed implementations reached a limb reduction path which constructs `NonZero<Limb>` from `0` when `c = 0`, causing a panic. This adds an early `wrapping_mul` return for the power-of-two modulus case and regression tests for both fixed and boxed integers.

Testing:

- `cargo test --all-features mul_mod_special_zero_c_is_wrapping_multiplication -- --nocapture`
- `cargo test --all-features uint::mul_mod::tests -- --nocapture`
- `cargo test --all-features uint::boxed::mul_mod::tests -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

-----
This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The vulnerability was identified primarily by the Codex coding agent, and manually reviewed before submission.