### PR TITLE
Fix nlimbs overflow near u32::MAX

### DIFF
--- a/src/limb.rs
+++ b/src/limb.rs
@@ -39,8 +39,8 @@ use serdect::serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[must_use]
 pub const fn nlimbs(bits: u32) -> usize {
     match cpubits::CPUBITS {
-        32 => ((bits + 31) >> 5) as usize,
-        64 => ((bits + 63) >> 6) as usize,
+        32 => (((bits as u64) + 31) >> 5) as usize,
+        64 => (((bits as u64) + 63) >> 6) as usize,
         _ => unreachable!(),
     }
 }
@@ -406,6 +406,12 @@ mod tests {
                 assert_eq!(super::nlimbs(256), 4);
             }
         }
+    }
+
+    #[test]
+    fn nlimbs_handles_max_bit_count() {
+        let expected = u64::from(u32::MAX).div_ceil(u64::from(Limb::BITS)) as usize;
+        assert_eq!(super::nlimbs(u32::MAX), expected);
     }
 
     #[cfg(feature = "alloc")]

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -410,7 +410,8 @@ mod tests {
 
     #[test]
     fn nlimbs_handles_max_bit_count() {
-        let expected = u64::from(u32::MAX).div_ceil(u64::from(Limb::BITS)) as usize;
+        let expected = usize::try_from(u64::from(u32::MAX).div_ceil(u64::from(Limb::BITS)))
+            .expect("limb count fits in usize");
         assert_eq!(super::nlimbs(u32::MAX), expected);
     }
 


### PR DESCRIPTION
## Summary

This fixes `limb::nlimbs` so rounding does not overflow for bit counts near `u32::MAX`.

## Problem

`nlimbs(bits)` rounds up by adding `Limb::BITS - 1` before shifting. Since `bits` is a `u32`, the intermediate addition overflows for bit counts near `u32::MAX`.

Concretely, this affects `bits > u32::MAX - 31` on 32-bit limbs and `bits > u32::MAX - 63` on 64-bit limbs. That panics in debug builds and wraps to an incorrect limb count in release builds.

## Fix

Cast `bits` to `u64` before adding the rounding constant, then shift to compute the ceiling limb count.

## Testing

Added a regression test for `u32::MAX`.

```sh
cargo test --all-features limb::tests::nlimbs_handles_max_bit_count -- --exact
cargo clippy --all-targets --all-features -- -D warnings
```

-----

This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The vulnerability was identified primarily by the Codex coding agent, and manually reviewed before submission.
