### PR TITLE
Implement Encoding for Int serde support

### DIFF
--- a/src/int/encoding.rs
+++ b/src/int/encoding.rs
@@ -1,6 +1,6 @@
 //! Const-friendly decoding/encoding operations for [`Int`].
 
-use crate::{Int, Uint};
+use crate::{EncodedUint, Encoding, Int, Uint};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Create a new [`Int`] from the provided big endian hex string.
@@ -12,5 +12,29 @@ impl<const LIMBS: usize> Int<LIMBS> {
     #[must_use]
     pub const fn from_be_hex(hex: &str) -> Self {
         Self(Uint::from_be_hex(hex))
+    }
+}
+
+impl<const LIMBS: usize> Encoding for Int<LIMBS> {
+    type Repr = EncodedUint<LIMBS>;
+
+    #[inline]
+    fn from_be_bytes(bytes: Self::Repr) -> Self {
+        Self(Uint::from_be_bytes(bytes))
+    }
+
+    #[inline]
+    fn from_le_bytes(bytes: Self::Repr) -> Self {
+        Self(Uint::from_le_bytes(bytes))
+    }
+
+    #[inline]
+    fn to_be_bytes(&self) -> Self::Repr {
+        self.0.to_be_bytes()
+    }
+
+    #[inline]
+    fn to_le_bytes(&self) -> Self::Repr {
+        self.0.to_le_bytes()
     }
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -4,8 +4,7 @@
 
 use crypto_bigint::{
     Checked, I64, I128, I256, I512, Limb, NonZero, Odd, U64, U128, U256, U512, Wrapping,
-    const_monty_params,
-    modular::ConstMontyForm,
+    const_monty_params, modular::ConstMontyForm,
 };
 use serdect::serde::{
     Deserialize, Serialize,
@@ -82,9 +81,7 @@ fn int_serde_deserialization_uses_serdect_encoding() {
     );
 
     let zero = "00".repeat(I256::BYTES);
-    assert!(
-        NonZero::<I256>::deserialize(StrDeserializer::<Error>::new(&zero)).is_err()
-    );
+    assert!(NonZero::<I256>::deserialize(StrDeserializer::<Error>::new(&zero)).is_err());
 
     let two = format!("02{}", "00".repeat(I256::BYTES - 1));
     assert!(Odd::<I256>::deserialize(StrDeserializer::<Error>::new(&two)).is_err());

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,91 @@
+//! Serde trait coverage tests.
+
+#![cfg(feature = "serde")]
+
+use crypto_bigint::{
+    Checked, I64, I128, I256, I512, Limb, NonZero, Odd, U64, U128, U256, U512, Wrapping,
+    const_monty_params,
+    modular::ConstMontyForm,
+};
+use serdect::serde::{
+    Deserialize, Serialize,
+    de::value::{Error, StrDeserializer},
+};
+
+const_monty_params!(
+    Modulus,
+    U256,
+    "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551"
+);
+
+type FieldElement = ConstMontyForm<Modulus, { U256::LIMBS }>;
+
+macro_rules! assert_serde_impls {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            assert_serde::<$ty>();
+        )+
+    };
+}
+
+fn assert_serde<T>()
+where
+    T: Serialize + for<'de> Deserialize<'de>,
+{
+}
+
+#[test]
+fn serde_impl_matrix() {
+    assert_serde_impls!(
+        Limb,
+        U64,
+        U128,
+        U256,
+        U512,
+        I64,
+        I128,
+        I256,
+        I512,
+        NonZero<Limb>,
+        NonZero<U256>,
+        NonZero<I256>,
+        NonZero<FieldElement>,
+        Odd<Limb>,
+        Odd<U256>,
+        Odd<I256>,
+        Wrapping<Limb>,
+        Wrapping<U256>,
+        Wrapping<I256>,
+        Wrapping<FieldElement>,
+        Checked<Limb>,
+        Checked<U256>,
+        Checked<I256>,
+        Checked<FieldElement>,
+        FieldElement,
+    );
+
+    #[cfg(feature = "alloc")]
+    assert_serde_impls!(
+        crypto_bigint::BoxedUint,
+        NonZero<crypto_bigint::BoxedUint>,
+        Odd<crypto_bigint::BoxedUint>,
+        Wrapping<crypto_bigint::BoxedUint>,
+    );
+}
+
+#[test]
+fn int_serde_deserialization_uses_serdect_encoding() {
+    let minus_one = "ff".repeat(I256::BYTES);
+    assert_eq!(
+        I256::deserialize(StrDeserializer::<Error>::new(&minus_one)).expect("I256 deserializes"),
+        I256::MINUS_ONE
+    );
+
+    let zero = "00".repeat(I256::BYTES);
+    assert!(
+        NonZero::<I256>::deserialize(StrDeserializer::<Error>::new(&zero)).is_err()
+    );
+
+    let two = format!("02{}", "00".repeat(I256::BYTES - 1));
+    assert!(Odd::<I256>::deserialize(StrDeserializer::<Error>::new(&two)).is_err());
+}


### PR DESCRIPTION
Implement `Encoding` for `Int<LIMBS>`.

`Int` already has `Serialize` and `Deserialize` impls behind the `serde` feature, but those impls require `Int<LIMBS>: Encoding`. Since `Int` did not implement `Encoding`, the serde impls were not reachable for signed fixed-width integer aliases like `I256`.

This implements `Encoding` for `Int<LIMBS>` by delegating to the wrapped `Uint<LIMBS>` representation. That preserves the existing two's-complement byte layout used by signed integers.

The tests add a dedicated serde trait coverage matrix for the crate's explicit serde impl surfaces, including representative fixed-width unsigned and signed integers, invariant wrappers, arithmetic wrappers, boxed integers under `alloc`, and `ConstMontyForm`. The tests also exercise `I256` deserialization through `serdect` without adding a concrete serializer dev-dependency.

-----
This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The vulnerability was identified primarily by the Codex coding agent, and manually reviewed before submission.