### PR TITLE
Preserve `NonZero` and `Odd` invariants in `Zeroize` impls

### DIFF
--- a/src/non_zero.rs
+++ b/src/non_zero.rs
@@ -662,9 +662,10 @@ where
 }
 
 #[cfg(feature = "zeroize")]
-impl<T: zeroize::Zeroize + Zero> zeroize::Zeroize for NonZero<T> {
+impl<T: zeroize::Zeroize + One> zeroize::Zeroize for NonZero<T> {
     fn zeroize(&mut self) {
         self.0.zeroize();
+        self.0 = T::one_like(&self.0);
     }
 }
 
@@ -673,6 +674,12 @@ mod tests {
     use super::NonZero;
     use crate::{I128, One, U128};
     use hex_literal::hex;
+
+    #[cfg(all(feature = "alloc", feature = "zeroize"))]
+    use crate::BoxedUint;
+
+    #[cfg(feature = "zeroize")]
+    use zeroize::Zeroize;
 
     #[test]
     fn default() {
@@ -707,6 +714,28 @@ mod tests {
                 .into_option(),
             None
         );
+    }
+
+    #[cfg(feature = "zeroize")]
+    #[test]
+    fn zeroize_preserves_invariant() {
+        let mut value = NonZero::new(U128::from(0x1234u64)).unwrap();
+
+        value.zeroize();
+
+        assert_eq!(*value.as_ref(), U128::ONE);
+    }
+
+    #[cfg(all(feature = "alloc", feature = "zeroize"))]
+    #[test]
+    fn boxed_zeroize_preserves_invariant_and_precision() {
+        let mut value =
+            NonZero::new(BoxedUint::from_be_slice(&[0x12, 0x34], 128).unwrap()).unwrap();
+
+        value.zeroize();
+
+        assert_eq!(value.as_ref(), &BoxedUint::one_with_precision(128));
+        assert_eq!(value.bits_precision(), 128);
     }
 
     #[test]

--- a/src/odd.rs
+++ b/src/odd.rs
@@ -510,9 +510,10 @@ where
 }
 
 #[cfg(feature = "zeroize")]
-impl<T: zeroize::Zeroize> zeroize::Zeroize for Odd<T> {
+impl<T: zeroize::Zeroize + One> zeroize::Zeroize for Odd<T> {
     fn zeroize(&mut self) {
         self.0.zeroize();
+        self.0 = T::one_like(&self.0);
     }
 }
 
@@ -523,6 +524,9 @@ mod tests {
 
     #[cfg(feature = "alloc")]
     use crate::BoxedUint;
+
+    #[cfg(feature = "zeroize")]
+    use zeroize::Zeroize;
 
     #[test]
     fn default() {
@@ -572,5 +576,25 @@ mod tests {
         assert!(bool::from(zero.is_none()));
         let two = Odd::new(BoxedUint::from(2u8));
         assert!(bool::from(two.is_none()));
+    }
+    #[cfg(feature = "zeroize")]
+    #[test]
+    fn zeroize_preserves_invariant() {
+        let mut value = Odd::new(U128::from(0x1235u64)).unwrap();
+
+        value.zeroize();
+
+        assert_eq!(*value.as_ref(), U128::ONE);
+    }
+
+    #[cfg(all(feature = "alloc", feature = "zeroize"))]
+    #[test]
+    fn boxed_zeroize_preserves_invariant_and_precision() {
+        let mut value = Odd::new(BoxedUint::from_be_slice(&[0x12, 0x35], 128).unwrap()).unwrap();
+
+        value.zeroize();
+
+        assert_eq!(value.as_ref(), &BoxedUint::one_with_precision(128));
+        assert_eq!(value.bits_precision(), 128);
     }
 }


### PR DESCRIPTION
Preserve `NonZero` and `Odd` wrapper invariants after `zeroize()`.

The current `Zeroize` impls zeroize the wrapped value directly. For `NonZero<T>` and `Odd<T>`, that can leave a live wrapper containing zero or an even value after a safe method call, violating the wrapper's type invariant.

This changes the impls to zeroize the inner storage and then restore a one-like sentinel value. That keeps the wrapper valid after zeroization, mirrors the `zeroize` crate's behavior for core `NonZero*` integer types, and preserves boxed integer precision through `One::one_like`.

The tests cover stack and boxed `NonZero`/`Odd` values, including boxed precision preservation after zeroization.

-----
This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The vulnerability was identified primarily by the Codex coding agent, and manually reviewed before submission.