### PR TITLE
CI: cache installed apt packages

### DIFF
--- a/.github/workflows/crypto-bigint.yml
+++ b/.github/workflows/crypto-bigint.yml
@@ -57,18 +57,18 @@ jobs:
           # `x86` Linux (32-bit)
           - target: i686-unknown-linux-gnu
             rust: 1.85.0 # MSRV
-            deps: sudo apt update && sudo apt-get install gcc-multilib
+            deps: gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: 1.85.0 # MSRV
             args: --release
-            deps: sudo apt update && sudo apt-get install gcc-multilib
+            deps: gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
-            deps: sudo apt update && sudo apt-get install gcc-multilib
+            deps: gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
             args: --release
-            deps: sudo apt update && sudo apt-get install gcc-multilib
+            deps: gcc-multilib
 
           # `x86_64` Linux
           - target: x86_64-unknown-linux-gnu
@@ -116,12 +116,14 @@ jobs:
     runs-on: ${{ matrix.runner != '' && matrix.runner || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
+      - uses: RustCrypto/actions/apt-install@master
+        if: ${{ matrix.deps != '' }}
+        with:
+          packages: ${{ matrix.deps }}
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
-      - run: ${{ matrix.deps }}
-        if: ${{ matrix.deps != '' }}
       - run: cargo check --target ${{ matrix.target }} --all-features # ensure it builds with all features
       - run: cargo test --target ${{ matrix.target }} --no-default-features ${{ matrix.args }}
       - run: cargo test --target ${{ matrix.target }}  ${{ matrix.args }}
@@ -196,7 +198,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - run: sudo apt update && sudo apt-get install gcc-multilib
+      - uses: RustCrypto/actions/apt-install@master
+        with:
+          packages: gcc-multilib
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools


### PR DESCRIPTION
~~I'm testing this out with a third-party action: `eth-pkg/apt-deb-cache@v0.2.6`~~

It's small and simple enough though if it works we can just vendor it and modify it for our own purposes.

Edit: vendored here: https://github.com/RustCrypto/actions/pull/60