### PR TITLE
Fix UintRef byte precision

### DIFF
--- a/src/uint/ref_type/bits.rs
+++ b/src/uint/ref_type/bits.rs
@@ -229,7 +229,7 @@ impl BitOps for UintRef {
 
     #[inline(always)]
     fn bytes_precision(&self) -> usize {
-        self.limbs.len()
+        self.limbs.len() * Limb::BYTES
     }
 
     fn leading_zeros(&self) -> u32 {
@@ -270,5 +270,17 @@ impl BitOps for UintRef {
 
     fn trailing_ones_vartime(&self) -> u32 {
         self.trailing_ones_vartime()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UintRef;
+    use crate::{BitOps, Limb};
+
+    #[test]
+    fn bitops_bytes_precision_counts_bytes_not_limbs() {
+        let limbs = [Limb::ZERO; 2];
+        assert_eq!(UintRef::new(&limbs).bytes_precision(), 2 * Limb::BYTES);
     }
 }


### PR DESCRIPTION
UintRef's BitOps implementation returns the number of limbs from
bytes_precision(), even though the trait reports precision in bytes.

Other BitOps implementations already return byte precision: Limb returns
Limb::BYTES, fixed Uint returns Self::BYTES, and BoxedUint returns its limb
count multiplied by Limb::BYTES. This changes UintRef to match that behavior
and adds a regression test for a multi-limb reference.

Tests:
- cargo test --all-features uint::ref_type::bits::tests::bitops_bytes_precision_counts_bytes_not_limbs -- --exact --nocapture
- cargo test --all-features --lib
- cargo fmt --all -- --check
- git diff --check

-----
This work was completed by Trail of Bits as part of the Patch The Planet project in collaboration with OpenAI. The vulnerability was identified primarily by the Codex coding agent, and manually reviewed before submission.
