### PR TITLE
bitlen: performance guesswork

### DIFF
--- a/src/bitlen.rs
+++ b/src/bitlen.rs
@@ -7,28 +7,33 @@ use crate::Limb;
 
 /// Calculate a `u32` representing a number of bits from the given number of bytes as a `usize`.
 #[cfg_attr(not(feature = "alloc"), allow(dead_code))]
+#[inline(always)]
 pub(crate) const fn from_bytes(nbytes: usize) -> u32 {
-    checked_mul(nbytes, 8)
+    mul(nbytes, 8)
 }
 
 /// Calculate a `u32` representing a number of bits in an integer with the given number of limbs.
+#[inline(always)]
 pub(crate) const fn from_limbs(nlimbs: usize) -> u32 {
-    checked_mul(nlimbs, Limb::BITS)
+    mul(nlimbs, Limb::BITS)
 }
 
 /// Calculate a `usize` representing the number of bytes required to store the given number of bits
 /// represented as a `u32` (i.e. rounding up).
 #[cfg_attr(not(feature = "alloc"), allow(dead_code))]
+#[inline(always)]
 pub(crate) const fn to_bytes(nbits: u32) -> usize {
     u32_to_usize(nbits.div_ceil(8))
 }
 
 /// Calculate a `usize` representing the number of limbs required to store the given number of bits
 /// represented as a `u32` (i.e. rounding up).
+#[inline(always)]
 pub(crate) const fn to_limbs(nbits: u32) -> usize {
     u32_to_usize(nbits.div_ceil(Limb::BITS))
 }
 
+#[inline(always)]
 const fn u32_to_usize(n: u32) -> usize {
     const {
         // Ensure cast from `u32` to `usize` won't overflow
@@ -42,13 +47,19 @@ const fn u32_to_usize(n: u32) -> usize {
     clippy::cast_possible_truncation,
     reason = "assertion ensures panic instead of truncation"
 )]
+#[inline(always)]
 const fn usize_to_u32(n: usize) -> u32 {
-    assert!(n < u32_to_usize(u32::MAX), "u32 overflow");
+    debug_assert!(n < u32_to_usize(u32::MAX), "u32 overflow");
     n as u32
 }
 
-const fn checked_mul(size: usize, n: u32) -> u32 {
-    usize_to_u32(size).checked_mul(n).expect("u32 overflow")
+#[inline(always)]
+const fn mul(size: usize, n: u32) -> u32 {
+    if cfg!(debug_assertions) {
+        usize_to_u32(size).checked_mul(n).expect("u32 overflow")
+    } else {
+        usize_to_u32(size) * n
+    }
 }
 
 #[cfg(test)]

--- a/src/uint/ref_type/bits.rs
+++ b/src/uint/ref_type/bits.rs
@@ -3,6 +3,7 @@ use crate::{Choice, Limb, bitlen, traits::BitOps, word};
 
 impl UintRef {
     /// Get the precision of this number in bits.
+    #[inline(always)]
     #[must_use]
     pub const fn bits_precision(&self) -> u32 {
         bitlen::from_limbs(self.limbs.len())


### PR DESCRIPTION
This is an attempt to address #1296, although unfortunately it doesn't have a self-contained benchmark, and when I tried to run what's available it uses FFI and needs a bunch of external dependencies. I didn't futz with any of that and just tried throwing everything at the wall in this PR hoping one of the changes addresses the problem.

First, it sprinkles `inline(always)` on everything. While that's generally an antipattern, these functions are both deeply nested and incredibly trivial: usually just one or two wrapping arithmetic ops in release builds, and they're deep in hot paths, so really they need to get aggressively inlined.

Speaking of that, this also completely ditches checks/assertions in release builds for performance, whereas before they were always compiled in. That should keep the hot path incredibly simple.

None of this had any major impact on `crypto-bigint`'s own benchmarks. The only change that seemed to be barely escaping the noise threshold was adding `#[inline(always)]` to `UintRef::bits_precision` which seemed to eek out some ~1.8% cross-cutting performance improvements, though I didn't check to see if they're reproducible and that's pretty much within the noise threshold so don't quote me on that.

Hopefully one of these changes addresses the situation in #1296.