### PR TITLE
Limb: add `pub const fn` encoding methods

### DIFF
--- a/src/limb/encoding.rs
+++ b/src/limb/encoding.rs
@@ -1,36 +1,127 @@
 //! Limb encoding
 
 use super::{Limb, Word};
-use crate::Encoding;
+use crate::{Encoding, bitlen};
 
 impl Limb {
+    /// Decode from big endian bytes.
+    #[inline]
+    #[must_use]
+    pub const fn from_be_bytes(bytes: [u8; Self::BYTES]) -> Self {
+        Limb(Word::from_be_bytes(bytes))
+    }
+
+    /// Decode from little endian bytes.
+    #[inline]
+    #[must_use]
+    pub const fn from_le_bytes(bytes: [u8; Self::BYTES]) -> Self {
+        Limb(Word::from_le_bytes(bytes))
+    }
+
     /// Decode limb from a big endian byte slice, which may be shorter than [`Limb::BYTES`].
     ///
     /// # Panics
-    /// - if the slice is larger than [`Limb::Repr`].
-    pub(crate) fn from_be_slice(bytes: &[u8]) -> Self {
-        let offset = Limb::BYTES
+    /// If the slice larger than [`Limb::BYTES`].
+    #[must_use]
+    #[track_caller]
+    pub const fn from_be_slice(bytes: &[u8]) -> Self {
+        let offset = Self::BYTES
             .checked_sub(bytes.len())
             .expect("The given slice is larger than Limb::BYTES");
 
-        let mut repr = Self::ZERO.to_be_bytes();
-        repr[offset..].copy_from_slice(bytes);
+        let mut repr = [0u8; Self::BYTES];
+        let mut i = 0;
+        while i < bytes.len() {
+            repr[offset + i] = bytes[i];
+            i += 1;
+        }
         Self::from_be_bytes(repr)
     }
 
     /// Decode limb from a little endian byte slice, which may be shorter than [`Limb::BYTES`].
     ///
     /// # Panics
-    /// - if the slice is not the same size as [`Limb::Repr`].
-    pub(crate) fn from_le_slice(bytes: &[u8]) -> Self {
+    /// If the slice larger than [`Limb::BYTES`].
+    #[must_use]
+    #[track_caller]
+    pub const fn from_le_slice(bytes: &[u8]) -> Self {
         assert!(
-            bytes.len() <= Limb::BYTES,
+            bytes.len() <= Self::BYTES,
             "The given slice is larger than Limb::BYTES"
         );
 
-        let mut repr = Self::ZERO.to_be_bytes();
-        repr[..bytes.len()].copy_from_slice(bytes);
+        let mut repr = [0u8; Self::BYTES];
+        let mut i = 0;
+        while i < bytes.len() {
+            repr[i] = bytes[i];
+            i += 1;
+        }
         Self::from_le_bytes(repr)
+    }
+
+    /// Decode limb from the provided big endian bytes, zero padding if necessary, and
+    /// truncating to the least significant bytes in the event the given amount of data exceeds
+    /// `bits_precision`.
+    ///
+    /// # Panics
+    /// If `bits_precision > Self::BITS`.
+    #[inline]
+    #[must_use]
+    #[track_caller]
+    pub const fn from_be_slice_truncated(mut bytes: &[u8], bits_precision: u32) -> Self {
+        assert!(bits_precision <= Self::BITS);
+        let bytes_precision = bitlen::to_bytes(bits_precision);
+        if bytes.len() > bytes_precision {
+            bytes = bytes
+                .split_at(bytes.len().saturating_sub(bytes_precision))
+                .1;
+        }
+
+        let mut ret = Self::from_be_slice(bytes);
+        ret.mask_to_precision(bits_precision);
+        ret
+    }
+
+    /// Decode limb from the provided little endian bytes, zero padding if necessary, and
+    /// truncating to the least significant bytes in the event the given amount of data exceeds
+    /// `bits_precision`.
+    ///
+    /// # Panics
+    /// If `bits_precision > Self::BITS`.
+    #[inline]
+    #[must_use]
+    #[track_caller]
+    pub const fn from_le_slice_truncated(mut bytes: &[u8], bits_precision: u32) -> Self {
+        assert!(bits_precision <= Self::BITS);
+        let bytes_precision = bitlen::to_bytes(bits_precision);
+        if bytes.len() > bytes_precision {
+            bytes = bytes.split_at(bytes_precision).0;
+        }
+
+        let mut ret = Self::from_le_slice(bytes);
+        ret.mask_to_precision(bits_precision);
+        ret
+    }
+
+    /// Encode as big endian bytes.
+    #[inline]
+    #[must_use]
+    pub const fn to_be_bytes(&self) -> [u8; Self::BYTES] {
+        self.0.to_be_bytes()
+    }
+
+    /// Encode as little endian bytes.
+    #[inline]
+    #[must_use]
+    pub const fn to_le_bytes(&self) -> [u8; Self::BYTES] {
+        self.0.to_le_bytes()
+    }
+
+    /// Mask to the given number of bits precision.
+    #[inline(always)]
+    pub(crate) const fn mask_to_precision(&mut self, bits_precision: u32) {
+        debug_assert!(bits_precision <= Self::BITS);
+        self.0 &= Word::MAX >> (Limb::BITS.saturating_sub(bits_precision));
     }
 }
 
@@ -39,22 +130,22 @@ impl Encoding for Limb {
 
     #[inline]
     fn from_be_bytes(bytes: Self::Repr) -> Self {
-        Limb(Word::from_be_bytes(bytes))
+        Self::from_be_bytes(bytes)
     }
 
     #[inline]
     fn from_le_bytes(bytes: Self::Repr) -> Self {
-        Limb(Word::from_le_bytes(bytes))
+        Self::from_le_bytes(bytes)
     }
 
     #[inline]
     fn to_be_bytes(&self) -> Self::Repr {
-        self.0.to_be_bytes()
+        self.to_be_bytes()
     }
 
     #[inline]
     fn to_le_bytes(&self) -> Self::Repr {
-        self.0.to_le_bytes()
+        self.to_le_bytes()
     }
 }
 
@@ -65,6 +156,40 @@ mod test {
     cpubits::cpubits! {
         32 => { const LIMB: Limb = Limb(0x7654_3210); }
         64 => { const LIMB: Limb = Limb(0xFEDCBA9876543210); }
+    }
+
+    #[test]
+    fn from_be_slice_truncated() {
+        // Enough capacity
+        let limb = Limb::from_be_slice_truncated(&[1], 32);
+        assert_eq!(limb, Limb::ONE);
+
+        // Result needs masking
+        let limb = Limb::from_be_slice_truncated(&[3], 1);
+        assert_eq!(limb, Limb::ONE);
+    }
+
+    #[test]
+    #[should_panic]
+    fn from_be_slice_truncated_oversized() {
+        let _ = Limb::from_be_slice_truncated(b"", 65);
+    }
+
+    #[test]
+    fn from_le_slice_truncated() {
+        // Enough capacity
+        let limb = Limb::from_le_slice_truncated(&[1], 32);
+        assert_eq!(limb, Limb::ONE);
+
+        // Result needs masking
+        let limb = Limb::from_le_slice_truncated(&[1], 1);
+        assert_eq!(limb, Limb::ONE);
+    }
+
+    #[test]
+    #[should_panic]
+    fn from_le_slice_truncated_oversized() {
+        let _ = Limb::from_le_slice_truncated(b"", 65);
     }
 
     #[test]

--- a/src/uint/encoding.rs
+++ b/src/uint/encoding.rs
@@ -23,7 +23,7 @@ const RADIX_ENCODING_MIN: u32 = 2;
 const RADIX_ENCODING_MAX: u32 = 36;
 
 impl<const LIMBS: usize> Uint<LIMBS> {
-    /// Create a new [`Uint`] from the provided big endian bytes.
+    /// Decode [`Uint`] from the provided big endian bytes.
     ///
     /// # Panics
     /// If the supplied byte slice is not equal to the byte length of this [`Uint`], i.e.
@@ -53,26 +53,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         Uint::new(res)
     }
 
-    /// Create a new [`Uint`] from the provided big endian bytes, zero padding if necessary,
-    /// and truncating to the least significant bytes in the event the given amount of data exceeds
-    /// `bits_precision`.
-    ///
-    /// # Panics
-    /// If `bits_precision > Self::BITS`.
-    #[must_use]
-    #[track_caller]
-    pub fn from_be_slice_truncated(bytes: &[u8], bits_precision: u32) -> Self {
-        let mut ret = Self::ZERO;
-        assert!(
-            fill_limbs_from_be_slice_truncated(bytes, &mut ret.limbs, bits_precision).is_ok(),
-            "U{} is too small to store requested {} bits",
-            Self::BITS,
-            bits_precision
-        );
-        ret
-    }
-
-    /// Create a new [`Uint`] from the provided little endian bytes.
+    /// Decode [`Uint`] from the provided little endian bytes.
     ///
     /// # Panics
     /// If the supplied byte slice is not equal to the byte length of this [`Uint`], i.e.
@@ -102,8 +83,27 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         Uint::new(res)
     }
 
-    /// Create a new [`Uint`] from the provided little endian bytes, zero padding if necessary,
-    /// and truncating to the least significant bytes in the event the given amount of data exceeds
+    /// Decode [`Uint`] from the provided big endian bytes, zero padding if necessary, and
+    /// truncating to the least significant bytes in the event the given amount of data exceeds
+    /// `bits_precision`.
+    ///
+    /// # Panics
+    /// If `bits_precision > Self::BITS`.
+    #[must_use]
+    #[track_caller]
+    pub fn from_be_slice_truncated(bytes: &[u8], bits_precision: u32) -> Self {
+        let mut ret = Self::ZERO;
+        assert!(
+            fill_limbs_from_be_slice_truncated(bytes, &mut ret.limbs, bits_precision).is_ok(),
+            "U{} is too small to store requested {} bits",
+            Self::BITS,
+            bits_precision
+        );
+        ret
+    }
+
+    /// Decode [`Uint`] from the provided little endian bytes, zero padding if necessary, and
+    /// truncating to the least significant bytes in the event the given amount of data exceeds
     /// `bits_precision`.
     ///
     /// # Panics
@@ -121,8 +121,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         ret
     }
 
-    /// Create a new [`Uint`] from the provided slice, using the supplied [`ByteOrder`] to
-    /// determine the endianness.
+    /// Decode [`Uint`] from the provided slice, using the supplied [`ByteOrder`] to determine the
+    /// endianness.
     ///
     /// # Panics
     /// If the supplied byte slice is not equal to the byte length of this [`Uint`], i.e.
@@ -136,8 +136,8 @@ impl<const LIMBS: usize> Uint<LIMBS> {
         }
     }
 
-    /// Create a new [`Uint`] from the provided bytes, using the supplied [`ByteOrder`] to
-    /// determine the endianness.
+    /// Decode [`Uint`] from the provided bytes, using the supplied [`ByteOrder`] to determine the
+    /// endianness.
     ///
     /// Zero pads if necessary, and truncates to the least significant bytes in the event the given
     /// amount of data exceeds `bits_precision`.
@@ -372,12 +372,12 @@ pub(crate) fn fill_limbs_from_le_slice_truncated(
 }
 
 /// Handle masking for the case that `bits_precision` is not aligned to `Limb::BITS`.
+#[inline(always)]
 fn mask_high_limb(limbs: &mut [Limb], bits_precision: u32) {
     debug_assert!(bitlen::from_limbs(limbs.len()) >= bits_precision);
     let unaligned_bits = bits_precision & (Limb::BITS - 1);
     if unaligned_bits != 0 {
-        let high_limb = bitlen::to_limbs(bits_precision) - 1;
-        limbs[high_limb].0 &= Word::MAX >> (Limb::BITS.saturating_sub(unaligned_bits));
+        limbs[bitlen::to_limbs(bits_precision) - 1].mask_to_precision(unaligned_bits);
     }
 }
 

--- a/src/uint/encoding/der.rs
+++ b/src/uint/encoding/der.rs
@@ -1,6 +1,6 @@
 //! Support for decoding/encoding [`Uint`] as an ASN.1 DER `INTEGER`.
 
-use crate::{ArrayEncoding, Encoding, Limb, Uint, UintRef, hybrid_array::Array};
+use crate::{ArrayEncoding, Limb, Uint, UintRef, hybrid_array::Array};
 use ::der::{
     DecodeValue, EncodeValue, FixedTag, Length, Tag,
     asn1::{AnyRef, UintRef as Asn1UintRef},

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,7 +3,7 @@
 // Different tests may use only a subset of the available functionality
 #![allow(dead_code)]
 
-use crypto_bigint::{Encoding, Limb};
+use crypto_bigint::Limb;
 use num_bigint::{BigInt, BigUint};
 
 /// [`Int`] to [`num_bigint::BigInt`]


### PR DESCRIPTION
Adds equivalents of all of the `Encoding` trait methods, but available as public `const fn`s, including a new implementation of the forthcoming `from_be_slice_truncated`/`from_le_slice_truncated` methods.