### PR TITLE
Fix carry result from Karatsuba `wrapping_square` for larger integers

### DIFF
--- a/src/uint/boxed/mul.rs
+++ b/src/uint/boxed/mul.rs
@@ -313,4 +313,19 @@ mod tests {
         let b = UintRef::new(&[Limb(456), Limb(0)]);
         assert_eq!(a * b, BoxedUint::from(562962957840u64));
     }
+
+    #[test]
+    fn overflow_check() {
+        for bits in (64..4096).step_by(2 * Limb::BITS as usize) {
+            let mut b = BoxedUint::max(bits);
+            b.restrict_bits(bits >> 1);
+            assert!(b.checked_mul(&b).is_some().to_bool_vartime());
+            assert!(b.checked_square().is_some().to_bool_vartime());
+            b.wrapping_add_assign(Limb::ONE);
+            assert!(b.checked_mul(&b).is_none().to_bool_vartime());
+            assert!(b.checked_square().is_none().to_bool_vartime());
+            assert!(b.saturating_mul(&b) == BoxedUint::max(bits));
+            assert!(b.saturating_square() == BoxedUint::max(bits));
+        }
+    }
 }

--- a/src/uint/mul/karatsuba.rs
+++ b/src/uint/mul/karatsuba.rs
@@ -469,7 +469,7 @@ pub(crate) const fn wrapping_square(uint: &UintRef, out: &mut UintRef) -> Limb {
         } else {
             let (z01, z2) = hi.split_at_mut(LIMBS);
             z01.copy_from(z0.1.as_uint_ref());
-            wrapping_square(x1, z2);
+            let z2_carry = wrapping_square(x1, z2);
             let mut dx0 = Uint::<LIMBS>::ZERO;
             dx0.as_mut_uint_ref().copy_from(x0);
             let (dx0, dx0_hi) = dx0.shl1_with_carry(Limb::ZERO);
@@ -483,10 +483,10 @@ pub(crate) const fn wrapping_square(uint: &UintRef, out: &mut UintRef) -> Limb {
                 Limb::ZERO,
                 dx0_hi.is_nonzero(),
             );
-            let (z1, z1tail) = hi.split_at_mut(LIMBS + z2_len);
+            let (z1, z1_tail) = hi.split_at_mut(LIMBS + z2_len);
             let c = wrapping_mul(dx0.as_uint_ref(), x1, z1, true);
             carry = carry.wrapping_add(c);
-            z1tail.add_assign_limb(carry)
+            z1_tail.add_assign_limb(carry).wrapping_add(z2_carry)
         }
     }
 
@@ -508,7 +508,7 @@ pub(crate) const fn wrapping_square(uint: &UintRef, out: &mut UintRef) -> Limb {
     // input size or more than MIN_STARTING_LIMBS limbs would be truncated.
     let mut split = previous_power_of_2(out.nlimbs());
     if split > x.nlimbs() || 2 * split >= out.nlimbs() + MIN_STARTING_LIMBS {
-        split /= 2;
+        split >>= 1;
     }
 
     // Select an optimized implementation for a fixed number of limbs


### PR DESCRIPTION
A carry value was silently dropped, leading to overflow being undetected in some cases where the Karatsuba `wrapping_square` method was used. This only affected some large integers at specific sizes (2112 and 2240 bits on 64-bit platforms for example). A test is added reproducing the issue.